### PR TITLE
Remove default loading of .bat extension files

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Settings.cs
@@ -9,7 +9,7 @@ namespace Flow.Launcher.Plugin.Program
         public DateTime LastIndexTime { get; set; }
         public List<ProgramSource> ProgramSources { get; set; } = new List<ProgramSource>();
         public List<DisabledProgramSource> DisabledProgramSources { get; set; } = new List<DisabledProgramSource>();
-        public string[] ProgramSuffixes { get; set; } = {"bat", "appref-ms", "exe", "lnk"};
+        public string[] ProgramSuffixes { get; set; } = {"appref-ms", "exe", "lnk"};
 
         public bool EnableStartMenuSource { get; set; } = true;
 


### PR DESCRIPTION
Remove default loading of .bat extension files, less clutter in program list. User can still add it if they choose to.