### PR TITLE
Folder plugin- Recursive delete sub folders and files

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Folder/ContextMenuLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.Folder/ContextMenuLoader.cs
@@ -89,7 +89,7 @@ namespace Flow.Launcher.Plugin.Folder
                                 if (record.Type == ResultType.File)
                                     File.Delete(record.FullPath);
                                 else
-                                    Directory.Delete(record.FullPath);
+                                    Directory.Delete(record.FullPath, true);
                             }
                             catch(Exception e)
                             {


### PR DESCRIPTION
Current folder delete function in Folder plugin does not delete folders that contain files. 

Fix by adding true to recursive delete