### PR TITLE
fix typo in IPublicAPI

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginInstaller.cs
+++ b/Flow.Launcher.Core/Plugin/PluginInstaller.cs
@@ -86,7 +86,7 @@ namespace Flow.Launcher.Core.Plugin
                                         "Restart Flow Launcher to take effect?",
                                         "Install plugin", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
                     {
-                        PluginManager.API.RestarApp();
+                        PluginManager.API.RestartApp();
                     }
                 }
             }

--- a/Flow.Launcher.Plugin/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/IPublicAPI.cs
@@ -43,6 +43,12 @@ namespace Flow.Launcher.Plugin
         /// <summary>
         /// Restart Flow Launcher
         /// </summary>
+        void RestartApp();
+
+        /// <summary>
+        /// Restart Flow Launcher
+        /// </summary>
+        [Obsolete("Use RestartApp instead. This method will be removed in Flow Launcher 1.3")]
         void RestarApp();
 
         /// <summary>

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -54,7 +54,7 @@ namespace Flow.Launcher
             Application.Current.MainWindow.Close();
         }
 
-        public void RestarApp()
+        public void RestartApp()
         {
             _mainVM.MainWindowVisibility = Visibility.Hidden;
 
@@ -64,6 +64,11 @@ namespace Flow.Launcher
             SaveAppAllSettings();
 
             UpdateManager.RestartApp(Constant.ApplicationFileName);
+        }
+
+        public void RestarApp()
+        {
+            RestartApp();
         }
 
         public void CheckForNewUpdate()

--- a/Plugins/Flow.Launcher.Plugin.PluginManagement/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginManagement/Main.cs
@@ -220,7 +220,7 @@ namespace Flow.Launcher.Plugin.PluginManagement
                                              "Install plugin", MessageBoxButton.YesNo, MessageBoxImage.Question);
                 if (result == MessageBoxResult.Yes)
                 {
-                    context.API.RestarApp();
+                    context.API.RestartApp();
                 }
             }
         }

--- a/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
@@ -205,7 +205,7 @@ namespace Flow.Launcher.Plugin.Sys
                     IcoPath = "Images\\app.png",
                     Action = c =>
                     {
-                        context.API.RestarApp();
+                        context.API.RestartApp();
                         return false;
                     }
                 },


### PR DESCRIPTION
Replace `IPublicAPI.RestarApp` with `IPublicAPI.RestartApp` and mark `IPublicAPI.RestarApp` obsolete.