### PR TITLE
Add support for F# plugins

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginsLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginsLoader.cs
@@ -20,21 +20,21 @@ namespace Flow.Launcher.Core.Plugin
 
         public static List<PluginPair> Plugins(List<PluginMetadata> metadatas, PluginsSettings settings)
         {
-            var csharpPlugins = CSharpPlugins(metadatas).ToList();
+            var dotnetPlugins = DotNetPlugins(metadatas).ToList();
             var pythonPlugins = PythonPlugins(metadatas, settings.PythonDirectory);
             var executablePlugins = ExecutablePlugins(metadatas);
-            var plugins = csharpPlugins.Concat(pythonPlugins).Concat(executablePlugins).ToList();
+            var plugins = dotnetPlugins.Concat(pythonPlugins).Concat(executablePlugins).ToList();
             return plugins;
         }
 
-        public static IEnumerable<PluginPair> CSharpPlugins(List<PluginMetadata> source)
+        public static IEnumerable<PluginPair> DotNetPlugins(List<PluginMetadata> source)
         {
             var plugins = new List<PluginPair>();
-            var metadatas = source.Where(o => o.Language.ToUpper() == AllowedLanguage.CSharp);
+            var metadatas = source.Where(o => AllowedLanguage.IsDotNet(o.Language));
 
             foreach (var metadata in metadatas)
             {
-                var milliseconds = Stopwatch.Debug($"|PluginsLoader.CSharpPlugins|Constructor init cost for {metadata.Name}", () =>
+                var milliseconds = Stopwatch.Debug($"|PluginsLoader.DotNetPlugins|Constructor init cost for {metadata.Name}", () =>
                 {
 
 #if DEBUG
@@ -50,7 +50,7 @@ namespace Flow.Launcher.Core.Plugin
                     }
                     catch (Exception e)
                     {
-                        Log.Exception($"|PluginsLoader.CSharpPlugins|Couldn't load assembly for {metadata.Name}", e);
+                        Log.Exception($"|PluginsLoader.DotNetPlugins|Couldn't load assembly for {metadata.Name}", e);
                         return;
                     }
                     var types = assembly.GetTypes();
@@ -61,7 +61,7 @@ namespace Flow.Launcher.Core.Plugin
                     }
                     catch (InvalidOperationException e)
                     {
-                        Log.Exception($"|PluginsLoader.CSharpPlugins|Can't find class implement IPlugin for <{metadata.Name}>", e);
+                        Log.Exception($"|PluginsLoader.DotNetPlugins|Can't find class implement IPlugin for <{metadata.Name}>", e);
                         return;
                     }
                     IPlugin plugin;
@@ -71,7 +71,7 @@ namespace Flow.Launcher.Core.Plugin
                     }
                     catch (Exception e)
                     {
-                        Log.Exception($"|PluginsLoader.CSharpPlugins|Can't create instance for <{metadata.Name}>", e);
+                        Log.Exception($"|PluginsLoader.DotNetPlugins|Can't create instance for <{metadata.Name}>", e);
                         return;
                     }
 #endif

--- a/Flow.Launcher.Plugin/AllowedLanguage.cs
+++ b/Flow.Launcher.Plugin/AllowedLanguage.cs
@@ -12,15 +12,26 @@
             get { return "CSHARP"; }
         }
 
+        public static string FSharp
+        {
+            get { return "FSHARP"; }
+        }
+
         public static string Executable
         {
             get { return "EXECUTABLE"; }
         }
 
+        public static bool IsDotNet(string language)
+        {
+            return language.ToUpper() == CSharp
+                || language.ToUpper() == FSharp;
+        }
+
         public static bool IsAllowed(string language)
         {
-            return language.ToUpper() == Python.ToUpper() 
-                || language.ToUpper() == CSharp.ToUpper()
+            return IsDotNet(language)
+                || language.ToUpper() == Python.ToUpper()
                 || language.ToUpper() == Executable.ToUpper();
         }
     }

--- a/Flow.Launcher.sln
+++ b/Flow.Launcher.sln
@@ -74,6 +74,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Flow.Launcher.Plugin.Browse
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Flow.Launcher.Plugin.Calculator", "Plugins\Flow.Launcher.Plugin.Calculator\Flow.Launcher.Plugin.Calculator.csproj", "{59BD9891-3837-438A-958D-ADC7F91F6F7E}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "HelloWorldFSharp", "Plugins\HelloWorldFSharp\HelloWorldFSharp.fsproj", "{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -313,6 +315,18 @@ Global
 		{59BD9891-3837-438A-958D-ADC7F91F6F7E}.Release|x64.Build.0 = Release|Any CPU
 		{59BD9891-3837-438A-958D-ADC7F91F6F7E}.Release|x86.ActiveCfg = Release|Any CPU
 		{59BD9891-3837-438A-958D-ADC7F91F6F7E}.Release|x86.Build.0 = Release|Any CPU
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}.Debug|x64.Build.0 = Debug|Any CPU
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}.Debug|x86.Build.0 = Debug|Any CPU
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}.Release|x64.ActiveCfg = Release|Any CPU
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}.Release|x64.Build.0 = Release|Any CPU
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}.Release|x86.ActiveCfg = Release|Any CPU
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -332,6 +346,7 @@ Global
 		{C21BFF9C-2C99-4B5F-B7C9-A5E6DDDB37B0} = {3A73F5A7-0335-40D8-BF7C-F20BE5D0BA87}
 		{9B130CC5-14FB-41FF-B310-0A95B6894C37} = {3A73F5A7-0335-40D8-BF7C-F20BE5D0BA87}
 		{59BD9891-3837-438A-958D-ADC7F91F6F7E} = {3A73F5A7-0335-40D8-BF7C-F20BE5D0BA87}
+		{30DDA7D9-3712-44F4-BD18-DC1C05B2DD9E} = {3A73F5A7-0335-40D8-BF7C-F20BE5D0BA87}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F26ACB50-3F6C-4907-B0C9-1ADACC1D0DED}

--- a/Plugins/HelloWorldFSharp/HelloWorldFSharp.fsproj
+++ b/Plugins/HelloWorldFSharp/HelloWorldFSharp.fsproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>..\..\Output\Debug\Plugins\HelloWorldFSharp\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>..\..\Output\Release\Plugins\HelloWorldFSharp\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="plugin.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Compile Include="Main.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Flow.Launcher.Plugin\Flow.Launcher.Plugin.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Plugins/HelloWorldFSharp/Main.fs
+++ b/Plugins/HelloWorldFSharp/Main.fs
@@ -1,0 +1,31 @@
+﻿namespace HelloWorldFSharp
+
+open Flow.Launcher.Plugin
+open System.Collections.Generic
+
+type HelloWorldFSharpPlugin() =
+
+    let mutable initContext = PluginInitContext()
+
+    interface IPlugin with
+        member this.Init (context: PluginInitContext) =
+            initContext <- context
+
+        member this.Query (query: Query) =
+            List<Result> [
+                Result (Title = "Hello World from F#",
+                        SubTitle = sprintf "Query: %s" query.Search)
+
+                Result (Title = "Browse source code of this plugin",
+                        SubTitle = "click to open in browser",
+                        Action = (fun ctx ->
+                                    initContext.CurrentPluginMetadata.Website
+                                        |> System.Diagnostics.Process.Start
+                                        |> ignore
+                                    true))
+
+                Result (Title = "Trigger a tray message",
+                        Action = (fun _ ->
+                                    initContext.API.ShowMsg ("Sample tray message", "from the F# plugin")
+                                    false))
+            ]

--- a/Plugins/HelloWorldFSharp/plugin.json
+++ b/Plugins/HelloWorldFSharp/plugin.json
@@ -1,0 +1,11 @@
+{
+    "ID":"8FF5D5C1F8194958A12E8668FB7ECC04",
+    "ActionKeyword":"hf",
+    "Name":"Hello World FSharp",
+    "Description":"Hello World FSharp",
+    "Author":"Ioannis G.",
+    "Version":"1.0.0",
+    "Language":"fsharp",
+    "Website":"https://github.com/Flow-Launcher/Flow.Launcher",
+    "ExecuteFileName":"HelloWorldFSharp.dll"
+}


### PR DESCRIPTION
It is trivial to write plugins in F# for Wox already, and I have written a few in the past ([example](https://github.com/JohnTheGr8/Wox.Plugin.Bang)). The only trick was to specify `csharp` in the plugin.json file.

This PR:
* adds F# to the supported languages in `PluginsLoader`
* adds `fsharp` as a supported value of the `Language` field in `plugin.json`
* adds a sample hello-world plugin project written in F#

Cheers