### PR TITLE
Fix translations for the main project

### DIFF
--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -55,6 +55,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="Languages\*.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="InputSimulator" Version="1.0.4" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Mages" Version="1.6.0" />


### PR DESCRIPTION
The translation files from `Flow.Launcher/Languages` are currently not included in the build output and are therefore not available at runtime. 
Changing the language from settings only affects the plugin-specific fields in the `Plugin` tab, because the plugin projects are copying their language files correctly.