### PR TITLE
Plugin enhancements

### DIFF
--- a/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
+++ b/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <PackageVersion>1.0.0-beta2</PackageVersion>
+    <PackageVersion>1.0.0-beta3</PackageVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
     <PackageId>Flow.Launcher.Plugin</PackageId>

--- a/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
+++ b/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
@@ -28,6 +28,10 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(APPVEYOR)' == 'True'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
+++ b/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
@@ -56,14 +56,7 @@
   
   <ItemGroup>
     <None Include="README.md" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <None Remove="FodyWeavers.xml" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Content Include="FodyWeavers.xml" />
+    <None Include="FodyWeavers.xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
+++ b/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
@@ -19,8 +19,6 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
     <PackageId>Flow.Launcher.Plugin</PackageId>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Authors>Flow-Launcher</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Flow-Launcher/Flow.Launcher</RepositoryUrl>
@@ -43,7 +41,7 @@
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>portable</DebugType>
+    <DebugType>embedded</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Output\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
+++ b/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
@@ -63,10 +63,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <Compile Include="..\SolutionAssemblyInfo.cs" Link="Properties\SolutionAssemblyInfo.cs" />
-  </ItemGroup>
-  
-  <ItemGroup>
     <Content Include="FodyWeavers.xml" />
   </ItemGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,5 +30,3 @@ artifacts:
   name: Zip
 - path: 'Output\Release\Flow.Launcher.Plugin.*.nupkg'
   name: Plugin nupkg
-- path: 'Output\Release\Flow.Launcher.Plugin.*.snupkg'
-  name: Plugin snupkg


### PR DESCRIPTION
This PR solves the issue we had with publishing symbols to nuget: `The checksum does not match for the dll(s) and corresponding pdb(s).`

After a bit of digging, I figured out that the problem was caused by Fody. Switching the PDB format to embedded solves this issue.

I have also:
* enabled deterministic builds for the plugin project in AppVeyor
* removed the `FodyWeavers.xml` file from the plugin project's nupkg
* removed `SolutionAssemblyInfo.cs` from the plugin project, which was causing the plugin dll to have the wrong `AssemblyFileVersion`, `AssemblyFileVersion` and `AssemblyInformationalVersion` in CI builds

Opening the nupkg file with NugetPackageExplorer verifies that SourceLink is valid now and the URLs are correctly embedded:

![image](https://user-images.githubusercontent.com/697917/82958222-9a06e580-9fbd-11ea-9691-0a093d97d11f.png)

I have also decompiled the dll with dotPeek and verified that Fody has done its magic correctly.