### PR TITLE
Exclude directory/network path for Web Search plugin

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -33,6 +33,9 @@ namespace Flow.Launcher.Plugin.WebSearch
 
         public List<Result> Query(Query query)
         {
+            if (FilesFolders.IsLocationPathString(query.Search))
+                return new List<Result>();
+
             var searchSourceList = new List<SearchSource>();
             var results = new List<Result>();
 


### PR DESCRIPTION
Web Search should not activate if query is a directory/network path

Before:
![image](https://user-images.githubusercontent.com/26427004/87257511-dbf0da00-c4de-11ea-8a06-5da8c36673d6.png)

After:
![image](https://user-images.githubusercontent.com/26427004/87257480-a6e48780-c4de-11ea-9c7d-fb90c0c3dab3.png)
