### PR TITLE
plugin/explorer: ensure environment variable paths are absolute

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
@@ -28,9 +28,11 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                     // we add a trailing slash to the path to make sure drive paths become valid absolute paths.
                     // for example, if %systemdrive% is C: we turn it to C:\
                     path = path.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
                     // if we don't have an absolute path, we use Path.GetFullPath to get one.
                     // for example, if %homepath% is \Users\John we turn it to C:\Users\John
                     path = Path.IsPathFullyQualified(path) ? path : Path.GetFullPath(path);
+
                     // Variables are returned with a mixture of all upper/lower case. 
                     // Call ToLower() to make the results look consistent
                     envStringPaths.Add(special.Key.ToString().ToLower(), path);

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
@@ -22,11 +22,18 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             foreach (DictionaryEntry special in Environment.GetEnvironmentVariables())
             {
-                if (Directory.Exists(special.Value.ToString()))
+                var path = special.Value.ToString();
+                if (Directory.Exists(path))
                 {
+                    // we add a trailing slash to the path to make sure drive paths become valid absolute paths.
+                    // for example, if %systemdrive% is C: we turn it to C:\
+                    path = path.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+                    // if we don't have an absolute path, we use Path.GetFullPath to get one.
+                    // for example, if %homepath% is \Users\John we turn it to C:\Users\John
+                    path = Path.IsPathFullyQualified(path) ? path : Path.GetFullPath(path);
                     // Variables are returned with a mixture of all upper/lower case. 
                     // Call ToLower() to make the results look consistent
-                    envStringPaths.Add(special.Key.ToString().ToLower(), special.Value.ToString());
+                    envStringPaths.Add(special.Key.ToString().ToLower(), path);
                 }
             }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -7,7 +7,7 @@
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",
-  "Version": "1.2.1",
+  "Version": "1.2.2",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
Ensure paths resolved from environment variables are absolute paths. Examples of fixed searches include `%homepath%`, `%homedrive%` and `%systemdrive%`.

fixes #139