### PR TITLE
Fix missing fragment portion of the file path

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -52,7 +52,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                                     if (dataReaderResults.GetValue(0) != DBNull.Value && dataReaderResults.GetValue(1) != DBNull.Value)
                                     {
                                         // # is URI syntax for the fragment component, need to be encoded so LocalPath returns complete path   
-                                        var encodedFragmentPath = dataReaderResults.GetString(1).Replace("#", "%23");
+                                        var encodedFragmentPath = dataReaderResults
+                                                                    .GetString(1)
+                                                                    .Replace("#", "%23", StringComparison.OrdinalIgnoreCase);
                                         
                                         var path = new Uri(encodedFragmentPath).LocalPath;
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -51,7 +51,10 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                                 {
                                     if (dataReaderResults.GetValue(0) != DBNull.Value && dataReaderResults.GetValue(1) != DBNull.Value)
                                     {
-                                        var path = new Uri(dataReaderResults.GetString(1)).LocalPath;
+                                        // # is URI syntax for the fragment component, need to be encoded so LocalPath returns complete path   
+                                        var encodedFragmentPath = dataReaderResults.GetString(1).Replace("#", "%23");
+                                        
+                                        var path = new Uri(encodedFragmentPath).LocalPath;
 
                                         if (dataReaderResults.GetString(2) == "Directory")
                                         {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -7,7 +7,7 @@
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",
-  "Version": "1.2.2",
+  "Version": "1.2.4",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
In the URI make up, the '#' symbol is the syntax to indicate the fragment part of the URI:
![image](https://user-images.githubusercontent.com/26427004/91670168-5690ba00-eb5e-11ea-83f8-8923e2bb3ecd.png)

We replace the symbol with the encoded syntax %23 so it is escaped and LocalPath property returns the full path.

Note:
the LocalPath property returns the unescaped localised path of a directory. I have not found a good replacement.

Closing https://github.com/Flow-Launcher/Flow.Launcher/issues/142