### PR TITLE
Fix Encoding Error

### DIFF
--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Text;
 using System.Threading.Tasks;
 using System.Timers;
 using System.Windows;
@@ -84,6 +85,8 @@ namespace Flow.Launcher
                 ThemeManager.Instance.ChangeTheme(_settings.Theme);
 
                 Http.Proxy = _settings.Proxy;
+
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
                 RegisterExitEvents();
 


### PR DESCRIPTION
Fixes #163

Fix Encoding error of "GB2312" due to .net core problem by adding the injection.