### PR TITLE
plugin/ProcessKiller: enhancements to the kill-all functionality

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.ProcessKiller/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.ProcessKiller/Languages/en.xaml
@@ -5,7 +5,8 @@
     <system:String x:Key="flowlauncher_plugin_processkiller_plugin_name">Process Killer</system:String>
     <system:String x:Key="flowlauncher_plugin_processkiller_plugin_description">Kill running processes from Flow Launcher</system:String>
 
-    <system:String x:Key="flowlauncher_plugin_processkiller_kill_all">kill all "{0}" processes</system:String>
+    <system:String x:Key="flowlauncher_plugin_processkiller_kill_all">kill all instances of "{0}"</system:String>
+    <system:String x:Key="flowlauncher_plugin_processkiller_kill_all_count">kill {0} processes</system:String>
     <system:String x:Key="flowlauncher_plugin_processkiller_kill_instances">kill all instances</system:String>
 
 </ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.ProcessKiller/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.ProcessKiller/Main.cs
@@ -52,21 +52,24 @@ namespace Flow.Launcher.Plugin.ProcessKiller
             // get all non-system processes whose file path matches that of the given result (processPath)
             var similarProcesses = processHelper.GetSimilarProcesses(processPath);
 
-            menuOptions.Add(new Result
+            if (similarProcesses.Count() > 0)
             {
-                Title = _context.API.GetTranslation("flowlauncher_plugin_processkiller_kill_instances"),
-                SubTitle = processPath,
-                Action = _ =>
+                menuOptions.Add(new Result
                 {
-                    foreach (var p in similarProcesses)
+                    Title = _context.API.GetTranslation("flowlauncher_plugin_processkiller_kill_instances"),
+                    SubTitle = processPath,
+                    Action = _ =>
                     {
-                        processHelper.TryKill(p);
-                    }
+                        foreach (var p in similarProcesses)
+                        {
+                            processHelper.TryKill(p);
+                        }
 
-                    return true;
-                },
-                IcoPath = processPath
-            });
+                        return true;
+                    },
+                    IcoPath = processPath
+                });
+            }
 
             return menuOptions;
         }

--- a/Plugins/Flow.Launcher.Plugin.ProcessKiller/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.ProcessKiller/Main.cs
@@ -89,6 +89,7 @@ namespace Flow.Launcher.Plugin.ProcessKiller
                     SubTitle = path,
                     TitleHighlightData = StringMatcher.FuzzySearch(termToSearch, p.ProcessName).MatchData,
                     Score = pr.Score,
+                    ContextData = p.ProcessName,
                     Action = (c) =>
                     {
                         processHelper.TryKill(p);
@@ -101,14 +102,14 @@ namespace Flow.Launcher.Plugin.ProcessKiller
 
             // When there are multiple results AND all of them are instances of the same executable
             // add a quick option to kill them all at the top of the results.
-            var firstResult = sortedResults.FirstOrDefault()?.SubTitle;
-            if (processlist.Count > 1 && !string.IsNullOrEmpty(termToSearch) && sortedResults.All(r => r.SubTitle == firstResult))
+            var firstResult = sortedResults.FirstOrDefault(x => !string.IsNullOrEmpty(x.SubTitle));
+            if (processlist.Count > 1 && !string.IsNullOrEmpty(termToSearch) && sortedResults.All(r => r.SubTitle == firstResult?.SubTitle))
             {
                 sortedResults.Insert(1, new Result()
                 {
-                    IcoPath = "Images/app.png",
-                    Title = string.Format(_context.API.GetTranslation("flowlauncher_plugin_processkiller_kill_all"), termToSearch),
-                    SubTitle = "",
+                    IcoPath = firstResult?.IcoPath,
+                    Title = string.Format(_context.API.GetTranslation("flowlauncher_plugin_processkiller_kill_all"), firstResult?.ContextData),
+                    SubTitle = string.Format(_context.API.GetTranslation("flowlauncher_plugin_processkiller_kill_all_count"), processlist.Count),
                     Score = 200,
                     Action = (c) =>
                     {


### PR DESCRIPTION
1. do not show a "kill all instances" item in the context-menu listing of "kill all X processes"
2. make the "kill all X processes" result item a bit nicer

Before:
![image](https://user-images.githubusercontent.com/697917/95690383-0bb79700-0c20-11eb-81d3-6d86039545c2.png)
After:
![image](https://user-images.githubusercontent.com/697917/95690387-0f4b1e00-0c20-11eb-9af8-12fd603bf6cd.png)

3. hide the "kill all X processes" option when the associated executable path is empty

Before:
![image](https://user-images.githubusercontent.com/697917/95690417-50433280-0c20-11eb-8c17-31b31fe4f38a.png)
After:
![image](https://user-images.githubusercontent.com/697917/95690419-53d6b980-0c20-11eb-9bb8-bd2bc5ebbb26.png)

