### PR TITLE
add global.json to pin SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+      "version": "3.1.201",
+      "rollForward": "latestFeature"
+    }
+  }


### PR DESCRIPTION
This PR fixes the recent build failures we have seen. 

I have pinned the .NET Core SDK version to `3.1.xxx` with a minimum of `3.1.201`. I think this is reasonable...

check [this link](https://www.appveyor.com/updates/2020/11/14/) for details
