### PR TITLE
Allow MissingImgIcon and DefaultIcon to be removed from image cache

### DIFF
--- a/Flow.Launcher.Infrastructure/Image/ImageCache.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageCache.cs
@@ -65,14 +65,8 @@ namespace Flow.Launcher.Infrastructure.Image
                 if (Data.Count > permissibleFactor * MaxCached)
                 {
                     // To delete the images from the data dictionary based on the resizing of the Usage Dictionary.
-
                     foreach (var key in Data.OrderBy(x => x.Value.usage).Take(Data.Count - MaxCached).Select(x => x.Key))
-                    {
-                        if (!(key.Equals(Constant.ErrorIcon) || key.Equals(Constant.DefaultIcon)))
-                        {
-                            Data.TryRemove(key, out _);
-                        }
-                    }
+                        Data.TryRemove(key, out _);
                 }
             }
         }


### PR DESCRIPTION
Allow MissingImgIcon and DefaultIcon to be removed from image cache.

If these two's usage is high, keeping it as original behaviour, but if low, shouldn't have any impact if removed from image cache as their usage drops.

Enhancements to #221 & #195 