### PR TITLE
Use CancellationToken to cancel Explorer index search task

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
@@ -3,6 +3,7 @@ using Flow.Launcher.Plugin.Explorer.Search;
 using Flow.Launcher.Plugin.Explorer.ViewModels;
 using Flow.Launcher.Plugin.Explorer.Views;
 using System.Collections.Generic;
+using System.Threading;
 using System.Windows.Controls;
 
 namespace Flow.Launcher.Plugin.Explorer
@@ -16,6 +17,8 @@ namespace Flow.Launcher.Plugin.Explorer
         private SettingsViewModel viewModel;
 
         private IContextMenu contextMenu;
+
+        public static CancellationTokenSource updateSource;
 
         public Control CreateSettingPanel()
         {
@@ -37,6 +40,8 @@ namespace Flow.Launcher.Plugin.Explorer
 
         public List<Result> Query(Query query)
         {
+            updateSource?.Cancel();
+            updateSource = new CancellationTokenSource();
             return new SearchManager(Settings, Context).Search(query);
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
@@ -18,7 +18,8 @@ namespace Flow.Launcher.Plugin.Explorer
 
         private IContextMenu contextMenu;
 
-        public static CancellationTokenSource updateSource;
+        private static CancellationTokenSource updateSource;
+        public static CancellationToken updateToken;
 
         public Control CreateSettingPanel()
         {
@@ -42,6 +43,7 @@ namespace Flow.Launcher.Plugin.Explorer
         {
             updateSource?.Cancel();
             updateSource = new CancellationTokenSource();
+            updateToken = updateSource.Token;
             return new SearchManager(Settings, Context).Search(query);
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -7,6 +7,7 @@ using System.Data.Common;
 using System.Data.OleDb;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
 {
@@ -30,7 +31,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
             resultManager = new ResultManager(context);
         }
 
-        internal List<Result> ExecuteWindowsIndexSearch(string indexQueryString, string connectionString, Query query)
+        internal async Task<List<Result>> ExecuteWindowsIndexSearch(string indexQueryString, string connectionString, Query query)
         {
             var folderResults = new List<Result>();
             var fileResults = new List<Result>();
@@ -46,7 +47,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                     {
                         // Results return as an OleDbDataReader.
                         var updateToken = Main.updateToken;
-                        using (dataReaderResults = command.ExecuteReaderAsync(updateToken).GetAwaiter().GetResult() as OleDbDataReader)
+                        using (dataReaderResults = await command.ExecuteReaderAsync(updateToken) as OleDbDataReader)
                         {
                             if (updateToken.IsCancellationRequested)
                                 return new List<Result>();
@@ -106,7 +107,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
             lock (_lock)
             {
                 var constructedQuery = constructQuery(searchString);
-                return ExecuteWindowsIndexSearch(constructedQuery, connectionString, query);
+                return ExecuteWindowsIndexSearch(constructedQuery, connectionString, query).GetAwaiter().GetResult();
             }
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -18,7 +18,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
         private OleDbConnection conn;
 
         private OleDbCommand command;
-        
+
         private OleDbDataReader dataReaderResults;
 
         private readonly ResultManager resultManager;
@@ -47,7 +47,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                     {
                         // Results return as an OleDbDataReader.
                         var updateToken = Main.updateToken;
-                        using (dataReaderResults = await command.ExecuteReaderAsync(updateToken) as OleDbDataReader)
+                        using (dataReaderResults = await command.ExecuteReaderAsync(updateToken).ConfigureAwait(false) as OleDbDataReader)
                         {
                             if (updateToken.IsCancellationRequested)
                                 return new List<Result>();
@@ -61,7 +61,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                                         var encodedFragmentPath = dataReaderResults
                                                                     .GetString(1)
                                                                     .Replace("#", "%23", StringComparison.OrdinalIgnoreCase);
-                                        
+
                                         var path = new Uri(encodedFragmentPath).LocalPath;
 
                                         if (dataReaderResults.GetString(2) == "Directory")
@@ -69,7 +69,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                                             folderResults.Add(resultManager.CreateFolderResult(
                                                                                 dataReaderResults.GetString(0),
                                                                                 path,
-                                                                                path, 
+                                                                                path,
                                                                                 query, true, true));
                                         }
                                         else

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -92,7 +92,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                 LogException("General error from performing index search", e);
             }
 
-            // Intial ordering, this order can be updated later by UpdateResultView.MainViewModel based on history of user selection.
+            // Initial ordering, this order can be updated later by UpdateResultView.MainViewModel based on history of user selection.
             return results.Concat(folderResults.OrderBy(x => x.Title)).Concat(fileResults.OrderBy(x => x.Title)).ToList(); ;
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -2,6 +2,7 @@
 using Microsoft.Search.Interop;
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Data.OleDb;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -16,7 +17,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
 
         private OleDbCommand command;
         
-        private OleDbDataReader dataReaderResults;
+        private DbDataReader dataReaderResults;
 
         private readonly ResultManager resultManager;
 
@@ -43,7 +44,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                     using (command = new OleDbCommand(indexQueryString, conn))
                     {
                         // Results return as an OleDbDataReader.
-                        using (dataReaderResults = command.ExecuteReader())
+                        using (dataReaderResults = command.ExecuteReaderAsync(Main.updateSource.Token).GetAwaiter().GetResult())
                         {
                             if (dataReaderResults.HasRows)
                             {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -2,6 +2,7 @@
 using Microsoft.Search.Interop;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.Data.OleDb;
 using System.Linq;
@@ -17,7 +18,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
 
         private OleDbCommand command;
         
-        private DbDataReader dataReaderResults;
+        private OleDbDataReader dataReaderResults;
 
         private readonly ResultManager resultManager;
 
@@ -44,8 +45,11 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                     using (command = new OleDbCommand(indexQueryString, conn))
                     {
                         // Results return as an OleDbDataReader.
-                        using (dataReaderResults = command.ExecuteReaderAsync(Main.updateSource.Token).GetAwaiter().GetResult())
+                        var updateToken = Main.updateToken;
+                        using (dataReaderResults = command.ExecuteReaderAsync(updateToken).GetAwaiter().GetResult() as OleDbDataReader)
                         {
+                            if (updateToken.IsCancellationRequested)
+                                return new List<Result>();
                             if (dataReaderResults.HasRows)
                             {
                                 while (dataReaderResults.Read())


### PR DESCRIPTION
Easy fix but compromised. I think it would be better if we can use full async instead of `GetAwaitor().GetResult`.
Link to #195 Explorer plugin cause threadpool task shortage.

#233 may allow this to become better if we don't need to create a new CancellationTokenSource but use the one in the main thread, and if we can make plugin use Task<Result> as result type, this can become even better that don't need to wait the result.