### PR TITLE
Plugin installation and uninstallation restart without prompt

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
@@ -6,13 +6,11 @@
     <system:String x:Key="plugin_pluginsmanager_downloading_plugin">Downloading plugin</system:String>
     <system:String x:Key="plugin_pluginsmanager_please_wait">Please wait...</system:String>
     <system:String x:Key="plugin_pluginsmanager_download_success">Successfully downloaded</system:String>
-    <system:String x:Key="plugin_pluginsmanager_uninstall_prompt">Do you want to uninstall the following plugin?{0}{1}{2} by {3}</system:String>
-    <system:String x:Key="plugin_pluginsmanager_install_prompt">Do you want to install the following plugin?{0}{1}{2} by {3}</system:String>
+    <system:String x:Key="plugin_pluginsmanager_uninstall_prompt">{0} by {1} {2}{3}Would you like to uninstall this plugin? After the uninstallation Flow will automatically restart.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_prompt">{0} by {1} {2}{3}Would you like to install this plugin? After the installation Flow will automatically restart.</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_title">Plugin Install</system:String>
     <system:String x:Key="plugin_pluginsmanager_uninstall_title">Plugin Uninstall</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_errormetadatafile">Install failed: unable to find the plugin.json metadata file from the new plugin</system:String>
-    <system:String x:Key="plugin_pluginsmanager_install_successandrestart">You have installed plugin {0} successfully.{1}Would you like to restart Flow Launcher to take effect?</system:String>
-    <system:String x:Key="plugin_pluginsmanager_uninstall_successandrestart">You have uninstalled plugin {0} successfully.{1}Would you like to restart Flow Launcher to take effect?</system:String>
     <!--Controls-->
     
     <!--Plugin Infos-->

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -36,8 +36,8 @@ namespace Flow.Launcher.Plugin.PluginsManager
             }
 
             var message = string.Format(Context.API.GetTranslation("plugin_pluginsmanager_install_prompt"),
-                                                                        Environment.NewLine, Environment.NewLine,
-                                                                        plugin.Name, plugin.Author);
+                                                                        plugin.Name, plugin.Author,
+                                                                        Environment.NewLine, Environment.NewLine);
 
             if (MessageBox.Show(message, Context.API.GetTranslation("plugin_pluginsmanager_install_title"), MessageBoxButton.YesNo) == MessageBoxResult.No)
                 return;
@@ -156,12 +156,8 @@ namespace Flow.Launcher.Plugin.PluginsManager
             string newPluginPath = Path.Combine(DataLocation.PluginsDirectory, $"{plugin.Name}{plugin.ID}");
 
             Directory.Move(pluginFolderPath, newPluginPath);
-
-            if (MessageBox.Show(string.Format(Context.API.GetTranslation("plugin_pluginsmanager_install_successandrestart"),
-                                                                            plugin.Name, Environment.NewLine),
-                                    Context.API.GetTranslation("plugin_pluginsmanager_install_title"),
-                                                                MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
-                Context.API.RestartApp();
+            
+            Context.API.RestartApp();
         }
 
         internal List<Result> RequestUninstall(string search)
@@ -216,19 +212,15 @@ namespace Flow.Launcher.Plugin.PluginsManager
         private void Uninstall(PluginMetadata plugin)
         {
             string message = string.Format(Context.API.GetTranslation("plugin_pluginsmanager_uninstall_prompt"),
-                                                                        Environment.NewLine, Environment.NewLine,
-                                                                        plugin.Name, plugin.Author);
+                                                                        plugin.Name, plugin.Author,
+                                                                        Environment.NewLine, Environment.NewLine);
 
             if (MessageBox.Show(message, Context.API.GetTranslation("plugin_pluginsmanager_uninstall_title"), 
                                                                         MessageBoxButton.YesNo) == MessageBoxResult.Yes)
             {
                 using var _ = File.CreateText(Path.Combine(plugin.PluginDirectory, "NeedDelete.txt"));
-
-                if (MessageBox.Show(string.Format(Context.API.GetTranslation("plugin_pluginsmanager_uninstall_successandrestart"),
-                                                                            plugin.Name, Environment.NewLine),
-                                    Context.API.GetTranslation("plugin_pluginsmanager_uninstall_title"),
-                                                                MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
-                    Context.API.RestartApp();
+                
+                Context.API.RestartApp();
             }
         }
     }

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
@@ -6,7 +6,7 @@
   "Name": "Plugins Manager",
   "Description": "Management of installing, uninstalling or updating Flow Launcher plugins",
   "Author": "Jeremy Wu",
-  "Version": "1.0.0",
+  "Version": "1.1.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.PluginsManager.dll",


### PR DESCRIPTION
Directly restart flow without another prompt after plugin install/uninstall. This helps make the experience more seamless