### PR TITLE
Remove post build script target of JsonRPC folder copy

### DIFF
--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -36,7 +36,6 @@ function Copy-Resources ($path, $config) {
     $output = "$path\Output"
     $target = "$output\$config"
     Copy-Item -Recurse -Force $project\Images\* $target\Images\
-    Copy-Item -Recurse -Force $path\JsonRPC $target\JsonRPC
     # making version static as multiple versions can exist in the nuget folder and in the case a breaking change is introduced.
     Copy-Item -Force $env:USERPROFILE\.nuget\packages\squirrel.windows\1.5.2\tools\Squirrel.exe $output\Update.exe
 }


### PR DESCRIPTION
JsonRPC folder is deleted as part of the work in #225, remove this copy command from postbuild script