### PR TITLE
Fix error handling in PluginsManager and plugins query, fixed postbuild script duplicate deletion during build

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -422,7 +422,7 @@ namespace Flow.Launcher.ViewModel
                                     }
                                     catch(Exception e)
                                     {
-                                        Log.Exception($"|MainViewModel|Exception when querying {plugin.Metadata.Name}", e);
+                                        Log.Exception("MainViewModel", $"Exception when querying the plugin {plugin.Metadata.Name}", e, "QueryResults");
                                     }
                                 }
                             });
@@ -442,7 +442,7 @@ namespace Flow.Launcher.ViewModel
                         }
                     }, currentCancellationToken).ContinueWith(t =>
                     {
-                        Log.Exception("|MainViewModel|Error when querying plugin", t.Exception?.InnerException);
+                        Log.Exception("MainViewModel", "Error when querying plugins", t.Exception?.InnerException, "QueryResults");
                     }, TaskContinuationOptions.OnlyOnFaulted);
                 }
             }

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -21,6 +21,7 @@ using Flow.Launcher.Plugin.SharedCommands;
 using Flow.Launcher.Storage;
 using System.Windows.Media;
 using Flow.Launcher.Infrastructure.Image;
+using Flow.Launcher.Infrastructure.Logger;
 
 namespace Flow.Launcher.ViewModel
 {
@@ -414,8 +415,15 @@ namespace Flow.Launcher.ViewModel
                             {
                                 if (!plugin.Metadata.Disabled)
                                 {
-                                    var results = PluginManager.QueryForPlugin(plugin, query);
-                                    UpdateResultView(results, plugin.Metadata, query);
+                                    try
+                                    {
+                                        var results = PluginManager.QueryForPlugin(plugin, query);
+                                        UpdateResultView(results, plugin.Metadata, query);
+                                    }
+                                    catch(Exception e)
+                                    {
+                                        Log.Exception($"|MainViewModel|Exception when querying {plugin.Metadata.Name}", e);
+                                    }
                                 }
                             });
                         }
@@ -432,7 +440,10 @@ namespace Flow.Launcher.ViewModel
                         { // update to hidden if this is still the current query
                             ProgressBarVisibility = Visibility.Hidden;
                         }
-                    }, currentCancellationToken);
+                    }, currentCancellationToken).ContinueWith(t =>
+                    {
+                        Log.Exception("|MainViewModel|Error when querying plugin", t.Exception?.InnerException);
+                    }, TaskContinuationOptions.OnlyOnFaulted);
                 }
             }
             else

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
@@ -6,6 +6,8 @@
     <system:String x:Key="plugin_pluginsmanager_downloading_plugin">Downloading plugin</system:String>
     <system:String x:Key="plugin_pluginsmanager_please_wait">Please wait...</system:String>
     <system:String x:Key="plugin_pluginsmanager_download_success">Successfully downloaded</system:String>
+    <system:String x:Key="plugin_pluginsmanager_download_error_title">Error downloading plugin</system:String>
+    <system:String x:Key="plugin_pluginsmanager_download_error_subtitle">Error occured while trying to download the plugin</system:String>
     <system:String x:Key="plugin_pluginsmanager_uninstall_prompt">{0} by {1} {2}{3}Would you like to uninstall this plugin? After the uninstallation Flow will automatically restart.</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_prompt">{0} by {1} {2}{3}Would you like to install this plugin? After the installation Flow will automatically restart.</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_title">Plugin Install</system:String>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
@@ -7,7 +7,7 @@
     <system:String x:Key="plugin_pluginsmanager_please_wait">Please wait...</system:String>
     <system:String x:Key="plugin_pluginsmanager_download_success">Successfully downloaded</system:String>
     <system:String x:Key="plugin_pluginsmanager_download_error_title">Error downloading plugin</system:String>
-    <system:String x:Key="plugin_pluginsmanager_download_error_subtitle">Error occured while trying to download the plugin</system:String>
+    <system:String x:Key="plugin_pluginsmanager_download_error_subtitle">Error occured while trying to download {0}</system:String>
     <system:String x:Key="plugin_pluginsmanager_uninstall_prompt">{0} by {1} {2}{3}Would you like to uninstall this plugin? After the uninstallation Flow will automatically restart.</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_prompt">{0} by {1} {2}{3}Would you like to install this plugin? After the installation Flow will automatically restart.</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_title">Plugin Install</system:String>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
@@ -6,13 +6,13 @@
     <system:String x:Key="plugin_pluginsmanager_downloading_plugin">Downloading plugin</system:String>
     <system:String x:Key="plugin_pluginsmanager_please_wait">Please wait...</system:String>
     <system:String x:Key="plugin_pluginsmanager_download_success">Successfully downloaded</system:String>
-    <system:String x:Key="plugin_pluginsmanager_download_error_title">Error downloading plugin</system:String>
-    <system:String x:Key="plugin_pluginsmanager_download_error_subtitle">Error occured while trying to download {0}</system:String>
     <system:String x:Key="plugin_pluginsmanager_uninstall_prompt">{0} by {1} {2}{3}Would you like to uninstall this plugin? After the uninstallation Flow will automatically restart.</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_prompt">{0} by {1} {2}{3}Would you like to install this plugin? After the installation Flow will automatically restart.</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_title">Plugin Install</system:String>
     <system:String x:Key="plugin_pluginsmanager_uninstall_title">Plugin Uninstall</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_errormetadatafile">Install failed: unable to find the plugin.json metadata file from the new plugin</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_error_title">Error installing plugin</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_error_subtitle">Error occured while trying to install {0}</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_noresult_title">No update available</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_noresult_subtitle">All plugins are up to date</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_prompt">{0} by {1} {2}{3}Would you like to update this plugin? After the update Flow will automatically restart.</system:String>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -135,7 +135,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
             catch (Exception e)
             {
                 Context.API.ShowMsg(Context.API.GetTranslation("plugin_pluginsmanager_download_error_title"),
-                    Context.API.GetTranslation("plugin_pluginsmanager_download_error_subtitle"));
+                    string.Format(Context.API.GetTranslation("plugin_pluginsmanager_download_error_subtitle"), plugin.Name));
 
                 Log.Exception("PluginsManager", "An error occured while downloading plugin", e, "PluginDownload");
             }

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -140,6 +140,8 @@ namespace Flow.Launcher.Plugin.PluginsManager
                     string.Format(Context.API.GetTranslation("plugin_pluginsmanager_install_error_subtitle"), plugin.Name));
 
                 Log.Exception("PluginsManager", "An error occured while downloading plugin", e, "InstallOrUpdate");
+
+                return;
             }
 
             Context.API.RestartApp();

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -134,8 +134,8 @@ namespace Flow.Launcher.Plugin.PluginsManager
             }
             catch (Exception e)
             {
-                Context.API.ShowMsg(Context.API.GetTranslation("plugin_pluginsmanager_downloading_plugin"),
-                    Context.API.GetTranslation("plugin_pluginsmanager_download_success"));
+                Context.API.ShowMsg(Context.API.GetTranslation("plugin_pluginsmanager_download_error_title"),
+                    Context.API.GetTranslation("plugin_pluginsmanager_download_error_subtitle"));
 
                 Log.Exception("PluginsManager", "An error occured while downloading plugin", e, "PluginDownload");
             }

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -131,16 +131,17 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
                 Context.API.ShowMsg(Context.API.GetTranslation("plugin_pluginsmanager_downloading_plugin"),
                     Context.API.GetTranslation("plugin_pluginsmanager_download_success"));
+
+                Install(plugin, filePath);
             }
             catch (Exception e)
             {
-                Context.API.ShowMsg(Context.API.GetTranslation("plugin_pluginsmanager_download_error_title"),
-                    string.Format(Context.API.GetTranslation("plugin_pluginsmanager_download_error_subtitle"), plugin.Name));
+                Context.API.ShowMsg(Context.API.GetTranslation("plugin_pluginsmanager_install_error_title"),
+                    string.Format(Context.API.GetTranslation("plugin_pluginsmanager_install_error_subtitle"), plugin.Name));
 
-                Log.Exception("PluginsManager", "An error occured while downloading plugin", e, "PluginDownload");
+                Log.Exception("PluginsManager", "An error occured while downloading plugin", e, "InstallOrUpdate");
             }
 
-            Install(plugin, filePath);
             Context.API.RestartApp();
         }
 

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
@@ -6,7 +6,7 @@
   "Name": "Plugins Manager",
   "Description": "Management of installing, uninstalling or updating Flow Launcher plugins",
   "Author": "Jeremy Wu",
-  "Version": "1.3.1",
+  "Version": "1.3.2",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.PluginsManager.dll",

--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -45,7 +45,7 @@ function Delete-Unused ($path, $config) {
     $included = Get-ChildItem $target -Filter "*.dll"
     foreach ($i in $included){
         $deleteList = Get-ChildItem $target\Plugins -Include $i -Recurse | Where {$_.VersionInfo.FileVersion -eq $i.VersionInfo.FileVersion} 
-        $deleteList | foreach-object{ Write-Host Deleting duplicated $_.Name with version $_.VersionInfo.FileVersion at location $_.Directory.FullName }
+        $deleteList | ForEach-Object{ Write-Host Deleting duplicated $_.Name with version $_.VersionInfo.FileVersion at location $_.Directory.FullName }
         $deleteList | Remove-Item
     }
     Remove-Item -Path $target -Include "*.xml" -Recurse 

--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -44,8 +44,9 @@ function Delete-Unused ($path, $config) {
     $target = "$path\Output\$config"
     $included = Get-ChildItem $target -Filter "*.dll"
     foreach ($i in $included){
-        Remove-Item -Path $target\Plugins -Include $i -Recurse 
-        Write-Host "Deleting duplicated $i"
+        $deleteList = Get-ChildItem $target\Plugins -Include $i -Recurse | Where {$_.VersionInfo.FileVersion -eq $i.VersionInfo.FileVersion} 
+        $deleteList | foreach-object{ Write-Host Deleting duplicated $_.Name with version $_.VersionInfo.FileVersion at location $_.Directory.FullName }
+        $deleteList | Remove-Item
     }
     Remove-Item -Path $target -Include "*.xml" -Recurse 
 }

--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -44,7 +44,7 @@ function Delete-Unused ($path, $config) {
     $target = "$path\Output\$config"
     $included = Get-ChildItem $target -Filter "*.dll"
     foreach ($i in $included){
-        $deleteList = Get-ChildItem $target\Plugins -Include $i -Recurse | Where {$_.VersionInfo.FileVersion -eq $i.VersionInfo.FileVersion} 
+        $deleteList = Get-ChildItem $target\Plugins -Include $i -Recurse | Where { $_.VersionInfo.FileVersion -eq $i.VersionInfo.FileVersion -And $_.Name -eq "$i" } 
         $deleteList | ForEach-Object{ Write-Host Deleting duplicated $_.Name with version $_.VersionInfo.FileVersion at location $_.Directory.FullName }
         $deleteList | Remove-Item
     }


### PR DESCRIPTION
- Fix wrong error message for PluginsManager
- Added try catch for install plugin call
- Added try catch for querying plugin and plugins tasks
- Fixed postbuild script to remove duplicate with the condition that the versions are the same. Specific to issue 256, the direct  package reference (ICSharpCode.SharpZipLib 1.2.0) used by PluginsManager has a different version to the output of other packages' ICSharpCode.SharpZipLib (0.86) dependency.

Closing #256