### PR TITLE
Use ValueTask instead of Task

### DIFF
--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -15,7 +15,7 @@ namespace Flow.Launcher.ViewModel
     {
         public class LazyAsync<T> : Lazy<ValueTask<T>>
         {
-            private T defaultValue;
+            private readonly T defaultValue;
 
             private readonly Action _updateCallback;
             public new T Value
@@ -24,7 +24,7 @@ namespace Flow.Launcher.ViewModel
                 {
                     if (!IsValueCreated)
                     {
-                        _ = Exercute();
+                        _ = Exercute(); // manually use callback strategy
 
                         return defaultValue;
                     }
@@ -34,8 +34,8 @@ namespace Flow.Launcher.ViewModel
 
                     return base.Value.Result;
 
-                    // If none of the variables captured by the local function are captured by other lambdas
-                    // , the compiler can avoid heap allocations.
+                    // If none of the variables captured by the local function are captured by other lambdas,
+                    // the compiler can avoid heap allocations.
                     async ValueTask Exercute()
                     {
                         await base.Value.ConfigureAwait(false);

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -29,7 +29,7 @@ namespace Flow.Launcher.ViewModel
                         return defaultValue;
                     }
 
-                    if (!base.Value.IsCompleted || base.Value.IsFaulted)
+                    if (!base.Value.IsCompletedSuccessfully)
                         return defaultValue;
 
                     return base.Value.Result;

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -68,7 +68,7 @@ namespace Flow.Launcher.ViewModel
                                 {
                                     OnPropertyChanged(nameof(Image));
                                 });
-            }
+            } 
 
             Settings = settings;
         }
@@ -101,7 +101,7 @@ namespace Flow.Launcher.ViewModel
                 catch (Exception e)
                 {
                     Log.Exception($"|ResultViewModel.Image|IcoPath is empty and exception when calling Icon() for result <{Result.Title}> of plugin <{Result.PluginDirectory}>", e);
-                    imagePath = Constant.MissingImgIcon;
+                    return ImageLoader.DefaultImage;
                 }
             }
 


### PR DESCRIPTION
Since most of the image will be stored on cache, so synchronous action will be done quite significant for SetImage method in ResultViewModel, using ValueTask instead of Task can avoid those cost.