### PR TITLE
Create and deploy releases from CI

### DIFF
--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -94,8 +94,4 @@
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="taskkill /f /fi &quot;IMAGENAME eq Flow.Launcher.exe&quot;" />
   </Target>
-
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -File $(SolutionDir)Scripts\post_build.ps1 $(ConfigurationName) $(SolutionDir) $(TargetPath)" />
-  </Target>
 </Project>

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -81,7 +81,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="PropertyChanged.Fody" Version="2.5.13" />
+    <PackageReference Include="PropertyChanged.Fody" Version="3.3.1" />
     <PackageReference Include="SharpVectors" Version="1.7.1" />
   </ItemGroup>
 

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Flow.Launcher.Plugin.Calculator.csproj
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Flow.Launcher.Plugin.Calculator.csproj
@@ -11,6 +11,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Flow.Launcher.Plugin.Explorer.csproj
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Flow.Launcher.Plugin.Explorer.csproj
@@ -7,6 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/Flow.Launcher.Plugin.PluginIndicator.csproj
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/Flow.Launcher.Plugin.PluginIndicator.csproj
@@ -10,6 +10,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -31,13 +31,9 @@ function Build-Path {
     return $p
 }
 
-function Copy-Resources ($path, $config) {
-    $project = "$path\Flow.Launcher"
-    $output = "$path\Output"
-    $target = "$output\$config"
-    Copy-Item -Recurse -Force $project\Images\* $target\Images\
+function Copy-Resources ($path) {
     # making version static as multiple versions can exist in the nuget folder and in the case a breaking change is introduced.
-    Copy-Item -Force $env:USERPROFILE\.nuget\packages\squirrel.windows\1.5.2\tools\Squirrel.exe $output\Update.exe
+    Copy-Item -Force $env:USERPROFILE\.nuget\packages\squirrel.windows\1.5.2\tools\Squirrel.exe $path\Output\Update.exe
 }
 
 function Delete-Unused ($path, $config) {
@@ -53,17 +49,6 @@ function Delete-Unused ($path, $config) {
 
 function Validate-Directory ($output) {
     New-Item $output -ItemType Directory -Force
-}
-
-function Zip-Release ($path, $version, $output) {
-    Write-Host "Begin zip release"
-
-    $content = "$path\Output\Release\*"
-    $zipFile = "$output\Flow-Launcher-v$version.zip"
-
-    Compress-Archive -Force -Path $content -DestinationPath $zipFile
-
-    Write-Host "End zip release"
 }
 
 function Pack-Squirrel-Installer ($path, $version, $output) {
@@ -115,7 +100,7 @@ function Publish-Self-Contained ($p) {
 function Main {
     $p = Build-Path
     $v = Build-Version
-    Copy-Resources $p $config
+    Copy-Resources $p
 
     if ($config -eq "Release"){
         
@@ -126,14 +111,6 @@ function Main {
         $o = "$p\Output\Packages"
         Validate-Directory $o
         Pack-Squirrel-Installer $p $v $o
-    
-        $isInCI = $env:APPVEYOR
-        if ($isInCI) {
-            Zip-Release $p $v $o
-        }
-
-        Write-Host "List output directory"
-        Get-ChildItem $o
     }
 }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,6 @@ after_build:
   - ps: .\Scripts\post_build.ps1
 
 artifacts:
-- path: 'Output\Packages\Flow-Launcher-*.zip'
-  name: Zip
 - path: 'Output\Release\Flow.Launcher.Plugin.*.nupkg'
   name: Plugin nupkg
 - path: 'Output\Packages\Flow-Launcher-*.exe'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,8 @@ before_build:
 build:
   project: Flow.Launcher.sln
   verbosity: minimal
+after_build:
+  - ps: .\Scripts\post_build.ps1
 
 artifacts:
 - path: 'Output\Packages\Flow-Launcher-*.zip'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,12 @@ artifacts:
   name: Zip
 - path: 'Output\Release\Flow.Launcher.Plugin.*.nupkg'
   name: Plugin nupkg
+- path: 'Output\Packages\Flow-Launcher-*.exe'
+  name: Squirrel Installer
+- path: 'Output\Packages\FlowLauncher-*-full.nupkg'
+  name: Squirrel nupkg
+- path: 'Output\Packages\RELEASES'
+  name: Squirrel RELEASES
 
 deploy:
   provider: NuGet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,9 +42,30 @@ artifacts:
   name: Squirrel RELEASES
 
 deploy:
-  provider: NuGet
-  artifact: /.*\.nupkg/
-  api_key:
-    secure: n80IeWR3pN81p0w4uXq4mO0TdTXoJSHHFL+yTB9YBJ0Wni2DjZGYwOFdaWzW4hRi
-  on:
-    branch: master
+  - provider: NuGet
+    artifact: Plugin nupkg
+    api_key:
+      secure: n80IeWR3pN81p0w4uXq4mO0TdTXoJSHHFL+yTB9YBJ0Wni2DjZGYwOFdaWzW4hRi
+    on:
+      branch: master
+
+  - provider: GitHub
+    release: v$(flowVersion)
+    auth_token:
+      secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
+    artifact: Squirrel Installer, Squirrel nupkg, Squirrel RELEASES
+    draft: true
+    force_update: true
+    on:
+      branch: master
+      APPVEYOR_REPO_TAG: false
+
+  - provider: GitHub
+    release: v$(flowVersion)
+    auth_token:
+      secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
+    artifact: Squirrel Installer, Squirrel nupkg, Squirrel RELEASES
+    force_update: true
+    on:
+      branch: master
+      APPVEYOR_REPO_TAG: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,6 @@ deploy:
     force_update: true
     on:
       branch: master
-      APPVEYOR_REPO_TAG: false
 
   - provider: GitHub
     release: v$(flowVersion)
@@ -65,5 +64,4 @@ deploy:
     artifact: Squirrel Installer, Squirrel nupkg, Squirrel RELEASES
     force_update: true
     on:
-      branch: master
       APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
This is the continuation of the work done in #35 back in May.

### Changes

The `post_build.ps1` script has been repurposed to be called from `AppVeyor` to create a self-contained version of the project. Squirrel artifacts are deployed to Github as a draft release, which means the only manual work for a release is to edit the draft release with release notes and press `Publish`.

Note that I have removed `post_build.ps1` as a post-build script of the main project because the script calls `dotnet publish` which has to build the main project again, and that would result in a build loop. I have also bumped `PropertyChanged.Fody` to `3.3.1` (which made this entire PR possible, see #248) and added `SatelliteResourceLanguages` to some plugin projects to reduce the output files.

### Objective

- merging into master will create a draft release that we can sanity-check and add release notes before publishing
- publishing the release will create the tag and cause a new build that will update the release assets on github. We could skip this step, but I think it's better to have release assets that match those built from the release tag.

### Todo

I open this PR as a draft with my own Github API credentials so that you guys can see/test that it works as expected and give your feedback. You can see that `AppVeyor` has produced all the [expected artifacts](https://ci.appveyor.com/project/JohnTheGr8/flow-launcher-wl238/builds/37109001/artifacts) and that they have been deployed to a [Github release on my fork](https://github.com/JohnTheGr8/Flow.Launcher/releases/tag/v1.6.0) (which I manually released).

~~Before we can merge this, @jjw24 I will need [a Github token](https://github.com/settings/tokens) with the `public_repo` scope, [encrypted by AppVeyor](https://ci.appveyor.com/tools/encrypt) to replace my own. I will also need to add the conditional to only deploy to Github from the master branch.~~