### PR TITLE
fix: copy svg images to output from the main project

### DIFF
--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -63,6 +63,9 @@
     <Content Include="Images\*.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Images\*.svg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The `mainsearch.svg` file is not being copied to the output folder, causing a "file not found" exception on start-up.

This one flew under the radar when #278 was merged and I re-based from #275 to resolve the merge conflict (admittedly, without testing). We used to copy all contents of `Flow.Launcher\Images` to the output folder from the post-build script but that [was removed](https://github.com/Flow-Launcher/Flow.Launcher/pull/275/files#diff-59a3ced9b3067f709e8217b1c76003031953426af6108db3390348574ae9da8aL38), so we need to copy the SVG file from the csproj.