### PR TITLE
Plugin manager init timeout

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
@@ -70,7 +70,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
             return search switch
             {
-                var s when s.StartsWith(Settings.HotKeyInstall) => await pluginManager.RequestInstallOrUpdate(s),
+                var s when s.StartsWith(Settings.HotKeyInstall) => await pluginManager.RequestInstallOrUpdate(s, token),
                 var s when s.StartsWith(Settings.HotkeyUninstall) => pluginManager.RequestUninstall(s),
                 var s when s.StartsWith(Settings.HotkeyUpdate) => pluginManager.RequestUpdate(s),
                 _ => pluginManager.GetDefaultHotKeys().Where(hotkey =>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -276,13 +276,18 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
         private Task _downloadManifestTask = Task.CompletedTask;
 
-        internal async ValueTask<List<Result>> RequestInstallOrUpdate(string searchName)
+        internal async ValueTask<List<Result>> RequestInstallOrUpdate(string searchName, CancellationToken token)
         {
-            if (!pluginsManifest.UserPlugins.Any() && _downloadManifestTask.IsCompleted)
+            if (!pluginsManifest.UserPlugins.Any() &&
+                _downloadManifestTask.IsCompleted ||
+                _downloadManifestTask.IsFaulted)
                 _downloadManifestTask = pluginsManifest.DownloadManifest();
 
             await _downloadManifestTask;
 
+            if (token.IsCancellationRequested)
+                return null;
+            
             var searchNameWithoutKeyword = searchName.Replace(Settings.HotKeyInstall, string.Empty).Trim();
 
             var results =

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -279,15 +279,16 @@ namespace Flow.Launcher.Plugin.PluginsManager
         internal async ValueTask<List<Result>> RequestInstallOrUpdate(string searchName, CancellationToken token)
         {
             if (!pluginsManifest.UserPlugins.Any() &&
-                _downloadManifestTask.IsCompleted ||
-                _downloadManifestTask.IsFaulted)
+                _downloadManifestTask.Status != TaskStatus.Running)
+            {
                 _downloadManifestTask = pluginsManifest.DownloadManifest();
+            }
 
             await _downloadManifestTask;
 
             if (token.IsCancellationRequested)
                 return null;
-            
+
             var searchNameWithoutKeyword = searchName.Replace(Settings.HotKeyInstall, string.Empty).Trim();
 
             var results =

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
@@ -6,7 +6,7 @@
   "Name": "Plugins Manager",
   "Description": "Management of installing, uninstalling or updating Flow Launcher plugins",
   "Author": "Jeremy Wu",
-  "Version": "1.5.0",
+  "Version": "1.5.1",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.PluginsManager.dll",


### PR DESCRIPTION
Allow Flow to be used without internet connection, or else it will wait a long time to startup during plugin initialization for downloading plugin manifest since we don't assign an timeout for Http.Get.