### PR TITLE
Fix unrecognized path

### DIFF
--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Windows;
 
 namespace Flow.Launcher.Plugin.SharedCommands
@@ -142,35 +143,28 @@ namespace Flow.Launcher.Plugin.SharedCommands
             Process.Start(FileExplorerProgramEXE, $" /select,\"{path}\"");
         }
 
+
         ///<summary>
         /// This checks whether a given string is a directory path or network location string. 
         /// It does not check if location actually exists.
         ///</summary>
         public static bool IsLocationPathString(string querySearchString)
         {
-            if (string.IsNullOrEmpty(querySearchString))
+            if (string.IsNullOrEmpty(querySearchString) || querySearchString.Length < 3)
                 return false;
 
             // // shared folder location, and not \\\location\
-            if (querySearchString.Length >= 3
-                && querySearchString.StartsWith(@"\\")
-                && char.IsLetter(querySearchString[2]))
+            if (querySearchString.StartsWith(@"\\")
+                && querySearchString[2] != '\\')
                 return true;
 
             // c:\
-            if (querySearchString.Length == 3
-                && char.IsLetter(querySearchString[0])
+            if (char.IsLetter(querySearchString[0])
                 && querySearchString[1] == ':'
                 && querySearchString[2] == '\\')
-                return true;
-
-            // c:\\
-            if (querySearchString.Length >= 4
-                && char.IsLetter(querySearchString[0])
-                && querySearchString[1] == ':'
-                && querySearchString[2] == '\\'
-                && char.IsLetter(querySearchString[3]))
-                return true;
+            {
+                return querySearchString.Length == 3 || querySearchString[3] != '\\';
+            }
 
             return false;
         }

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Text.RegularExpressions;
-using System.Windows;
 
 namespace Flow.Launcher.Plugin.SharedCommands
 {
@@ -142,7 +140,6 @@ namespace Flow.Launcher.Plugin.SharedCommands
         {
             Process.Start(FileExplorerProgramEXE, $" /select,\"{path}\"");
         }
-
 
         ///<summary>
         /// This checks whether a given string is a directory path or network location string. 

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Windows;
 
 namespace Flow.Launcher.Plugin.SharedCommands
 {

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -148,7 +148,7 @@ namespace Flow.Launcher.Plugin.SharedCommands
         /// This checks whether a given string is a directory path or network location string. 
         /// It does not check if location actually exists.
         ///</summary>
-        public static bool IsLocationPathString(string querySearchString)
+        public static bool IsLocationPathString(this string querySearchString)
         {
             if (string.IsNullOrEmpty(querySearchString) || querySearchString.Length < 3)
                 return false;

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -243,6 +243,9 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase(@"cc:\", false)]
         [TestCase(@"\\\SomeNetworkLocation\", false)]
         [TestCase("RandomFile", false)]
+        [TestCase(@"c:\>*", true)]
+        [TestCase(@"c:\>", true)]
+        [TestCase(@"c:\SomeLocation\SomeOtherLocation\>", true)]
         public void WhenGivenQuerySearchString_ThenShouldIndicateIfIsLocationPathString(string querySearchString, bool expectedResult)
         {
             // When, Given

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -58,7 +58,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             // Query is a location path with a full environment variable, eg. %appdata%\somefolder\
             var isEnvironmentVariablePath = querySearch[1..].Contains("%\\");
 
-            if (!FilesFolders.IsLocationPathString(querySearch) && !isEnvironmentVariablePath)
+            if (!querySearch.IsLocationPathString() && !isEnvironmentVariablePath)
             {
                 results.AddRange(await WindowsIndexFilesAndFoldersSearchAsync(query, querySearch, token).ConfigureAwait(false));
 
@@ -70,7 +70,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             if (isEnvironmentVariablePath)
                 locationPath = EnvironmentVariables.TranslateEnvironmentVariablePath(locationPath);
 
-            if (!FilesFolders.LocationExists(FilesFolders.ReturnPreviousDirectoryIfIncompleteString(locationPath)))
+            if (!FilesFolders.ReturnPreviousDirectoryIfIncompleteString(locationPath).IsLocationPathString())
                 return results;
 
             var useIndexSearch = UseWindowsIndexForDirectorySearch(locationPath);

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -70,7 +70,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             if (isEnvironmentVariablePath)
                 locationPath = EnvironmentVariables.TranslateEnvironmentVariablePath(locationPath);
 
-            if (!FilesFolders.ReturnPreviousDirectoryIfIncompleteString(locationPath).IsLocationPathString())
+            if (!FilesFolders.LocationExists(FilesFolders.ReturnPreviousDirectoryIfIncompleteString(locationPath)))
                 return results;
 
             var useIndexSearch = UseWindowsIndexForDirectorySearch(locationPath);

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -70,6 +70,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             if (isEnvironmentVariablePath)
                 locationPath = EnvironmentVariables.TranslateEnvironmentVariablePath(locationPath);
 
+            // Check that actual location exists, otherwise directory search will throw directory not found exception
             if (!FilesFolders.LocationExists(FilesFolders.ReturnPreviousDirectoryIfIncompleteString(locationPath)))
                 return results;
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -7,7 +7,7 @@
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",
-  "Version": "1.4.0",
+  "Version": "1.4.1",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
fix #308 
The reason is `IsLocationPathString(string)` unable to recongnize `D:\>*` as location string, so that it treat it as a file search. 