### PR TITLE
Make most class in Explorer plugin become static class

### DIFF
--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -317,11 +317,9 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase("c:\\somefolder\\", "*")]
         public void GivenDirectoryInfoSearch_WhenSearchPatternHotKeyIsSearchAll_ThenSearchCriteriaShouldUseCriteriaString(string path, string expectedString)
         {
-            // Given
-            var criteriaConstructor = new DirectoryInfoSearch(new PluginInitContext());
 
             //When
-            var resultString = criteriaConstructor.ConstructSearchCriteria(path);
+            var resultString = DirectoryInfoSearch.ConstructSearchCriteria(path);
 
             // Then
             Assert.IsTrue(resultString == expectedString,

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
@@ -44,6 +44,7 @@ namespace Flow.Launcher.Plugin.Explorer
 
             contextMenu = new ContextMenu(Context, Settings, viewModel);
             searchManager = new SearchManager(Settings, Context);
+            ResultManager.Init(Context);
         }
 
         public List<Result> LoadContextMenus(Result selectedResult)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
@@ -8,16 +8,9 @@ using System.Threading;
 
 namespace Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo
 {
-    public class DirectoryInfoSearch
+    public static class DirectoryInfoSearch
     {
-        private readonly ResultManager resultManager;
-
-        public DirectoryInfoSearch(PluginInitContext context)
-        {
-            resultManager = new ResultManager(context);
-        }
-
-        internal List<Result> TopLevelDirectorySearch(Query query, string search, CancellationToken token)
+        internal static List<Result> TopLevelDirectorySearch(Query query, string search, CancellationToken token)
         {
             var criteria = ConstructSearchCriteria(search);
 
@@ -31,7 +24,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo
             return DirectorySearch(new EnumerationOptions(), query, search, criteria, token); // null will be passed as default
         }
 
-        public string ConstructSearchCriteria(string search)
+        public static string ConstructSearchCriteria(string search)
         {
             string incompleteName = "";
 
@@ -50,7 +43,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo
             return incompleteName;
         }
 
-        private List<Result> DirectorySearch(EnumerationOptions enumerationOption, Query query, string search,
+        private static List<Result> DirectorySearch(EnumerationOptions enumerationOption, Query query, string search,
             string searchCriteria, CancellationToken token)
         {
             var results = new List<Result>();
@@ -68,12 +61,12 @@ namespace Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo
                 {
                     if (fileSystemInfo is System.IO.DirectoryInfo)
                     {
-                        folderList.Add(resultManager.CreateFolderResult(fileSystemInfo.Name, fileSystemInfo.FullName,
+                        folderList.Add(ResultManager.CreateFolderResult(fileSystemInfo.Name, fileSystemInfo.FullName,
                             fileSystemInfo.FullName, query, true, false));
                     }
                     else
                     {
-                        fileList.Add(resultManager.CreateFileResult(fileSystemInfo.FullName, query, true, false));
+                        fileList.Add(ResultManager.CreateFileResult(fileSystemInfo.FullName, query, true, false));
                     }
 
                     token.ThrowIfCancellationRequested();

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
@@ -76,7 +76,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 {
                     var expandedPath = environmentVariables[search];
                    
-                    results.Add(new ResultManager(context).CreateFolderResult($"%{search}%", expandedPath, expandedPath, query));
+                    results.Add(ResultManager.CreateFolderResult($"%{search}%", expandedPath, expandedPath, query));
                     
                     return results;
                 }
@@ -95,7 +95,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             {
                 if (p.Key.StartsWith(search, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    results.Add(new ResultManager(context).CreateFolderResult($"%{p.Key}%", p.Value, p.Value, query));
+                    results.Add(ResultManager.CreateFolderResult($"%{p.Key}%", p.Value, p.Value, query));
                 }
             }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
@@ -4,16 +4,9 @@ using System.Linq;
 
 namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
 {
-    public class QuickAccess
+    internal static class QuickAccess
     {
-        private readonly ResultManager resultManager;
-
-        public QuickAccess(PluginInitContext context)
-        {
-            resultManager = new ResultManager(context);
-        }
-
-        internal List<Result> AccessLinkListMatched(Query query, List<AccessLink> accessLinks)
+        internal static List<Result> AccessLinkListMatched(Query query, List<AccessLink> accessLinks)
         {
             if (string.IsNullOrEmpty(query.Search))
                 return new List<Result>();
@@ -28,21 +21,21 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
 
             return queriedAccessLinks.Select(l => l.Type switch
             {
-                ResultType.Folder => resultManager.CreateFolderResult(l.Nickname, l.Path, l.Path, query),
-                ResultType.File => resultManager.CreateFileResult(l.Path, query),
+                ResultType.Folder => ResultManager.CreateFolderResult(l.Nickname, l.Path, l.Path, query),
+                ResultType.File => ResultManager.CreateFileResult(l.Path, query),
                 _ => throw new ArgumentOutOfRangeException()
 
             }).ToList();
         }
 
-        internal List<Result> AccessLinkListAll(Query query, List<AccessLink> accessLinks)
+        internal static List<Result> AccessLinkListAll(Query query, List<AccessLink> accessLinks)
             => accessLinks
                 .OrderBy(x => x.Type)
                 .ThenBy(x => x.Nickname)
                 .Select(l => l.Type switch
                 {
-                    ResultType.Folder => resultManager.CreateFolderResult(l.Nickname, l.Path, l.Path, query),
-                    ResultType.File => resultManager.CreateFileResult(l.Path, query),
+                    ResultType.Folder => ResultManager.CreateFolderResult(l.Nickname, l.Path, l.Path, query),
+                    ResultType.File => ResultManager.CreateFileResult(l.Path, query),
                     _ => throw new ArgumentOutOfRangeException()
 
                 }).ToList();

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -4,19 +4,21 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Windows;
 
 namespace Flow.Launcher.Plugin.Explorer.Search
 {
-    public class ResultManager
+    public static class ResultManager
     {
-        private readonly PluginInitContext context;
+        private static PluginInitContext Context;
 
-        public ResultManager(PluginInitContext context)
+        public static void Init(PluginInitContext context)
         {
-            this.context = context;
+            Context = context;
         }
-        internal Result CreateFolderResult(string title, string subtitle, string path, Query query, bool showIndexState = false, bool windowsIndexed = false)
+
+        internal static Result CreateFolderResult(string title, string subtitle, string path, Query query, bool showIndexState = false, bool windowsIndexed = false)
         {
             return new Result
             {
@@ -41,7 +43,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                     }
 
                     string changeTo = path.EndsWith(Constants.DirectorySeperator) ? path : path + Constants.DirectorySeperator;
-                    context.API.ChangeQuery(string.IsNullOrEmpty(query.ActionKeyword) ?
+                    Context.API.ChangeQuery(string.IsNullOrEmpty(query.ActionKeyword) ?
                         changeTo :
                         query.ActionKeyword + " " + changeTo);
                     return false;
@@ -52,7 +54,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             };
         }
 
-        internal Result CreateOpenCurrentFolderResult(string path, bool windowsIndexed = false)
+        internal static Result CreateOpenCurrentFolderResult(string path, bool windowsIndexed = false)
         {
             var retrievedDirectoryPath = FilesFolders.ReturnPreviousDirectoryIfIncompleteString(path);
 
@@ -94,7 +96,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             };
         }
 
-        internal Result CreateFileResult(string filePath, Query query, bool showIndexState = false, bool windowsIndexed = false)
+        internal static Result CreateFileResult(string filePath, Query query, bool showIndexState = false, bool windowsIndexed = false)
         {
             var result = new Result
             {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -14,21 +14,12 @@ namespace Flow.Launcher.Plugin.Explorer.Search
     {
         private readonly PluginInitContext context;
 
-        private readonly IndexSearch indexSearch;
-
-        private readonly QuickAccess quickAccess;
-
-        private readonly ResultManager resultManager;
-
         private readonly Settings settings;
 
         public SearchManager(Settings settings, PluginInitContext context)
         {
             this.context = context;
-            indexSearch = new IndexSearch(context);
-            resultManager = new ResultManager(context);
             this.settings = settings;
-            quickAccess = new QuickAccess(context);
         }
 
         internal async Task<List<Result>> SearchAsync(Query query, CancellationToken token)
@@ -42,9 +33,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             // This allows the user to type the assigned action keyword and only see the list of quick folder links
             if (string.IsNullOrEmpty(query.Search))
-                return quickAccess.AccessLinkListAll(query, settings.QuickAccessLinks);
+                return QuickAccess.AccessLinkListAll(query, settings.QuickAccessLinks);
 
-            var quickaccessLinks = quickAccess.AccessLinkListMatched(query, settings.QuickAccessLinks);
+            var quickaccessLinks = QuickAccess.AccessLinkListMatched(query, settings.QuickAccessLinks);
 
             if (quickaccessLinks.Count > 0)
                 results.AddRange(quickaccessLinks);
@@ -75,7 +66,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             var useIndexSearch = UseWindowsIndexForDirectorySearch(locationPath);
 
-            results.Add(resultManager.CreateOpenCurrentFolderResult(locationPath, useIndexSearch));
+            results.Add(ResultManager.CreateOpenCurrentFolderResult(locationPath, useIndexSearch));
 
             token.ThrowIfCancellationRequested();
 
@@ -100,7 +91,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             if (string.IsNullOrEmpty(querySearchString))
                 return new List<Result>();
 
-            return await indexSearch.WindowsIndexSearchAsync(querySearchString,
+            return await IndexSearch.WindowsIndexSearchAsync(querySearchString,
                                                     queryConstructor.CreateQueryHelper().ConnectionString,
                                                     queryConstructor.QueryForFileContentSearch,
                                                     query,
@@ -114,9 +105,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
         private List<Result> DirectoryInfoClassSearch(Query query, string querySearch, CancellationToken token)
         {
-            var directoryInfoSearch = new DirectoryInfoSearch(context);
-
-            return directoryInfoSearch.TopLevelDirectorySearch(query, querySearch, token);
+            return DirectoryInfoSearch.TopLevelDirectorySearch(query, querySearch, token);
         }
 
         public async Task<List<Result>> TopLevelDirectorySearchBehaviourAsync(
@@ -137,7 +126,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         {
             var queryConstructor = new QueryConstructor(settings);
 
-            return await indexSearch.WindowsIndexSearchAsync(querySearchString,
+            return await IndexSearch.WindowsIndexSearchAsync(querySearchString,
                                                    queryConstructor.CreateQueryHelper().ConnectionString,
                                                    queryConstructor.QueryForAllFilesAndFolders,
                                                    query,
@@ -148,7 +137,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         {
             var queryConstructor = new QueryConstructor(settings);
 
-            return await indexSearch.WindowsIndexSearchAsync(path,
+            return await IndexSearch.WindowsIndexSearchAsync(path,
                                                    queryConstructor.CreateQueryHelper().ConnectionString,
                                                    queryConstructor.QueryForTopLevelDirectorySearch,
                                                    query,
@@ -167,7 +156,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                                         .StartsWith(x.Path, StringComparison.OrdinalIgnoreCase)))
                 return false;
 
-            return indexSearch.PathIsIndexed(pathToDirectory);
+            return IndexSearch.PathIsIndexed(pathToDirectory);
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -10,19 +10,13 @@ using System.Threading.Tasks;
 
 namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
 {
-    internal class IndexSearch
+    internal static class IndexSearch
     {
-        private readonly ResultManager resultManager;
 
         // Reserved keywords in oleDB
-        private readonly string reservedStringPattern = @"^[`\@\#\^,\&\/\\\$\%_]+$";
+        private const string reservedStringPattern = @"^[`\@\#\^,\&\/\\\$\%_]+$";
 
-        internal IndexSearch(PluginInitContext context)
-        {
-            resultManager = new ResultManager(context);
-        }
-
-        internal async Task<List<Result>> ExecuteWindowsIndexSearchAsync(string indexQueryString, string connectionString, Query query, CancellationToken token)
+        internal async static Task<List<Result>> ExecuteWindowsIndexSearchAsync(string indexQueryString, string connectionString, Query query, CancellationToken token)
         {
             var results = new List<Result>();
             var fileResults = new List<Result>();
@@ -54,7 +48,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
 
                             if (dataReaderResults.GetString(2) == "Directory")
                             {
-                                results.Add(resultManager.CreateFolderResult(
+                                results.Add(ResultManager.CreateFolderResult(
                                                                     dataReaderResults.GetString(0),
                                                                     path,
                                                                     path,
@@ -62,7 +56,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                             }
                             else
                             {
-                                fileResults.Add(resultManager.CreateFileResult(path, query, true, true));
+                                fileResults.Add(ResultManager.CreateFileResult(path, query, true, true));
                             }
                         }
                     }
@@ -88,7 +82,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
              return results;
         }
 
-        internal async Task<List<Result>> WindowsIndexSearchAsync(string searchString, string connectionString,
+        internal async static Task<List<Result>> WindowsIndexSearchAsync(string searchString, string connectionString,
                                                                   Func<string, string> constructQuery, Query query,
                                                                   CancellationToken token)
         {
@@ -102,14 +96,14 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
 
         }
 
-        internal bool PathIsIndexed(string path)
+        internal static bool PathIsIndexed(string path)
         {
             var csm = new CSearchManager();
             var indexManager = csm.GetCatalog("SystemIndex").GetCrawlScopeManager();
             return indexManager.IncludedInCrawlScope(path) > 0;
         }
 
-        private void LogException(string message, Exception e)
+        private static void LogException(string message, Exception e)
         {
 #if DEBUG // Please investigate and handle error from index search
             throw e;


### PR DESCRIPTION
Make most helper class in Explorer become static class.

I am not sure why by design, they are instance class, and there are multiple duplicate instances. This pr makes them become static class because most of them don't save any information (except for ResultManager, which contains the PluginInitContext to change query), but just be used as a group of methods.