### PR TITLE
Use HttpCompletionOption.ResponseHeadersRead

### DIFF
--- a/Flow.Launcher.Infrastructure/Http/Http.cs
+++ b/Flow.Launcher.Infrastructure/Http/Http.cs
@@ -75,7 +75,7 @@ namespace Flow.Launcher.Infrastructure.Http
         {
             try
             {
-                using var response = await client.GetAsync(url, token);
+                using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, token);
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
                     await using var fileStream = new FileStream(filePath, FileMode.CreateNew);
@@ -135,7 +135,7 @@ namespace Flow.Launcher.Infrastructure.Http
         public static async Task<Stream> GetStreamAsync([NotNull] string url, CancellationToken token = default)
         {
             Log.Debug($"|Http.Get|Url <{url}>");
-            var response = await client.GetAsync(url, token);
+            var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, token);
             return await response.Content.ReadAsStreamAsync();
         }
     }


### PR DESCRIPTION
For stream reading and copy, we don't need to wait until the body finish and then start processing them.
According to some internet resource, this can help reduce the use of memory for storing the temp stream, and improve speed (no wait before processing).