### PR TITLE
Use Channel instead of BufferBlock

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -98,15 +98,15 @@ namespace Flow.Launcher.ViewModel
                 // it is not supposed to be false because it won't be complete
                 while (await queueReader.WaitToReadAsync())
                 {
-                    queue.Clear();
                     await Task.Delay(20);
-                    await foreach (var item in queueReader.ReadAllAsync())
+                    while (queueReader.TryRead(out var item))
                     {
                         if (!item.Token.IsCancellationRequested)
                             queue[item.ID] = item;
                     }
 
                     UpdateResultView(queue.Values);
+                    queue.Clear();
                 }
 
                 Log.Error("MainViewModel", "Unexpected ResultViewUpdate ends");

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -538,10 +538,7 @@ namespace Flow.Launcher.ViewModel
                         await Task.Yield();
 
                         var results = await PluginManager.QueryForPlugin(plugin, query, currentCancellationToken);
-                        if (currentCancellationToken.IsCancellationRequested || results == null)
-                        {
-                            return;
-                        }
+                        if (currentCancellationToken.IsCancellationRequested || results == null) return;
 
                         if (!_resultsUpdateQueue.Writer.TryWrite(new ResultsForUpdate(results, plugin.Metadata, query, currentCancellationToken)))
                         {

--- a/Flow.Launcher/ViewModel/ResultsForUpdate.cs
+++ b/Flow.Launcher/ViewModel/ResultsForUpdate.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace Flow.Launcher.ViewModel
 {
-    public class ResultsForUpdate
+    public struct ResultsForUpdate
     {
         public List<Result> Results { get; }
 
@@ -15,13 +15,6 @@ namespace Flow.Launcher.ViewModel
 
         public Query Query { get; }
         public CancellationToken Token { get; }
-
-        public ResultsForUpdate(List<Result> results, string resultID, CancellationToken token)
-        {
-            Results = results;
-            ID = resultID;
-            Token = token;
-        }
 
         public ResultsForUpdate(List<Result> results, PluginMetadata metadata, Query query, CancellationToken token)
         {

--- a/Flow.Launcher/ViewModel/ResultsViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultsViewModel.cs
@@ -183,13 +183,12 @@ namespace Flow.Launcher.ViewModel
         private List<ResultViewModel> NewResults(List<Result> newRawResults, string resultId)
         {
             if (newRawResults.Count == 0)
-                return Results.ToList();
+                return Results;
 
-            var results = Results as IEnumerable<ResultViewModel>;
 
             var newResults = newRawResults.Select(r => new ResultViewModel(r, _settings));
 
-            return results.Where(r => r.Result.PluginID != resultId)
+            return Results.Where(r => r.Result.PluginID != resultId)
                 .Concat(newResults)
                 .OrderByDescending(r => r.Result.Score)
                 .ToList();
@@ -198,11 +197,9 @@ namespace Flow.Launcher.ViewModel
         private List<ResultViewModel> NewResults(IEnumerable<ResultsForUpdate> resultsForUpdates)
         {
             if (!resultsForUpdates.Any())
-                return Results.ToList();
+                return Results;
 
-            var results = Results as IEnumerable<ResultViewModel>;
-
-            return results.Where(r => r != null && !resultsForUpdates.Any(u => u.Metadata.ID == r.Result.PluginID))
+            return Results.Where(r => r != null && !resultsForUpdates.Any(u => u.ID == r.Result.PluginID))
                           .Concat(resultsForUpdates.SelectMany(u => u.Results, (u, r) => new ResultViewModel(r, _settings)))
                           .OrderByDescending(rv => rv.Result.Score)
                           .ToList();


### PR DESCRIPTION
I just heard that there is a new, faster, lower cost Channel class for doing the producer-consumer logic we want. Therefore, no need to include the TPL because it is much heavier, and we didn't use other feature of TPL.

Channel class use ValueTask instead of Task, IAsyncEnumerable instead of creating another IList when reading them all.
Although we should only have a few items in the queue (generally less than 20), reading is quite frequently.

It won't be a large difference, because we didn't include async read & write, but more than nothing.