### PR TITLE
Remove unused check for Stream length

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -195,11 +195,11 @@ namespace Flow.Launcher.Core.Plugin
             catch (OperationCanceledException)
             {
                 // null will be fine since the results will only be added into queue if the token hasn't been cancelled
-                return results = null;
+                return null;
             }
             catch (Exception e)
             {
-                Log.Exception($"|PluginManager.QueryForPlugin|Exception for plugin <{pair.Metadata.Name}> when query <{query}>", e);
+               Log.Exception($"|PluginManager.QueryForPlugin|Exception for plugin <{pair.Metadata.Name}> when query <{query}>", e);
             }
 
             return results;

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -123,12 +123,12 @@ namespace Flow.Launcher.Plugin.WebSearch
             var source = _settings.SelectedSuggestion;
             if (source != null)
             {
-                var suggestions = await source.Suggestions(keyword, token);
+                var suggestions = await source.Suggestions(keyword, token).ConfigureAwait(false);
 
                 if (token.IsCancellationRequested)
                     return null;
 
-                var resultsFromSuggestion = suggestions.Select(o => new Result
+                var resultsFromSuggestion = suggestions?.Select(o => new Result
                 {
                     Title = o,
                     SubTitle = subtitle,

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Baidu.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Baidu.cs
@@ -32,7 +32,7 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
             catch (HttpRequestException e)
             {
                 Log.Exception("|Baidu.Suggestions|Can't get suggestion from baidu", e);
-                return new List<string>();
+                return null;
             }
 
             if (string.IsNullOrEmpty(result)) return new List<string>();

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Bing.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Bing.cs
@@ -24,16 +24,13 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
                 const string api = "https://api.bing.com/qsonhs.aspx?q=";
                 
                 using var resultStream = await Http.GetStreamAsync(api + Uri.EscapeUriString(query), token).ConfigureAwait(false);
-                
-                if (resultStream.Length == 0) 
-                    return new List<string>(); // this handles the cancellation
-                
+
                 json = (await JsonDocument.ParseAsync(resultStream, cancellationToken: token)).RootElement.GetProperty("AS");
 
             }
             catch (TaskCanceledException)
             {
-                return null;
+                return new List<string>();
             }
             catch (HttpRequestException e)
             {

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Google.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Google.cs
@@ -33,7 +33,7 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
             }
             catch (HttpRequestException e)
             {
-                // Log.Exception("|Google.Suggestions|Can't get suggestion from google", e);
+                Log.Exception("|Google.Suggestions|Can't get suggestion from google", e);
                 return new List<string>();
             }
             catch (JsonException e)

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Google.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Google.cs
@@ -24,19 +24,16 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
 
                 using var resultStream = await Http.GetStreamAsync(api + Uri.EscapeUriString(query)).ConfigureAwait(false);
                 
-                if (resultStream.Length == 0) 
-                    return new List<string>();
-                
                 json = await JsonDocument.ParseAsync(resultStream);
 
             }
             catch (TaskCanceledException)
             {
-                return null;
+                return new List<string>();
             }
             catch (HttpRequestException e)
             {
-                Log.Exception("|Google.Suggestions|Can't get suggestion from google", e);
+                // Log.Exception("|Google.Suggestions|Can't get suggestion from google", e);
                 return new List<string>();
             }
             catch (JsonException e)


### PR DESCRIPTION
fix #345 

The cancellation process is done by HttpClient natively by throwing TaskCancelledException, so no need to check the Stream length for that.

Seems that throwing exceptions makes the programs runs really slow in debug mode? Not quite sure for that.