### PR TITLE
Remove duplicate entry

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -778,7 +778,7 @@ namespace Flow.Launcher.ViewModel
         /// <summary>
         /// To avoid deadlock, this method should not called from main thread
         /// </summary>
-        public void UpdateResultView(IReadOnlyCollection<ResultsForUpdate> resultsForUpdates)
+        public void UpdateResultView(IEnumerable<ResultsForUpdate> resultsForUpdates)
         {
             if (!resultsForUpdates.Any())
                 return;

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -778,7 +778,7 @@ namespace Flow.Launcher.ViewModel
         /// <summary>
         /// To avoid deadlock, this method should not called from main thread
         /// </summary>
-        public void UpdateResultView(IEnumerable<ResultsForUpdate> resultsForUpdates)
+        public void UpdateResultView(IReadOnlyCollection<ResultsForUpdate> resultsForUpdates)
         {
             if (!resultsForUpdates.Any())
                 return;

--- a/Flow.Launcher/ViewModel/ResultsViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultsViewModel.cs
@@ -143,7 +143,7 @@ namespace Flow.Launcher.ViewModel
         /// <summary>
         /// To avoid deadlock, this method should not called from main thread
         /// </summary>
-        public void AddResults(IReadOnlyCollection<ResultsForUpdate> resultsForUpdates, CancellationToken token)
+        public void AddResults(IEnumerable<ResultsForUpdate> resultsForUpdates, CancellationToken token)
         {
             var newResults = NewResults(resultsForUpdates);
 
@@ -188,11 +188,10 @@ namespace Flow.Launcher.ViewModel
             return Results.Where(r => r.Result.PluginID != resultId)
                 .Concat(newResults)
                 .OrderByDescending(r => r.Result.Score)
-                .Distinct()
                 .ToList();
         }
 
-        private List<ResultViewModel> NewResults(IReadOnlyCollection<ResultsForUpdate> resultsForUpdates)
+        private List<ResultViewModel> NewResults(IEnumerable<ResultsForUpdate> resultsForUpdates)
         {
             if (!resultsForUpdates.Any())
                 return Results;
@@ -200,7 +199,6 @@ namespace Flow.Launcher.ViewModel
             return Results.Where(r => r != null && !resultsForUpdates.Any(u => u.ID == r.Result.PluginID))
                           .Concat(resultsForUpdates.SelectMany(u => u.Results, (u, r) => new ResultViewModel(r, _settings)))
                           .OrderByDescending(rv => rv.Result.Score)
-                          .Distinct()
                           .ToList();
         }
         #endregion

--- a/Flow.Launcher/ViewModel/ResultsViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultsViewModel.cs
@@ -1,16 +1,13 @@
-﻿using System;
+﻿using Flow.Launcher.Infrastructure.UserSettings;
+using Flow.Launcher.Plugin;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
-using Flow.Launcher.Infrastructure.UserSettings;
-using Flow.Launcher.Plugin;
 
 namespace Flow.Launcher.ViewModel
 {
@@ -146,7 +143,7 @@ namespace Flow.Launcher.ViewModel
         /// <summary>
         /// To avoid deadlock, this method should not called from main thread
         /// </summary>
-        public void AddResults(IEnumerable<ResultsForUpdate> resultsForUpdates, CancellationToken token)
+        public void AddResults(IReadOnlyCollection<ResultsForUpdate> resultsForUpdates, CancellationToken token)
         {
             var newResults = NewResults(resultsForUpdates);
 
@@ -191,10 +188,11 @@ namespace Flow.Launcher.ViewModel
             return Results.Where(r => r.Result.PluginID != resultId)
                 .Concat(newResults)
                 .OrderByDescending(r => r.Result.Score)
+                .Distinct()
                 .ToList();
         }
 
-        private List<ResultViewModel> NewResults(IEnumerable<ResultsForUpdate> resultsForUpdates)
+        private List<ResultViewModel> NewResults(IReadOnlyCollection<ResultsForUpdate> resultsForUpdates)
         {
             if (!resultsForUpdates.Any())
                 return Results;
@@ -202,6 +200,7 @@ namespace Flow.Launcher.ViewModel
             return Results.Where(r => r != null && !resultsForUpdates.Any(u => u.ID == r.Result.PluginID))
                           .Concat(resultsForUpdates.SelectMany(u => u.Results, (u, r) => new ResultViewModel(r, _settings)))
                           .OrderByDescending(rv => rv.Result.Score)
+                          .Distinct()
                           .ToList();
         }
         #endregion

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -38,7 +38,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             var quickaccessLinks = QuickAccess.AccessLinkListMatched(query, settings.QuickAccessLinks);
 
             if (quickaccessLinks.Count > 0)
-                results.AddRange(quickaccessLinks);
+                results.Union(quickaccessLinks);
 
             var isEnvironmentVariable = EnvironmentVariables.IsEnvironmentVariableSearch(querySearch);
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -54,7 +54,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             var quickaccessLinks = QuickAccess.AccessLinkListMatched(query, settings.QuickAccessLinks);
 
             if (quickaccessLinks.Count > 0)
-                results.AddRange(quickaccessLinks);
+                results.UnionWith(quickaccessLinks);
 
             var isEnvironmentVariable = EnvironmentVariables.IsEnvironmentVariableSearch(querySearch);
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -22,9 +22,25 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             this.settings = settings;
         }
 
+        private class PathEqualityComparator : IEqualityComparer<Result>
+        {
+            private static PathEqualityComparator instance;
+            public static PathEqualityComparator Instance => instance ??= new PathEqualityComparator();
+            public bool Equals(Result x, Result y)
+            {
+                return x.SubTitle == y.SubTitle;
+            }
+
+            public int GetHashCode(Result obj)
+            {
+                return obj.SubTitle.GetHashCode();
+            }
+
+        }
+
         internal async Task<List<Result>> SearchAsync(Query query, CancellationToken token)
         {
-            var results = new List<Result>();
+            var results = new HashSet<Result>(PathEqualityComparator.Instance);
 
             var querySearch = query.Search;
 
@@ -50,9 +66,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             if (!querySearch.IsLocationPathString() && !isEnvironmentVariablePath)
             {
-                results.AddRange(await WindowsIndexFilesAndFoldersSearchAsync(query, querySearch, token).ConfigureAwait(false));
+                results.UnionWith(await WindowsIndexFilesAndFoldersSearchAsync(query, querySearch, token).ConfigureAwait(false));
 
-                return results;
+                return results.ToList();
             }
 
             var locationPath = querySearch;
@@ -62,7 +78,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             // Check that actual location exists, otherwise directory search will throw directory not found exception
             if (!FilesFolders.LocationExists(FilesFolders.ReturnPreviousDirectoryIfIncompleteString(locationPath)))
-                return results;
+                return results.ToList();
 
             var useIndexSearch = UseWindowsIndexForDirectorySearch(locationPath);
 
@@ -79,9 +95,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             token.ThrowIfCancellationRequested();
 
-            results.AddRange(directoryResult);
+            results.UnionWith(directoryResult);
 
-            return results;
+            return results.ToList();
         }
 
         private async Task<List<Result>> WindowsIndexFileContentSearchAsync(Query query, string querySearchString, CancellationToken token)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -35,7 +35,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             {
                 return obj.SubTitle.GetHashCode();
             }
-
         }
 
         internal async Task<List<Result>> SearchAsync(Query query, CancellationToken token)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -7,7 +7,7 @@
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",
-  "Version": "1.7.0",
+  "Version": "1.7.1",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
When result exists from both Quick Access and file search, use unionwith and custom comparer instead of append, so this will return distinct results of duplicates 