### PR TITLE
add taskcanceledexception to updater exception catch

### DIFF
--- a/Flow.Launcher.Core/Updater.cs
+++ b/Flow.Launcher.Core/Updater.cs
@@ -87,7 +87,7 @@ namespace Flow.Launcher.Core
                     UpdateManager.RestartApp(Constant.ApplicationFileName);
                 }
             }
-            catch (Exception e) when (e is HttpRequestException || e is WebException || e is SocketException)
+            catch (Exception e) when (e is HttpRequestException || e is WebException || e is SocketException || e is TaskCanceledException)
             {
                 Log.Exception($"|Updater.UpdateApp|Check your connection and proxy settings to github-cloud.s3.amazonaws.com.", e);
                 api.ShowMsg(api.GetTranslation("update_flowlauncher_fail"),


### PR DESCRIPTION
fix #357
This may because HttpClient throws TaskCanceledException when timeout instead of HttpException, which is previously thrown by the old HttpWebRequest.