### PR TITLE
Change WebSearch default to global

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -25,6 +25,10 @@ namespace Flow.Launcher.Plugin.WebSearch
         internal static string DefaultImagesDirectory;
         internal static string CustomImagesDirectory;
 
+        private readonly int scoreStandard = 50;
+
+        private readonly int scoreSuggestions = 48;
+
         private readonly string SearchSourceGlobalPluginWildCardSign = "*";
 
         public void Save()
@@ -49,13 +53,17 @@ namespace Flow.Launcher.Plugin.WebSearch
                 var title = keyword;
                 string subtitle = _context.API.GetTranslation("flowlauncher_plugin_websearch_search") + " " + searchSource.Title;
 
+                //Action Keyword match apear on top
+                var score = searchSource.ActionKeyword == SearchSourceGlobalPluginWildCardSign ? scoreStandard : scoreStandard + 1;
+
                 if (string.IsNullOrEmpty(keyword))
                 {
                     var result = new Result
                     {
                         Title = subtitle,
                         SubTitle = string.Empty,
-                        IcoPath = searchSource.IconPath
+                        IcoPath = searchSource.IconPath,
+                        Score = score
                     };
                     results.Add(result);
                 }
@@ -65,9 +73,9 @@ namespace Flow.Launcher.Plugin.WebSearch
                     {
                         Title = title,
                         SubTitle = subtitle,
-                        Score = 6,
                         IcoPath = searchSource.IconPath,
                         ActionKeywordAssigned = searchSource.ActionKeyword == SearchSourceGlobalPluginWildCardSign ? string.Empty : searchSource.ActionKeyword,
+                        Score = score,
                         Action = c =>
                         {
                             if (_settings.OpenInNewBrowser)
@@ -123,6 +131,9 @@ namespace Flow.Launcher.Plugin.WebSearch
             var source = _settings.SelectedSuggestion;
             if (source != null)
             {
+                //Suggestions appear below actual result, and appear above global action keyword match if non-global;
+                var score = searchSource.ActionKeyword == SearchSourceGlobalPluginWildCardSign ? scoreSuggestions : scoreSuggestions + 1;
+
                 var suggestions = await source.Suggestions(keyword, token).ConfigureAwait(false);
 
                 token.ThrowIfCancellationRequested();
@@ -131,7 +142,7 @@ namespace Flow.Launcher.Plugin.WebSearch
                 {
                     Title = o,
                     SubTitle = subtitle,
-                    Score = 5,
+                    Score = score,
                     IcoPath = searchSource.IconPath,
                     ActionKeywordAssigned = searchSource.ActionKeyword == SearchSourceGlobalPluginWildCardSign ? string.Empty : searchSource.ActionKeyword,
                     Action = c =>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Settings.cs
@@ -21,7 +21,7 @@ namespace Flow.Launcher.Plugin.WebSearch
             new SearchSource
             {
                 Title = "Google",
-                ActionKeyword = "g",
+                ActionKeyword = "*",
                 Icon = "google.png",
                 Url = "https://www.google.com/search?q={q}",
                 Enabled = true

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json
@@ -25,7 +25,7 @@
   "Name": "Web Searches",
   "Description": "Provide the web search ability",
   "Author": "qianlifeng",
-  "Version": "1.3.4",
+  "Version": "1.3.5",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.WebSearch.dll",

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json
@@ -1,7 +1,7 @@
 {
   "ID": "565B73353DBF4806919830B9202EE3BF",
   "ActionKeywords": [
-    "g",
+    "*",
     "wiki",
     "findicon",
     "facebook",

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/setting.json
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/setting.json
@@ -2,7 +2,7 @@
   "WebSearches": [
     {
       "Title": "Google",
-      "ActionKeyword": "g",
+      "ActionKeyword": "*",
       "IconPath": "Images\\google.png",
       "Url": "https://www.google.com/search?q={q}",
       "Enabled": true


### PR DESCRIPTION
1. Since web searches is performed many times, let's change the default to global action keyword so first time users do not need to go hunting in settings to find out the action keyword to activate it.

2. Update so if a action keyword is matched, display on top of global action keyword ('*') 
before:
![image](https://user-images.githubusercontent.com/26427004/109476313-e2ae7a80-7aca-11eb-845c-860be46c0789.png)

after: 
![image](https://user-images.githubusercontent.com/26427004/109476346-ee01a600-7aca-11eb-855d-cce19d27ffae.png)

suggestions also follow the same format.