### PR TITLE
Fix missing google scholar action keyword

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json
@@ -2,6 +2,7 @@
   "ID": "565B73353DBF4806919830B9202EE3BF",
   "ActionKeywords": [
     "*",
+    "sc",
     "wiki",
     "findicon",
     "facebook",
@@ -25,7 +26,7 @@
   "Name": "Web Searches",
   "Description": "Provide the web search ability",
   "Author": "qianlifeng",
-  "Version": "1.3.5",
+  "Version": "1.3.6",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.WebSearch.dll",


### PR DESCRIPTION
Realised Google Scholar action keyword is missing- 'sc', this adds it back in.