### PR TITLE
Fix exclusion of Windows Index search for files and folders

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -172,11 +172,19 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             foreach (var r in results)
             {
+                var excludeResult = false;
+
                 for (var i = 0; i < indexExclusionListCount; i++)
                 {
-                    if (!r.SubTitle.StartsWith(indexExclusionList[i].Path, StringComparison.OrdinalIgnoreCase))
-                        filteredResults.Add(r);
+                    if (r.SubTitle.StartsWith(indexExclusionList[i].Path, StringComparison.OrdinalIgnoreCase))
+                    {
+                        excludeResult = true;
+                        break;
+                    }
                 }
+
+                if (!excludeResult)
+                    filteredResults.Add(r);
             }
 
             return filteredResults;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -67,7 +67,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             {
                 results.UnionWith(await WindowsIndexFilesAndFoldersSearchAsync(query, querySearch, token).ConfigureAwait(false));
 
-                return results.ToList();
+                return FilterOutResultsFromWindowsIndexExclusionList(results).ToList();
             }
 
             var locationPath = querySearch;
@@ -157,6 +157,29 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                                                    queryConstructor.QueryForTopLevelDirectorySearch,
                                                    query,
                                                    token).ConfigureAwait(false);
+        }
+
+        private HashSet<Result> FilterOutResultsFromWindowsIndexExclusionList(HashSet<Result> results)
+        {
+            var indexExclusionList = settings.IndexSearchExcludedSubdirectoryPaths;
+
+            var indexExclusionListCount = indexExclusionList.Count;
+
+            if (indexExclusionListCount == 0)
+                return results;
+
+            var filteredResults = new HashSet<Result>(PathEqualityComparator.Instance);
+
+            foreach (var r in results)
+            {
+                for (var i = 0; i < indexExclusionListCount; i++)
+                {
+                    if (!r.SubTitle.StartsWith(indexExclusionList[0].Path, StringComparison.OrdinalIgnoreCase))
+                        filteredResults.Add(r);
+                }
+            }
+
+            return filteredResults;
         }
 
         private bool UseWindowsIndexForDirectorySearch(string locationPath)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -1,4 +1,4 @@
-﻿using Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo;
+using Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo;
 using Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks;
 using Flow.Launcher.Plugin.Explorer.Search.WindowsIndex;
 using Flow.Launcher.Plugin.SharedCommands;
@@ -65,9 +65,12 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             if (!querySearch.IsLocationPathString() && !isEnvironmentVariablePath)
             {
-                results.UnionWith(await WindowsIndexFilesAndFoldersSearchAsync(query, querySearch, token).ConfigureAwait(false));
+                var filteredResults = FilterOutResultsFromWindowsIndexExclusionList(
+                        await WindowsIndexFilesAndFoldersSearchAsync(query, querySearch, token).ConfigureAwait(false));
 
-                return FilterOutResultsFromWindowsIndexExclusionList(results).ToList();
+                results.UnionWith(filteredResults);
+
+                return results.ToList();
             }
 
             var locationPath = querySearch;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -1,4 +1,4 @@
-using Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo;
+﻿using Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo;
 using Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks;
 using Flow.Launcher.Plugin.Explorer.Search.WindowsIndex;
 using Flow.Launcher.Plugin.SharedCommands;
@@ -162,24 +162,24 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                                                    token).ConfigureAwait(false);
         }
 
-        private HashSet<Result> FilterOutResultsFromWindowsIndexExclusionList(HashSet<Result> results)
+        private HashSet<Result> FilterOutResultsFromWindowsIndexExclusionList(List<Result> results)
         {
             var indexExclusionList = settings.IndexSearchExcludedSubdirectoryPaths;
 
             var indexExclusionListCount = indexExclusionList.Count;
 
             if (indexExclusionListCount == 0)
-                return results;
+                return results.ToHashSet();
 
             var filteredResults = new HashSet<Result>(PathEqualityComparator.Instance);
 
-            foreach (var r in results)
+            for (var index = 0; index < results.Count; index++)
             {
                 var excludeResult = false;
 
                 for (var i = 0; i < indexExclusionListCount; i++)
                 {
-                    if (r.SubTitle.StartsWith(indexExclusionList[i].Path, StringComparison.OrdinalIgnoreCase))
+                    if (results[index].SubTitle.StartsWith(indexExclusionList[i].Path, StringComparison.OrdinalIgnoreCase))
                     {
                         excludeResult = true;
                         break;
@@ -187,7 +187,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 }
 
                 if (!excludeResult)
-                    filteredResults.Add(r);
+                    filteredResults.Add(results[index]);
             }
 
             return filteredResults;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -174,7 +174,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             {
                 for (var i = 0; i < indexExclusionListCount; i++)
                 {
-                    if (!r.SubTitle.StartsWith(indexExclusionList[0].Path, StringComparison.OrdinalIgnoreCase))
+                    if (!r.SubTitle.StartsWith(indexExclusionList[i].Path, StringComparison.OrdinalIgnoreCase))
                         filteredResults.Add(r);
                 }
             }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -7,7 +7,7 @@
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",
-  "Version": "1.7.1",
+  "Version": "1.7.2",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
'Index Search Excluded' path does not kick in when using Windows Index to search for files and folders. This adds an exclusion call to filter out the index search result from exclusion list.

closing #384