### PR TITLE
Add ConfigureWait and cancellation token & remove unnecessary OperationCanceledException

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -63,10 +63,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                     }
                 }
             }
-            catch (OperationCanceledException)
-            {
-                return new List<Result>(); // The source code indicates that without adding members, it won't allocate an array
-            }
             catch (InvalidOperationException e)
             {
                 // Internal error from ExecuteReader(): Connection closed.

--- a/Plugins/Flow.Launcher.Plugin.Program/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Main.cs
@@ -50,35 +50,21 @@ namespace Flow.Launcher.Plugin.Program
             win32 = _win32s;
             uwps = _uwps;
 
-            try
+            var result = await Task.Run(delegate
             {
-                var result = await Task.Run(delegate
-                {
-                    try
-                    {
-                        return win32.Cast<IProgram>()
-                            .Concat(uwps)
-                            .AsParallel()
-                            .WithCancellation(token)
-                            .Where(p => p.Enabled)
-                            .Select(p => p.Result(query.Search, _context.API))
-                            .Where(r => r?.Score > 0)
-                            .ToList();
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        return null;
-                    }
-                }, token).ConfigureAwait(false);
+                return win32.Cast<IProgram>()
+                    .Concat(uwps)
+                    .AsParallel()
+                    .WithCancellation(token)
+                    .Where(p => p.Enabled)
+                    .Select(p => p.Result(query.Search, _context.API))
+                    .Where(r => r?.Score > 0)
+                    .ToList();
+            }, token).ConfigureAwait(false);
 
-                token.ThrowIfCancellationRequested();
+            token.ThrowIfCancellationRequested();
 
-                return result;
-            }
-            catch (OperationCanceledException)
-            {
-                return null;
-            }
+            return result;
         }
 
         public async Task InitAsync(PluginInitContext context)

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Baidu.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Baidu.cs
@@ -30,11 +30,6 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
                 Log.Exception("|Baidu.Suggestions|Can't get suggestion from baidu", e);
                 return null;
             }
-            catch (OperationCanceledException)
-            {
-                return null;
-            }
-
 
             if (string.IsNullOrEmpty(result)) return new List<string>();
             Match match = _reg.Match(result);

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Bing.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Bing.cs
@@ -45,10 +45,6 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
                 Log.Exception("|Baidu.Suggestions|Can't get suggestion from baidu", e);
                 return null;
             }
-            catch (OperationCanceledException)
-            {
-                return new List<string>();
-            }
             catch (JsonException e)
             {
                 Log.Exception("|Bing.Suggestions|can't parse suggestions", e);

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Google.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Google.cs
@@ -37,10 +37,6 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
                 Log.Exception("|Baidu.Suggestions|Can't get suggestion from baidu", e);
                 return null;
             }
-            catch (OperationCanceledException)
-            {
-                return new List<string>();
-            }
             catch (JsonException e)
             {
                 Log.Exception("|Google.Suggestions|can't parse suggestions", e);


### PR DESCRIPTION
- Add ConfigureWait and cancellation token for https://github.com/Flow-Launcher/Flow.Launcher/pull/386
- Remove unnecessary catching of OperationCanceledException because it will be caught by PluginManager from each plugin query call