### PR TITLE
Make IPlugin inherit from IAsyncPlugin

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginAssemblyLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginAssemblyLoader.cs
@@ -49,10 +49,10 @@ namespace Flow.Launcher.Core.Plugin
             return LoadFromAssemblyPath(assemblyPath);
         }
 
-        internal Type FromAssemblyGetTypeOfInterface(Assembly assembly, params Type[] types)
+        internal Type FromAssemblyGetTypeOfInterface(Assembly assembly, Type type)
         {
             var allTypes = assembly.ExportedTypes;
-            return allTypes.First(o => o.IsClass && !o.IsAbstract && o.GetInterfaces().Intersect(types).Any());
+            return allTypes.First(o => o.IsClass && !o.IsAbstract && o.GetInterfaces().Any(t => t == type));
         }
 
         internal bool ExistsInReferencedPackage(AssemblyName assemblyName)

--- a/Flow.Launcher.Core/Plugin/PluginsLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginsLoader.cs
@@ -44,23 +44,23 @@ namespace Flow.Launcher.Core.Plugin
 #if DEBUG
                         var assemblyLoader = new PluginAssemblyLoader(metadata.ExecuteFilePath);
                         var assembly = assemblyLoader.LoadAssemblyAndDependencies();
-                        var type = assemblyLoader.FromAssemblyGetTypeOfInterface(assembly, typeof(IPlugin),
+                        var type = assemblyLoader.FromAssemblyGetTypeOfInterface(assembly,
                             typeof(IAsyncPlugin));
 
-                        var plugin = Activator.CreateInstance(type);
+                        var plugin = Activator.CreateInstance(type) as IAsyncPlugin;
 #else
                         Assembly assembly = null;
-                        object plugin = null;
+                        IAsyncPlugin plugin = null;
 
                         try
                         {
                             var assemblyLoader = new PluginAssemblyLoader(metadata.ExecuteFilePath);
                             assembly = assemblyLoader.LoadAssemblyAndDependencies();
 
-                            var type = assemblyLoader.FromAssemblyGetTypeOfInterface(assembly, typeof(IPlugin), 
+                            var type = assemblyLoader.FromAssemblyGetTypeOfInterface(assembly,
                                 typeof(IAsyncPlugin));
 
-                            plugin = Activator.CreateInstance(type);
+                            plugin = Activator.CreateInstance(type) as IAsyncPlugin;
                         }
                         catch (Exception e) when (assembly == null)
                         {
@@ -78,13 +78,13 @@ namespace Flow.Launcher.Core.Plugin
                         {
                             Log.Exception($"|PluginsLoader.DotNetPlugins|The following plugin has errored and can not be loaded: <{metadata.Name}>", e);
                         }
-
+#endif
                         if (plugin == null)
                         {
                             erroredPlugins.Add(metadata.Name);
                             return;
                         }
-#endif
+
                         plugins.Add(new PluginPair
                         {
                             Plugin = plugin,
@@ -139,7 +139,7 @@ namespace Flow.Launcher.Core.Plugin
                     }
                     else
                     {
-                        Log.Error("PluginsLoader","Failed to set Python path despite the environment variable PATH is found", "PythonPlugins");
+                        Log.Error("PluginsLoader", "Failed to set Python path despite the environment variable PATH is found", "PythonPlugins");
                     }
                 }
             }
@@ -152,7 +152,7 @@ namespace Flow.Launcher.Core.Plugin
                 }
                 else
                 {
-                    Log.Error("PluginsLoader",$"Tried to automatically set from Settings.PythonDirectory " +
+                    Log.Error("PluginsLoader", $"Tried to automatically set from Settings.PythonDirectory " +
                         $"but can't find python executable in {path}", "PythonPlugins");
                 }
             }
@@ -205,7 +205,7 @@ namespace Flow.Launcher.Core.Plugin
                     }
                     else
                     {
-                        Log.Error("PluginsLoader", 
+                        Log.Error("PluginsLoader",
                             $"Failed to set Python path after Droplex install, {pythonPath} does not exist",
                             "PythonPlugins");
                     }
@@ -215,8 +215,8 @@ namespace Flow.Launcher.Core.Plugin
             if (string.IsNullOrEmpty(settings.PythonDirectory))
             {
                 MessageBox.Show("Unable to set Python executable path, please try from Flow's settings (scroll down to the bottom).");
-                Log.Error("PluginsLoader", 
-                    $"Not able to successfully set Python path, the PythonDirectory variable is still an empty string.", 
+                Log.Error("PluginsLoader",
+                    $"Not able to successfully set Python path, the PythonDirectory variable is still an empty string.",
                     "PythonPlugins");
 
                 return new List<PluginPair>();

--- a/Flow.Launcher.Plugin/IAsyncPlugin.cs
+++ b/Flow.Launcher.Plugin/IAsyncPlugin.cs
@@ -19,7 +19,7 @@ namespace Flow.Launcher.Plugin
         /// <param name="query">Query to search</param>
         /// <param name="token">Cancel when querying job is obsolete</param>
         /// <returns></returns>
-        Task<List<Result>> QueryAsync(Query query, CancellationToken token);
+        abstract Task<List<Result>> QueryAsync(Query query, CancellationToken token);
 
         /// <summary>
         /// Initialize plugin asynchrously (will still wait finish to continue)

--- a/Flow.Launcher.Plugin/IAsyncPlugin.cs
+++ b/Flow.Launcher.Plugin/IAsyncPlugin.cs
@@ -19,7 +19,7 @@ namespace Flow.Launcher.Plugin
         /// <param name="query">Query to search</param>
         /// <param name="token">Cancel when querying job is obsolete</param>
         /// <returns></returns>
-        abstract Task<List<Result>> QueryAsync(Query query, CancellationToken token);
+        Task<List<Result>> QueryAsync(Query query, CancellationToken token);
 
         /// <summary>
         /// Initialize plugin asynchrously (will still wait finish to continue)

--- a/Flow.Launcher.Plugin/IPlugin.cs
+++ b/Flow.Launcher.Plugin/IPlugin.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Flow.Launcher.Plugin
 {
@@ -9,7 +11,7 @@ namespace Flow.Launcher.Plugin
     /// or performaing CPU intense jobs (performing better with cancellation), please try the IAsyncPlugin interface
     /// </para>
     /// </summary>
-    public interface IPlugin
+    public interface IPlugin : IAsyncPlugin
     {
         /// <summary>
         /// Querying when user's search changes
@@ -27,5 +29,9 @@ namespace Flow.Launcher.Plugin
         /// </summary>
         /// <param name="context"></param>
         void Init(PluginInitContext context);
+
+        Task IAsyncPlugin.InitAsync(PluginInitContext context) => Task.Run(() => Init(context));
+
+        Task<List<Result>> IAsyncPlugin.QueryAsync(Query query, CancellationToken token) => Task.Run(() => Query(query));
     }
 }

--- a/Flow.Launcher.Plugin/PluginPair.cs
+++ b/Flow.Launcher.Plugin/PluginPair.cs
@@ -2,7 +2,7 @@
 {
     public class PluginPair
     {
-        public object Plugin { get; internal set; }
+        public IAsyncPlugin Plugin { get; internal set; }
         public PluginMetadata Metadata { get; internal set; }
 
         


### PR DESCRIPTION
The currently separated interface create quite significant code duplicate, so I try making the old plugin interface extends from the new plugin interface with the default implementation of interface from c# 8. (This is similar to the first version of the new Async model which directly use the default implementation in IPlugin interface).

It is hard to say which choice is better🤔🤔🤔, but this prevents the weird empty default implementation in legacy Query method.