### PR TITLE
Make PluginJsonStorage in IPublicAPI become single instance per type

### DIFF
--- a/Flow.Launcher.Plugin/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/IPublicAPI.cs
@@ -165,10 +165,26 @@ namespace Flow.Launcher.Plugin
         T LoadJsonStorage<T>() where T : new();
 
         /// <summary>
-        /// Save JsonStorage for current plugin. This is the method used to save settings to json in Flow
+        /// Save JsonStorage for current plugin. This is the method used to save settings to json in Flow.Launcher
+        /// This method will save the original instance loaded with LoadJsonStorage.
         /// </summary>
         /// <typeparam name="T">Type for Serialization</typeparam>
         /// <returns></returns>
-        void SaveJsonStorage<T>(T setting) where T : new();
+        void SaveJsonStorage<T>() where T : new();
+
+        /// <summary>
+        /// Save JsonStorage for current plugin. This is the method used to save settings to json in Flow.Launcher
+        /// This method will override the original class instance loaded from LoadJsonStorage
+        /// </summary>
+        /// <typeparam name="T">Type for Serialization</typeparam>
+        /// <returns></returns>
+        void SaveJsonStorage<T>(T settings) where T : new();
+
+        /// <summary>
+        /// Backup the JsonStorage you loaded from LoadJsonStorage
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="settings"></param>
+        void BackupJsonStorage<T>() where T : new();
     }
 }

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -131,9 +131,42 @@ namespace Flow.Launcher
 
         public void LogException(string className, string message, Exception e, [CallerMemberName] string methodName = "") => Log.Exception(className, message, e, methodName);
 
-        public T LoadJsonStorage<T>() where T : new() => new PluginJsonStorage<T>().Load();
+        private readonly Dictionary<Type, dynamic> PluginJsonStorages = new Dictionary<Type, dynamic>();
 
-        public void SaveJsonStorage<T>(T setting) where T : new() => new PluginJsonStorage<T>(setting).Save();
+        public T LoadJsonStorage<T>() where T : new()
+        {
+            var type = typeof(T);
+            if (!PluginJsonStorages.ContainsKey(type))
+                PluginJsonStorages[type] = new PluginJsonStorage<T>();
+
+            return PluginJsonStorages[type].Load();
+        }
+
+        public void SaveJsonStorage<T>() where T : new()
+        {
+            var type = typeof(T);
+            if (!PluginJsonStorages.ContainsKey(type))
+                PluginJsonStorages[type] = new PluginJsonStorage<T>();
+
+            PluginJsonStorages[type].Save();
+        }
+
+        public void SaveJsonStorage<T>(T settings) where T : new()
+        {
+            var type = typeof(T);
+            PluginJsonStorages[type] = new PluginJsonStorage<T>(settings);
+
+            PluginJsonStorages[type].Save();
+        }
+
+        public void BackupJsonStorage<T>() where T : new()
+        {
+            var type = typeof(T);
+            if (!PluginJsonStorages.ContainsKey(type))
+                throw new InvalidOperationException("You haven't registered the JsonStorage for specific Type");
+
+            PluginJsonStorages[type].BackupOriginFile();
+        }
 
         public event FlowLauncherGlobalKeyboardEventHandler GlobalKeyboardEvent;
 


### PR DESCRIPTION
Keep align with the usage of JsonStorage that use an instance holding the data to load and save instead of creating a new one every time. It uses dynamic to fit the generic type, but I also see someone use a generic type with static class to achieve similar result, but that will change quite significantly.
#388 