### PR TITLE
add score bumping with query and do hashcode customized

### DIFF
--- a/Flow.Launcher/Storage/UserSelectedRecord.cs
+++ b/Flow.Launcher/Storage/UserSelectedRecord.cs
@@ -10,6 +10,9 @@ namespace Flow.Launcher.Storage
 {
     public class UserSelectedRecord
     {
+        private const int HASH_MULTIPLIER = 31;
+        private const int HASH_INITIAL = 23;
+
         [JsonInclude]
         public Dictionary<int, int> records { get; private set; }
 
@@ -20,7 +23,7 @@ namespace Flow.Launcher.Storage
 
         private static int GenerateCustomHashCode(Query query, Result result)
         {
-            int hashcode = 23;
+            int hashcode = HASH_INITIAL;
 
             unchecked
             {
@@ -31,25 +34,25 @@ namespace Flow.Launcher.Storage
                 for (int i = 0; i < query.ActionKeyword.Length; i++)
                 {
                     char item = query.ActionKeyword[i];
-                    hashcode = hashcode * 31 + item;
+                    hashcode = hashcode * HASH_MULTIPLIER + item;
                 }
                 
                 for (int i = 0; i < query.Search.Length; i++)
                 {
                     char item = query.Search[i];
-                    hashcode = hashcode * 31 + item;
+                    hashcode = hashcode * HASH_MULTIPLIER + item;
                 }
 
                 for (int i = 0; i < result.Title.Length; i++)
                 {
                     char item = result.Title[i];
-                    hashcode = hashcode * 31 + item;
+                    hashcode = hashcode * HASH_MULTIPLIER + item;
                 }
 
                 for (int i = 0; i < result.SubTitle.Length; i++)
                 {
                     char item = result.SubTitle[i];
-                    hashcode = hashcode * 31 + item;
+                    hashcode = hashcode * HASH_MULTIPLIER + item;
                 }
                 return hashcode;
 

--- a/Flow.Launcher/Storage/UserSelectedRecord.cs
+++ b/Flow.Launcher/Storage/UserSelectedRecord.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
 using Flow.Launcher.Infrastructure;
@@ -24,18 +25,30 @@ namespace Flow.Launcher.Storage
             unchecked
             {
                 // skip the empty space
-                foreach (var item in query.ActionKeyword.Concat(query.Search))
+                // https://stackoverflow.com/a/5155015 31 prime and is 2^5 - 1 which allows fast
+                //    optimization without information lost when int overflow
+                
+                for (int i = 0; i < query.ActionKeyword.Length; i++)
                 {
+                    char item = query.ActionKeyword[i];
+                    hashcode = hashcode * 31 + item;
+                }
+                
+                for (int i = 0; i < query.Search.Length; i++)
+                {
+                    char item = query.Search[i];
                     hashcode = hashcode * 31 + item;
                 }
 
-                foreach (var item in result.Title)
+                for (int i = 0; i < result.Title.Length; i++)
                 {
+                    char item = result.Title[i];
                     hashcode = hashcode * 31 + item;
                 }
 
-                foreach (var item in result.SubTitle)
+                for (int i = 0; i < result.SubTitle.Length; i++)
                 {
+                    char item = result.SubTitle[i];
                     hashcode = hashcode * 31 + item;
                 }
                 return hashcode;

--- a/Flow.Launcher/Storage/UserSelectedRecord.cs
+++ b/Flow.Launcher/Storage/UserSelectedRecord.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
+using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin;
 
@@ -8,16 +10,42 @@ namespace Flow.Launcher.Storage
     public class UserSelectedRecord
     {
         [JsonInclude]
-        public Dictionary<string, int> records { get; private set; }
+        public Dictionary<int, int> records { get; private set; }
 
         public UserSelectedRecord()
         {
-            records = new Dictionary<string, int>();
+            records = new Dictionary<int, int>();
+        }
+
+        private static int GenerateCustomHashCode(Query query, Result result)
+        {
+            int hashcode = 23;
+
+            unchecked
+            {
+                // skip the empty space
+                foreach (var item in query.ActionKeyword.Concat(query.Search))
+                {
+                    hashcode = hashcode * 31 + item;
+                }
+
+                foreach (var item in result.Title)
+                {
+                    hashcode = hashcode * 31 + item;
+                }
+
+                foreach (var item in result.SubTitle)
+                {
+                    hashcode = hashcode * 31 + item;
+                }
+                return hashcode;
+
+            }
         }
 
         public void Add(Result result)
         {
-            var key = result.ToString();
+            var key = GenerateCustomHashCode(result.OriginQuery, result);
             if (records.ContainsKey(key))
             {
                 records[key]++;
@@ -31,7 +59,7 @@ namespace Flow.Launcher.Storage
 
         public int GetSelectedCount(Result result)
         {
-            if (records.TryGetValue(result.ToString(), out int value))
+            if (records.TryGetValue(GenerateCustomHashCode(result.OriginQuery, result), out int value))
             {
                 return value;
             }


### PR DESCRIPTION
Only bump score when not only the result has been matched, but also the query has been match.
This will help users to separate the use of query for different high score results that both can be matched with separated query.

close #394 