### PR TITLE
Allow Quick Access Links to be accessed with middle string

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
@@ -62,11 +62,11 @@ namespace Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo
                     if (fileSystemInfo is System.IO.DirectoryInfo)
                     {
                         folderList.Add(ResultManager.CreateFolderResult(fileSystemInfo.Name, fileSystemInfo.FullName,
-                            fileSystemInfo.FullName, query, true, false));
+                            fileSystemInfo.FullName, query, 0, true, false));
                     }
                     else
                     {
-                        fileList.Add(ResultManager.CreateFileResult(fileSystemInfo.FullName, query, true, false));
+                        fileList.Add(ResultManager.CreateFileResult(fileSystemInfo.FullName, query, 0, true, false));
                     }
 
                     token.ThrowIfCancellationRequested();

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
@@ -15,17 +15,24 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
 
             var queriedAccessLinks =
                 accessLinks
-                .Where(x => x.Nickname.StartsWith(search, StringComparison.OrdinalIgnoreCase))
+                .Where(x => x.Nickname.Contains(search, StringComparison.OrdinalIgnoreCase))
                 .OrderBy(x => x.Type)
                 .ThenBy(x => x.Nickname);
 
-            return queriedAccessLinks.Select(l => l.Type switch
+            var matched = queriedAccessLinks.Select(l => l.Type switch
             {
                 ResultType.Folder => ResultManager.CreateFolderResult(l.Nickname, l.Path, l.Path, query),
                 ResultType.File => ResultManager.CreateFileResult(l.Path, query),
                 _ => throw new ArgumentOutOfRangeException()
 
             }).ToList();
+
+            foreach (var r in matched)
+            {
+                r.Score = 100;
+            }
+
+            return matched;
         }
 
         internal static List<Result> AccessLinkListAll(Query query, List<AccessLink> accessLinks)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
@@ -19,20 +19,13 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
                 .OrderBy(x => x.Type)
                 .ThenBy(x => x.Nickname);
 
-            var matched = queriedAccessLinks.Select(l => l.Type switch
+            return queriedAccessLinks.Select(l => l.Type switch
             {
-                ResultType.Folder => ResultManager.CreateFolderResult(l.Nickname, l.Path, l.Path, query),
-                ResultType.File => ResultManager.CreateFileResult(l.Path, query),
+                ResultType.Folder => ResultManager.CreateFolderResult(l.Nickname, l.Path, l.Path, query, 100),
+                ResultType.File => ResultManager.CreateFileResult(l.Path, query, 100),
                 _ => throw new ArgumentOutOfRangeException()
 
             }).ToList();
-
-            foreach (var r in matched)
-            {
-                r.Score = 100;
-            }
-
-            return matched;
         }
 
         internal static List<Result> AccessLinkListAll(Query query, List<AccessLink> accessLinks)
@@ -42,7 +35,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
                 .Select(l => l.Type switch
                 {
                     ResultType.Folder => ResultManager.CreateFolderResult(l.Nickname, l.Path, l.Path, query),
-                    ResultType.File => ResultManager.CreateFileResult(l.Path, query),
+                    ResultType.File => ResultManager.CreateFileResult(l.Path, query, 100),
                     _ => throw new ArgumentOutOfRangeException()
 
                 }).ToList();

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -16,7 +16,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             Context = context;
         }
 
-        internal static Result CreateFolderResult(string title, string subtitle, string path, Query query, bool showIndexState = false, bool windowsIndexed = false)
+        internal static Result CreateFolderResult(string title, string subtitle, string path, Query query, int score = 0, bool showIndexState = false, bool windowsIndexed = false)
         {
             return new Result
             {
@@ -46,6 +46,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                         query.ActionKeyword + " " + changeTo);
                     return false;
                 },
+                Score = score,
                 TitleToolTip = Constants.ToolTipOpenDirectory,
                 SubTitleToolTip = Constants.ToolTipOpenDirectory,
                 ContextData = new SearchResult { Type = ResultType.Folder, FullPath = path, ShowIndexState = showIndexState, WindowsIndexed = windowsIndexed }
@@ -69,9 +70,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             if (retrievedDirectoryPath != path)
                 title = "Open " + folderName;
 
-            
+
             var subtitleFolderName = folderName;
-            
+
             // ie. max characters can be displayed without subtitle cutting off: "Program Files (x86)"
             if (folderName.Length > 19)
                 subtitleFolderName = "the directory";
@@ -94,7 +95,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             };
         }
 
-        internal static Result CreateFileResult(string filePath, Query query, bool showIndexState = false, bool windowsIndexed = false)
+        internal static Result CreateFileResult(string filePath, Query query, int score = 0, bool showIndexState = false, bool windowsIndexed = false)
         {
             var result = new Result
             {
@@ -102,6 +103,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 SubTitle = filePath,
                 IcoPath = filePath,
                 TitleHighlightData = StringMatcher.FuzzySearch(query.Search, Path.GetFileName(filePath)).MatchData,
+                Score = score,
                 Action = c =>
                 {
                     try

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -53,11 +53,11 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                                                                     dataReaderResults.GetString(0),
                                                                     path,
                                                                     path,
-                                                                    query, true, true));
+                                                                    query, 0, true, true));
                             }
                             else
                             {
-                                fileResults.Add(ResultManager.CreateFileResult(path, query, true, true));
+                                fileResults.Add(ResultManager.CreateFileResult(path, query, 0, true, true));
                             }
                         }
                     }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -7,7 +7,7 @@
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",
-  "Version": "1.7.2",
+  "Version": "1.7.3",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
Use `Contains` instead of `StartWith` to allows search with middle part of name, also score bump to 100 since it is not a fuzzy, but a full matched.

Or using Fuzzy would be better?