### PR TITLE
Remove redundant QuickAccess folder nickname path

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/AccessLink.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/AccessLink.cs
@@ -11,7 +11,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
         public ResultType Type { get; set; } = ResultType.Folder;
 
         [JsonIgnore]
-        public string Nickname
+        public string Name
         {
             get
             {
@@ -21,8 +21,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
                     return path[0..^1] + " Drive";
 
                 return path.Split(new[] { System.IO.Path.DirectorySeparatorChar }, StringSplitOptions.None)
-                            .Last()
-                            + " (" + System.IO.Path.GetDirectoryName(Path) + ")";
+                           .Last();
             }
         }
     }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
@@ -6,6 +6,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
 {
     internal static class QuickAccess
     {
+        private const int quickAccessResultScore = 100;
+
         internal static List<Result> AccessLinkListMatched(Query query, List<AccessLink> accessLinks)
         {
             if (string.IsNullOrEmpty(query.Search))
@@ -21,8 +23,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
 
             return queriedAccessLinks.Select(l => l.Type switch
             {
-                ResultType.Folder => ResultManager.CreateFolderResult(l.Name, l.Path, l.Path, query, 100),
-                ResultType.File => ResultManager.CreateFileResult(l.Path, query, 100),
+                ResultType.Folder => ResultManager.CreateFolderResult(l.Name, l.Path, l.Path, query, quickAccessResultScore),
+                ResultType.File => ResultManager.CreateFileResult(l.Path, query, quickAccessResultScore),
                 _ => throw new ArgumentOutOfRangeException()
             }).ToList();
         }
@@ -34,7 +36,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
                 .Select(l => l.Type switch
                 {
                     ResultType.Folder => ResultManager.CreateFolderResult(l.Name, l.Path, l.Path, query),
-                    ResultType.File => ResultManager.CreateFileResult(l.Path, query, 100),
+                    ResultType.File => ResultManager.CreateFileResult(l.Path, query, quickAccessResultScore),
                     _ => throw new ArgumentOutOfRangeException()
                 }).ToList();
     }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
@@ -15,29 +15,27 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
 
             var queriedAccessLinks =
                 accessLinks
-                .Where(x => x.Nickname.Contains(search, StringComparison.OrdinalIgnoreCase))
+                .Where(x => x.Name.Contains(search, StringComparison.OrdinalIgnoreCase))
                 .OrderBy(x => x.Type)
-                .ThenBy(x => x.Nickname);
+                .ThenBy(x => x.Name);
 
             return queriedAccessLinks.Select(l => l.Type switch
             {
-                ResultType.Folder => ResultManager.CreateFolderResult(l.Nickname, l.Path, l.Path, query, 100),
+                ResultType.Folder => ResultManager.CreateFolderResult(l.Name, l.Path, l.Path, query, 100),
                 ResultType.File => ResultManager.CreateFileResult(l.Path, query, 100),
                 _ => throw new ArgumentOutOfRangeException()
-
             }).ToList();
         }
 
         internal static List<Result> AccessLinkListAll(Query query, List<AccessLink> accessLinks)
             => accessLinks
                 .OrderBy(x => x.Type)
-                .ThenBy(x => x.Nickname)
+                .ThenBy(x => x.Name)
                 .Select(l => l.Type switch
                 {
-                    ResultType.Folder => ResultManager.CreateFolderResult(l.Nickname, l.Path, l.Path, query),
+                    ResultType.Folder => ResultManager.CreateFolderResult(l.Name, l.Path, l.Path, query),
                     ResultType.File => ResultManager.CreateFileResult(l.Path, query, 100),
                     _ => throw new ArgumentOutOfRangeException()
-
                 }).ToList();
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -7,7 +7,7 @@
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",
-  "Version": "1.7.3",
+  "Version": "1.7.4",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
Remove the brackets in folder name display from this:

![image](https://user-images.githubusercontent.com/26427004/114709218-a760c600-9d6f-11eb-8c3e-66fe0748e8fa.png)

To:

![image](https://user-images.githubusercontent.com/26427004/114709375-d7a86480-9d6f-11eb-8ea5-168a0ee1fdbd.png)
