### PR TITLE
Add API error msg method

### DIFF
--- a/Flow.Launcher.Plugin/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/IPublicAPI.cs
@@ -48,6 +48,13 @@ namespace Flow.Launcher.Plugin
         void CheckForNewUpdate();
 
         /// <summary>
+        /// Show the error message using Flow's standard error icon.
+        /// </summary>
+        /// <param name="title">Message title</param>
+        /// <param name="subTitle">Optional message subtitle</param>
+        void ShowMsgError(string title, string subTitle = "");
+
+        /// <summary>
         /// Show message box
         /// </summary>
         /// <param name="title">Message title</param>

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -84,6 +84,8 @@ namespace Flow.Launcher
 
         public Task ReloadAllPluginData() => PluginManager.ReloadData();
 
+        public void ShowMsgError(string title, string subTitle = "") => ShowMsg(title, subTitle, Constant.ErrorIcon, true);
+
         public void ShowMsg(string title, string subTitle = "", string iconPath = "") => ShowMsg(title, subTitle, iconPath, true);
 
         public void ShowMsg(string title, string subTitle, string iconPath, bool useMainWindowAsOwner = true)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
@@ -184,7 +184,7 @@ namespace Flow.Launcher.Plugin.Explorer
                             {
                                 var message = $"Fail to delete {fileOrFolder} at {record.FullPath}";
                                 LogException(message, e);
-                                Context.API.ShowMsg(message);
+                                Context.API.ShowMsgError(message);
                                 return false;
                             }
 
@@ -208,7 +208,7 @@ namespace Flow.Launcher.Plugin.Explorer
                             {
                                 var name = "Plugin: Folder";
                                 var message = $"File not found: {e.Message}";
-                                Context.API.ShowMsg(name, message);
+                                Context.API.ShowMsgError(name, message);
                             }
 
                             return true;
@@ -236,7 +236,7 @@ namespace Flow.Launcher.Plugin.Explorer
                     {
                         var message = $"Fail to open file at {record.FullPath}";
                         LogException(message, e);
-                        Context.API.ShowMsg(message);
+                        Context.API.ShowMsgError(message);
                         return false;
                     }
 
@@ -267,7 +267,7 @@ namespace Flow.Launcher.Plugin.Explorer
                     {
                         var message = $"Failed to open editor for file at {record.FullPath}";
                         LogException(message, e);
-                        Context.API.ShowMsg(message);
+                        Context.API.ShowMsgError(message);
                         return false;
                     }
                 },
@@ -326,7 +326,7 @@ namespace Flow.Launcher.Plugin.Explorer
                     {
                         var message = Context.API.GetTranslation("plugin_explorer_openindexingoptions_errormsg");
                         LogException(message, e);
-                        Context.API.ShowMsg(message);
+                        Context.API.ShowMsgError(message);
                         return false;
                     }
                 },

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -7,7 +7,7 @@
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",
-  "Version": "1.7.4",
+  "Version": "1.7.5",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
Add API error msg method to display message with Flow's standard error icon. This fixes the Explorer's confusing error message which shows with default Flow icon.