### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Windows may complain about security due to code not being signed, this will be c
 
 ## Plugins
 
-There is a [list of actively maintained plugins](https://github.com/Flow-Launcher/docs/Plugins.md) in the documentation section, some of which are integrated from other launchers.
+There is a [list of actively maintained plugins](https://github.com/Flow-Launcher/docs/blob/main/Plugins.md) in the documentation section, some of which are integrated from other launchers.
 
 ## Status
 


### PR DESCRIPTION
`https://github.com/Flow-Launcher/docs/Plugins.md` gives a 404 to me, I think we need that `blob/<branch>/.