### PR TITLE
fix Plugin Indicator when more than one query term is typed

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/Main.cs
@@ -10,6 +10,11 @@ namespace Flow.Launcher.Plugin.PluginIndicator
 
         public List<Result> Query(Query query)
         {
+            // if query contains more than one word, eg. github tips 
+            // user has decided to type something else rather than wanting to see the available action keywords
+            if (query.Terms.Length > 1)
+                return new List<Result>();
+
             var results = from keyword in PluginManager.NonGlobalPlugins.Keys
                           where keyword.StartsWith(query.Terms[0])
                           let metadata = PluginManager.NonGlobalPlugins[keyword].Metadata

--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Plugin Indicator",
   "Description": "Provide plugin actionword suggestion",
   "Author": "qianlifeng",
-  "Version": "1.1.2",
+  "Version": "1.1.3",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.PluginIndicator.dll",

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -214,7 +214,6 @@ namespace Flow.Launcher.Plugin.PluginsManager
                     }
                 };
 
-
             var results = resultsForUpdate
                 .Select(x =>
                     new Result


### PR DESCRIPTION
Problem:
The Plugin Indicator's result should not continue if user continues typing, otherwise when hitting enter would go to the github action keyword instead of google search git tips:
![image](https://user-images.githubusercontent.com/26427004/117647185-ffa0b180-b1cf-11eb-9bb7-d2c39da450c1.png)

Solution:
Only activates Plugin Indicator if the query has only one word/term:
![image](https://user-images.githubusercontent.com/26427004/117647517-66be6600-b1d0-11eb-960e-2b6d0120b7ab.png)

![image](https://user-images.githubusercontent.com/26427004/117647753-bb61e100-b1d0-11eb-80c6-2a7093408866.png)


 