### PR TITLE
Dev branch: Fix Explorer path display in settings

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -9,12 +9,12 @@
     <UserControl.Resources>
         <DataTemplate x:Key="ListViewTemplateAccessLinks">
             <TextBlock
-                Text="{Binding Nickname, Mode=OneTime}"
+                Text="{Binding Path, Mode=OneTime}"
                 Margin="0,5,0,5" />
         </DataTemplate>
         <DataTemplate x:Key="ListViewTemplateExcludedPaths">
             <TextBlock
-                Text="{Binding Nickname, Mode=OneTime}"
+                Text="{Binding Path, Mode=OneTime}"
                 Margin="0,5,0,5" />
         </DataTemplate>
         <DataTemplate x:Key="ListViewActionKeywords">

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
@@ -108,7 +108,7 @@ namespace Flow.Launcher.Plugin.Explorer.Views
         private void expActionKeywords_Click(object sender, RoutedEventArgs e)
         {
             if (expActionKeywords.IsExpanded)
-                expActionKeywords.Height = 215;
+                expActionKeywords.Height = 205;
 
             if (expExcludedPaths.IsExpanded)
                 expExcludedPaths.IsExpanded = false;
@@ -128,7 +128,7 @@ namespace Flow.Launcher.Plugin.Explorer.Views
         private void expAccessLinks_Click(object sender, RoutedEventArgs e)
         {
             if (expAccessLinks.IsExpanded)
-                expAccessLinks.Height = 215;
+                expAccessLinks.Height = 205;
 
             if (expExcludedPaths.IsExpanded)
                 expExcludedPaths.IsExpanded = false;


### PR DESCRIPTION
- fix view display referencing obsolete property for Quick Access Links and Index Search Excluded Paths controls

- adjusted the heights of Quick Access and Excluded Paths controls, otherwise Index Search Excluded Paths control drops too low

close #423 