### PR TITLE
Fix loading when no action keywords present for a plugin in user plugin setting

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/PluginSettings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/PluginSettings.cs
@@ -30,6 +30,11 @@ namespace Flow.Launcher.Infrastructure.UserSettings
                         metadata.ActionKeywords = settings.ActionKeywords;
                         metadata.ActionKeyword = settings.ActionKeywords[0];
                     }
+                    else
+                    {
+                        metadata.ActionKeywords = new List<string>();
+                        metadata.ActionKeyword = string.Empty;
+                    }
                     metadata.Disabled = settings.Disabled;
                     metadata.Priority = settings.Priority;
                 }

--- a/Flow.Launcher/ViewModel/PluginViewModel.cs
+++ b/Flow.Launcher/ViewModel/PluginViewModel.cs
@@ -1,7 +1,6 @@
 using System.Windows;
 using System.Windows.Media;
 using Flow.Launcher.Plugin;
-using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Infrastructure.Image;
 using Flow.Launcher.Core.Plugin;
 
@@ -10,8 +9,6 @@ namespace Flow.Launcher.ViewModel
     public class PluginViewModel : BaseModel
     {
         public PluginPair PluginPair { get; set; }
-
-        private readonly Internationalization _translator = InternationalizationManager.Instance;
 
         public ImageSource Image => ImageLoader.Load(PluginPair.Metadata.IcoPath);
         public bool PluginState

--- a/Flow.Launcher/ViewModel/PluginViewModel.cs
+++ b/Flow.Launcher/ViewModel/PluginViewModel.cs
@@ -22,7 +22,7 @@ namespace Flow.Launcher.ViewModel
                 PluginPair.Metadata.Disabled = !value; 
             }
         }
-        public Visibility ActionKeywordsVisibility => PluginPair.Metadata.ActionKeywords.Count > 1 ? Visibility.Collapsed : Visibility.Visible;
+        public Visibility ActionKeywordsVisibility => PluginPair.Metadata.ActionKeywords.Count == 1 ? Visibility.Visible : Visibility.Collapsed;
         public string InitilizaTime => PluginPair.Metadata.InitTime.ToString() + "ms";
         public string QueryTime => PluginPair.Metadata.AvgQueryTime + "ms";
         public string ActionKeywordsText => string.Join(Query.ActionKeywordSeperater, PluginPair.Metadata.ActionKeywords);

--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
@@ -13,8 +13,11 @@
     <system:String x:Key="flowlauncher_plugin_program_reindex">Reindex</system:String>
     <system:String x:Key="flowlauncher_plugin_program_indexing">Indexing</system:String>
     <system:String x:Key="flowlauncher_plugin_program_index_start">Index Start Menu</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_index_start_tooltip">When enabled, Flow will load programs from the start menu</system:String>
     <system:String x:Key="flowlauncher_plugin_program_index_registry">Index Registry</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_index_registry_tooltip">When enabled, Flow will load programs from the registry</system:String>
     <system:String x:Key="flowlauncher_plugin_program_enable_description">Enable Program Description</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable_description_tooltip">Disabling this will also stop Flow from searching via the program desciption</system:String>
     <system:String x:Key="flowlauncher_plugin_program_suffixes_header">Suffixes</system:String>
     <system:String x:Key="flowlauncher_plugin_program_max_depth_header">Max Depth</system:String>
 

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
@@ -16,9 +16,9 @@
         </Grid.RowDefinitions>
         <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Stretch">
             <StackPanel Orientation="Vertical" Width="250">
-                <CheckBox Name="StartMenuEnabled" IsChecked="{Binding EnableStartMenuSource}" Margin="5" Content="{DynamicResource flowlauncher_plugin_program_index_start}" />
-                <CheckBox Name="RegistryEnabled" IsChecked="{Binding EnableRegistrySource}"  Margin="5" Content="{DynamicResource flowlauncher_plugin_program_index_registry}" />
-                <CheckBox Name="DescriptionEnabled" IsChecked="{Binding EnableDescription}" Margin="5" Content="{DynamicResource flowlauncher_plugin_program_enable_description}" />
+                <CheckBox Name="StartMenuEnabled" IsChecked="{Binding EnableStartMenuSource}" Margin="5" Content="{DynamicResource flowlauncher_plugin_program_index_start}" ToolTip="{DynamicResource flowlauncher_plugin_program_index_start_tooltip}" />
+                <CheckBox Name="RegistryEnabled" IsChecked="{Binding EnableRegistrySource}"  Margin="5" Content="{DynamicResource flowlauncher_plugin_program_index_registry}" ToolTip="{DynamicResource flowlauncher_plugin_program_index_registry_tooltip}" />
+                <CheckBox Name="DescriptionEnabled" IsChecked="{Binding EnableDescription}" Margin="5" Content="{DynamicResource flowlauncher_plugin_program_enable_description}" ToolTip="{DynamicResource flowlauncher_plugin_program_enable_description_tooltip}" />
             </StackPanel>
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                 <Button Height="31" HorizontalAlignment="Right" Margin="10" Width="100" x:Name="btnLoadAllProgramSource" Click="btnLoadAllProgramSource_OnClick" Content="{DynamicResource flowlauncher_plugin_program_all_programs}" />

--- a/Plugins/Flow.Launcher.Plugin.Program/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Program/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Program",
   "Description": "Search programs in Flow.Launcher",
   "Author": "qianlifeng",
-  "Version": "1.5.1",
+  "Version": "1.5.2",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Program.dll",


### PR DESCRIPTION
Web Searches plugin allows users to fully delete all search setting entries, resulting in a scenario where there could be empty action keyword. Current code when flow starts up and there are no action keywords present for the plugin, it switches to populating the action keywords from metadata (plugin.json). 

For Web Searches plugin, this causes a mismatch between the flow's setting plugin action keywords data (has action keywords because repopulated from metadata) and the action keywords in Web Searches plugin's own setting (has no action keywords because all deleted).

close #432 

also added tool tips to make functionality clearer
