### PR TITLE
fix duplicate query searches from same global action keywords

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -21,8 +21,8 @@ namespace Flow.Launcher.Core.Plugin
         private static IEnumerable<PluginPair> _contextMenuPlugins;
 
         public static List<PluginPair> AllPlugins { get; private set; }
-        public static readonly List<PluginPair> GlobalPlugins = new List<PluginPair>();
-        public static readonly Dictionary<string, PluginPair> NonGlobalPlugins = new Dictionary<string, PluginPair>();
+        public static readonly HashSet<PluginPair> GlobalPlugins = new();
+        public static readonly Dictionary<string, PluginPair> NonGlobalPlugins = new ();
 
         public static IPublicAPI API { private set; get; }
 
@@ -143,7 +143,7 @@ namespace Flow.Launcher.Core.Plugin
             }
         }
 
-        public static List<PluginPair> ValidPluginsForQuery(Query query)
+        public static ICollection<PluginPair> ValidPluginsForQuery(Query query)
         {
             if (NonGlobalPlugins.ContainsKey(query.ActionKeyword))
             {
@@ -285,9 +285,7 @@ namespace Flow.Launcher.Core.Plugin
             if (oldActionkeyword == Query.GlobalPluginWildcardSign
                 && // Plugins may have multiple ActionKeywords that are global, eg. WebSearch
                 plugin.Metadata.ActionKeywords
-                    .Where(x => x == Query.GlobalPluginWildcardSign)
-                    .ToList()
-                    .Count == 1)
+                    .Count(x => x == Query.GlobalPluginWildcardSign) == 1)
             {
                 GlobalPlugins.Remove(plugin);
             }

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -118,7 +118,9 @@ namespace Flow.Launcher.Core.Plugin
             _contextMenuPlugins = GetPluginsForInterface<IContextMenu>();
             foreach (var plugin in AllPlugins)
             {
-                foreach (var actionKeyword in plugin.Metadata.ActionKeywords)
+                // set distinct on each plugin's action keywords helps only firing global(*) and action keywords once where a plugin
+                // has multiple global and action keywords because we will only add them here once.
+                foreach (var actionKeyword in plugin.Metadata.ActionKeywords.Distinct())
                 {
                     switch (actionKeyword)
                     {

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -494,21 +494,16 @@ namespace Flow.Launcher.ViewModel
                         }
                     }, currentCancellationToken);
 
-                    Task[] tasks = new Task[plugins.Count];
+                    // plugins is ICollection, meaning LINQ will get the Count and preallocate Array
+
+                    Task[] tasks = plugins.Select(plugin => plugin.Metadata.Disabled switch
+                    {
+                        false => QueryTask(plugin),
+                        true => Task.CompletedTask
+                    }).ToArray();
+
                     try
                     {
-                        for (var i = 0; i < plugins.Count; i++)
-                        {
-                            if (!plugins[i].Metadata.Disabled)
-                            {
-                                tasks[i] = QueryTask(plugins[i]);
-                            }
-                            else
-                            {
-                                tasks[i] = Task.CompletedTask; // Avoid Null
-                            }
-                        }
-
                         // Check the code, WhenAll will translate all type of IEnumerable or Collection to Array, so make an array at first
                         await Task.WhenAll(tasks);
                     }


### PR DESCRIPTION
When a plugin has multiple global action keywords, flow loops through the plugin's global (*) and action keywords and fire them off to query. This creates a scenario where a plugin with multiple global action keywords (*), for example 4, running the plugin search 4 times unnecessarily. This also could potentially have a performance cost to it.

This fix excludes adding multiple duplicate global and action keywords even if the plugin has 4 global action keywords, only fire search once.