### PR TITLE
change sequence of loading for shell plugin to avoid null reference

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -271,8 +271,8 @@ namespace Flow.Launcher.Plugin.Shell
         public void Init(PluginInitContext context)
         {
             this.context = context;
-            context.API.GlobalKeyboardEvent += API_GlobalKeyboardEvent;
             _settings = context.API.LoadSettingJsonStorage<Settings>();
+            context.API.GlobalKeyboardEvent += API_GlobalKeyboardEvent;
         }
 
         bool API_GlobalKeyboardEvent(int keyevent, int vkcode, SpecialKeyState state)

--- a/Plugins/Flow.Launcher.Plugin.Shell/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Shell/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Shell",
   "Description": "Provide executing commands from Flow Launcher",
   "Author": "qianlifeng",
-  "Version": "1.4.1",
+  "Version": "1.4.2",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Shell.dll",


### PR DESCRIPTION
fix a bug that setting hasn't been initialized but was accessed