### PR TITLE
Fix unparsed property

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonPRCModel.cs
+++ b/Flow.Launcher.Core/Plugin/JsonPRCModel.cs
@@ -51,8 +51,10 @@ namespace Flow.Launcher.Core.Plugin
 
     public class JsonRPCRequestModel : JsonRPCModelBase
     {
+        [JsonPropertyName("method")]
         public string Method { get; set; }
 
+        [JsonPropertyName("parameters")]
         public object[] Parameters { get; set; }
 
         public override string ToString()


### PR DESCRIPTION
It seems that System.Text.Json won't parse base class property? Add property name fix that. This change fix the broken python plugin callback.
#459 

Do we want a hotfix for that (though we don't have much python plugin)?