### PR TITLE
dev branch: switch to python 3.8.9 embeddable

### DIFF
--- a/Flow.Launcher.Core/Flow.Launcher.Core.csproj
+++ b/Flow.Launcher.Core/Flow.Launcher.Core.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Droplex" Version="1.2.0" />
+    <PackageReference Include="Droplex" Version="1.3.0" />
     <PackageReference Include="FSharp.Core" Version="4.7.1" />
     <PackageReference Include="squirrel.windows" Version="1.5.2" />
   </ItemGroup>

--- a/Flow.Launcher.Core/Flow.Launcher.Core.csproj
+++ b/Flow.Launcher.Core/Flow.Launcher.Core.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Droplex" Version="1.3.0" />
+    <PackageReference Include="Droplex" Version="1.3.1" />
     <PackageReference Include="FSharp.Core" Version="4.7.1" />
     <PackageReference Include="squirrel.windows" Version="1.5.2" />
   </ItemGroup>

--- a/Flow.Launcher.Core/Plugin/PluginsLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginsLoader.cs
@@ -209,7 +209,8 @@ namespace Flow.Launcher.Core.Plugin
                 }
                 else
                 {
-                    DroplexPackage.Drop(App.python3_9_1).Wait();
+                    // Python 3.8.9 is used for Windows 7 compatibility
+                    DroplexPackage.Drop(App.python_3_8_9_embeddable, Path.Combine(DataLocation.DataDirectory(), "Python Embeddable")).Wait();
 
                     var installedPythonDirectory =
                         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),

--- a/Flow.Launcher.Core/Plugin/PluginsLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginsLoader.cs
@@ -115,7 +115,7 @@ namespace Flow.Launcher.Core.Plugin
             if (!source.Any(o => o.Language.ToUpper() == AllowedLanguage.Python))
                 return new List<PluginPair>();
 
-            if (!string.IsNullOrEmpty(settings.PythonDirectory))
+            if (!string.IsNullOrEmpty(settings.PythonDirectory) && FilesFolders.LocationExists(settings.PythonDirectory))
                 return SetPythonPathForPluginPairs(source, Path.Combine(settings.PythonDirectory, PythonExecutable));
 
             var pythonPath = string.Empty;

--- a/Flow.Launcher.Core/Plugin/PluginsLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginsLoader.cs
@@ -18,8 +18,6 @@ namespace Flow.Launcher.Core.Plugin
 {
     public static class PluginsLoader
     {
-        public const string PATH = "PATH";
-        public const string Python = "python";
         public const string PythonExecutable = "pythonw.exe";
 
         public static List<PluginPair> Plugins(List<PluginMetadata> metadatas, PluginsSettings settings)
@@ -116,62 +114,6 @@ namespace Flow.Launcher.Core.Plugin
         {
             if (!source.Any(o => o.Language.ToUpper() == AllowedLanguage.Python))
                 return new List<PluginPair>();
-
-            // Try setting Constant.PythonPath first, either from
-            // PATH or from the given pythonDirectory
-            if (string.IsNullOrEmpty(settings.PythonDirectory))
-            {
-                var whereProcess = Process.Start(new ProcessStartInfo
-                {
-                    FileName = "where.exe",
-                    Arguments = "pythonw",
-                    RedirectStandardOutput = true,
-                    CreateNoWindow = true,
-                    UseShellExecute = false
-                });
-
-                var pythonPath = whereProcess?.StandardOutput.ReadToEnd().Trim();
-
-                if (!string.IsNullOrEmpty(pythonPath))
-                {
-                    pythonPath = FilesFolders.GetPreviousExistingDirectory(FilesFolders.LocationExists, pythonPath);
-                }
-
-                if (string.IsNullOrEmpty(pythonPath))
-                {
-                    var paths = Environment.GetEnvironmentVariable(PATH);
-
-                    pythonPath = paths?
-                        .Split(';')
-                        .FirstOrDefault(p => p.ToLower().Contains(Python));
-                }
-
-                if (!string.IsNullOrEmpty(pythonPath))
-                {
-                    Constant.PythonPath = Path.Combine(pythonPath, PythonExecutable);
-                    settings.PythonDirectory =
-                        FilesFolders.GetPreviousExistingDirectory(FilesFolders.LocationExists, Constant.PythonPath);
-                }
-                else
-                {
-                    Log.Error("PluginsLoader",
-                        "Failed to set Python path despite the environment variable PATH is found",
-                        "PythonPlugins");
-                }
-            }
-            else
-            {
-                var path = Path.Combine(settings.PythonDirectory, PythonExecutable);
-                if (File.Exists(path))
-                {
-                    Constant.PythonPath = path;
-                }
-                else
-                {
-                    Log.Error("PluginsLoader", $"Tried to automatically set from Settings.PythonDirectory " +
-                                               $"but can't find python executable in {path}", "PythonPlugins");
-                }
-            }
 
             if (string.IsNullOrEmpty(settings.PythonDirectory))
             {

--- a/Flow.Launcher.Core/Plugin/PluginsLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginsLoader.cs
@@ -209,12 +209,11 @@ namespace Flow.Launcher.Core.Plugin
                 }
                 else
                 {
-                    // Python 3.8.9 is used for Windows 7 compatibility
-                    DroplexPackage.Drop(App.python_3_8_9_embeddable, Path.Combine(DataLocation.DataDirectory(), "Python Embeddable")).Wait();
+                    var installedPythonDirectory = Path.Combine(DataLocation.DataDirectory(), "Python Embeddable");
 
-                    var installedPythonDirectory =
-                        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                            @"Programs\Python\Python39");
+                    // Python 3.8.9 is used for Windows 7 compatibility
+                    DroplexPackage.Drop(App.python_3_8_9_embeddable, installedPythonDirectory).Wait();
+
                     var pythonPath = Path.Combine(installedPythonDirectory, PythonExecutable);
                     if (FilesFolders.FileExists(pythonPath))
                     {


### PR DESCRIPTION
switch to using python 3.8.9 embeddable

1. prompt user if want to manually set python path or use Python Embeddable 3.8.9
2. if user chooses manually set, dialog box opens for selecting the folder
3. if chooses to let flow install python flow will download and extract the Python Embeddable and set it as the python path for use on python plugins