### PR TITLE
Handle incompatible plugins from major upgrade

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -79,6 +79,9 @@ namespace Flow.Launcher.Core.Plugin
         /// <param name="settings"></param>
         public static void LoadPlugins(PluginsSettings settings)
         {
+            if (PluginUpgrader.ForceUpgradeRequired(settings))
+                PluginUpgrader.ForceUpgrade(settings);
+
             _metadatas = PluginConfig.Parse(Directories);
             Settings = settings;
             Settings.UpdatePluginSettings(_metadatas);

--- a/Flow.Launcher.Core/Plugin/PluginUpgrader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginUpgrader.cs
@@ -1,0 +1,41 @@
+﻿using Flow.Launcher.Infrastructure.UserSettings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Flow.Launcher.Core.Plugin
+{
+    public static class PluginUpgrader
+    {
+        /// <summary>
+        /// Indicates these plugins need to have version greater than currently recorded
+        /// </summary>
+        private static readonly Dictionary<string, PluginVersion> PluginsUpgradeRequiredVersion = new()
+        {
+            { "D2D2C23B084D411DB66FE0C79D6C2A6E", new PluginVersion { ForceUpgradeRequiredVersion = "1.4.9" }  }
+        };
+
+        internal static void ForceUpgrade(PluginsSettings settings)
+        {
+            // if new version is added for PluginVersion.NewVersionDownloadUrl=> remove older plugin, download & extract
+            // if PluginVersion.NewVersionDownloadUrl does not contain new version url, disable plugin and prompt to notify user
+        }
+
+        internal static bool ForceUpgradeRequired(PluginsSettings settings)
+        {
+            return 
+                settings.Plugins
+                .Any(t1 => PluginsUpgradeRequiredVersion
+                            .Any(x => x.Key == t1.Key && x.Value.ForceUpgradeRequiredVersion == t1.Value.Version));
+        }
+    }
+
+    internal class PluginVersion
+    {
+        internal string ForceUpgradeRequiredVersion;
+
+        internal string NewVersionDownloadUrl = string.Empty;
+    }
+}


### PR DESCRIPTION
@Flow-Launcher/team thinking of how to handle incompatible plugins after a major upgrade. This is brought about by 1.8.0, but we would likely hit this again in the near future. This is for situations where it is not feasible to provide backwards compatibility, i.e. Everything plugin.

When a plugin is incompatible, I think we can do:

1. mark the plugins in the code that will be incompatible, this is for the dev making the major upgrade to do.
2. either provide a new plugin version release that these incompatible plugins have,
3. or disable these plugins
4. if a plugin has a new compatible version release then download, extract the new plugin and make it ready for use