### PR TITLE
[UI/UX] Remove bottom margin of General tab (Settings)

### DIFF
--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -36,7 +36,7 @@
 
     <TabControl Height="auto" SelectedIndex="0">
         <TabItem Header="{DynamicResource general}">
-            <ScrollViewer ui:ScrollViewerHelper.AutoHideScrollBars="{Binding AutoHideScrollBar, Mode=OneWay}" Margin="60,30,0,30">
+            <ScrollViewer ui:ScrollViewerHelper.AutoHideScrollBars="{Binding AutoHideScrollBar, Mode=OneWay}" Margin="60,30,0,0">
                 <StackPanel Orientation="Vertical">
                     <ui:ToggleSwitch Margin="10" IsOn="{Binding PortableMode}">
                         <TextBlock Text="{DynamicResource portableMode}" />


### PR DESCRIPTION
**Why:** The bottom margin (little gap) under General tab of Settings
make it hard to "feel" the space is scrollable or not.

New Windows 10 Settings style and websites tend to not have margin in the bottom

Related to: Issue [#443](https://github.com/Flow-Launcher/Flow.Launcher/issues/433) and PR #440

Before:
<img src="https://user-images.githubusercontent.com/10551242/122758189-b52c4d80-d2c2-11eb-952f-f774b6e5286e.png" width="400">

After:
<img src="https://user-images.githubusercontent.com/10551242/122758219-bd848880-d2c2-11eb-9fcf-d22185552e5f.png" width="400">

