### PR TITLE
[UI] Fix `Settings-window` doesn't show back up when minimized in taskbar by user

### DIFF
--- a/Flow.Launcher/Helper/SingletonWindowOpener.cs
+++ b/Flow.Launcher/Helper/SingletonWindowOpener.cs
@@ -11,7 +11,19 @@ namespace Flow.Launcher.Helper
             var window = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.GetType() == typeof(T))
                          ?? (T)Activator.CreateInstance(typeof(T), args);
             Application.Current.MainWindow.Hide();
+            
+            
+            // Fix UI bug
+            // If only use `window.Show()`, Settings-window doesn't show when minimized in taskbar 
+            // Not sure why this works tho
+            // Probably because, when `.Show()` failed, `window.WindowState == Minimized` (not `Normal`) 
+            // https://stackoverflow.com/a/59719760/4230390
+            // Not sure why need .Activate() too
+            window.WindowState = WindowState.Normal; 
             window.Show();
+            window.Activate();
+            
+            
             window.Focus();
 
             return (T)window;

--- a/Flow.Launcher/Helper/SingletonWindowOpener.cs
+++ b/Flow.Launcher/Helper/SingletonWindowOpener.cs
@@ -12,7 +12,6 @@ namespace Flow.Launcher.Helper
                          ?? (T)Activator.CreateInstance(typeof(T), args);
             Application.Current.MainWindow.Hide();
             
-            
             // Fix UI bug
             // Add `window.WindowState = WindowState.Normal`
             // If only use `window.Show()`, Settings-window doesn't show when minimized in taskbar 
@@ -21,7 +20,6 @@ namespace Flow.Launcher.Helper
             // https://stackoverflow.com/a/59719760/4230390
             window.WindowState = WindowState.Normal; 
             window.Show();
-            
             
             window.Focus();
 

--- a/Flow.Launcher/Helper/SingletonWindowOpener.cs
+++ b/Flow.Launcher/Helper/SingletonWindowOpener.cs
@@ -14,14 +14,13 @@ namespace Flow.Launcher.Helper
             
             
             // Fix UI bug
+            // Add `window.WindowState = WindowState.Normal`
             // If only use `window.Show()`, Settings-window doesn't show when minimized in taskbar 
             // Not sure why this works tho
-            // Probably because, when `.Show()` failed, `window.WindowState == Minimized` (not `Normal`) 
+            // Probably because, when `.Show()` fails, `window.WindowState == Minimized` (not `Normal`) 
             // https://stackoverflow.com/a/59719760/4230390
-            // Not sure why need .Activate() too
             window.WindowState = WindowState.Normal; 
             window.Show();
-            window.Activate();
             
             
             window.Focus();


### PR DESCRIPTION
Bug reproduce steps:
1. Right click on Flow icon in Notification Area, click settings
2. Minimize Settings-window (or Alt+Tab to different window)
3. Right click on Flow icon in Notification Area, click settings
4. Settings-window will not show back up 

I'm not really sure why this solution works tho 😅 

Maybe `.Show()` fails when `window.WindowState == Minimized` (not `Normal`)
Not sure why need .Activate() too

Ref: https://stackoverflow.com/a/59719760/4230390

Please delete unnecessary comments if this is too obvious to C# devs 😅 