### PR TITLE
Fix ContextMenu bug

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -211,7 +211,10 @@ namespace Flow.Launcher.ViewModel
             {
                 if (SelectedIsFromQueryResults())
                 {
-                    SelectedResults = ContextMenu;
+                    // When switch to ContextMenu from QueryResults, but no item being chosen, should do nothing
+                    // i.e. Shift+Enter/Ctrl+O right after Alt + Space should do nothing
+                    if (SelectedResults.SelectedItem != null)
+                        SelectedResults = ContextMenu;
                 }
                 else
                 {


### PR DESCRIPTION
When `Shift+Enter/Ctrl+O` right after `Alt+Space` (input query (QueryTextBox?) is **empty**, i.e. `SelectedItems == null`), Flow still switch to ContextMenu mode, which cause a really weird UX, user sees nothing happen on the screen but the mode is switched.

When switch to ContextMenu from QueryResults, but no item being chosen, should do nothing
i.e. Shift+Enter/Ctrl+O right after Alt + Space should do nothing

Solution: Detect SelectedItems == null

