### PR TITLE
Remove top margin of General tab (Settings)

### DIFF
--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -36,8 +36,8 @@
 
     <TabControl Height="auto" SelectedIndex="0">
         <TabItem Header="{DynamicResource general}">
-            <ScrollViewer ui:ScrollViewerHelper.AutoHideScrollBars="{Binding AutoHideScrollBar, Mode=OneWay}" Margin="60,30,0,0">
-                <StackPanel Orientation="Vertical">
+            <ScrollViewer ui:ScrollViewerHelper.AutoHideScrollBars="{Binding AutoHideScrollBar, Mode=OneWay}" Margin="60,0,0,0">
+                <StackPanel Orientation="Vertical" Margin="0,30,0,0">
                     <ui:ToggleSwitch Margin="10" IsOn="{Binding PortableMode}">
                         <TextBlock Text="{DynamicResource portableMode}" />
                     </ui:ToggleSwitch>


### PR DESCRIPTION
Why?
Seems cleaner and similar UX to other apps/website

Before:
<img src="https://user-images.githubusercontent.com/10551242/123534012-0cf40a00-d744-11eb-85c9-5f71df79d5f2.gif" width="400">

After:
<img src="https://user-images.githubusercontent.com/10551242/123534019-141b1800-d744-11eb-8cac-a2e308312b88.gif" width="400">
