### PR TITLE
Make progress bar bigger, solid, and always visible when have any queries running

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -97,9 +97,9 @@
                     <svgc:SvgControl Source="{Binding Image}" HorizontalAlignment="Right" Width="48" Height="48"
                                      Background="Transparent"/>
                 </Grid>
-                <Line x:Name="ProgressBar" HorizontalAlignment="Right"
+                <Line x:Name="ProgressBar" HorizontalAlignment="Left"
                   Style="{DynamicResource PendingLineStyle}" Visibility="{Binding ProgressBarVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
-                  Y1="0" Y2="0" X2="100" Height="2" Width="752" StrokeThickness="1">
+                  Y1="0" Y2="0" X1="0" X2="752" Height="8" Width="752" StrokeThickness="15">
                 </Line>
                 <ContentControl>
                     <flowlauncher:ResultListBox x:Name="ResultListBox" DataContext="{Binding Results}" PreviewMouseDown="OnPreviewMouseButtonDown" />

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -199,15 +199,20 @@ namespace Flow.Launcher
 
         private void InitProgressbarAnimation()
         {
-            var da = new DoubleAnimation(ProgressBar.X2, ActualWidth + 100,
-                new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
-            var da1 = new DoubleAnimation(ProgressBar.X1, ActualWidth, new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
-            Storyboard.SetTargetProperty(da, new PropertyPath("(Line.X2)"));
-            Storyboard.SetTargetProperty(da1, new PropertyPath("(Line.X1)"));
-            _progressBarStoryboard.Children.Add(da);
-            _progressBarStoryboard.Children.Add(da1);
-            _progressBarStoryboard.RepeatBehavior = RepeatBehavior.Forever;
-
+            var da = new DoubleAnimation(ProgressBar.X2, ActualWidth+100, new Duration(new TimeSpan(0, 0, 0, 0, 30000)));
+            var da1 = new DoubleAnimation(ProgressBar.X1, ActualWidth, new Duration(new TimeSpan(0, 0, 0, 0, 30000)));
+            // Storyboard.SetTargetProperty(da, new PropertyPath("(Line.X2)"));
+            // Storyboard.SetTargetProperty(da1, new PropertyPath("(Line.X1)"));
+            
+            
+            
+            // _progressBarStoryboard.Children.Add(da);
+            // _progressBarStoryboard.Children.Add(da1);
+            // _progressBarStoryboard.RepeatBehavior = RepeatBehavior.Forever;
+            // ProgressBar.BeginStoryboard(_progressBarStoryboard);
+            
+            
+            
             _viewModel.ProgressBarVisibility = Visibility.Hidden;
             isProgressBarStoryboardPaused = true;
         }

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -489,7 +489,7 @@ namespace Flow.Launcher.ViewModel
                             return;
                     }
 
-                    _ = Task.Delay(200, currentCancellationToken).ContinueWith(_ =>
+                    _ = Task.Delay(1, currentCancellationToken).ContinueWith(_ =>
                     {
                         // start the progress bar if query takes more than 200 ms and this is the current running query and it didn't finish yet
                         if (!currentCancellationToken.IsCancellationRequested && _isQueryRunning)


### PR DESCRIPTION
Why:
For experiment, seems better UX

An experiment for https://github.com/Flow-Launcher/Flow.Launcher/issues/55

> This kind of like a experiment, I want to see what is the effect of removing the 200ms delay and make progress bar extremely obvious. The result seems make the UX much better, feel snappier, more reliable 😊

The difference is more obvious when using plugins that have high latency like Explorer or Currency