### PR TITLE
fix unintended use of direct startInfo.Arguments in context menu

### DIFF
--- a/Flow.Launcher.Core/Plugin/PythonPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/PythonPlugin.cs
@@ -61,7 +61,7 @@ namespace Flow.Launcher.Core.Plugin
             {
                 Method = "context_menu", Parameters = new object[] {selectedResult.ContextData},
             };
-            _startInfo.Arguments = $"-B \"{context.CurrentPluginMetadata.ExecuteFilePath}\" \"{request}\"";
+            _startInfo.ArgumentList[2] = request.ToString();
             _startInfo.WorkingDirectory = context.CurrentPluginMetadata.PluginDirectory;
 
             // TODO: Async Action


### PR DESCRIPTION
This will cause we are unable to query once loading a context menu for the specific python plugin.