### PR TITLE
Fix flow's hotkey not working correctly after changing in settings

### DIFF
--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -68,6 +68,9 @@ namespace Flow.Launcher
 
                 PluginManager.LoadPlugins(_settings.PluginSettings);
                 _mainVM = new MainViewModel(_settings);
+
+                HotKeyMapper.Initialize(_mainVM);
+
                 API = new PublicAPIInstance(_settingsVM, _mainVM, _alphabet);
 
                 Http.API = API;

--- a/Flow.Launcher/CustomQueryHotkeySetting.xaml.cs
+++ b/Flow.Launcher/CustomQueryHotkeySetting.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Flow.Launcher.Core.Resource;
+using Flow.Launcher.Helper;
 using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Infrastructure.UserSettings;
 using NHotkey;
@@ -52,11 +53,7 @@ namespace Flow.Launcher
                 };
                 _settings.CustomPluginHotkeys.Add(pluginHotkey);
 
-                SetHotkey(ctlHotkey.CurrentHotkey, delegate
-                {
-                    App.API.ChangeQuery(pluginHotkey.ActionKeyword);
-                    ShowMainWindow();
-                });
+                HotKeyMapper.SetCustomQueryHotkey(pluginHotkey);
             }
             else
             {
@@ -69,22 +66,11 @@ namespace Flow.Launcher
                 updateCustomHotkey.ActionKeyword = tbAction.Text;
                 updateCustomHotkey.Hotkey = ctlHotkey.CurrentHotkey.ToString();
                 //remove origin hotkey
-                RemoveHotkey(oldHotkey);
-                SetHotkey(new HotkeyModel(updateCustomHotkey.Hotkey), delegate
-                {
-                    App.API.ChangeQuery(updateCustomHotkey.ActionKeyword);
-                    ShowMainWindow();
-                });
+                HotKeyMapper.RemoveHotkey(oldHotkey);
+                HotKeyMapper.SetCustomQueryHotkey(updateCustomHotkey);
             }
 
             Close();
-
-            static void ShowMainWindow()
-            {
-                Window mainWindow = Application.Current.MainWindow;
-                mainWindow.Visibility = Visibility.Visible;
-                mainWindow.Focus();
-            }
         }
 
         public void UpdateItem(CustomPluginHotkey item)
@@ -107,28 +93,6 @@ namespace Flow.Launcher
         {
             App.API.ChangeQuery(tbAction.Text);
             Application.Current.MainWindow.Visibility = Visibility.Visible;
-        }
-
-        private void RemoveHotkey(string hotkeyStr)
-        {
-            if (!string.IsNullOrEmpty(hotkeyStr))
-            {
-                HotkeyManager.Current.Remove(hotkeyStr);
-            }
-        }
-
-        private void SetHotkey(HotkeyModel hotkey, EventHandler<HotkeyEventArgs> action)
-        {
-            string hotkeyStr = hotkey.ToString();
-            try
-            {
-                HotkeyManager.Current.AddOrReplace(hotkeyStr, hotkey.CharKey, hotkey.ModifierKeys, action);
-            }
-            catch (Exception)
-            {
-                string errorMsg = string.Format(InternationalizationManager.Instance.GetTranslation("registerHotkeyFailed"), hotkeyStr);
-                MessageBox.Show(errorMsg);
-            }
         }
 
         private void cmdEsc_OnPress(object sender, ExecutedRoutedEventArgs e)

--- a/Flow.Launcher/CustomQueryHotkeySetting.xaml.cs
+++ b/Flow.Launcher/CustomQueryHotkeySetting.xaml.cs
@@ -2,8 +2,6 @@
 using Flow.Launcher.Helper;
 using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Infrastructure.UserSettings;
-using NHotkey;
-using NHotkey.Wpf;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/Flow.Launcher/CustomQueryHotkeySetting.xaml.cs
+++ b/Flow.Launcher/CustomQueryHotkeySetting.xaml.cs
@@ -91,6 +91,8 @@ namespace Flow.Launcher
         {
             App.API.ChangeQuery(tbAction.Text);
             Application.Current.MainWindow.Visibility = Visibility.Visible;
+            Application.Current.MainWindow.Focus();
+
         }
 
         private void cmdEsc_OnPress(object sender, ExecutedRoutedEventArgs e)

--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -20,7 +20,7 @@ namespace Flow.Launcher.Helper
             settings = mainViewModel._settings;
 
             SetHotkey(settings.Hotkey, OnHotkey);
-            SetCustomPluginHotkey();
+            LoadCustomPluginHotkey();
         }
 
         private static void SetHotkey(string hotkeyStr, EventHandler<HotkeyEventArgs> action)
@@ -91,22 +91,29 @@ namespace Flow.Launcher.Helper
             }
         }
 
-        private static void SetCustomPluginHotkey()
+        internal static void LoadCustomPluginHotkey()
         {
-            if (settings.CustomPluginHotkeys == null) return;
+            if (settings.CustomPluginHotkeys == null)
+                return;
+
             foreach (CustomPluginHotkey hotkey in settings.CustomPluginHotkeys)
             {
-                SetHotkey(hotkey.Hotkey, (s, e) =>
-                {
-                    if (ShouldIgnoreHotkeys())
-                        return;
-
-                    UpdateLastQUeryMode();
-
-                    mainViewModel.MainWindowVisibility = Visibility.Visible;
-                    mainViewModel.ChangeQueryText(hotkey.ActionKeyword);
-                });
+                SetCustomQueryHotkey(hotkey);
             }
+        }
+
+        internal static void SetCustomQueryHotkey(CustomPluginHotkey hotkey)
+        {
+            SetHotkey(hotkey.Hotkey, (s, e) =>
+            {
+                if (ShouldIgnoreHotkeys())
+                    return;
+
+                UpdateLastQUeryMode();
+
+                mainViewModel.MainWindowVisibility = Visibility.Visible;
+                mainViewModel.ChangeQueryText(hotkey.ActionKeyword);
+            });
         }
     }
 }

--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -1,0 +1,110 @@
+﻿using Flow.Launcher.Infrastructure.Hotkey;
+using Flow.Launcher.Infrastructure.UserSettings;
+using System;
+using NHotkey;
+using NHotkey.Wpf;
+using Flow.Launcher.Core.Resource;
+using System.Windows;
+using Flow.Launcher.ViewModel;
+
+namespace Flow.Launcher.Helper
+{
+    internal static class HotKeyMapper
+    {
+        private static Settings settings;
+        private static MainViewModel mainViewModel;
+
+        internal static void Initialize(MainViewModel mainVM)
+        {
+            mainViewModel = mainVM;
+            settings = mainViewModel._settings;
+
+            SetHotkey(settings.Hotkey, OnHotkey);
+            SetCustomPluginHotkey();
+        }
+
+        private static void SetHotkey(string hotkeyStr, EventHandler<HotkeyEventArgs> action)
+        {
+            var hotkey = new HotkeyModel(hotkeyStr);
+            SetHotkey(hotkey, action);
+        }
+
+        internal static void SetHotkey(HotkeyModel hotkey, EventHandler<HotkeyEventArgs> action)
+        {
+            string hotkeyStr = hotkey.ToString();
+            try
+            {
+                HotkeyManager.Current.AddOrReplace(hotkeyStr, hotkey.CharKey, hotkey.ModifierKeys, action);
+            }
+            catch (Exception)
+            {
+                string errorMsg =
+                    string.Format(InternationalizationManager.Instance.GetTranslation("registerHotkeyFailed"),
+                        hotkeyStr);
+                MessageBox.Show(errorMsg);
+            }
+        }
+
+        internal static void RemoveHotkey(string hotkeyStr)
+        {
+            if (!string.IsNullOrEmpty(hotkeyStr))
+            {
+                HotkeyManager.Current.Remove(hotkeyStr);
+            }
+        }
+
+        internal static void OnHotkey(object sender, HotkeyEventArgs e)
+        {
+            if (!ShouldIgnoreHotkeys())
+            {
+                if (settings.LastQueryMode == LastQueryMode.Empty)
+                {
+                    mainViewModel.ChangeQueryText(string.Empty);
+                }
+                else if (settings.LastQueryMode == LastQueryMode.Preserved)
+                {
+                    mainViewModel.LastQuerySelected = true;
+                }
+                else if (settings.LastQueryMode == LastQueryMode.Selected)
+                {
+                    mainViewModel.LastQuerySelected = false;
+                }
+                else
+                {
+                    throw new ArgumentException($"wrong LastQueryMode: <{settings.LastQueryMode}>");
+                }
+
+                mainViewModel.ToggleFlowLauncher();
+                e.Handled = true;
+            }
+        }
+
+        /// <summary>
+        /// Checks if Flow Launcher should ignore any hotkeys
+        /// </summary>
+        /// <returns></returns>
+        private static bool ShouldIgnoreHotkeys()
+        {
+            //double if to omit calling win32 function
+            if (settings.IgnoreHotkeysOnFullscreen)
+                if (WindowsInteropHelper.IsWindowFullscreen())
+                    return true;
+
+            return false;
+        }
+
+        private static void SetCustomPluginHotkey()
+        {
+            if (settings.CustomPluginHotkeys == null) return;
+            foreach (CustomPluginHotkey hotkey in settings.CustomPluginHotkeys)
+            {
+                SetHotkey(hotkey.Hotkey, (s, e) =>
+                {
+                    if (ShouldIgnoreHotkeys()) return;
+                    mainViewModel.MainWindowVisibility = Visibility.Visible;
+                    mainViewModel.ChangeQueryText(hotkey.ActionKeyword);
+                });
+            }
+        }
+    }
+}

--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -1,4 +1,4 @@
-﻿using Flow.Launcher.Infrastructure.Hotkey;
+using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Infrastructure.UserSettings;
 using System;
 using NHotkey;
@@ -82,15 +82,9 @@ namespace Flow.Launcher.Helper
         /// <summary>
         /// Checks if Flow Launcher should ignore any hotkeys
         /// </summary>
-        /// <returns></returns>
         private static bool ShouldIgnoreHotkeys()
         {
-            //double if to omit calling win32 function
-            if (settings.IgnoreHotkeysOnFullscreen)
-                if (WindowsInteropHelper.IsWindowFullscreen())
-                    return true;
-
-            return false;
+            return settings.IgnoreHotkeysOnFullscreen && WindowsInteropHelper.IsWindowFullscreen();
         }
 
         private static void SetCustomPluginHotkey()

--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -109,8 +109,6 @@ namespace Flow.Launcher.Helper
                 if (ShouldIgnoreHotkeys())
                     return;
 
-                UpdateLastQUeryMode();
-
                 mainViewModel.MainWindowVisibility = Visibility.Visible;
                 mainViewModel.ChangeQueryText(hotkey.ActionKeyword);
             });

--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -113,5 +113,24 @@ namespace Flow.Launcher.Helper
                 mainViewModel.ChangeQueryText(hotkey.ActionKeyword);
             });
         }
+
+        internal static bool CheckAvailability(HotkeyModel currentHotkey)
+        {
+            try
+            {
+                HotkeyManager.Current.AddOrReplace("HotkeyAvailabilityTest", currentHotkey.CharKey, currentHotkey.ModifierKeys, (sender, e) => { });
+
+                return true;
+            }
+            catch
+            {
+            }
+            finally
+            {
+                HotkeyManager.Current.Remove("HotkeyAvailabilityTest");
+            }
+
+            return false;
+        }
     }
 }

--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -57,22 +57,7 @@ namespace Flow.Launcher.Helper
         {
             if (!ShouldIgnoreHotkeys())
             {
-                if (settings.LastQueryMode == LastQueryMode.Empty)
-                {
-                    mainViewModel.ChangeQueryText(string.Empty);
-                }
-                else if (settings.LastQueryMode == LastQueryMode.Preserved)
-                {
-                    mainViewModel.LastQuerySelected = true;
-                }
-                else if (settings.LastQueryMode == LastQueryMode.Selected)
-                {
-                    mainViewModel.LastQuerySelected = false;
-                }
-                else
-                {
-                    throw new ArgumentException($"wrong LastQueryMode: <{settings.LastQueryMode}>");
-                }
+                UpdateLastQUeryMode();
 
                 mainViewModel.ToggleFlowLauncher();
                 e.Handled = true;
@@ -87,6 +72,25 @@ namespace Flow.Launcher.Helper
             return settings.IgnoreHotkeysOnFullscreen && WindowsInteropHelper.IsWindowFullscreen();
         }
 
+        private static void UpdateLastQUeryMode()
+        {
+            switch(settings.LastQueryMode)
+            {
+                case LastQueryMode.Empty:
+                    mainViewModel.ChangeQueryText(string.Empty);
+                    break;
+                case LastQueryMode.Preserved:
+                    mainViewModel.LastQuerySelected = true;
+                    break;
+                case LastQueryMode.Selected:
+                    mainViewModel.LastQuerySelected = false;
+                    break;
+                default:
+                    throw new ArgumentException($"wrong LastQueryMode: <{settings.LastQueryMode}>");
+
+            }
+        }
+
         private static void SetCustomPluginHotkey()
         {
             if (settings.CustomPluginHotkeys == null) return;
@@ -94,7 +98,11 @@ namespace Flow.Launcher.Helper
             {
                 SetHotkey(hotkey.Hotkey, (s, e) =>
                 {
-                    if (ShouldIgnoreHotkeys()) return;
+                    if (ShouldIgnoreHotkeys())
+                        return;
+
+                    UpdateLastQUeryMode();
+
                     mainViewModel.MainWindowVisibility = Visibility.Visible;
                     mainViewModel.ChangeQueryText(hotkey.ActionKeyword);
                 });

--- a/Flow.Launcher/HotkeyControl.xaml
+++ b/Flow.Launcher/HotkeyControl.xaml
@@ -10,7 +10,7 @@
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="150" />
-            <ColumnDefinition Width="120" />
+            <ColumnDefinition Width="125" />
         </Grid.ColumnDefinitions>
         <TextBox x:Name="tbHotkey" TabIndex="100" VerticalContentAlignment="Center" Grid.Column="0"
                  PreviewKeyDown="TbHotkey_OnPreviewKeyDown" input:InputMethod.IsInputMethodEnabled="False"/>

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -21,7 +21,9 @@ namespace Flow.Launcher
         protected virtual void OnHotkeyChanged()
         {
             EventHandler handler = HotkeyChanged;
-            if (handler != null) handler(this, EventArgs.Empty);
+
+            if (handler != null)
+                handler(this, EventArgs.Empty);
         }
 
         public HotkeyControl()

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -4,8 +4,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
-using NHotkey.Wpf;
 using Flow.Launcher.Core.Resource;
+using Flow.Launcher.Helper;
 using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Plugin;
 
@@ -92,24 +92,7 @@ namespace Flow.Launcher
             SetHotkey(new HotkeyModel(keyStr), triggerValidate);
         }
 
-        private bool CheckHotkeyAvailability()
-        {
-            try
-            {
-                HotkeyManager.Current.AddOrReplace("HotkeyAvailabilityTest", CurrentHotkey.CharKey, CurrentHotkey.ModifierKeys, (sender, e) => { });
-
-                return true;
-            }
-            catch
-            {
-            }
-            finally
-            {
-                HotkeyManager.Current.Remove("HotkeyAvailabilityTest");
-            }
-
-            return false;
-        }
+        private bool CheckHotkeyAvailability() => HotKeyMapper.CheckAvailability(CurrentHotkey);
 
         public new bool IsFocused
         {

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -18,13 +18,7 @@ namespace Flow.Launcher
 
         public event EventHandler HotkeyChanged;
 
-        protected virtual void OnHotkeyChanged()
-        {
-            EventHandler handler = HotkeyChanged;
-
-            if (handler != null)
-                handler(this, EventArgs.Empty);
-        }
+        protected virtual void OnHotkeyChanged() => HotkeyChanged?.Invoke(this, EventArgs.Empty);
 
         public HotkeyControl()
         {

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -46,7 +46,7 @@
     <system:String x:Key="browserMorePlugins">Find more plugins</system:String>
     <system:String x:Key="enable">Enable</system:String>
     <system:String x:Key="disable">Disable</system:String>
-    <system:String x:Key="actionKeywords">Action keyword:</system:String>
+    <system:String x:Key="actionKeywords">Query</system:String>
     <system:String x:Key="currentActionKeywords">Current action keyword:</system:String>
     <system:String x:Key="newActionKeyword">New action keyword:</system:String>
     <system:String x:Key="currentPriority">Current Priority:</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -139,7 +139,7 @@
     <system:String x:Key="update">Update</system:String>
 
     <!--Hotkey Control-->
-    <system:String x:Key="hotkeyUnavailable">Hotkey unavailable</system:String>
+    <system:String x:Key="hotkeyUnavailable">Hotkey Unavailable</system:String>
 
     <!--Crash Reporter-->
     <system:String x:Key="reportWindow_version">Version</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -46,7 +46,7 @@
     <system:String x:Key="browserMorePlugins">Find more plugins</system:String>
     <system:String x:Key="enable">Enable</system:String>
     <system:String x:Key="disable">Disable</system:String>
-    <system:String x:Key="actionKeywords">Query</system:String>
+    <system:String x:Key="actionKeywords">Action keyword:</system:String>
     <system:String x:Key="currentActionKeywords">Current action keyword:</system:String>
     <system:String x:Key="newActionKeyword">New action keyword:</system:String>
     <system:String x:Key="currentPriority">Current Priority:</system:String>
@@ -73,6 +73,7 @@
     <system:String x:Key="openResultModifiers">Open Result Modifiers</system:String>
     <system:String x:Key="showOpenResultHotkey">Show Hotkey</system:String>
     <system:String x:Key="customQueryHotkey">Custom Query Hotkey</system:String>
+    <system:String x:Key="customQuery">Query</system:String>
     <system:String x:Key="delete">Delete</system:String>
     <system:String x:Key="edit">Edit</system:String>
     <system:String x:Key="add">Add</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -51,6 +51,7 @@
     <system:String x:Key="newActionKeyword">New action keyword:</system:String>
     <system:String x:Key="currentPriority">Current Priority:</system:String>
     <system:String x:Key="newPriority">New Priority:</system:String>
+    <system:String x:Key="priority">Priority:</system:String>
     <system:String x:Key="pluginDirectory">Plugin Directory</system:String>
     <system:String x:Key="author">Author</system:String>
     <system:String x:Key="plugin_init_time">Init time:</system:String>

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -180,7 +180,7 @@
                                        Text="{Binding PluginPair.Metadata.Description}"
                                        Grid.Row="1" Opacity="0.5" Grid.Column="2" />
                             <DockPanel Grid.ColumnSpan="2" Grid.Row="2" Margin="0 10 0 8" HorizontalAlignment="Right">
-                                <TextBlock Text="Priority" Margin="15,0,0,0" MaxWidth="100"/>
+                                <TextBlock Text="{DynamicResource priority}" Margin="15,0,0,0" MaxWidth="100"/>
                                 <TextBlock Text="{Binding Priority}"
                                             ToolTip="Change Plugin Results Priority"
                                             Margin="5 0 0 0" Cursor="Hand" Foreground="Blue"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -365,7 +365,7 @@
                                     </DataTemplate>
                                 </GridViewColumn.CellTemplate>
                             </GridViewColumn>
-                            <GridViewColumn Header="{DynamicResource actionKeywords}" Width="546">
+                            <GridViewColumn Header="{DynamicResource customQuery}" Width="546">
                                 <GridViewColumn.CellTemplate>
                                     <DataTemplate DataType="userSettings:CustomPluginHotkey">
                                         <TextBlock Text="{Binding ActionKeyword}" />

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -5,16 +5,14 @@ using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Navigation;
 using Microsoft.Win32;
-using NHotkey;
-using NHotkey.Wpf;
 using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Infrastructure;
-using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.SharedCommands;
 using Flow.Launcher.ViewModel;
+using Flow.Launcher.Helper;
 
 namespace Flow.Launcher
 {
@@ -127,42 +125,10 @@ namespace Flow.Launcher
         {
             if (HotkeyControl.CurrentHotkeyAvailable)
             {
-                SetHotkey(HotkeyControl.CurrentHotkey, (o, args) =>
-                {
-                    if (!Application.Current.MainWindow.IsVisible)
-                    {
-                        Application.Current.MainWindow.Visibility = Visibility.Visible;
-                    }
-                    else
-                    {
-                        Application.Current.MainWindow.Visibility = Visibility.Hidden;
-                    }
-                });
-                RemoveHotkey(settings.Hotkey);
+
+                HotKeyMapper.SetHotkey(HotkeyControl.CurrentHotkey, HotKeyMapper.OnHotkey);
+                HotKeyMapper.RemoveHotkey(settings.Hotkey);
                 settings.Hotkey = HotkeyControl.CurrentHotkey.ToString();
-            }
-        }
-
-        void SetHotkey(HotkeyModel hotkey, EventHandler<HotkeyEventArgs> action)
-        {
-            string hotkeyStr = hotkey.ToString();
-            try
-            {
-                HotkeyManager.Current.AddOrReplace(hotkeyStr, hotkey.CharKey, hotkey.ModifierKeys, action);
-            }
-            catch (Exception)
-            {
-                string errorMsg =
-                    string.Format(InternationalizationManager.Instance.GetTranslation("registerHotkeyFailed"), hotkeyStr);
-                MessageBox.Show(errorMsg);
-            }
-        }
-
-        void RemoveHotkey(string hotkeyStr)
-        {
-            if (!string.IsNullOrEmpty(hotkeyStr))
-            {
-                HotkeyManager.Current.Remove(hotkeyStr);
             }
         }
 
@@ -183,7 +149,7 @@ namespace Flow.Launcher
                     MessageBoxButton.YesNo) == MessageBoxResult.Yes)
             {
                 settings.CustomPluginHotkeys.Remove(item);
-                RemoveHotkey(item.Hotkey);
+                HotKeyMapper.RemoveHotkey(item.Hotkey);
             }
         }
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -567,7 +567,6 @@ namespace Flow.Launcher.ViewModel
             }
         }
 
-
         private void RemoveOldQueryResults(Query query)
         {
             if (_lastQuery.ActionKeyword != query.ActionKeyword)
@@ -710,7 +709,6 @@ namespace Flow.Launcher.ViewModel
                 token = default;
             }
 #endif
-
 
             foreach (var metaResults in resultsForUpdates)
             {

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -6,8 +6,6 @@ using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using System.Windows;
 using System.Windows.Input;
-using NHotkey;
-using NHotkey.Wpf;
 using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Helper;


### PR DESCRIPTION
**Description**
After changing the hotkey that triggers flow's query window, the query window that get triggered by new hotkey can not be used- unable to move up and down on the result list, unable to move the cursor on the query test box, the query text is not select if you have this option enabled, and query window's position is not in the same place as previous. 

**Changes**
- consolidated duplicate hotkey behaviour code into one class HotkeyMapper
- added focus to custom query hotkey preview so can be used when previewing
- behaviour should be the same for when a hot key/custom query hotkey is changed and when these hotkeys are loaded during startup

**How to reproduce**
Change hotkey. Trigger the query window, then unable to use it with the issues described above.

**Tested with this PR:**
- changed hotkey and made sure new hotkey works afterwards
- changed hotkey and check all 'Last Query Style' options are working afterwards
- changed hotkey and set ignore hotkey in full screen mode
- able to trigger Custom Query Hotkeys and query window position is correct

Close #166