### PR TITLE
fix Custom Plugin Hotkey not deselect text

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -79,7 +79,6 @@
                     Style="{DynamicResource QueryBoxStyle}"
                      Text="{Binding QueryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                      PreviewDragOver="OnPreviewDragOver"
-                     TextChanged="OnTextChanged"
                      AllowDrop="True"
                      Visibility="Visible"
                     Background="Transparent"

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -125,6 +125,13 @@ namespace Flow.Launcher
 
                         break;
                     }
+                    case nameof(MainViewModel.QueryTextCursorMovedToEnd):
+                        if (_viewModel.QueryTextCursorMovedToEnd)
+                        {
+                            MoveQueryTextToEnd();
+                            _viewModel.QueryTextCursorMovedToEnd = false;
+                        }
+                        break;
                 }
             };
             _settings.PropertyChanged += (o, e) =>
@@ -329,13 +336,9 @@ namespace Flow.Launcher
             }
         }
 
-        private void OnTextChanged(object sender, TextChangedEventArgs e)
+        private void MoveQueryTextToEnd()
         {
-            if (_viewModel.QueryTextCursorMovedToEnd)
-            {
-                QueryTextBox.CaretIndex = QueryTextBox.Text.Length;
-                _viewModel.QueryTextCursorMovedToEnd = false;
-            }
+            QueryTextBox.CaretIndex = QueryTextBox.Text.Length;
         }
     }
 }

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -289,8 +289,8 @@ namespace Flow.Launcher.ViewModel
         /// <param name="queryText"></param>
         public void ChangeQueryText(string queryText)
         {
-            QueryTextCursorMovedToEnd = true;
             QueryText = queryText;
+            QueryTextCursorMovedToEnd = true;
         }
 
         public bool LastQuerySelected { get; set; }


### PR DESCRIPTION
fix Custom Plugin Hotkey not deselect text when current query text is equal to custom plugin hotkey.

The part I describe in #565.