### PR TITLE
[Test.Explorer] Fix hard-coded  LCID (1033 - en-US)

### DIFF
--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -133,6 +133,13 @@ namespace Flow.Launcher.Test.Plugins
         {
             // Given
             var queryConstructor = new QueryConstructor(new Settings());
+            var baseQuery =  queryConstructor.CreateBaseQuery();
+            
+            
+            var queryKeywordLocale = baseQuery.QueryKeywordLocale;
+            expectedString = expectedString.Replace("1033", queryKeywordLocale.ToString());
+            
+            
 
             //When
             var resultString = queryConstructor.QueryForAllFilesAndFolders(userSearchString);


### PR DESCRIPTION
This test fails when run on system have different locale than en-US, because of the hard-coded 1033 LCID (en-US).