### PR TITLE
Add portable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Flow Launcher. Dedicated to make your workflow flow more seamlessly. Aimed at be
 
 ### Installation
 
-| [Windows 7 and up installer](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest) | `WinGet install "Flow Launcher"` |
-| -------------------------------------------------------------------------------------------- | -------------------------------- |
+| [Windows 7 and up installer](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest) | [Portable](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest/Flow-Launcher-Portable.zip) | `WinGet install "Flow Launcher"` |
+| --------------------------------- | --------------------------------- | --------------------------------- |
 
 Windows may complain about security due to code not being signed, this will be completed at a later stage. If you downloaded from this repo, you are good to continue the set up. 
 

--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -111,7 +111,7 @@ function Publish-Portable ($outputLocation, $version) {
     
     & $outputLocation\Flow-Launcher-v$v.exe --silent | Out-Null
     mkdir "$env:LocalAppData\FlowLauncher\app-$version\UserData"
-    Compress-Archive -Path $env:LocalAppData\FlowLauncher -DestinationPath $outputLocation\Flow-Launcher-v$version-Portable.zip
+    Compress-Archive -Path $env:LocalAppData\FlowLauncher -DestinationPath $outputLocation\Flow-Launcher-Portable.zip
 }
 
 function Main {

--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -107,6 +107,13 @@ function Publish-Self-Contained ($p) {
     dotnet publish -c Release $csproj /p:PublishProfile=$profile
 }
 
+function Publish-Portable ($outputLocation, $version) {
+    
+    & $outputLocation\Flow-Launcher-v$v.exe --silent | Out-Null
+    mkdir "$env:LocalAppData\FlowLauncher\app-$version\UserData"
+    Compress-Archive -Path $env:LocalAppData\FlowLauncher -DestinationPath $outputLocation\Flow-Launcher-v$version-Portable.zip
+}
+
 function Main {
     $p = Build-Path
     $v = Build-Version
@@ -123,6 +130,8 @@ function Main {
         $o = "$p\Output\Packages"
         Validate-Directory $o
         Pack-Squirrel-Installer $p $v $o
+
+        Publish-Portable $o $v
     }
 }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ artifacts:
   name: Plugin nupkg
 - path: 'Output\Packages\Flow-Launcher-*.exe'
   name: Squirrel Installer
-- path: 'Output\Packages\Flow-Launcher-v$env:flowVersion-Portable.zip'
+- path: Output\Packages\Flow-Launcher-v$(flowVersion)-Portable.zip
   name: Portable Version
 - path: 'Output\Packages\FlowLauncher-*-full.nupkg'
   name: Squirrel nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,8 @@ artifacts:
   name: Plugin nupkg
 - path: 'Output\Packages\Flow-Launcher-*.exe'
   name: Squirrel Installer
+- path: 'Output\Packages\Flow-Launcher-v$env:flowVersion-Portable.zip'
+  name: Portable Version
 - path: 'Output\Packages\FlowLauncher-*-full.nupkg'
   name: Squirrel nupkg
 - path: 'Output\Packages\RELEASES'
@@ -53,7 +55,7 @@ deploy:
     release: v$(flowVersion)
     auth_token:
       secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
-    artifact: Squirrel Installer, Squirrel nupkg, Squirrel RELEASES
+    artifact: Squirrel Installer, Portable Version, Squirrel nupkg, Squirrel RELEASES
     draft: true
     force_update: true
     on:
@@ -63,7 +65,7 @@ deploy:
     release: v$(flowVersion)
     auth_token:
       secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
-    artifact: Squirrel Installer, Squirrel nupkg, Squirrel RELEASES
+    artifact: Squirrel Installer, Portable Version, Squirrel nupkg, Squirrel RELEASES
     force_update: true
     on:
       APPVEYOR_REPO_TAG: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ artifacts:
   name: Plugin nupkg
 - path: 'Output\Packages\Flow-Launcher-*.exe'
   name: Squirrel Installer
-- path: Output\Packages\Flow-Launcher-v$(flowVersion)-Portable.zip
+- path: Output\Packages\Flow-Launcher-Portable.zip
   name: Portable Version
 - path: 'Output\Packages\FlowLauncher-*-full.nupkg'
   name: Squirrel nupkg


### PR DESCRIPTION
Pack flow for portable release

1. install with silent flag
2. create userdata folder
3. zip to output location
4. upload artifact

This release is also helpful for users who are unable to use the installer