### PR TITLE
Fix Windows Index Search service not activated

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -10,6 +10,8 @@
     <system:String x:Key="plugin_explorer_deletefilefoldersuccess">Deletion successful</system:String>
     <system:String x:Key="plugin_explorer_deletefilefoldersuccess_detail">Successfully deleted the {0}</system:String>
     <system:String x:Key="plugin_explorer_globalActionKeywordInvalid">Assigning the global action keyword could bring up too many results during search. Please choose a specific action keyword</system:String>
+    <system:String x:Key="plugin_explorer_windowsSearchServiceNotRunning">The required service for Windows Index Search does not appear to be running</system:String>
+    <system:String x:Key="plugin_explorer_windowsSearchServiceFix">To fix this, start the Windows Search service. Select here to remove this warning</system:String>
 
     <!--Controls-->
     <system:String x:Key="plugin_explorer_delete">Delete</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -12,6 +12,8 @@
     <system:String x:Key="plugin_explorer_globalActionKeywordInvalid">Assigning the global action keyword could bring up too many results during search. Please choose a specific action keyword</system:String>
     <system:String x:Key="plugin_explorer_windowsSearchServiceNotRunning">The required service for Windows Index Search does not appear to be running</system:String>
     <system:String x:Key="plugin_explorer_windowsSearchServiceFix">To fix this, start the Windows Search service. Select here to remove this warning</system:String>
+    <system:String x:Key="plugin_explorer_alternative">The warning message has been switched off. As an alternative for searching files and folders, would you like to install Everything plugin?{0}{0}Select 'Yes' to install Everything plugin, or 'No' to return</system:String>
+    <system:String x:Key="plugin_explorer_alternative_title">Explorer Alternative</system:String>
 
     <!--Controls-->
     <system:String x:Key="plugin_explorer_delete">Delete</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -14,12 +14,12 @@ namespace Flow.Launcher.Plugin.Explorer.Search
     {
         internal static PluginInitContext Context;
 
-        private readonly Settings settings;
+        internal static Settings Settings;
 
         public SearchManager(Settings settings, PluginInitContext context)
         {
             Context = context;
-            this.settings = settings;
+            Settings = settings;
         }
 
         private class PathEqualityComparator : IEqualityComparer<Result>
@@ -71,14 +71,14 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             return allowedActionKeyword switch
             {
-                Settings.ActionKeyword.SearchActionKeyword => settings.SearchActionKeywordEnabled &&
-                                                              keyword == settings.SearchActionKeyword,
-                Settings.ActionKeyword.PathSearchActionKeyword => settings.PathSearchKeywordEnabled &&
-                                                                  keyword == settings.PathSearchActionKeyword,
+                Settings.ActionKeyword.SearchActionKeyword => Settings.SearchActionKeywordEnabled &&
+                                                              keyword == Settings.SearchActionKeyword,
+                Settings.ActionKeyword.PathSearchActionKeyword => Settings.PathSearchKeywordEnabled &&
+                                                                  keyword == Settings.PathSearchActionKeyword,
                 Settings.ActionKeyword.FileContentSearchActionKeyword => keyword ==
-                                                                         settings.FileContentSearchActionKeyword,
-                Settings.ActionKeyword.IndexSearchActionKeyword => settings.IndexOnlySearchKeywordEnabled &&
-                                                                       keyword == settings.IndexSearchActionKeyword
+                                                                         Settings.FileContentSearchActionKeyword,
+                Settings.ActionKeyword.IndexSearchActionKeyword => Settings.IndexOnlySearchKeywordEnabled &&
+                                                                       keyword == Settings.IndexSearchActionKeyword
             };
         }
 
@@ -88,11 +88,11 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             // This allows the user to type the assigned action keyword and only see the list of quick folder links
             if (string.IsNullOrEmpty(query.Search))
-                return QuickAccess.AccessLinkListAll(query, settings.QuickAccessLinks);
+                return QuickAccess.AccessLinkListAll(query, Settings.QuickAccessLinks);
 
             var results = new HashSet<Result>(PathEqualityComparator.Instance);
 
-            var quickaccessLinks = QuickAccess.AccessLinkListMatched(query, settings.QuickAccessLinks);
+            var quickaccessLinks = QuickAccess.AccessLinkListMatched(query, Settings.QuickAccessLinks);
 
             results.UnionWith(quickaccessLinks);
 
@@ -136,7 +136,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         private async Task<List<Result>> WindowsIndexFileContentSearchAsync(Query query, string querySearchString,
             CancellationToken token)
         {
-            var queryConstructor = new QueryConstructor(settings);
+            var queryConstructor = new QueryConstructor(Settings);
 
             if (string.IsNullOrEmpty(querySearchString))
                 return new List<Result>();
@@ -145,14 +145,14 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 querySearchString,
                 queryConstructor.CreateQueryHelper,
                 queryConstructor.QueryForFileContentSearch,
-                settings.IndexSearchExcludedSubdirectoryPaths,
+                Settings.IndexSearchExcludedSubdirectoryPaths,
                 query,
                 token).ConfigureAwait(false);
         }
 
         public bool IsFileContentSearch(string actionKeyword)
         {
-            return actionKeyword == settings.FileContentSearchActionKeyword;
+            return actionKeyword == Settings.FileContentSearchActionKeyword;
         }
 
         private List<Result> DirectoryInfoClassSearch(Query query, string querySearch, CancellationToken token)
@@ -177,13 +177,13 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         private async Task<List<Result>> WindowsIndexFilesAndFoldersSearchAsync(Query query, string querySearchString,
             CancellationToken token)
         {
-            var queryConstructor = new QueryConstructor(settings);
+            var queryConstructor = new QueryConstructor(Settings);
 
             return await IndexSearch.WindowsIndexSearchAsync(
                 querySearchString,
                 queryConstructor.CreateQueryHelper,
                 queryConstructor.QueryForAllFilesAndFolders,
-                settings.IndexSearchExcludedSubdirectoryPaths,
+                Settings.IndexSearchExcludedSubdirectoryPaths,
                 query,
                 token).ConfigureAwait(false);
         }
@@ -191,12 +191,12 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         private async Task<List<Result>> WindowsIndexTopLevelFolderSearchAsync(Query query, string path,
             CancellationToken token)
         {
-            var queryConstructor = new QueryConstructor(settings);
+            var queryConstructor = new QueryConstructor(Settings);
 
             return await IndexSearch.WindowsIndexSearchAsync(path,
                 queryConstructor.CreateQueryHelper,
                 queryConstructor.QueryForTopLevelDirectorySearch,
-                settings.IndexSearchExcludedSubdirectoryPaths,
+                Settings.IndexSearchExcludedSubdirectoryPaths,
                 query,
                 token).ConfigureAwait(false);
         }
@@ -205,10 +205,10 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         {
             var pathToDirectory = FilesFolders.ReturnPreviousDirectoryIfIncompleteString(locationPath);
 
-            if (!settings.UseWindowsIndexForDirectorySearch)
+            if (!Settings.UseWindowsIndexForDirectorySearch)
                 return false;
 
-            if (settings.IndexSearchExcludedSubdirectoryPaths
+            if (Settings.IndexSearchExcludedSubdirectoryPaths
                 .Any(x => FilesFolders.ReturnPreviousDirectoryIfIncompleteString(pathToDirectory)
                     .StartsWith(x.Path, StringComparison.OrdinalIgnoreCase)))
                 return false;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -12,13 +12,13 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 {
     public class SearchManager
     {
-        private readonly PluginInitContext context;
+        internal static PluginInitContext Context;
 
         private readonly Settings settings;
 
         public SearchManager(Settings settings, PluginInitContext context)
         {
-            this.context = context;
+            Context = context;
             this.settings = settings;
         }
 
@@ -99,7 +99,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             var isEnvironmentVariable = EnvironmentVariables.IsEnvironmentVariableSearch(querySearch);
 
             if (isEnvironmentVariable)
-                return EnvironmentVariables.GetEnvironmentStringPathSuggestions(querySearch, query, context);
+                return EnvironmentVariables.GetEnvironmentStringPathSuggestions(querySearch, query, Context);
 
             // Query is a location path with a full environment variable, eg. %appdata%\somefolder\
             var isEnvironmentVariablePath = querySearch[1..].Contains("%\\");
@@ -141,8 +141,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             if (string.IsNullOrEmpty(querySearchString))
                 return new List<Result>();
 
-            return await IndexSearch.WindowsIndexSearchAsync(querySearchString,
-                queryConstructor.CreateQueryHelper().ConnectionString,
+            return await IndexSearch.WindowsIndexSearchAsync(
+                querySearchString,
+                queryConstructor.CreateQueryHelper,
                 queryConstructor.QueryForFileContentSearch,
                 settings.IndexSearchExcludedSubdirectoryPaths,
                 query,
@@ -178,8 +179,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         {
             var queryConstructor = new QueryConstructor(settings);
 
-            return await IndexSearch.WindowsIndexSearchAsync(querySearchString,
-                queryConstructor.CreateQueryHelper().ConnectionString,
+            return await IndexSearch.WindowsIndexSearchAsync(
+                querySearchString,
+                queryConstructor.CreateQueryHelper,
                 queryConstructor.QueryForAllFilesAndFolders,
                 settings.IndexSearchExcludedSubdirectoryPaths,
                 query,
@@ -192,7 +194,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             var queryConstructor = new QueryConstructor(settings);
 
             return await IndexSearch.WindowsIndexSearchAsync(path,
-                queryConstructor.CreateQueryHelper().ConnectionString,
+                queryConstructor.CreateQueryHelper,
                 queryConstructor.QueryForTopLevelDirectorySearch,
                 settings.IndexSearchExcludedSubdirectoryPaths,
                 query,

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -1,4 +1,4 @@
-﻿using Flow.Launcher.Plugin.Explorer.Search;
+using Flow.Launcher.Plugin.Explorer.Search;
 using Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks;
 using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption;
 using System;
@@ -32,6 +32,8 @@ namespace Flow.Launcher.Plugin.Explorer
         public string IndexSearchActionKeyword { get; set; } = Query.GlobalPluginWildcardSign;
 
         public bool IndexOnlySearchKeywordEnabled { get; set; }
+
+        public bool WarnWindowsSearchServiceOff { get; set; } = true;
 
         internal enum ActionKeyword
         {


### PR DESCRIPTION
Resolves the issue where the Windows Search service required for Windows Index Search in Explorer plugin is turned off by the user intentionally and currently throwing the error report window on every character typed.

To replicate this issue, you need to stop Windows Search service, disable it so it wont be activated by other services, and then type in the search window to trigger Explorer 's Windows Index Search.

Solution:
- Add exception handling, and then output a warning window to let user know.
- Add option for user to remove the message, as well as an alternative to install Everything plugin.
  Users who intentionally stopped the service usually are inclined to use Everything instead.

![image](https://user-images.githubusercontent.com/26427004/126895502-5a132400-8b45-4f75-903c-1361ceb73c78.png)

![image](https://user-images.githubusercontent.com/26427004/126895508-59274e70-24c5-4ef5-b603-b8a4f71653c3.png)

![image](https://user-images.githubusercontent.com/26427004/126895515-bc7319bb-95ed-4ebf-8f3b-810c8581ff49.png)
 