### PR TITLE
Fix PluginsManager context menu crashing

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/ContextMenu.cs
@@ -19,6 +19,9 @@ namespace Flow.Launcher.Plugin.PluginsManager
         {
             var pluginManifestInfo = selectedResult.ContextData as UserPlugin;
 
+            if (pluginManifestInfo == null)
+                return new List<Result>();
+
             return new List<Result>
             {
                 new Result

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/ContextMenu.cs
@@ -17,9 +17,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
         public List<Result> LoadContextMenus(Result selectedResult)
         {
-            var pluginManifestInfo = selectedResult.ContextData as UserPlugin;
-
-            if (pluginManifestInfo == null)
+            if(selectedResult.ContextData is not UserPlugin pluginManifestInfo) 
                 return new List<Result>();
 
             return new List<Result>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -269,7 +269,13 @@ namespace Flow.Launcher.Plugin.PluginsManager
                             }
 
                             return false;
-                        }
+                        },
+                        ContextData = 
+                            new UserPlugin
+                            {
+                                Website = x.PluginNewUserPlugin.Website,
+                                UrlSourceCode = x.PluginNewUserPlugin.UrlSourceCode
+                            }
                     });
 
             return Search(results, uninstallSearch);

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
@@ -6,7 +6,7 @@
   "Name": "Plugins Manager",
   "Description": "Management of installing, uninstalling or updating Flow Launcher plugins",
   "Author": "Jeremy Wu",
-  "Version": "1.8.3",
+  "Version": "1.8.4",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.PluginsManager.dll",


### PR DESCRIPTION
Repro:
Going to any context menu other than pm install and select open website will get the exception pop up

Fix:
- Added handling when the object can not be cast as UserPlugins. This means the selected result was not provided the plugins list from the manifest, as a result we bypass creating menu items for them.
- Added context menu for pm update

Tested:
- pm install and pm update all can use the context menu
- all other context menus will go to the default items with out those options available in install and update
