### PR TITLE
Standardise Flow's exe installer + readme update

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -108,9 +108,7 @@ namespace Flow.Launcher.ViewModel
                 }
 
                 Log.Error("MainViewModel", "Unexpected ResultViewUpdate ends");
-            }
-
-            ;
+            };
 
             void continueAction(Task t)
             {

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -185,7 +185,6 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
             var uninstallSearch = search.Replace(Settings.HotkeyUpdate, string.Empty).TrimStart();
 
-
             var resultsForUpdate =
                 from existingPlugin in Context.API.GetAllPlugins()
                 join pluginFromManifest in pluginsManifest.UserPlugins

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Flow Launcher. Dedicated to make your workflow flow more seamlessly. Aimed at be
 
 ### Installation
 
-| [Windows 7 and up installer](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest) | [Portable](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest/download/Flow-Launcher-Portable.zip) | `WinGet install "Flow Launcher"` |
+| [Windows 7 and up installer](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest/download/Flow-Launcher-Setup.exe) | [Portable](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest/download/Flow-Launcher-Portable.zip) | `WinGet install "Flow Launcher"` |
 | --------------------------------- | --------------------------------- | --------------------------------- |
 
 Windows may complain about security due to code not being signed, this will be completed at a later stage. If you downloaded from this repo, you are good to continue the set up. 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Flow Launcher. Dedicated to make your workflow flow more seamlessly. Aimed at be
 
 ### Installation
 
-| [Windows 7 and up installer](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest/download/Flow-Launcher-Setup.exe) | [Portable](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest/download/Flow-Launcher-Portable.zip) | `WinGet install "Flow Launcher"` |
+| [Windows 7+ installer](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest/download/Flow-Launcher-Setup.exe) | [Portable](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest/download/Flow-Launcher-Portable.zip) | `WinGet install "Flow Launcher"` |
 | --------------------------------- | --------------------------------- | --------------------------------- |
 
 Windows may complain about security due to code not being signed, this will be completed at a later stage. If you downloaded from this repo, you are good to continue the set up. 
@@ -59,10 +59,10 @@ Windows may complain about security due to code not being signed, this will be c
 - Open context menu: on the selected result, press <kbd>Ctrl</kbd>+<kbd>O</kbd>/<kbd>Shift</kbd>+<kbd>Enter</kbd>.
 - Cancel/Return to previous screen: <kbd>Esc</kbd>.
 - Install/Uninstall/Update plugins: in the search window, type `pm` `install`/`uninstall`/`update` + the plugin name.
-- Saved user settings are located:
+- Type `flow user data` to open your saved user settings folder. They are located at:
   - If using roaming: `%APPDATA%\FlowLauncher`
   - If using portable, by default: `%localappdata%\FlowLauncher\app-<VersionOfYourFlowLauncher>\UserData` 
-- Logs are saved along with your user settings folder.
+- Type `open log location` to open your logs folder, they are saved along with your user settings folder.
 
 [More tips](https://flow-launcher.github.io/docs/#/usage-tips)
 
@@ -74,7 +74,7 @@ If you are using Python plugins, flow will prompt to either select the location 
 
 Vist [here](https://flow-launcher.github.io/docs/#/plugins) for our plugin portfolio.
 
-If you are keen to write your own plugin for flow, please take a look at our plugin development documentation for [C#](https://flow-launcher.github.io/docs/#/develop-csharp-plugins) or [Python](https://flow-launcher.github.io/docs/#/develop-py-plugins)
+If you are keen to write your own plugin for flow, please take a look at our plugin development documentation for [C#](https://flow-launcher.github.io/docs/#/develop-dotnet-plugins) or [Python](https://flow-launcher.github.io/docs/#/develop-py-plugins)
 
 ## Questions/Suggestions
 

--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -89,7 +89,7 @@ function Pack-Squirrel-Installer ($path, $version, $output) {
     Move-Item $temp\* $output -Force
     Remove-Item $temp
     
-    $file = "$output\Flow-Launcher-v$version.exe"
+    $file = "$output\Flow-Launcher-Setup.exe"
     Write-Host "Filename: $file"
 
     Move-Item "$output\Setup.exe" $file -Force
@@ -109,7 +109,7 @@ function Publish-Self-Contained ($p) {
 
 function Publish-Portable ($outputLocation, $version) {
     
-    & $outputLocation\Flow-Launcher-v$v.exe --silent | Out-Null
+    & $outputLocation\Flow-Launcher-Setup.exe --silent | Out-Null
     mkdir "$env:LocalAppData\FlowLauncher\app-$version\UserData"
     Compress-Archive -Path $env:LocalAppData\FlowLauncher -DestinationPath $outputLocation\Flow-Launcher-Portable.zip
 }


### PR DESCRIPTION
Standardise Flow's exe installer by removing the version at the end, this will make it easier to link to the latest download e.g. https://github.com/Flow-Launcher/Flow.Launcher/releases/latest/download/Flow-Launcher-Setup.exe

Tested:

1. changed the build version to 1.0.0 for testing
2. downloaded the artifact after build
3. Enabled portable mode
4. moved to different location
5. disabled portable mode
6. update to the latest via update command in query window
7. redid the steps 2-5 and updated flow via settings About tab
8. redid 2-7 for portable zip version

Updated readme to fix c# plugin dev doc and getting started section