### PR TITLE
Delay the create query helper call to avoid Windows Search not running

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -143,7 +143,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             return await IndexSearch.WindowsIndexSearchAsync(
                 querySearchString,
-                queryConstructor.CreateQueryHelper(),
+                queryConstructor.CreateQueryHelper,
                 queryConstructor.QueryForFileContentSearch,
                 Settings.IndexSearchExcludedSubdirectoryPaths,
                 query,
@@ -181,7 +181,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             return await IndexSearch.WindowsIndexSearchAsync(
                 querySearchString,
-                queryConstructor.CreateQueryHelper(),
+                queryConstructor.CreateQueryHelper,
                 queryConstructor.QueryForAllFilesAndFolders,
                 Settings.IndexSearchExcludedSubdirectoryPaths,
                 query,
@@ -195,7 +195,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             return await IndexSearch.WindowsIndexSearchAsync(
                 path,
-                queryConstructor.CreateQueryHelper(),
+                queryConstructor.CreateQueryHelper,
                 queryConstructor.QueryForTopLevelDirectorySearch,
                 Settings.IndexSearchExcludedSubdirectoryPaths,
                 query,

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -88,7 +88,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
 
         internal async static Task<List<Result>> WindowsIndexSearchAsync(
             string searchString,
-            CSearchQueryHelper queryHelper,
+            Func<CSearchQueryHelper> createQueryHelper,
             Func<string, string> constructQuery,
             List<AccessLink> exclusionList,
             Query query,
@@ -104,7 +104,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                 var constructedQuery = constructQuery(searchString);
 
                 return RemoveResultsInExclusionList(
-                        await ExecuteWindowsIndexSearchAsync(constructedQuery, queryHelper.ConnectionString, query, token).ConfigureAwait(false),
+                        await ExecuteWindowsIndexSearchAsync(constructedQuery, createQueryHelper().ConnectionString, query, token).ConfigureAwait(false),
                         exclusionList,
                         token);
             }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -9,7 +9,7 @@
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",
-  "Version": "1.8.2",
+  "Version": "1.8.3",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
Delay the create query helper call to avoid Windows Search not running, follows on from #599 , missed the query helper call which also requires Windows Search service.