### PR TITLE
Fix Explorer's file result subtitle tool tip as file path instead

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -144,7 +144,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                     return true;
                 },
                 TitleToolTip = Constants.ToolTipOpenContainingFolder,
-                SubTitleToolTip = Constants.ToolTipOpenContainingFolder,
+                SubTitleToolTip = filePath,
                 ContextData = new SearchResult
                 {
                     Type = ResultType.File,

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -52,7 +52,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 },
                 Score = score,
                 TitleToolTip = Constants.ToolTipOpenDirectory,
-                SubTitleToolTip = Constants.ToolTipOpenDirectory,
+                SubTitleToolTip = subtitle,
                 ContextData = new SearchResult
                 {
                     Type = ResultType.Folder,

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -52,7 +52,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 },
                 Score = score,
                 TitleToolTip = Constants.ToolTipOpenDirectory,
-                SubTitleToolTip = subtitle,
+                SubTitleToolTip = path,
                 ContextData = new SearchResult
                 {
                     Type = ResultType.Folder,

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -9,7 +9,7 @@
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",
-  "Version": "1.8.3",
+  "Version": "1.8.4",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
Fix Explorer's file result subtitle tool tip as file path instead