### PR TITLE
Refactor JsonRPC structure

### DIFF
--- a/Flow.Launcher.Core/Plugin/ExecutablePlugin.cs
+++ b/Flow.Launcher.Core/Plugin/ExecutablePlugin.cs
@@ -24,35 +24,15 @@ namespace Flow.Launcher.Core.Plugin
             };
         }
 
-        protected override Task<Stream> ExecuteQueryAsync(Query query, CancellationToken token)
+        protected override Task<Stream> RequestAsync(JsonRPCRequestModel request, CancellationToken token = default)
         {
-            JsonRPCServerRequestModel request = new JsonRPCServerRequestModel
-            {
-                Method = "query",
-                Parameters = new object[] {query.Search},
-            };
-
             _startInfo.Arguments = $"\"{request}\"";
-
             return ExecuteAsync(_startInfo, token);
         }
 
-        protected override string ExecuteCallback(JsonRPCRequestModel rpcRequest)
+        protected override string Request(JsonRPCRequestModel rpcRequest, CancellationToken token = default)
         {
             _startInfo.Arguments = $"\"{rpcRequest}\"";
-            return Execute(_startInfo);
-        }
-
-        protected override string ExecuteContextMenu(Result selectedResult)
-        {
-            JsonRPCServerRequestModel request = new JsonRPCServerRequestModel
-            {
-                Method = "contextmenu",
-                Parameters = new object[] {selectedResult.ContextData},
-            };
-
-            _startInfo.Arguments = $"\"{request}\"";
-
             return Execute(_startInfo);
         }
     }

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -30,16 +30,22 @@ namespace Flow.Launcher.Core.Plugin
         /// The language this JsonRPCPlugin support
         /// </summary>
         public abstract string SupportedLanguage { get; set; }
-
-        protected abstract Task<Stream> ExecuteQueryAsync(Query query, CancellationToken token);
-        protected abstract string ExecuteCallback(JsonRPCRequestModel rpcRequest);
-        protected abstract string ExecuteContextMenu(Result selectedResult);
+        protected abstract Task<Stream> RequestAsync(JsonRPCRequestModel rpcRequest, CancellationToken token = default);
+        protected abstract string Request(JsonRPCRequestModel rpcRequest, CancellationToken token = default);
 
         private static readonly RecyclableMemoryStreamManager BufferManager = new();
 
         public List<Result> LoadContextMenus(Result selectedResult)
         {
-            var output = ExecuteContextMenu(selectedResult);
+            var request = new JsonRPCRequestModel
+            {
+                Method = "context_menu",
+                Parameters = new[]
+                {
+                    selectedResult.ContextData
+                }
+            };
+            var output = Request(request);
             return DeserializedResult(output);
         }
 
@@ -100,7 +106,7 @@ namespace Flow.Launcher.Core.Plugin
                     }
                     else
                     {
-                        var actionResponse = ExecuteCallback(result.JsonRPCAction);
+                        var actionResponse = Request(result.JsonRPCAction);
 
                         if (string.IsNullOrEmpty(actionResponse))
                         {
@@ -255,8 +261,8 @@ namespace Flow.Launcher.Core.Plugin
 
                 if (buffer.Length == 0)
                 {
-                    var errorMessage = process.StandardError.EndOfStream ? 
-                        "Empty JSONRPC Response" : 
+                    var errorMessage = process.StandardError.EndOfStream ?
+                        "Empty JSONRPC Response" :
                         await process.StandardError.ReadToEndAsync();
                     throw new InvalidDataException($"{context.CurrentPluginMetadata.Name}|{errorMessage}");
                 }
@@ -283,7 +289,15 @@ namespace Flow.Launcher.Core.Plugin
 
         public async Task<List<Result>> QueryAsync(Query query, CancellationToken token)
         {
-            var output = await ExecuteQueryAsync(query, token);
+            var request = new JsonRPCRequestModel
+            {
+                Method = "query",
+                Parameters = new[]
+                {
+                    query.Search
+                }
+            };
+            var output = await RequestAsync(request, token);
             return await DeserializedResultAsync(output);
         }
 

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -198,15 +198,6 @@ namespace Flow.Launcher.Core.Plugin
                     return string.Empty;
                 }
 
-                if (result.StartsWith("DEBUG:"))
-                {
-                    MessageBox.Show(new Form
-                    {
-                        TopMost = true
-                    }, result.Substring(6));
-                    return string.Empty;
-                }
-
                 return result;
             }
             catch (Exception e)

--- a/Flow.Launcher.Core/Plugin/PythonPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/PythonPlugin.cs
@@ -32,13 +32,8 @@ namespace Flow.Launcher.Core.Plugin
             _startInfo.ArgumentList.Add("-B");
         }
 
-        protected override Task<Stream> ExecuteQueryAsync(Query query, CancellationToken token)
+        protected override Task<Stream> RequestAsync(JsonRPCRequestModel request, CancellationToken token = default)
         {
-            JsonRPCServerRequestModel request = new JsonRPCServerRequestModel
-            {
-                Method = "query", Parameters = new object[] {query.Search},
-            };
-
             _startInfo.ArgumentList[2] = request.ToString();
 
             // todo happlebao why context can't be used in constructor
@@ -47,27 +42,13 @@ namespace Flow.Launcher.Core.Plugin
             return ExecuteAsync(_startInfo, token);
         }
 
-        protected override string ExecuteCallback(JsonRPCRequestModel rpcRequest)
+        protected override string Request(JsonRPCRequestModel rpcRequest, CancellationToken token = default)
         {
             _startInfo.ArgumentList[2] = rpcRequest.ToString();
             _startInfo.WorkingDirectory = context.CurrentPluginMetadata.PluginDirectory;
             // TODO: Async Action
             return Execute(_startInfo);
         }
-
-        protected override string ExecuteContextMenu(Result selectedResult)
-        {
-            JsonRPCServerRequestModel request = new JsonRPCServerRequestModel
-            {
-                Method = "context_menu", Parameters = new object[] {selectedResult.ContextData},
-            };
-            _startInfo.ArgumentList[2] = request.ToString();
-            _startInfo.WorkingDirectory = context.CurrentPluginMetadata.PluginDirectory;
-
-            // TODO: Async Action
-            return Execute(_startInfo);
-        }
-
         public override Task InitAsync(PluginInitContext context)
         {
             this.context = context;

--- a/Flow.Launcher.Core/Plugin/PythonPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/PythonPlugin.cs
@@ -36,9 +36,6 @@ namespace Flow.Launcher.Core.Plugin
         {
             _startInfo.ArgumentList[2] = request.ToString();
 
-            // todo happlebao why context can't be used in constructor
-            _startInfo.WorkingDirectory = context.CurrentPluginMetadata.PluginDirectory;
-
             return ExecuteAsync(_startInfo, token);
         }
 
@@ -54,6 +51,9 @@ namespace Flow.Launcher.Core.Plugin
             this.context = context;
             _startInfo.ArgumentList.Add(context.CurrentPluginMetadata.ExecuteFilePath);
             _startInfo.ArgumentList.Add("");
+
+            _startInfo.WorkingDirectory = context.CurrentPluginMetadata.PluginDirectory;
+
             return Task.CompletedTask;
         }
     }

--- a/Flow.Launcher.Test/Plugins/JsonRPCPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/JsonRPCPluginTest.cs
@@ -18,19 +18,14 @@ namespace Flow.Launcher.Test.Plugins
     {
         public override string SupportedLanguage { get; set; } = AllowedLanguage.Executable;
 
-        protected override string ExecuteCallback(JsonRPCRequestModel rpcRequest)
+        protected override string Request(JsonRPCRequestModel rpcRequest, CancellationToken token = default)
         {
             throw new System.NotImplementedException();
         }
 
-        protected override string ExecuteContextMenu(Result selectedResult)
+        protected override Task<Stream> RequestAsync(JsonRPCRequestModel request, CancellationToken token = default)
         {
-            throw new System.NotImplementedException();
-        }
-
-        protected override Task<Stream> ExecuteQueryAsync(Query query, CancellationToken token)
-        {
-            var byteInfo = Encoding.UTF8.GetBytes(query.RawQuery);
+            var byteInfo = Encoding.UTF8.GetBytes(request.Parameters[0] as string ?? string.Empty);
 
             var resultStream = new MemoryStream(byteInfo);
             return Task.FromResult((Stream)resultStream);
@@ -45,7 +40,7 @@ namespace Flow.Launcher.Test.Plugins
         {
             var results = await QueryAsync(new Query
             {
-                RawQuery = resultText
+                Search = resultText
             }, default);
 
             Assert.IsNotNull(results);
@@ -85,8 +80,8 @@ namespace Flow.Launcher.Test.Plugins
 
             var pascalText = JsonSerializer.Serialize(reference);
 
-            var results1 = await QueryAsync(new Query { RawQuery = camelText }, default);
-            var results2 = await QueryAsync(new Query { RawQuery = pascalText }, default);
+            var results1 = await QueryAsync(new Query { Search = camelText }, default);
+            var results2 = await QueryAsync(new Query { Search = pascalText }, default);
 
             Assert.IsNotNull(results1);
             Assert.IsNotNull(results2);


### PR DESCRIPTION
We don't need to provide a virtual method separately for query, context menu, and callback. The virtual method should only provide a way to pass the request model to the executable or something received the jsonrpc request.

Query, ContextMenu, and Callback should be indicated within the JsonRPC model.