### PR TITLE
Fix File Content action keyword change error

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -77,7 +77,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                                                                   keyword == Settings.PathSearchActionKeyword,
                 Settings.ActionKeyword.FileContentSearchActionKeyword => Settings.FileContentSearchKeywordEnabled &&
                                                                          keyword == Settings.FileContentSearchActionKeyword,
-                Settings.ActionKeyword.IndexSearchActionKeyword => Settings.IndexOnlySearchKeywordEnabled &&
+                Settings.ActionKeyword.IndexSearchActionKeyword => Settings.IndexSearchKeywordEnabled &&
                                                                    keyword == Settings.IndexSearchActionKeyword
             };
         }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -75,10 +75,10 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                                                               keyword == Settings.SearchActionKeyword,
                 Settings.ActionKeyword.PathSearchActionKeyword => Settings.PathSearchKeywordEnabled &&
                                                                   keyword == Settings.PathSearchActionKeyword,
-                Settings.ActionKeyword.FileContentSearchActionKeyword => keyword ==
-                                                                         Settings.FileContentSearchActionKeyword,
+                Settings.ActionKeyword.FileContentSearchActionKeyword => Settings.FileContentSearchKeywordEnabled &&
+                                                                         keyword == Settings.FileContentSearchActionKeyword,
                 Settings.ActionKeyword.IndexSearchActionKeyword => Settings.IndexOnlySearchKeywordEnabled &&
-                                                                       keyword == Settings.IndexSearchActionKeyword
+                                                                   keyword == Settings.IndexSearchActionKeyword
             };
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -33,7 +33,7 @@ namespace Flow.Launcher.Plugin.Explorer
 
         public string IndexSearchActionKeyword { get; set; } = Query.GlobalPluginWildcardSign;
 
-        public bool IndexOnlySearchKeywordEnabled { get; set; }
+        public bool IndexSearchKeywordEnabled { get; set; }
 
         public bool WarnWindowsSearchServiceOff { get; set; } = true;
 
@@ -67,7 +67,7 @@ namespace Flow.Launcher.Plugin.Explorer
         {
             ActionKeyword.SearchActionKeyword => SearchActionKeywordEnabled,
             ActionKeyword.PathSearchActionKeyword => PathSearchKeywordEnabled,
-            ActionKeyword.IndexSearchActionKeyword => IndexOnlySearchKeywordEnabled,
+            ActionKeyword.IndexSearchActionKeyword => IndexSearchKeywordEnabled,
             ActionKeyword.FileContentSearchActionKeyword => FileContentSearchKeywordEnabled,
             _ => throw new ArgumentOutOfRangeException(nameof(actionKeyword), actionKeyword, "ActionKeyword enabled status not defined")
         };
@@ -76,7 +76,7 @@ namespace Flow.Launcher.Plugin.Explorer
         {
             ActionKeyword.SearchActionKeyword => SearchActionKeywordEnabled = enable,
             ActionKeyword.PathSearchActionKeyword => PathSearchKeywordEnabled = enable,
-            ActionKeyword.IndexSearchActionKeyword => IndexOnlySearchKeywordEnabled = enable,
+            ActionKeyword.IndexSearchActionKeyword => IndexSearchKeywordEnabled = enable,
             ActionKeyword.FileContentSearchActionKeyword => FileContentSearchKeywordEnabled = enable,
             _ => throw new ArgumentOutOfRangeException(nameof(actionKeyword), actionKeyword, "ActionKeyword enabled status not defined")
         };

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -1,9 +1,7 @@
 using Flow.Launcher.Plugin.Explorer.Search;
 using Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks;
-using Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption;
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace Flow.Launcher.Plugin.Explorer
 {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -25,6 +25,8 @@ namespace Flow.Launcher.Plugin.Explorer
 
         public string FileContentSearchActionKeyword { get; set; } = Constants.DefaultContentSearchActionKeyword;
 
+        public bool FileContentSearchKeywordEnabled { get; set; } = true;
+
         public string PathSearchActionKeyword { get; set; } = Query.GlobalPluginWildcardSign;
 
         public bool PathSearchKeywordEnabled { get; set; }
@@ -48,7 +50,8 @@ namespace Flow.Launcher.Plugin.Explorer
             ActionKeyword.SearchActionKeyword => SearchActionKeyword,
             ActionKeyword.PathSearchActionKeyword => PathSearchActionKeyword,
             ActionKeyword.FileContentSearchActionKeyword => FileContentSearchActionKeyword,
-            ActionKeyword.IndexSearchActionKeyword => IndexSearchActionKeyword
+            ActionKeyword.IndexSearchActionKeyword => IndexSearchActionKeyword,
+            _ => throw new ArgumentOutOfRangeException(nameof(actionKeyword), actionKeyword, "ActionKeyWord property not found")
         };
 
         internal void SetActionKeyword(ActionKeyword actionKeyword, string keyword) => _ = actionKeyword switch
@@ -57,15 +60,16 @@ namespace Flow.Launcher.Plugin.Explorer
             ActionKeyword.PathSearchActionKeyword => PathSearchActionKeyword = keyword,
             ActionKeyword.FileContentSearchActionKeyword => FileContentSearchActionKeyword = keyword,
             ActionKeyword.IndexSearchActionKeyword => IndexSearchActionKeyword = keyword,
-            _ => throw new ArgumentOutOfRangeException(nameof(actionKeyword), actionKeyword, "Unexpected property")
+            _ => throw new ArgumentOutOfRangeException(nameof(actionKeyword), actionKeyword, "ActionKeyWord property not found")
         };
 
-        internal bool? GetActionKeywordEnabled(ActionKeyword actionKeyword) => actionKeyword switch
+        internal bool GetActionKeywordEnabled(ActionKeyword actionKeyword) => actionKeyword switch
         {
             ActionKeyword.SearchActionKeyword => SearchActionKeywordEnabled,
             ActionKeyword.PathSearchActionKeyword => PathSearchKeywordEnabled,
             ActionKeyword.IndexSearchActionKeyword => IndexOnlySearchKeywordEnabled,
-            _ => null
+            ActionKeyword.FileContentSearchActionKeyword => FileContentSearchKeywordEnabled,
+            _ => throw new ArgumentOutOfRangeException(nameof(actionKeyword), actionKeyword, "ActionKeyword enabled status not defined")
         };
 
         internal void SetActionKeywordEnabled(ActionKeyword actionKeyword, bool enable) => _ = actionKeyword switch
@@ -73,7 +77,8 @@ namespace Flow.Launcher.Plugin.Explorer
             ActionKeyword.SearchActionKeyword => SearchActionKeywordEnabled = enable,
             ActionKeyword.PathSearchActionKeyword => PathSearchKeywordEnabled = enable,
             ActionKeyword.IndexSearchActionKeyword => IndexOnlySearchKeywordEnabled = enable,
-            _ => throw new ArgumentOutOfRangeException(nameof(actionKeyword), actionKeyword, "Unexpected property")
+            ActionKeyword.FileContentSearchActionKeyword => FileContentSearchKeywordEnabled = enable,
+            _ => throw new ArgumentOutOfRangeException(nameof(actionKeyword), actionKeyword, "ActionKeyword enabled status not defined")
         };
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml
@@ -30,8 +30,7 @@
         <CheckBox Name="ChkActionKeywordEnabled" ToolTip="{DynamicResource plugin_explorer_actionkeyword_enabled_tooltip}"
                   Margin="10" Grid.Row="0" Grid.Column="2" Content="{DynamicResource plugin_explorer_actionkeyword_enabled}"
                   Width="auto"
-                  VerticalAlignment="Center" IsChecked="{Binding Enabled}"
-                  Visibility="{Binding EnabledVisibility}"/>
+                  VerticalAlignment="Center" IsChecked="{Binding Enabled}" />
         <Button Name="DownButton"
                 Click="OnDoneButtonClick" Grid.Row="1" Grid.Column="2"
                 Margin="10 0 10 0" Width="80" Height="35"

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml
@@ -31,7 +31,7 @@
                   Margin="10" Grid.Row="0" Grid.Column="2" Content="{DynamicResource plugin_explorer_actionkeyword_enabled}"
                   Width="auto"
                   VerticalAlignment="Center" IsChecked="{Binding Enabled}"
-                  Visibility="{Binding Visible}"/>
+                  Visibility="{Binding EnabledVisibility}"/>
         <Button Name="DownButton"
                 Click="OnDoneButtonClick" Grid.Row="1" Grid.Column="2"
                 Margin="10 0 10 0" Width="80" Height="35"

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
@@ -19,18 +19,18 @@ namespace Flow.Launcher.Plugin.Explorer.Views
 
         public string ActionKeyword
         {
-            get => _actionKeyword;
+            get => actionKeyword;
             set
             {
                 // Set Enable to be true if user change ActionKeyword
                 Enabled = true;
-                _actionKeyword = value;
+                actionKeyword = value;
             }
         }
 
         public bool Enabled { get; set; }
 
-        private string _actionKeyword;
+        private string actionKeyword;
 
         public Visibility EnabledVisibility 
             => CurrentActionKeyword.KeywordProperty == Settings.ActionKeyword.FileContentSearchActionKeyword

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
@@ -74,8 +74,7 @@ namespace Flow.Launcher.Plugin.Explorer.Views
 
             var oldActionKeyword = CurrentActionKeyword.Keyword;
 
-            // == because of nullable
-            if (Enabled == false || !settingsViewModel.IsActionKeywordAlreadyAssigned(ActionKeyword))
+            if (!Enabled || !settingsViewModel.IsActionKeywordAlreadyAssigned(ActionKeyword))
             {
                 // Update View Data
                 CurrentActionKeyword.Keyword = Enabled == true ? ActionKeyword : Query.GlobalPluginWildcardSign;
@@ -84,7 +83,7 @@ namespace Flow.Launcher.Plugin.Explorer.Views
                 switch (Enabled)
                 {
                     // reset to global so it does not take up an action keyword when disabled
-                    //     not for null Enable plugin
+                    // not for null Enable plugin
                     case false when oldActionKeyword != Query.GlobalPluginWildcardSign:
                         settingsViewModel.UpdateActionKeyword(CurrentActionKeyword.KeywordProperty,
                             Query.GlobalPluginWildcardSign, oldActionKeyword);

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
@@ -32,10 +32,6 @@ namespace Flow.Launcher.Plugin.Explorer.Views
 
         private string actionKeyword;
 
-        public Visibility EnabledVisibility 
-            => CurrentActionKeyword.KeywordProperty == Settings.ActionKeyword.FileContentSearchActionKeyword
-                ? Visibility.Collapsed : Visibility.Visible;
-
         public ActionKeywordSetting(SettingsViewModel settingsViewModel,
             ActionKeywordView selectedActionKeyword)
         {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
@@ -23,18 +23,18 @@ namespace Flow.Launcher.Plugin.Explorer.Views
             set
             {
                 // Set Enable to be true if user change ActionKeyword
-                if (Enabled is not null)
-                    Enabled = true;
+                Enabled = true;
                 _actionKeyword = value;
             }
         }
 
-        public bool? Enabled { get; set; }
+        public bool Enabled { get; set; }
 
         private string _actionKeyword;
 
-        public Visibility Visible =>
-            CurrentActionKeyword.Enabled is not null ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility EnabledVisibility 
+            => CurrentActionKeyword.KeywordProperty == Settings.ActionKeyword.FileContentSearchActionKeyword
+                ? Visibility.Collapsed : Visibility.Visible;
 
         public ActionKeywordSetting(SettingsViewModel settingsViewModel,
             ActionKeywordView selectedActionKeyword)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
@@ -325,7 +325,7 @@ namespace Flow.Launcher.Plugin.Explorer.Views
         }
 
         public string Description { get; private init; }
-        public string Color => Enabled ?? true ? "Black" : "Gray";
+        public string Color => Enabled ? "Black" : "Gray";
 
         internal Settings.ActionKeyword KeywordProperty { get; }
 
@@ -335,11 +335,10 @@ namespace Flow.Launcher.Plugin.Explorer.Views
             set => _settings.SetActionKeyword(KeywordProperty, value);
         }
 
-        public bool? Enabled
+        public bool Enabled
         {
             get => _settings.GetActionKeywordEnabled(KeywordProperty);
-            set => _settings.SetActionKeywordEnabled(KeywordProperty,
-                value ?? throw new ArgumentException("Unexpected null value"));
+            set => _settings.SetActionKeywordEnabled(KeywordProperty, value);
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -9,7 +9,7 @@
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",
-  "Version": "1.8.4",
+  "Version": "1.8.5",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
Fix error from changing the File Content action keyword

Changes:
- add File Content Search Enabled status property
- remove null state from action keyword Enabled status
- rename IndexOnlySearchKeywordEnabled for consistency
- allow File Content Search to be turned on/off

Close #669 