### PR TITLE
Fix winget update causing incompatibility with always retrieving latest

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,6 +78,6 @@ on_success:
   - ps: |
         if ($env:APPVEYOR_REPO_BRANCH -eq "master" -and $env:APPVEYOR_REPO_TAG -eq "true")
         {
-            iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+            iwr https://github.com/microsoft/winget-create/releases/download/v0.2.0.29-preview/wingetcreate.exe -OutFile wingetcreate.exe
             .\wingetcreate.exe update Flow-Launcher.Flow-Launcher -s true -u https://github.com/Flow-Launcher/Flow.Launcher/releases/download/v$env:flowVersion/Flow-Launcher-Setup.exe -v $env:flowVersion -t $env:winget_token
         }


### PR DESCRIPTION
This stems from the 1.8.3 release which failed with the latest winget-create version. Simplest fix is just to fix the version we are using since our release is a simple straight forward update.