### PR TITLE
fix custom font setting not avaliable when shadow effects enabled

### DIFF
--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -146,10 +146,8 @@ namespace Flow.Launcher.Core.Resource
         {
             var dict = CurrentThemeResourceDictionary();
 
-            Style queryBoxStyle = dict["QueryBoxStyle"] as Style;
-            Style querySuggestionBoxStyle = dict["QuerySuggestionBoxStyle"] as Style;
-
-            if (queryBoxStyle != null && querySuggestionBoxStyle != null)
+            if (dict["QueryBoxStyle"] is Style queryBoxStyle && 
+                dict["QuerySuggestionBoxStyle"] is Style querySuggestionBoxStyle)
             {
                 var fontFamily = new FontFamily(Settings.QueryBoxFont);
                 var fontStyle = FontHelper.GetFontStyleFromInvariantStringOrNormal(Settings.QueryBoxFontStyle);
@@ -174,11 +172,10 @@ namespace Flow.Launcher.Core.Resource
                 querySuggestionBoxStyle.Setters.Add(new Setter(TextBox.FontStretchProperty, fontStretch));
             }
 
-            Style resultItemStyle = dict["ItemTitleStyle"] as Style;
-            Style resultSubItemStyle = dict["ItemSubTitleStyle"] as Style;
-            Style resultItemSelectedStyle = dict["ItemTitleSelectedStyle"] as Style;
-            Style resultSubItemSelectedStyle = dict["ItemSubTitleSelectedStyle"] as Style;
-            if (resultItemStyle != null && resultSubItemStyle != null && resultSubItemSelectedStyle != null && resultItemSelectedStyle != null)
+            if (dict["ItemTitleStyle"] is Style resultItemStyle &&
+                dict["ItemSubTitleStyle"] is Style resultSubItemStyle && 
+                dict["ItemSubTitleSelectedStyle"] is Style resultSubItemSelectedStyle &&
+                dict["ItemTitleSelectedStyle"] is Style resultItemSelectedStyle)
             {
                 Setter fontFamily = new Setter(TextBlock.FontFamilyProperty, new FontFamily(Settings.ResultFont));
                 Setter fontStyle = new Setter(TextBlock.FontStyleProperty, FontHelper.GetFontStyleFromInvariantStringOrNormal(Settings.ResultFontStyle));
@@ -236,17 +233,19 @@ namespace Flow.Launcher.Core.Resource
 
         public void AddDropShadowEffectToCurrentTheme()
         {
-            var dict = CurrentThemeResourceDictionary();
+            var dict = GetResourceDictionary();
 
             var windowBorderStyle = dict["WindowBorderStyle"] as Style;
 
-            var effectSetter = new Setter();
-            effectSetter.Property = Border.EffectProperty;
-            effectSetter.Value = new DropShadowEffect
+            var effectSetter = new Setter
             {
-                Opacity = 0.9,
-                ShadowDepth = 2,
-                BlurRadius = 15
+                Property = Border.EffectProperty,
+                Value = new DropShadowEffect
+                {
+                    Opacity = 0.9,
+                    ShadowDepth = 2,
+                    BlurRadius = 15
+                }
             };
 
             var marginSetter = windowBorderStyle.Setters.FirstOrDefault(setterBase => setterBase is Setter setter && setter.Property == Border.MarginProperty) as Setter;
@@ -277,7 +276,7 @@ namespace Flow.Launcher.Core.Resource
 
         public void RemoveDropShadowEffectFromCurrentTheme()
         {
-            var dict = CurrentThemeResourceDictionary();
+            var dict = GetResourceDictionary();
             var windowBorderStyle = dict["WindowBorderStyle"] as Style;
 
             var effectSetter = windowBorderStyle.Setters.FirstOrDefault(setterBase => setterBase is Setter setter && setter.Property == Border.EffectProperty) as Setter;


### PR DESCRIPTION
@onesounds
I fixes the issue. It is caused by getting a theme resources dictionary without any customized setting in add/remove drop shadow effect. The rest is just a few refactor. You can merge this branch to your branch and check whether it is hard to merge. If it is hard to merge, just copy the below change to your branch.