### PR TITLE
Dev branch: fix issue with converters casting to null values

### DIFF
--- a/Flow.Launcher/Converters/OpenResultHotkeyVisibilityConverter.cs
+++ b/Flow.Launcher/Converters/OpenResultHotkeyVisibilityConverter.cs
@@ -16,12 +16,10 @@ namespace Flow.Launcher.Converters
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var hotkeyNumber = int.MaxValue;
-             
-            if (value is ListBoxItem listBoxItem)
-            {
-                ListBox listBox = ItemsControl.ItemsControlFromItemContainer(listBoxItem) as ListBox;
+
+            if (value is ListBoxItem listBoxItem
+                && ItemsControl.ItemsControlFromItemContainer(listBoxItem) is ListBox listBox)
                 hotkeyNumber = listBox.ItemContainerGenerator.IndexFromContainer(listBoxItem) + 1;
-            }
 
             return hotkeyNumber <= MaxVisibleHotkeys ? Visibility.Visible : Visibility.Collapsed;
         }

--- a/Flow.Launcher/Converters/OrdinalConverter.cs
+++ b/Flow.Launcher/Converters/OrdinalConverter.cs
@@ -8,11 +8,9 @@ namespace Flow.Launcher.Converters
     {
         public object Convert(object value, System.Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is ListBoxItem listBoxItem)
-            {
-                ListBox listBox = ItemsControl.ItemsControlFromItemContainer(listBoxItem) as ListBox;
+            if (value is ListBoxItem listBoxItem
+                && ItemsControl.ItemsControlFromItemContainer(listBoxItem) is ListBox listBox)
                 return listBox.ItemContainerGenerator.IndexFromContainer(listBoxItem) + 1;
-            }
 
             return 0;
         }


### PR DESCRIPTION
when changing themes, occasionally run into null casts:
![image](https://user-images.githubusercontent.com/26427004/137217573-1eaca37e-706d-47a8-bddd-8c6b71db1fa4.png)

![image](https://user-images.githubusercontent.com/26427004/137217597-bbc9d078-76e4-408f-a43d-cdf354cfd37f.png)

not sure why the ListBoxItem is 'DisconnectedItem', maybe WPF bug?

repro:
go to the themes settings, select and switch themes quickly by holding down the left mouse button and slide across different themes and eventually will run into the exception.

solution:
use pattern matching 

discovered in:
#704 