### PR TITLE
Dev branch: Fix width of the query box varies depending on the shadow state of the window.

### DIFF
--- a/Flow.Launcher/Themes/Base.xaml
+++ b/Flow.Launcher/Themes/Base.xaml
@@ -8,14 +8,13 @@
         <Setter Property="FontSize" Value="28" />
         <Setter Property="FontWeight" Value="Regular" />
         <Setter Property="Margin" Value="16 7 0 7" />
-        <Setter Property="Padding" Value="0 4 0 0" />
+        <Setter Property="Padding" Value="0 4 68 0" />
         <Setter Property="Background" Value="#2F2F2F" />
-        <Setter Property="Width" Value="664" />
         <Setter Property="Height" Value="48" />
         <Setter Property="Foreground" Value="#E3E0E3" />
         <Setter Property="CaretBrush" Value="#E3E0E3" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
@@ -42,10 +41,9 @@
         <Setter Property="Foreground" Value="DarkGray" />
         <Setter Property="Height" Value="48" />
         <Setter Property="Margin" Value="16 7 0 7" />
-        <Setter Property="Width" Value="664" />
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Padding" Value="0 4 0 0" />
-        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="Padding" Value="0 4 68 0" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
 

--- a/Flow.Launcher/Themes/Discord Dark.xaml
+++ b/Flow.Launcher/Themes/Discord Dark.xaml
@@ -12,16 +12,16 @@
         <Setter Property="Background" Value="#36393f" />
         <Setter Property="CaretBrush" Value="#ffffff" />
         <Setter Property="SelectionBrush" Value="#0a68d8"/>
-        <Setter Property="Width" Value="490" />
         <Setter Property="Height" Value="42" />
         <Setter Property="FontSize" Value="24" />
+        <Setter Property="Padding" Value="0 0 66 0" />
     </Style>
     <Style x:Key="QuerySuggestionBoxStyle" BasedOn="{StaticResource BaseQuerySuggestionBoxStyle}" TargetType="{x:Type TextBox}">
         <Setter Property="Foreground" Value="#72767d" />
         <Setter Property="Background" Value="#36393f" />
-        <Setter Property="Width" Value="490" />
         <Setter Property="Height" Value="42" />
         <Setter Property="FontSize" Value="24" />
+        <Setter Property="Padding" Value="0 0 66 0" />
     </Style>
     <Style x:Key="WindowBorderStyle" BasedOn="{StaticResource BaseWindowBorderStyle}" TargetType="{x:Type Border}">
         <Setter Property="BorderThickness" Value="2" />

--- a/Flow.Launcher/Themes/League.xaml
+++ b/Flow.Launcher/Themes/League.xaml
@@ -6,7 +6,7 @@
         <Setter Property="Background" Value="#161614"/>
         <Setter Property="Foreground" Value="#b88f3a" />
         <Setter Property="CaretBrush" Value="#b88f3a" />
-        <Setter Property="Width" Value="490" />
+        <Setter Property="Padding" Value="0 0 66 0" />
         <Setter Property="Height" Value="42" />
     </Style>
     <Style x:Key="ItemGlyph"  BasedOn="{StaticResource BaseGlyphStyle}" TargetType="{x:Type TextBlock}">
@@ -15,7 +15,7 @@
     <Style x:Key="QuerySuggestionBoxStyle" BasedOn="{StaticResource BaseQuerySuggestionBoxStyle}" TargetType="{x:Type TextBox}">    
         <Setter Property="Background" Value="#161614"/>
         <Setter Property="Foreground" Value="#a09b8c" />
-        <Setter Property="Width" Value="490" />
+        <Setter Property="Padding" Value="0 0 66 0" />
         <Setter Property="Height" Value="42" />
     </Style>
 

--- a/Flow.Launcher/Themes/Metro Server.xaml
+++ b/Flow.Launcher/Themes/Metro Server.xaml
@@ -8,10 +8,12 @@
     <Style x:Key="QueryBoxStyle" BasedOn="{StaticResource BaseQueryBoxStyle}" TargetType="{x:Type TextBox}">
         <Setter Property="Foreground" Value="#FFFFFF" />
         <Setter Property="Background" Value="#001e4e"/>
+        <Setter Property="Padding" Value="0 0 18 0" />
     </Style>
     <Style x:Key="QuerySuggestionBoxStyle" BasedOn="{StaticResource BaseQuerySuggestionBoxStyle}" TargetType="{x:Type TextBox}">
         <Setter Property="Foreground" Value="#344c71" />
         <Setter Property="Background" Value="#001e4e" />
+        <Setter Property="Padding" Value="0 0 18 0" />
     </Style>
 
     <Style x:Key="WindowBorderStyle" BasedOn="{StaticResource BaseWindowBorderStyle}" TargetType="{x:Type Border}">

--- a/Flow.Launcher/Themes/Sublime.xaml
+++ b/Flow.Launcher/Themes/Sublime.xaml
@@ -13,17 +13,15 @@
         <Setter Property="Foreground" Value="#d2d8e5" />
         <Setter Property="CaretBrush" Value="#FFAA47" />
         <Setter Property="FontSize" Value="26" />
-        <Setter Property="Width" Value="490" />
         <Setter Property="Height" Value="42" />
-        <Setter Property="Padding" Value="0 4 0 0" />
+        <Setter Property="Padding" Value="0 4 66 0" />
     </Style>
     <Style x:Key="QuerySuggestionBoxStyle" BasedOn="{StaticResource BaseQuerySuggestionBoxStyle}" TargetType="{x:Type TextBox}">
         <Setter Property="Background" Value="#303840" />
         <Setter Property="Foreground" Value="#798189" />
         <Setter Property="FontSize" Value="26" />
-        <Setter Property="Width" Value="490" />
         <Setter Property="Height" Value="42" />
-        <Setter Property="Padding" Value="0 4 0 0" />
+        <Setter Property="Padding" Value="0 4 66 0" />
     </Style>
     <Style x:Key="WindowBorderStyle" BasedOn="{StaticResource BaseWindowBorderStyle}" TargetType="{x:Type Border}">
         <Setter Property="BorderThickness" Value="2" />

--- a/Flow.Launcher/Themes/Win10Light.xaml
+++ b/Flow.Launcher/Themes/Win10Light.xaml
@@ -16,16 +16,14 @@
         <Setter Property="BorderBrush" Value="Black"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="FontSize" Value="28" />
-        <Setter Property="Width" Value="490" />
         <Setter Property="Height" Value="42" />
-        <Setter Property="Padding" Value="0 4 0 0" />
+        <Setter Property="Padding" Value="0 4 66 0" />
     </Style>
     <Style x:Key="QuerySuggestionBoxStyle" BasedOn="{StaticResource BaseQuerySuggestionBoxStyle}" TargetType="{x:Type TextBox}">
         <Setter Property="Background" Value="#dddddd" />
         <Setter Property="Foreground" Value="#c6c6c6" />
         <Setter Property="FontSize" Value="28" />
-        <Setter Property="Padding" Value="0 4 0 0" />
-        <Setter Property="Width" Value="490" />
+        <Setter Property="Padding" Value="0 4 66 0" />
         <Setter Property="Height" Value="42" />
     </Style>
     <Style x:Key="WindowBorderStyle" BasedOn="{StaticResource BaseWindowBorderStyle}" TargetType="{x:Type Border}">

--- a/Flow.Launcher/Themes/Win11Dark.xaml
+++ b/Flow.Launcher/Themes/Win11Dark.xaml
@@ -14,16 +14,14 @@
         <Setter Property="Foreground" Value="#FFFFFF" />
         <Setter Property="CaretBrush" Value="#FFFFFF" />
         <Setter Property="FontSize" Value="26" />
-        <Setter Property="Padding" Value="0 4 0 0" />
-        <Setter Property="Width" Value="490" />
+        <Setter Property="Padding" Value="0 4 66 0" />
         <Setter Property="Height" Value="42" />
     </Style>
     <Style x:Key="QuerySuggestionBoxStyle" BasedOn="{StaticResource BaseQuerySuggestionBoxStyle}" TargetType="{x:Type TextBox}">
         <Setter Property="Background" Value="#202020" />
         <Setter Property="Foreground" Value="#7b7b7b" />
         <Setter Property="FontSize" Value="26" />
-        <Setter Property="Padding" Value="0 4 0 0" />
-        <Setter Property="Width" Value="490" />
+        <Setter Property="Padding" Value="0 4 66 0" />
         <Setter Property="Height" Value="42" />
     </Style>
     <Style x:Key="WindowBorderStyle" BasedOn="{StaticResource BaseWindowBorderStyle}" TargetType="{x:Type Border}">

--- a/Flow.Launcher/Themes/Win11Light.xaml
+++ b/Flow.Launcher/Themes/Win11Light.xaml
@@ -14,16 +14,14 @@
         <Setter Property="Foreground" Value="#000000" />
         <Setter Property="CaretBrush" Value="#000000" />
         <Setter Property="FontSize" Value="26" />
-        <Setter Property="Padding" Value="0 4 0 0" />
-        <Setter Property="Width" Value="490" />
+        <Setter Property="Padding" Value="0 4 66 0" />
         <Setter Property="Height" Value="42" />
     </Style>
     <Style x:Key="QuerySuggestionBoxStyle" BasedOn="{StaticResource BaseQuerySuggestionBoxStyle}" TargetType="{x:Type TextBox}">
         <Setter Property="Background" Value="#f3f3f3" />
         <Setter Property="Foreground" Value="#b5b5b5" />
         <Setter Property="FontSize" Value="26" />
-        <Setter Property="Padding" Value="0 4 0 0" />
-        <Setter Property="Width" Value="490" />
+        <Setter Property="Padding" Value="0 4 66 0" />
         <Setter Property="Height" Value="42" />
     </Style>
     <Style x:Key="WindowBorderStyle" BasedOn="{StaticResource BaseWindowBorderStyle}" TargetType="{x:Type Border}">


### PR DESCRIPTION
**Issue**

![image](https://user-images.githubusercontent.com/6903107/137264848-143d4166-cf3e-4085-8315-664806668dfb.png)


- in modern theme PR (in 1.9 pre Release).
- If the query box text is prolonged, it invades the icon area when On shadow of window in setting
- This is because the window size varies depending on the shadow on/off.

**Fix**
- Fixed Width Value for all themes have been removed.
- I added padding as much as the icon area.
- The size of the query box does not change regardless of the shadow.

![image](https://user-images.githubusercontent.com/6903107/137264877-98ee4543-cf25-40aa-a7a8-4b2462b654c2.png)


**Test**
- Enter a query that exceeds the window area.
- change the state of window shadow.
- Type long query again.