### PR TITLE
Fix Change "Max Result Count" to be applied immediately

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -10,7 +10,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
     public class Settings : BaseModel
     {
         private string language = "en";
-
+        private int maxresult = 5;
         public string Hotkey { get; set; } = $"{KeyConstant.Alt} + {KeyConstant.Space}";
         public string OpenResultModifiers { get; set; } = KeyConstant.Alt;
         public bool ShowOpenResultHotkey { get; set; } = true;
@@ -72,7 +72,14 @@ namespace Flow.Launcher.Infrastructure.UserSettings
 
         public double WindowLeft { get; set; }
         public double WindowTop { get; set; }
-        public int MaxResultsToShow { get; set; } = 5;
+        public int MaxResultsToShow
+        {
+            get => maxresult; set
+            {
+                maxresult = value;
+                OnPropertyChanged();
+            }
+        }
         public int ActivateTimes { get; set; }
 
 


### PR DESCRIPTION
Fix https://github.com/Flow-Launcher/Flow.Launcher/issues/684.
Actually, it's not bug. There was no code to apply immediately when changing.