### PR TITLE
quick exit when children property is not found

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
@@ -26,7 +26,7 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
             }
             return bookmarks;
         }
-        
+
         protected List<Bookmark> LoadBookmarksFromFile(string path, string source)
         {
             if (!File.Exists(path))
@@ -44,7 +44,9 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
 
         private void EnumerateFolderBookmark(JsonElement folderElement, List<Bookmark> bookmarks, string source)
         {
-            foreach (var subElement in folderElement.GetProperty("children").EnumerateArray())
+            if (!folderElement.TryGetProperty("children", out var childrenElement))
+                return;
+            foreach (var subElement in childrenElement.EnumerateArray())
             {
                 switch (subElement.GetProperty("type").GetString())
                 {


### PR DESCRIPTION
Sometimes the bookmark file may not be constructed property, leading the issue. This patch add a check for that to safely handle that.