### PR TITLE
Force Exit & Fix HideonStartup (#783)

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -185,7 +185,7 @@ namespace Flow.Launcher
             var setting = items.Add(InternationalizationManager.Instance.GetTranslation("iconTraySettings"));
             setting.Click += (o, e) => App.API.OpenSettingDialog();
             var exit = items.Add(InternationalizationManager.Instance.GetTranslation("iconTrayExit"));
-            exit.Click += (o, e) => Environment.Exit(0);
+            exit.Click += (o, e) => Close();
 
             _notifyIcon.ContextMenuStrip = menu;
             _notifyIcon.MouseClick += (o, e) =>

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -53,7 +53,7 @@ namespace Flow.Launcher
             _viewModel.Save();
             e.Cancel = true;
             await PluginManager.DisposePluginsAsync();
-            Application.Current.Shutdown();
+            Environment.Exit(0);
         }
 
         private void OnInitialized(object sender, EventArgs e)

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -273,7 +273,7 @@ namespace Flow.Launcher.ViewModel
             ReloadPluginDataCommand = new RelayCommand(_ =>
             {
                 Hide();
-                
+
                 PluginManager
                     .ReloadData()
                     .ContinueWith(_ =>
@@ -315,7 +315,7 @@ namespace Flow.Launcher.ViewModel
         /// <param name="queryText"></param>
         public void ChangeQueryText(string queryText, bool reQuery = false)
         {
-            if (QueryText!=queryText) 
+            if (QueryText != queryText)
             {
                 // re-query is done in QueryText's setter method
                 QueryText = queryText;
@@ -696,7 +696,7 @@ namespace Flow.Launcher.ViewModel
             OpenResultCommandModifiers = _settings.OpenResultModifiers ?? DefaultOpenResultModifiers;
         }
 
-        public async void ToggleFlowLauncher()
+        public void ToggleFlowLauncher()
         {
             if (MainWindowVisibility != Visibility.Visible)
             {

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -704,33 +704,30 @@ namespace Flow.Launcher.ViewModel
             }
             else
             {
-                switch (_settings.LastQueryMode)
-                {
-                    case LastQueryMode.Empty:
-                        ChangeQueryText(string.Empty);
-                        Application.Current.MainWindow.Opacity = 0; // Trick for no delay
-                        await Task.Delay(100);
-                        Application.Current.MainWindow.Opacity = 1;
-                        break;
-                    case LastQueryMode.Preserved:
-                        LastQuerySelected = true;
-                        break;
-                    case LastQueryMode.Selected:
-                        LastQuerySelected = false;
-                        break;
-                    default:
-                        throw new ArgumentException($"wrong LastQueryMode: <{_settings.LastQueryMode}>");
-                }
-                MainWindowVisibility = Visibility.Collapsed;
+                Hide();
             }
         }
 
-        public void Hide()
+        public async void Hide()
         {
-            if (MainWindowVisibility != Visibility.Collapsed)
+            switch (_settings.LastQueryMode)
             {
-                ToggleFlowLauncher();
+                case LastQueryMode.Empty:
+                    ChangeQueryText(string.Empty);
+                    Application.Current.MainWindow.Opacity = 0; // Trick for no delay
+                    await Task.Delay(100);
+                    Application.Current.MainWindow.Opacity = 1;
+                    break;
+                case LastQueryMode.Preserved:
+                    LastQuerySelected = true;
+                    break;
+                case LastQueryMode.Selected:
+                    LastQuerySelected = false;
+                    break;
+                default:
+                    throw new ArgumentException($"wrong LastQueryMode: <{_settings.LastQueryMode}>");
             }
+            MainWindowVisibility = Visibility.Collapsed;
         }
 
         #endregion


### PR DESCRIPTION
Fix #783 

1. There is no problem with 'Hide on startup' and config
2. It related https://github.com/Flow-Launcher/Flow.Launcher/pull/749
3. The Hide() function uses the toggleFlowLauncher function. (Copied from PT)
4. Hide() run when start of the flow in somewhere. Since this function was wearing a toggle, it was a problem that the hidden state was toggled again at the beginning.
5. Power Toy seems to have had something different because it doesn't have Startup Setting.
6. I changed Hide() to just close window.

There was no problem when I tested it, but I don't know if it'll be okay because I didn't understand the code exactly. Please check.