### PR TITLE
Remove Unneeded Project Reference for plugins

### DIFF
--- a/Flow.Launcher.Core/Plugin/ExecutablePlugin.cs
+++ b/Flow.Launcher.Core/Plugin/ExecutablePlugin.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Flow.Launcher.Core/Plugin/JsonPRCModel.cs
+++ b/Flow.Launcher.Core/Plugin/JsonPRCModel.cs
@@ -12,9 +12,7 @@
  * 
  */
 
-using Flow.Launcher.Core.Resource;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json.Serialization;
 using Flow.Launcher.Plugin;
 using System.Text.Json;

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -8,11 +8,8 @@ using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Plugin;
-using ICSharpCode.SharpZipLib.Zip;
-using JetBrains.Annotations;
 using Microsoft.IO;
 
 namespace Flow.Launcher.Core.Plugin

--- a/Flow.Launcher.Core/Plugin/PluginAssemblyLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginAssemblyLoader.cs
@@ -1,5 +1,4 @@
-﻿using Flow.Launcher.Infrastructure;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;

--- a/Flow.Launcher.Core/Plugin/PluginsLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginsLoader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Droplex;

--- a/Flow.Launcher.Core/Plugin/PluginsLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginsLoader.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Droplex;
@@ -11,7 +10,6 @@ using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.SharedCommands;
-using System.Diagnostics;
 using Stopwatch = Flow.Launcher.Infrastructure.Stopwatch;
 
 namespace Flow.Launcher.Core.Plugin

--- a/Flow.Launcher.Core/Plugin/PythonPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/PythonPlugin.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Flow.Launcher.Core/Plugin/QueryBuilder.cs
+++ b/Flow.Launcher.Core/Plugin/QueryBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Flow.Launcher.Plugin;
 
 namespace Flow.Launcher.Core.Plugin

--- a/Flow.Launcher.Infrastructure/Exception/ExceptionFormatter.cs
+++ b/Flow.Launcher.Infrastructure/Exception/ExceptionFormatter.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using System.Xml;
 using Microsoft.Win32;
 
 namespace Flow.Launcher.Infrastructure.Exception

--- a/Flow.Launcher.Infrastructure/Helper.cs
+++ b/Flow.Launcher.Infrastructure/Helper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/Flow.Launcher.Infrastructure/Http/Http.cs
+++ b/Flow.Launcher.Infrastructure/Http/Http.cs
@@ -1,15 +1,12 @@
 ﻿using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.UserSettings;
 using System;
-using System.ComponentModel;
 using System.Threading;
-using System.Windows.Interop;
 using Flow.Launcher.Plugin;
 
 namespace Flow.Launcher.Infrastructure.Http

--- a/Flow.Launcher.Infrastructure/Image/ImageCache.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageCache.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Media;
 
 namespace Flow.Launcher.Infrastructure.Image

--- a/Flow.Launcher.Infrastructure/Logger/Log.cs
+++ b/Flow.Launcher.Infrastructure/Logger/Log.cs
@@ -5,8 +5,6 @@ using NLog;
 using NLog.Config;
 using NLog.Targets;
 using Flow.Launcher.Infrastructure.UserSettings;
-using JetBrains.Annotations;
-using NLog.Fluent;
 using NLog.Targets.Wrappers;
 using System.Runtime.ExceptionServices;
 using System.Text;

--- a/Flow.Launcher.Infrastructure/Storage/FlowLauncherJsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/FlowLauncherJsonStorage.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.IO;
 using Flow.Launcher.Infrastructure.UserSettings;
 
 namespace Flow.Launcher.Infrastructure.Storage

--- a/Flow.Launcher.Infrastructure/Storage/PluginJsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/PluginJsonStorage.cs
@@ -10,7 +10,7 @@ namespace Flow.Launcher.Infrastructure.Storage
             // C# related, add python related below
             var dataType = typeof(T);
             var assemblyName = dataType.Assembly.GetName().Name;
-            DirectoryPath = Path.Combine(DataLocation.DataDirectory(), DirectoryName, Constant.Plugins, assemblyName);
+            DirectoryPath = Path.Combine(DataLocation.PluginSettingsDirectory, assemblyName);
             Helper.ValidateDirectory(DirectoryPath);
 
             FilePath = Path.Combine(DirectoryPath, $"{dataType.Name}{FileSuffix}");

--- a/Flow.Launcher.Infrastructure/UserSettings/DataLocation.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/DataLocation.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Flow.Launcher.Infrastructure.UserSettings
 {

--- a/Flow.Launcher.Infrastructure/UserSettings/HttpProxy.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/HttpProxy.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel;
-
-namespace Flow.Launcher.Infrastructure.UserSettings
+﻿namespace Flow.Launcher.Infrastructure.UserSettings
 {
     public enum ProxyProperty
     {

--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -4,7 +4,6 @@ using System.Drawing;
 using System.Text.Json.Serialization;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.SharedModels;
-using Flow.Launcher;
 
 namespace Flow.Launcher.Infrastructure.UserSettings
 {

--- a/Flow.Launcher.Plugin/Features.cs
+++ b/Flow.Launcher.Plugin/Features.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Threading;
-
-namespace Flow.Launcher.Plugin
+﻿namespace Flow.Launcher.Plugin
 {
     /// <summary>
     /// Base Interface for Flow's special plugin feature interface

--- a/Flow.Launcher.Plugin/GlyphInfo.cs
+++ b/Flow.Launcher.Plugin/GlyphInfo.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Media;
-
-namespace Flow.Launcher.Plugin
+﻿namespace Flow.Launcher.Plugin
 {
     public record GlyphInfo(string FontFamily, string Glyph);
 }

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -153,6 +153,13 @@ namespace Flow.Launcher.Plugin
         void RemoveActionKeyword(string pluginId, string oldActionKeyword);
 
         /// <summary>
+        /// Check whether actionKeyword is registered
+        /// </summary>
+        /// <param name="actionKeyword"></param>
+        /// <returns></returns>
+        bool ActionKeywordRegistered(string actionKeyword);
+
+        /// <summary>
         /// Log debug message
         /// Message will only be logged in Debug mode
         /// </summary>

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -100,6 +100,8 @@ namespace Flow.Launcher.Plugin
         /// <returns></returns>
         List<PluginPair> GetAllPlugins();
 
+        string GetSettingLocation();
+
         /// <summary>
         /// Fired after global keyboard events
         /// if you want to hook something like Ctrl+R, you should use this event

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Media;
 
 namespace Flow.Launcher.Plugin
 {
@@ -100,7 +101,18 @@ namespace Flow.Launcher.Plugin
         /// <returns></returns>
         List<PluginPair> GetAllPlugins();
 
+        /// <summary>
+        /// Get Current Plugin Setting Location (through reflection)
+        /// </summary>
+        /// <returns></returns>
         string GetSettingLocation();
+
+        /// <summary>
+        /// Load a ImageSource through Flow's Image Management System
+        /// </summary>
+        /// <param name="pathToImage"></param>
+        /// <returns></returns>
+        ImageSource LoadImage(string pathToImage, bool loadFullImage = false);
 
         /// <summary>
         /// Fired after global keyboard events

--- a/Flow.Launcher.Plugin/PluginInitContext.cs
+++ b/Flow.Launcher.Plugin/PluginInitContext.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Flow.Launcher.Plugin
+﻿namespace Flow.Launcher.Plugin
 {
     public class PluginInitContext
     {

--- a/Flow.Launcher.Plugin/PluginMetadata.cs
+++ b/Flow.Launcher.Plugin/PluginMetadata.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Text.Json.Serialization;
 

--- a/Flow.Launcher.Plugin/Query.cs
+++ b/Flow.Launcher.Plugin/Query.cs
@@ -1,7 +1,4 @@
-﻿using JetBrains.Annotations;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 
 namespace Flow.Launcher.Plugin
 {

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Windows;
 
 namespace Flow.Launcher.Plugin.SharedCommands
 {

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Windows;
 
 namespace Flow.Launcher.Plugin.SharedCommands
 {

--- a/Flow.Launcher.Plugin/SharedCommands/ShellCommand.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/ShellCommand.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Flow.Launcher.Plugin.SharedCommands
 {

--- a/Flow.Launcher.Test/HttpTest.cs
+++ b/Flow.Launcher.Test/HttpTest.cs
@@ -1,7 +1,5 @@
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Infrastructure.Http;
 

--- a/Flow.Launcher.Test/Plugins/JsonRPCPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/JsonRPCPluginTest.cs
@@ -1,5 +1,4 @@
-﻿using NUnit;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Plugin;
 using System.Threading.Tasks;

--- a/Flow.Launcher.Test/Plugins/PluginInitTest.cs
+++ b/Flow.Launcher.Test/Plugins/PluginInitTest.cs
@@ -1,6 +1,4 @@
 ﻿using NUnit.Framework;
-using Flow.Launcher.Core.Plugin;
-using Flow.Launcher.Infrastructure.Exception;
 
 namespace Flow.Launcher.Test.Plugins
 {

--- a/Flow.Launcher.Test/Plugins/ProgramTest.cs
+++ b/Flow.Launcher.Test/Plugins/ProgramTest.cs
@@ -1,7 +1,6 @@
 ﻿using Flow.Launcher.Plugin.Program.Programs;
 using NUnit.Framework;
 using System;
-using Windows.ApplicationModel;
 
 namespace Flow.Launcher.Test.Plugins
 {

--- a/Flow.Launcher/ActionKeywords.xaml.cs
+++ b/Flow.Launcher/ActionKeywords.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System.Windows;
 using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Core.Resource;
-using Flow.Launcher.Infrastructure.Exception;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.ViewModel;

--- a/Flow.Launcher/Converters/BorderClipConverter.cs
+++ b/Flow.Launcher/Converters/BorderClipConverter.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
-using System.Windows.Documents;
 using System.Windows.Shapes;
 
 // For Clipping inside listbox item

--- a/Flow.Launcher/Converters/HighlightTextConverter.cs
+++ b/Flow.Launcher/Converters/HighlightTextConverter.cs
@@ -2,11 +2,8 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Data;
-using System.Windows.Media;
 using System.Windows.Documents;
 
 namespace Flow.Launcher.Converters

--- a/Flow.Launcher/Converters/OpenResultHotkeyVisibilityConverter.cs
+++ b/Flow.Launcher/Converters/OpenResultHotkeyVisibilityConverter.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;

--- a/Flow.Launcher/CustomQueryHotkeySetting.xaml.cs
+++ b/Flow.Launcher/CustomQueryHotkeySetting.xaml.cs
@@ -1,8 +1,6 @@
 ﻿using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Helper;
-using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Infrastructure.UserSettings;
-using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;

--- a/Flow.Launcher/Helper/ErrorReporting.cs
+++ b/Flow.Launcher/Helper/ErrorReporting.cs
@@ -3,8 +3,6 @@ using System.Windows.Threading;
 using NLog;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Exception;
-using NLog.Fluent;
-using Log = Flow.Launcher.Infrastructure.Logger.Log;
 
 namespace Flow.Launcher.Helper
 {

--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -6,8 +6,6 @@ using NHotkey.Wpf;
 using Flow.Launcher.Core.Resource;
 using System.Windows;
 using Flow.Launcher.ViewModel;
-using System.Threading.Tasks;
-using System.Threading;
 
 namespace Flow.Launcher.Helper
 {

--- a/Flow.Launcher/Helper/SingleInstance.cs
+++ b/Flow.Launcher/Helper/SingleInstance.cs
@@ -1,21 +1,18 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.IO.Pipes;
-using System.Runtime.Serialization.Formatters;
 using System.Security;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Threading;
 
 // http://blogs.microsoft.co.il/arik/2010/05/28/wpf-single-instance-application/
 // modified to allow single instace restart
-namespace Flow.Launcher.Helper 
+namespace Flow.Launcher.Helper
 {
     internal enum WM
     {

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -11,16 +11,11 @@ using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Helper;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.ViewModel;
-using Microsoft.AspNetCore.Authorization;
-using Application = System.Windows.Application;
 using Screen = System.Windows.Forms.Screen;
 using ContextMenuStrip = System.Windows.Forms.ContextMenuStrip;
-using DataFormats = System.Windows.DataFormats;
 using DragEventArgs = System.Windows.DragEventArgs;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
-using MessageBox = System.Windows.MessageBox;
 using NotifyIcon = System.Windows.Forms.NotifyIcon;
-using System.Windows.Interop;
 
 namespace Flow.Launcher
 {

--- a/Flow.Launcher/Msg.xaml.cs
+++ b/Flow.Launcher/Msg.xaml.cs
@@ -4,7 +4,6 @@ using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media.Animation;
-using System.Windows.Media.Imaging;
 using Flow.Launcher.Helper;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Image;

--- a/Flow.Launcher/PriorityChangeWindow.xaml.cs
+++ b/Flow.Launcher/PriorityChangeWindow.xaml.cs
@@ -3,17 +3,9 @@ using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.ViewModel;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace Flow.Launcher
 {

--- a/Flow.Launcher/Properties/AssemblyInfo.cs
+++ b/Flow.Launcher/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
-﻿using System.Reflection;
-using System.Windows;
+﻿using System.Windows;
 
 [assembly: ThemeInfo(
-    ResourceDictionaryLocation.None, 
+    ResourceDictionaryLocation.None,
     ResourceDictionaryLocation.SourceAssembly
-)]
+)] 

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -22,6 +22,8 @@ using System.Runtime.CompilerServices;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.Storage;
 using System.Collections.Concurrent;
+using System.Reflection;
+using Flow.Launcher.Infrastructure.UserSettings;
 
 namespace Flow.Launcher
 {
@@ -78,6 +80,11 @@ namespace Flow.Launcher
             _mainVM.Save();
             _settingsVM.Save();
             ImageLoader.Save();
+        }
+
+        public string GetSettingLocation()
+        {
+           return Path.Combine(DataLocation.PluginSettingsDirectory, Assembly.GetCallingAssembly().GetName().Name)
         }
 
         public Task ReloadAllPluginData() => PluginManager.ReloadData();

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -123,6 +123,7 @@ namespace Flow.Launcher
         public Task HttpDownloadAsync([NotNull] string url, [NotNull] string filePath,
             CancellationToken token = default) => Http.DownloadAsync(url, filePath, token);
 
+        public bool ActionKeywordRegistered(string actionKeyword) => PluginManager.ActionKeywordRegistered(actionKeyword);
         public void AddActionKeyword(string pluginId, string newActionKeyword) =>
             PluginManager.AddActionKeyword(pluginId, newActionKeyword);
 
@@ -158,7 +159,7 @@ namespace Flow.Launcher
             if (!_pluginJsonStorages.ContainsKey(type))
                 _pluginJsonStorages[type] = new PluginJsonStorage<T>();
 
-            return ((PluginJsonStorage<T>) _pluginJsonStorages[type]).Load();
+            return ((PluginJsonStorage<T>)_pluginJsonStorages[type]).Load();
         }
 
         public void SaveSettingJsonStorage<T>() where T : new()
@@ -167,7 +168,7 @@ namespace Flow.Launcher
             if (!_pluginJsonStorages.ContainsKey(type))
                 _pluginJsonStorages[type] = new PluginJsonStorage<T>();
 
-            ((PluginJsonStorage<T>) _pluginJsonStorages[type]).Save();
+            ((PluginJsonStorage<T>)_pluginJsonStorages[type]).Save();
         }
 
         public void SaveJsonStorage<T>(T settings) where T : new()
@@ -175,7 +176,7 @@ namespace Flow.Launcher
             var type = typeof(T);
             _pluginJsonStorages[type] = new PluginJsonStorage<T>(settings);
 
-            ((PluginJsonStorage<T>) _pluginJsonStorages[type]).Save();
+            ((PluginJsonStorage<T>)_pluginJsonStorages[type]).Save();
         }
 
         public event FlowLauncherGlobalKeyboardEventHandler GlobalKeyboardEvent;
@@ -188,7 +189,7 @@ namespace Flow.Launcher
         {
             if (GlobalKeyboardEvent != null)
             {
-                return GlobalKeyboardEvent((int) keyevent, vkcode, state);
+                return GlobalKeyboardEvent((int)keyevent, vkcode, state);
             }
 
             return true;

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -24,6 +24,7 @@ using Flow.Launcher.Infrastructure.Storage;
 using System.Collections.Concurrent;
 using System.Reflection;
 using Flow.Launcher.Infrastructure.UserSettings;
+using System.Windows.Media;
 
 namespace Flow.Launcher
 {
@@ -84,7 +85,7 @@ namespace Flow.Launcher
 
         public string GetSettingLocation()
         {
-           return Path.Combine(DataLocation.PluginSettingsDirectory, Assembly.GetCallingAssembly().GetName().Name)
+            return Path.Combine(DataLocation.PluginSettingsDirectory, Assembly.GetCallingAssembly().GetName().Name);
         }
 
         public Task ReloadAllPluginData() => PluginManager.ReloadData();
@@ -122,10 +123,12 @@ namespace Flow.Launcher
         public MatchResult FuzzySearch(string query, string stringToCompare) =>
             StringMatcher.FuzzySearch(query, stringToCompare);
 
-        public Task<string> HttpGetStringAsync(string url, CancellationToken token = default) => Http.GetAsync(url);
+        public ImageSource LoadImage(string pathToImage, bool loadFullImage) => ImageLoader.Load(pathToImage, loadFullImage);
+
+        public Task<string> HttpGetStringAsync(string url, CancellationToken token = default) => Http.GetAsync(url, token);
 
         public Task<Stream> HttpGetStreamAsync(string url, CancellationToken token = default) =>
-            Http.GetStreamAsync(url);
+            Http.GetStreamAsync(url, token);
 
         public Task HttpDownloadAsync([NotNull] string url, [NotNull] string filePath,
             CancellationToken token = default) => Http.DownloadAsync(url, filePath, token);

--- a/Flow.Launcher/ReportWindow.xaml.cs
+++ b/Flow.Launcher/ReportWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text;

--- a/Flow.Launcher/Storage/UserSelectedRecord.cs
+++ b/Flow.Launcher/Storage/UserSelectedRecord.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using Flow.Launcher.Infrastructure;
-using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin;
-using Flow.Launcher.ViewModel;
 
 namespace Flow.Launcher.Storage
 {

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
 using System.Windows;
 using System.Windows.Input;
 using Flow.Launcher.Core.Plugin;
@@ -20,9 +19,6 @@ using Flow.Launcher.Infrastructure.Logger;
 using Microsoft.VisualStudio.Threading;
 using System.Threading.Channels;
 using ISavable = Flow.Launcher.Plugin.ISavable;
-using System.Windows.Threading;
-using NHotkey;
-using Windows.Web.Syndication;
 
 
 namespace Flow.Launcher.ViewModel

--- a/Flow.Launcher/ViewModel/ResultsForUpdate.cs
+++ b/Flow.Launcher/ViewModel/ResultsForUpdate.cs
@@ -1,7 +1,5 @@
 ﻿using Flow.Launcher.Plugin;
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 
 namespace Flow.Launcher.ViewModel

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -15,7 +15,6 @@ using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Helper;
 using Flow.Launcher.Infrastructure;
-using Flow.Launcher.Infrastructure.Image;
 using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromeBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromeBookmarkLoader.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace Flow.Launcher.Plugin.BrowserBookmark
 {

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
@@ -1,5 +1,4 @@
 ﻿using Flow.Launcher.Plugin.BrowserBookmark.Models;
-using Microsoft.AspNetCore.Authentication;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Commands/BookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Commands/BookmarkLoader.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Plugin.BrowserBookmark.Models;
 using Flow.Launcher.Plugin.SharedModels;
 
@@ -8,13 +7,15 @@ namespace Flow.Launcher.Plugin.BrowserBookmark.Commands
 {
     internal static class BookmarkLoader
     {
+        public static IPublicAPI publicAPI { get; internal set; }
+
         internal static MatchResult MatchProgram(Bookmark bookmark, string queryString)
         {
-            var match = StringMatcher.FuzzySearch(queryString, bookmark.Name);
+            var match = publicAPI.FuzzySearch(queryString, bookmark.Name);
             if (match.IsSearchPrecisionScoreMet())
                 return match;
 
-            return StringMatcher.FuzzySearch(queryString, bookmark.Url);
+            return publicAPI.FuzzySearch(queryString, bookmark.Url);
         }
 
         internal static List<Bookmark> LoadAllBookmarks(Settings setting)

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/EdgeBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/EdgeBookmarkLoader.cs
@@ -2,9 +2,6 @@ using Flow.Launcher.Plugin.BrowserBookmark.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text.Json;
-using System.Text.RegularExpressions;
 
 namespace Flow.Launcher.Plugin.BrowserBookmark
 {

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Flow.Launcher.Plugin.BrowserBookmark.csproj
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Flow.Launcher.Plugin.BrowserBookmark.csproj
@@ -50,7 +50,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Flow.Launcher.Infrastructure\Flow.Launcher.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Flow.Launcher.Plugin\Flow.Launcher.Plugin.csproj" />
   </ItemGroup>
 

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using Flow.Launcher.Infrastructure.Logger;
-using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin.BrowserBookmark.Commands;
 using Flow.Launcher.Plugin.BrowserBookmark.Models;
 using Flow.Launcher.Plugin.BrowserBookmark.Views;
@@ -18,13 +16,14 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
 
         private List<Bookmark> cachedBookmarks = new List<Bookmark>();
 
-        private Settings _settings { get; set;}
+        private Settings _settings { get; set; }
 
         public void Init(PluginInitContext context)
         {
             this.context = context;
-            
+
             _settings = context.API.LoadSettingJsonStorage<Settings>();
+            BookmarkLoader.publicAPI = context.API;
 
             cachedBookmarks = BookmarkLoader.LoadAllBookmarks(_settings);
         }
@@ -129,7 +128,7 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
                         catch (Exception e)
                         {
                             var message = "Failed to set url in clipboard";
-                            Log.Exception("Main",message, e, "LoadContextMenus");
+                            context.API.LogException($"BrowserBookmark.{nameof(Main)}",message, e, "LoadContextMenus");
 
                             context.API.ShowMsg(message);
 

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Models/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Models/Settings.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Text.Json.Serialization;
+﻿using System.Collections.ObjectModel;
 
 namespace Flow.Launcher.Plugin.BrowserBookmark.Models
 {

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/CustomBrowserSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/CustomBrowserSetting.xaml.cs
@@ -1,17 +1,7 @@
 ﻿using Flow.Launcher.Plugin.BrowserBookmark.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace Flow.Launcher.Plugin.BrowserBookmark.Views
 {

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/SettingsControl.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/SettingsControl.xaml.cs
@@ -1,6 +1,5 @@
 using Microsoft.Win32;
 using System.Windows;
-using System.Windows.Controls;
 using Flow.Launcher.Plugin.BrowserBookmark.Models;
 using System.Windows.Input;
 using System.ComponentModel;

--- a/Plugins/Flow.Launcher.Plugin.Calculator/DecimalSeparator.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/DecimalSeparator.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel;
 using Flow.Launcher.Core;
 
 namespace Flow.Launcher.Plugin.Caculator
-{    
+{
     [TypeConverter(typeof(LocalizationConverter))]
     public enum DecimalSeparator
     {

--- a/Plugins/Flow.Launcher.Plugin.Calculator/LocalizationHelper/LocalizationConverter.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/LocalizationHelper/LocalizationConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Reflection;
+using System.Windows.Data;
+
+namespace Flow.Launcher.Plugin.Caculator.LocalizationHelper
+{
+    public class LocalizationConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (targetType == typeof(string) && value != null)
+            {
+                FieldInfo fi = value.GetType().GetField(value.ToString());
+                if (fi != null)
+                {
+                    string localizedDescription = string.Empty;
+                    var attributes = (DescriptionAttribute[])fi.GetCustomAttributes(typeof(DescriptionAttribute), false);
+                    if ((attributes.Length > 0) && (!String.IsNullOrEmpty(attributes[0].Description)))
+                    {
+                        localizedDescription = attributes[0].Description;
+                    }
+
+                    return (!String.IsNullOrEmpty(localizedDescription)) ? localizedDescription : value.ToString();
+                }
+            }
+            
+            return string.Empty;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Plugins/Flow.Launcher.Plugin.Calculator/LocalizationHelper/LocalizedDescriptionAttribute.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/LocalizationHelper/LocalizedDescriptionAttribute.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+
+namespace Flow.Launcher.Plugin.Caculator.LocalizationHelper
+{
+    public class LocalizedDescriptionAttribute : DescriptionAttribute
+    {
+        private readonly IPublicAPI publicAPI;
+        private readonly string _resourceKey;
+
+        public LocalizedDescriptionAttribute(IPublicAPI api, string resourceKey)
+        {
+            publicAPI = api;
+            _resourceKey = resourceKey;
+        }
+
+        public override string Description
+        {
+            get
+            {
+                string description = publicAPI.GetTranslation(_resourceKey);
+                return string.IsNullOrWhiteSpace(description) ?
+                    string.Format("[[{0}]]", _resourceKey) : description;
+            }
+        }
+    }
+}

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
@@ -6,7 +6,6 @@ using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 using Mages.Core;
-using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin.Caculator.ViewModels;
 using Flow.Launcher.Plugin.Caculator.Views;
 

--- a/Plugins/Flow.Launcher.Plugin.Calculator/NumberTranslator.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/NumberTranslator.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
+﻿using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Flow.Launcher.Plugin.Caculator
 {

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Settings.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Flow.Launcher.Plugin.Caculator
+﻿namespace Flow.Launcher.Plugin.Caculator
 {
     public class Settings
     {

--- a/Plugins/Flow.Launcher.Plugin.Calculator/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/ViewModels/SettingsViewModel.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Flow.Launcher.Infrastructure.Storage;
-using Flow.Launcher.Infrastructure.UserSettings;
 
 namespace Flow.Launcher.Plugin.Caculator.ViewModels
 {

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Views/CalculatorSettings.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Views/CalculatorSettings.xaml.cs
@@ -1,17 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using Flow.Launcher.Plugin.Caculator.ViewModels;
 
 namespace Flow.Launcher.Plugin.Caculator.Views

--- a/Plugins/Flow.Launcher.Plugin.ControlPanel/Flow.Launcher.Plugin.ControlPanel.csproj
+++ b/Plugins/Flow.Launcher.Plugin.ControlPanel/Flow.Launcher.Plugin.ControlPanel.csproj
@@ -40,7 +40,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Flow.Launcher.Infrastructure\Flow.Launcher.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Flow.Launcher.Plugin\Flow.Launcher.Plugin.csproj" />
   </ItemGroup>
   
@@ -53,6 +52,10 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Plugins/Flow.Launcher.Plugin.ControlPanel/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.ControlPanel/Main.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
-using Flow.Launcher.Infrastructure;
 
 namespace Flow.Launcher.Plugin.ControlPanel
 {
@@ -42,8 +40,8 @@ namespace Flow.Launcher.Plugin.ControlPanel
 
             foreach (var item in controlPanelItems)
             {
-                var titleMatch = StringMatcher.FuzzySearch(query.Search, item.LocalizedString);
-                var subTitleMatch = StringMatcher.FuzzySearch(query.Search, item.InfoTip);
+                var titleMatch = context.API.FuzzySearch(query.Search, item.LocalizedString);
+                var subTitleMatch = context.API.FuzzySearch(query.Search, item.InfoTip);
                 
                 item.Score = Math.Max(titleMatch.Score, subTitleMatch.Score);
                 if (item.Score > 0)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
-using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Plugin.SharedCommands;
 using Flow.Launcher.Plugin.Explorer.Search;
 using Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks;
@@ -14,6 +13,7 @@ using MessageBoxIcon = System.Windows.Forms.MessageBoxIcon;
 using MessageBoxButton = System.Windows.Forms.MessageBoxButtons;
 using DialogResult = System.Windows.Forms.DialogResult;
 using Flow.Launcher.Plugin.Explorer.ViewModels;
+using System.Runtime.CompilerServices;
 
 namespace Flow.Launcher.Plugin.Explorer
 {
@@ -48,9 +48,13 @@ namespace Flow.Launcher.Plugin.Explorer
                 contextMenus.Add(CreateOpenWindowsIndexingOptions());
 
                 if (record.ShowIndexState)
-                    contextMenus.Add(new Result {Title = "From index search: " + (record.WindowsIndexed ? "Yes" : "No"), 
-                                                    SubTitle = "Location: " + record.FullPath,
-                                                    Score = 501, IcoPath = Constants.IndexImagePath});
+                    contextMenus.Add(new Result
+                    {
+                        Title = "From index search: " + (record.WindowsIndexed ? "Yes" : "No"),
+                        SubTitle = "Location: " + record.FullPath,
+                        Score = 501,
+                        IcoPath = Constants.IndexImagePath
+                    });
 
                 var icoPath = (record.Type == ResultType.File) ? Constants.FileImagePath : Constants.FolderImagePath;
                 var fileOrFolder = (record.Type == ResultType.File) ? "file" : "folder";
@@ -105,7 +109,7 @@ namespace Flow.Launcher.Plugin.Explorer
                         IcoPath = Constants.RemoveQuickAccessImagePath
                     });
                 }
-                
+
                 contextMenus.Add(new Result
                 {
                     Title = Context.API.GetTranslation("plugin_explorer_copypath"),
@@ -161,10 +165,10 @@ namespace Flow.Launcher.Plugin.Explorer
                             try
                             {
                                 if (MessageBox.Show(
-                                        string.Format(Context.API.GetTranslation("plugin_explorer_deletefilefolderconfirm"),fileOrFolder), 
-                                        string.Empty, 
-                                        MessageBoxButton.YesNo, 
-                                        MessageBoxIcon.Warning) 
+                                        string.Format(Context.API.GetTranslation("plugin_explorer_deletefilefolderconfirm"), fileOrFolder),
+                                        string.Empty,
+                                        MessageBoxButton.YesNo,
+                                        MessageBoxIcon.Warning)
                                     == DialogResult.No)
                                     return false;
 
@@ -176,7 +180,7 @@ namespace Flow.Launcher.Plugin.Explorer
                                 Task.Run(() =>
                                 {
                                     Context.API.ShowMsg(Context.API.GetTranslation("plugin_explorer_deletefilefoldersuccess"),
-                                                                        string.Format(Context.API.GetTranslation("plugin_explorer_deletefilefoldersuccess_detail"), fileOrFolder), 
+                                                                        string.Format(Context.API.GetTranslation("plugin_explorer_deletefilefoldersuccess_detail"), fileOrFolder),
                                                                         Constants.ExplorerIconImageFullPath);
                                 });
                             }
@@ -250,7 +254,7 @@ namespace Flow.Launcher.Plugin.Explorer
         {
             string editorPath = "Notepad.exe"; // TODO add the ability to create a custom editor
 
-            var name = Context.API.GetTranslation("plugin_explorer_openwitheditor") 
+            var name = Context.API.GetTranslation("plugin_explorer_openwitheditor")
                                     + " " + Path.GetFileNameWithoutExtension(editorPath);
 
             return new Result
@@ -283,13 +287,13 @@ namespace Flow.Launcher.Plugin.Explorer
                 SubTitle = Context.API.GetTranslation("plugin_explorer_path") + " " + record.FullPath,
                 Action = _ =>
                 {
-                    if(!Settings.IndexSearchExcludedSubdirectoryPaths.Any(x => x.Path == record.FullPath))
+                    if (!Settings.IndexSearchExcludedSubdirectoryPaths.Any(x => x.Path == record.FullPath))
                         Settings.IndexSearchExcludedSubdirectoryPaths.Add(new AccessLink { Path = record.FullPath });
 
                     Task.Run(() =>
                     {
-                        Context.API.ShowMsg(Context.API.GetTranslation("plugin_explorer_excludedfromindexsearch_msg"), 
-                                                            Context.API.GetTranslation("plugin_explorer_path") + 
+                        Context.API.ShowMsg(Context.API.GetTranslation("plugin_explorer_excludedfromindexsearch_msg"),
+                                                            Context.API.GetTranslation("plugin_explorer_path") +
                                                             " " + record.FullPath, Constants.ExplorerIconImageFullPath);
 
                         // so the new path can be persisted to storage and not wait till next ViewModel save.
@@ -313,11 +317,11 @@ namespace Flow.Launcher.Plugin.Explorer
                     try
                     {
                         var psi = new ProcessStartInfo
-                                    {
-                                        FileName = "control.exe",
-                                        UseShellExecute = true,
-                                        Arguments = "srchadmin.dll"
-                                    };
+                        {
+                            FileName = "control.exe",
+                            UseShellExecute = true,
+                            Arguments = "srchadmin.dll"
+                        };
 
                         Process.Start(psi);
                         return true;
@@ -334,9 +338,9 @@ namespace Flow.Launcher.Plugin.Explorer
             };
         }
 
-        public void LogException(string message, Exception e)
+        public void LogException(string message, Exception e, [CallerMemberName] string methodName = "")
         {
-            Log.Exception($"|Flow.Launcher.Plugin.Folder.ContextMenu|{message}", e);
+            Context.API.LogException("Flow.Launcher.Plugin.Folder", message, e, methodName);
         }
 
         private bool CanRunAsDifferentUser(string path)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Flow.Launcher.Plugin.Explorer.csproj
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Flow.Launcher.Plugin.Explorer.csproj
@@ -43,8 +43,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Flow.Launcher.Core\Flow.Launcher.Core.csproj" />
-    <ProjectReference Include="..\..\Flow.Launcher.Infrastructure\Flow.Launcher.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Flow.Launcher.Plugin\Flow.Launcher.Plugin.csproj" />
   </ItemGroup>
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
@@ -1,10 +1,13 @@
 using Flow.Launcher.Plugin.Explorer.Search;
 using Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo;
 using Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks;
+using Flow.Launcher.Plugin.Explorer.Search.WindowsIndex;
 using Flow.Launcher.Plugin.Explorer.ViewModels;
 using Flow.Launcher.Plugin.Explorer.Views;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Controls;
@@ -48,6 +51,7 @@ namespace Flow.Launcher.Plugin.Explorer
             searchManager = new SearchManager(Settings, Context);
             ResultManager.Init(Context, Settings);
             DirectoryInfoSearch.PublicAPI = Context.API;
+            IndexSearch.PublicAPI = Context.API;
 
             return Task.CompletedTask;
         }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
@@ -1,5 +1,5 @@
-using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin.Explorer.Search;
+using Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo;
 using Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks;
 using Flow.Launcher.Plugin.Explorer.ViewModels;
 using Flow.Launcher.Plugin.Explorer.Views;
@@ -47,6 +47,7 @@ namespace Flow.Launcher.Plugin.Explorer
             contextMenu = new ContextMenu(Context, Settings, viewModel);
             searchManager = new SearchManager(Settings, Context);
             ResultManager.Init(Context, Settings);
+            DirectoryInfoSearch.PublicAPI = Context.API;
 
             return Task.CompletedTask;
         }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Constants.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Constants.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Reflection;
 
 namespace Flow.Launcher.Plugin.Explorer.Search

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
@@ -1,5 +1,4 @@
-﻿using Flow.Launcher.Infrastructure.Logger;
-using Flow.Launcher.Plugin.SharedCommands;
+﻿using Flow.Launcher.Plugin.SharedCommands;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -10,6 +9,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo
 {
     public static class DirectoryInfoSearch
     {
+        public static IPublicAPI PublicAPI { get; set; }
+
         internal static List<Result> TopLevelDirectorySearch(Query query, string search, CancellationToken token)
         {
             var criteria = ConstructSearchCriteria(search);
@@ -76,7 +77,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo
             }
             catch (Exception e)
             {
-                Log.Exception("Flow.Plugin.Explorer.", nameof(DirectoryInfoSearch), e);
+                PublicAPI.LogException("Flow.Plugin.Explorer.", nameof(DirectoryInfoSearch), e);
                 results.Add(new Result {Title = e.Message, Score = 501});
 
                 return results;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace Flow.Launcher.Plugin.Explorer.Search
 {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -1,5 +1,4 @@
-﻿using Flow.Launcher.Infrastructure;
-using Flow.Launcher.Plugin.SharedCommands;
+﻿using Flow.Launcher.Plugin.SharedCommands;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -27,7 +26,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 Title = title,
                 IcoPath = path,
                 SubTitle = subtitle,
-                TitleHighlightData = StringMatcher.FuzzySearch(query.Search, title).MatchData,
+                TitleHighlightData = Context.API.FuzzySearch(query.Search, title).MatchData,
                 Action = c =>
                 {
                     if (c.SpecialKeyState.CtrlPressed || (!Settings.PathSearchKeywordEnabled && !Settings.SearchActionKeywordEnabled))
@@ -123,7 +122,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 Title = Path.GetFileName(filePath),
                 SubTitle = filePath,
                 IcoPath = filePath,
-                TitleHighlightData = StringMatcher.FuzzySearch(query.Search, Path.GetFileName(filePath)).MatchData,
+                TitleHighlightData = Context.API.FuzzySearch(query.Search, Path.GetFileName(filePath)).MatchData,
                 Score = score,
                 Action = c =>
                 {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -14,6 +14,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
 {
     internal static class IndexSearch
     {
+        internal static IPublicAPI PublicAPI { get; set; }
+
 
         // Reserved keywords in oleDB
         private const string reservedStringPattern = @"^[`\@\#\^,\&\/\\\$\%_;\[\]]+$";
@@ -219,7 +221,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
 #if DEBUG // Please investigate and handle error from index search
             throw e;
 #else
-            Log.Exception($"|Flow.Launcher.Plugin.Explorer.IndexSearch|{message}", e);
+            PublicAPI.LogException("Flow.Plugin.Explorer",message, e);
 #endif            
         }
     }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/IndexSearch.cs
@@ -1,4 +1,3 @@
-using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks;
 using Microsoft.Search.Interop;
 using System;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -1,9 +1,6 @@
-﻿using Flow.Launcher.Core.Plugin;
-using Flow.Launcher.Infrastructure.Storage;
-using Flow.Launcher.Plugin.Explorer.Search;
+﻿using Flow.Launcher.Plugin.Explorer.Search;
 using Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks;
 using System.Diagnostics;
-using System.Threading.Tasks;
 
 namespace Flow.Launcher.Plugin.Explorer.ViewModels
 {
@@ -43,12 +40,13 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
 
         internal void UpdateActionKeyword(Settings.ActionKeyword modifiedActionKeyword, string newActionKeyword, string oldActionKeyword)
         {
-            PluginManager.ReplaceActionKeyword(Context.CurrentPluginMetadata.ID, oldActionKeyword, newActionKeyword);
+            Context.API.RemoveActionKeyword(Context.CurrentPluginMetadata.ID, oldActionKeyword);
+            Context.API.AddActionKeyword(Context.CurrentPluginMetadata.ID, newActionKeyword);
         }
 
         internal bool IsActionKeywordAlreadyAssigned(string newActionKeyword)
         {
-            return PluginManager.ActionKeywordRegistered(newActionKeyword);
+            return Context.API.ActionKeywordRegistered(newActionKeyword);
         }
 
         internal bool IsNewActionKeywordGlobal(string newActionKeyword) => newActionKeyword == Query.GlobalPluginWildcardSign;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
@@ -1,8 +1,4 @@
 using Flow.Launcher.Plugin.Explorer.ViewModels;
-using ICSharpCode.SharpZipLib.Zip;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Windows;
 using System.Windows.Input;
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
@@ -1,6 +1,5 @@
 using Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks;
 using Flow.Launcher.Plugin.Explorer.ViewModels;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;

--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/Flow.Launcher.Plugin.PluginIndicator.csproj
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/Flow.Launcher.Plugin.PluginIndicator.csproj
@@ -42,8 +42,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Flow.Launcher.Core\Flow.Launcher.Core.csproj" />
-    <ProjectReference Include="..\..\Flow.Launcher.Infrastructure\Flow.Launcher.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\Flow.Launcher.Plugin\Flow.Launcher.Plugin.csproj" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/ContextMenu.cs
@@ -1,8 +1,5 @@
 ﻿using Flow.Launcher.Core.ExternalPlugins;
-using Flow.Launcher.Infrastructure.UserSettings;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Flow.Launcher.Plugin.PluginsManager
 {

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Flow.Launcher.Plugin.PluginsManager.csproj
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Flow.Launcher.Plugin.PluginsManager.csproj
@@ -17,9 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Flow.Launcher.Infrastructure\Flow.Launcher.Infrastructure.csproj" />
-	<ProjectReference Include="..\..\Flow.Launcher.Core\Flow.Launcher.Core.csproj" />
-    <ProjectReference Include="..\..\Flow.Launcher.Plugin\Flow.Launcher.Plugin.csproj" />
+    <ProjectReference Include="..\..\Flow.Launcher.Core\Flow.Launcher.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,7 +25,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  
+
   <ItemGroup>
     <Content Include="Languages\*.xaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -36,7 +34,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="SharpZipLib" Version="1.3.2" />
   </ItemGroup>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
@@ -1,5 +1,4 @@
-﻿using Flow.Launcher.Infrastructure.Storage;
-using Flow.Launcher.Plugin.PluginsManager.ViewModels;
+﻿using Flow.Launcher.Plugin.PluginsManager.ViewModels;
 using Flow.Launcher.Plugin.PluginsManager.Views;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +7,6 @@ using Flow.Launcher.Infrastructure;
 using System;
 using System.Threading.Tasks;
 using System.Threading;
-using System.Windows;
 
 namespace Flow.Launcher.Plugin.PluginsManager
 {

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Settings.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Flow.Launcher.Plugin.PluginsManager
+﻿namespace Flow.Launcher.Plugin.PluginsManager
 {
     internal class Settings
     {

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Utilities.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Utilities.cs
@@ -1,7 +1,5 @@
-﻿using Flow.Launcher.Infrastructure.Http;
-using ICSharpCode.SharpZipLib.Zip;
+﻿using ICSharpCode.SharpZipLib.Zip;
 using System.IO;
-using System.Net;
 
 namespace Flow.Launcher.Plugin.PluginsManager
 {

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/ViewModels/SettingsViewModel.cs
@@ -1,7 +1,4 @@
-﻿using Flow.Launcher.Infrastructure.Storage;
-using Flow.Launcher.Infrastructure.UserSettings;
-
-namespace Flow.Launcher.Plugin.PluginsManager.ViewModels
+﻿namespace Flow.Launcher.Plugin.PluginsManager.ViewModels
 {
     internal class SettingsViewModel
     {

--- a/Plugins/Flow.Launcher.Plugin.ProcessKiller/Flow.Launcher.Plugin.ProcessKiller.csproj
+++ b/Plugins/Flow.Launcher.Plugin.ProcessKiller/Flow.Launcher.Plugin.ProcessKiller.csproj
@@ -50,7 +50,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Flow.Launcher.Infrastructure\Flow.Launcher.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Flow.Launcher.Plugin\Flow.Launcher.Plugin.csproj" />
   </ItemGroup>
 

--- a/Plugins/Flow.Launcher.Plugin.ProcessKiller/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.ProcessKiller/Main.cs
@@ -1,24 +1,18 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Diagnostics;
-using System.Dynamic;
-using System.Runtime.InteropServices;
-using Flow.Launcher.Infrastructure;
-using Flow.Launcher.Infrastructure.Logger;
 
 namespace Flow.Launcher.Plugin.ProcessKiller
 {
     public class Main : IPlugin, IPluginI18n, IContextMenu
     {
-        private ProcessHelper processHelper = new ProcessHelper();
+        private ProcessHelper processHelper;
 
         private static PluginInitContext _context;
 
         public void Init(PluginInitContext context)
         {
             _context = context;
+            processHelper = new(context.API);
         }
 
         public List<Result> Query(Query query)
@@ -85,7 +79,7 @@ namespace Flow.Launcher.Plugin.ProcessKiller
                     IcoPath = path,
                     Title = p.ProcessName + " - " + p.Id,
                     SubTitle = path,
-                    TitleHighlightData = StringMatcher.FuzzySearch(termToSearch, p.ProcessName).MatchData,
+                    TitleHighlightData = _context.API.FuzzySearch(termToSearch, p.ProcessName).MatchData,
                     Score = pr.Score,
                     ContextData = p.ProcessName,
                     Action = (c) =>

--- a/Plugins/Flow.Launcher.Plugin.ProcessKiller/ProcessHelper.cs
+++ b/Plugins/Flow.Launcher.Plugin.ProcessKiller/ProcessHelper.cs
@@ -1,6 +1,4 @@
-﻿using Flow.Launcher.Infrastructure;
-using Flow.Launcher.Infrastructure.Logger;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -11,6 +9,13 @@ namespace Flow.Launcher.Plugin.ProcessKiller
 {
     internal class ProcessHelper
     {
+        public IPublicAPI API { get; init; }
+
+        public ProcessHelper (IPublicAPI api)
+        {
+            API = api;
+        }
+
         private readonly HashSet<string> _systemProcessList = new HashSet<string>()
         {
             "conhost",
@@ -49,7 +54,7 @@ namespace Flow.Launcher.Plugin.ProcessKiller
                 }
                 else
                 {
-                    var score = StringMatcher.FuzzySearch(searchTerm, p.ProcessName + p.Id).Score;
+                    var score = API.FuzzySearch(searchTerm, p.ProcessName + p.Id).Score;
                     if (score > 0)
                     {
                         processlist.Add(new ProcessResult(p, score));
@@ -79,7 +84,7 @@ namespace Flow.Launcher.Plugin.ProcessKiller
             }
             catch (Exception e)
             {
-                Log.Exception($"|ProcessKiller.CreateResultsFromProcesses|Failed to kill process {p.ProcessName}", e);
+                API.LogException("ProcessKiller","Failed to kill process {p.ProcessName}", e);
             }
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Program/FileChangeWatcher.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/FileChangeWatcher.cs
@@ -1,10 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
-using Flow.Launcher.Infrastructure.Logger;
-using Flow.Launcher.Plugin.Program.Programs;
-
-namespace Flow.Launcher.Plugin.Program
+﻿namespace Flow.Launcher.Plugin.Program
 {
     //internal static class FileChangeWatcher
     //{

--- a/Plugins/Flow.Launcher.Plugin.Program/Logger/ProgramLogger.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Logger/ProgramLogger.cs
@@ -1,13 +1,8 @@
 using NLog;
-using NLog.Config;
-using NLog.Targets;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Security;
-using Flow.Launcher.Infrastructure;
-using Flow.Launcher.Infrastructure.UserSettings;
 
 namespace Flow.Launcher.Plugin.Program.Logger
 {

--- a/Plugins/Flow.Launcher.Plugin.Program/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Main.cs
@@ -1,19 +1,14 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Controls;
-using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin.Program.Programs;
 using Flow.Launcher.Plugin.Program.Views;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Primitives;
 using Stopwatch = Flow.Launcher.Infrastructure.Stopwatch;
 
 namespace Flow.Launcher.Plugin.Program
@@ -26,7 +21,7 @@ namespace Flow.Launcher.Plugin.Program
 
         private static bool IsStartupIndexProgramsRequired => _settings.LastIndexTime.AddDays(3) < DateTime.Today;
 
-        private static PluginInitContext _context;
+        internal static PluginInitContext Context { get; private set; }
 
         private static BinaryStorage<Win32[]> _win32Storage;
         private static BinaryStorage<UWP.Application[]> _uwpStorage;
@@ -63,7 +58,7 @@ namespace Flow.Launcher.Plugin.Program
                           .AsParallel()
                           .WithCancellation(token)
                           .Where(p => p.Enabled)
-                          .Select(p => p.Result(query.Search, _context.API))
+                          .Select(p => p.Result(query.Search, Context.API))
                           .Where(r => r?.Score > 0)
                           .ToList());
 
@@ -80,7 +75,7 @@ namespace Flow.Launcher.Plugin.Program
 
         public async Task InitAsync(PluginInitContext context)
         {
-            _context = context;
+            Context = context;
 
             _settings = context.API.LoadSettingJsonStorage<Settings>();
 
@@ -93,8 +88,8 @@ namespace Flow.Launcher.Plugin.Program
                 _uwpStorage = new BinaryStorage<UWP.Application[]>("UWP");
                 _uwps = _uwpStorage.TryLoad(new UWP.Application[] { });
             });
-            Log.Info($"|Flow.Launcher.Plugin.Program.Main|Number of preload win32 programs <{_win32s.Length}>");
-            Log.Info($"|Flow.Launcher.Plugin.Program.Main|Number of preload uwps <{_uwps.Length}>");
+            context.API.LogInfo("Flow.Launcher.Plugin.Program.Main", $"Number of preload win32 programs <{_win32s.Length}>");
+            context.API.LogInfo("Flow.Launcher.Plugin.Program.Main", $"Number of preload uwps <{_uwps.Length}>");
 
 
             bool indexedWinApps = false;
@@ -155,17 +150,17 @@ namespace Flow.Launcher.Plugin.Program
 
         public Control CreateSettingPanel()
         {
-            return new ProgramSetting(_context, _settings, _win32s, _uwps);
+            return new ProgramSetting(Context, _settings, _win32s, _uwps);
         }
 
         public string GetTranslatedPluginTitle()
         {
-            return _context.API.GetTranslation("flowlauncher_plugin_program_plugin_name");
+            return Context.API.GetTranslation("flowlauncher_plugin_program_plugin_name");
         }
 
         public string GetTranslatedPluginDescription()
         {
-            return _context.API.GetTranslation("flowlauncher_plugin_program_plugin_description");
+            return Context.API.GetTranslation("flowlauncher_plugin_program_plugin_description");
         }
 
         public List<Result> LoadContextMenus(Result selectedResult)
@@ -174,19 +169,19 @@ namespace Flow.Launcher.Plugin.Program
             var program = selectedResult.ContextData as IProgram;
             if (program != null)
             {
-                menuOptions = program.ContextMenus(_context.API);
+                menuOptions = program.ContextMenus(Context.API);
             }
 
             menuOptions.Add(
                 new Result
                 {
-                    Title = _context.API.GetTranslation("flowlauncher_plugin_program_disable_program"),
+                    Title = Context.API.GetTranslation("flowlauncher_plugin_program_disable_program"),
                     Action = c =>
                     {
                         DisableProgram(program);
-                        _context.API.ShowMsg(
-                            _context.API.GetTranslation("flowlauncher_plugin_program_disable_dlgtitle_success"),
-                            _context.API.GetTranslation(
+                        Context.API.ShowMsg(
+                            Context.API.GetTranslation("flowlauncher_plugin_program_disable_dlgtitle_success"),
+                            Context.API.GetTranslation(
                                 "flowlauncher_plugin_program_disable_dlgtitle_success_message"));
                         return false;
                     },
@@ -235,7 +230,7 @@ namespace Flow.Launcher.Plugin.Program
             {
                 var name = "Plugin: Program";
                 var message = $"Unable to start: {info.FileName}";
-                _context.API.ShowMsg(name, message, string.Empty);
+                Context.API.ShowMsg(name, message, string.Empty);
             }
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/ApplicationActivationHelper.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/ApplicationActivationHelper.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 
 namespace Flow.Launcher.Plugin.Program.Programs
 {

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/AppxPackageHelper.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/AppxPackageHelper.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
-using Windows.Storage;
 
 namespace Flow.Launcher.Plugin.Program.Programs
 {

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/ShellLinkHelper.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/ShellLinkHelper.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 using System.Runtime.InteropServices;
-using System.IO;
 using Accessibility;
 using System.Runtime.InteropServices.ComTypes;
-using System.Security.Policy;
 
 namespace Flow.Launcher.Plugin.Program.Programs
 {

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/UWP.cs
@@ -13,11 +13,10 @@ using System.Windows.Media.Imaging;
 using System.Xml.Linq;
 using Windows.ApplicationModel;
 using Windows.Management.Deployment;
-using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Plugin.Program.Logger;
 using Rect = System.Windows.Rect;
 using Flow.Launcher.Plugin.SharedModels;
-using Flow.Launcher.Infrastructure.Logger;
+using Flow.Launcher.Infrastructure;
 
 namespace Flow.Launcher.Plugin.Program.Programs
 {
@@ -85,7 +84,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
             if (Marshal.ReleaseComObject(stream) > 0)
             {
-                Log.Error("Flow.Launcher.Plugin.Program.Programs.UWP", "AppxManifest.xml was leaked");
+                Main.Context.API.LogException("Flow.Launcher.Plugin.Program.Programs.UWP", "AppxManifest.xml was leaked", new ContextMarshalException());
             }
         }
 
@@ -285,18 +284,18 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 if (!Main._settings.EnableDescription || Description == null || Name.StartsWith(Description))
                 {
                     title = Name;
-                    matchResult = StringMatcher.FuzzySearch(query, title);
+                    matchResult = Main.Context.API.FuzzySearch(query, title);
                 }
                 else if (Description.StartsWith(Name))
                 {
                     title = Description;
-                    matchResult = StringMatcher.FuzzySearch(query, Description);
+                    matchResult = Main.Context.API.FuzzySearch(query, Description);
                 }
                 else
                 {
                     title = $"{Name}: {Description}";
-                    var nameMatch = StringMatcher.FuzzySearch(query, Name);
-                    var desciptionMatch = StringMatcher.FuzzySearch(query, Description);
+                    var nameMatch = Main.Context.API.FuzzySearch(query, Name);
+                    var desciptionMatch = Main.Context.API.FuzzySearch(query, Description);
                     if (desciptionMatch.Score > nameMatch.Score)
                     {
                         for (int i = 0; i < desciptionMatch.MatchData.Count; i++)

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -7,13 +7,10 @@ using System.Security;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Win32;
-using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Plugin.Program.Logger;
 using Flow.Launcher.Plugin.SharedCommands;
 using Flow.Launcher.Plugin.SharedModels;
-using Flow.Launcher.Infrastructure.Logger;
 using System.Diagnostics;
-using Stopwatch = Flow.Launcher.Infrastructure.Stopwatch;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Flow.Launcher.Plugin.Program.Programs
@@ -60,18 +57,18 @@ namespace Flow.Launcher.Plugin.Program.Programs
             if (!Main._settings.EnableDescription || Description == null || Name.StartsWith(Description))
             {
                 title = Name;
-                matchResult = StringMatcher.FuzzySearch(query, title);
+                matchResult = Main.Context.API.FuzzySearch(query, title);
             }
             else if (Description.StartsWith(Name))
             {
                 title = Description;
-                matchResult = StringMatcher.FuzzySearch(query, Description);
+                matchResult = Main.Context.API.FuzzySearch(query, Description);
             }
             else
             {
                 title = $"{Name}: {Description}";
-                var nameMatch = StringMatcher.FuzzySearch(query, Name);
-                var desciptionMatch = StringMatcher.FuzzySearch(query, Description);
+                var nameMatch = Main.Context.API.FuzzySearch(query, Name);
+                var desciptionMatch = Main.Context.API.FuzzySearch(query, Description);
                 if (desciptionMatch.Score > nameMatch.Score)
                 {
                     for (int i = 0; i < desciptionMatch.MatchData.Count; i++)
@@ -86,7 +83,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
             if (!matchResult.IsSearchPrecisionScoreMet())
             {
                 if (ExecutableName != null) // only lnk program will need this one
-                    matchResult = StringMatcher.FuzzySearch(query, ExecutableName);
+                    matchResult = Main.Context.API.FuzzySearch(query, ExecutableName);
 
                 if (!matchResult.IsSearchPrecisionScoreMet())
                     return null;

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/Commands/ProgramSettingDisplay.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/Commands/ProgramSettingDisplay.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Flow.Launcher.Plugin.Program.Views.Models;
 
 namespace Flow.Launcher.Plugin.Program.Views.Commands

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -8,13 +8,11 @@ using System.Threading.Tasks;
 using System.Windows;
 using WindowsInput;
 using WindowsInput.Native;
-using Flow.Launcher.Infrastructure.Hotkey;
-using Flow.Launcher.Infrastructure.Logger;
-using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin.SharedCommands;
 using Application = System.Windows.Application;
 using Control = System.Windows.Controls.Control;
 using Keys = System.Windows.Forms.Keys;
+using Flow.Launcher.Infrastructure.Hotkey;
 
 namespace Flow.Launcher.Plugin.Shell
 {
@@ -88,7 +86,7 @@ namespace Flow.Launcher.Plugin.Shell
                 }
                 catch (Exception e)
                 {
-                    Log.Exception($"|Flow.Launcher.Plugin.Shell.Main.Query|Exception when query for <{query}>", e);
+                    context.API.LogException("Flow.Launcher.Plugin.Shell.Main", $"Exception when query for <{query}>", e);
                 }
                 return results;
             }

--- a/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
@@ -59,8 +59,8 @@ namespace Flow.Launcher.Plugin.Sys
             var results = new List<Result>();
             foreach (var c in commands)
             {
-                var titleMatch = StringMatcher.FuzzySearch(query.Search, c.Title);
-                var subTitleMatch = StringMatcher.FuzzySearch(query.Search, c.SubTitle);
+                var titleMatch = context.API.FuzzySearch(query.Search, c.Title);
+                var subTitleMatch = context.API.FuzzySearch(query.Search, c.SubTitle);
 
                 var score = Math.Max(titleMatch.Score, subTitleMatch.Score);
                 if (score > 0)

--- a/Plugins/Flow.Launcher.Plugin.Url/Flow.Launcher.Plugin.Url.csproj
+++ b/Plugins/Flow.Launcher.Plugin.Url/Flow.Launcher.Plugin.Url.csproj
@@ -41,7 +41,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Flow.Launcher.Infrastructure\Flow.Launcher.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Flow.Launcher.Plugin\Flow.Launcher.Plugin.csproj" />
   </ItemGroup>
 

--- a/Plugins/Flow.Launcher.Plugin.Url/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Url/Main.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Windows.Controls;
-using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Plugin.Url

--- a/Plugins/Flow.Launcher.Plugin.Url/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Url/Settings.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Flow.Launcher.Plugin.Url
+﻿namespace Flow.Launcher.Plugin.Url
 {
     public class Settings
     {

--- a/Plugins/Flow.Launcher.Plugin.Url/SettingsControl.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Url/SettingsControl.xaml.cs
@@ -1,17 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using Microsoft.Win32;
 
 

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Flow.Launcher.Plugin.WebSearch.csproj
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Flow.Launcher.Plugin.WebSearch.csproj
@@ -51,8 +51,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Flow.Launcher.Core\Flow.Launcher.Core.csproj" />
-    <ProjectReference Include="..\..\Flow.Launcher.Infrastructure\Flow.Launcher.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Flow.Launcher.Plugin\Flow.Launcher.Plugin.csproj" />
   </ItemGroup>
 

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -5,15 +5,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Controls;
-using Flow.Launcher.Infrastructure;
-using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Plugin.WebSearch
 {
     public class Main : IAsyncPlugin, ISettingProvider, IPluginI18n, IResultUpdated
     {
-        private PluginInitContext _context;
+        internal static PluginInitContext Context { get; private set; }
 
         private Settings _settings;
         private SettingsViewModel _viewModel;
@@ -44,7 +42,7 @@ namespace Flow.Launcher.Plugin.WebSearch
                 string keyword = string.Empty;
                 keyword = searchSource.ActionKeyword == SearchSourceGlobalPluginWildCardSign ? query.ToString() : query.Search;
                 var title = keyword;
-                string subtitle = _context.API.GetTranslation("flowlauncher_plugin_websearch_search") + " " + searchSource.Title;
+                string subtitle = Context.API.GetTranslation("flowlauncher_plugin_websearch_search") + " " + searchSource.Title;
 
                 //Action Keyword match apear on top
                 var score = searchSource.ActionKeyword == SearchSourceGlobalPluginWildCardSign ? scoreStandard : scoreStandard + 1;
@@ -163,21 +161,19 @@ namespace Flow.Launcher.Plugin.WebSearch
 
             void Init()
             {
-                _context = context;
+                Context = context;
 
-                _settings = _context.API.LoadSettingJsonStorage<Settings>();
+                _settings = Context.API.LoadSettingJsonStorage<Settings>();
                 _viewModel = new SettingsViewModel(_settings);
-                
-                var pluginDirectory = _context.CurrentPluginMetadata.PluginDirectory;
-                var bundledImagesDirectory = Path.Combine(pluginDirectory, Images);
+
+                var pluginDirectory = Context.CurrentPluginMetadata.PluginDirectory;
 
                 // Default images directory is in the WebSearch's application folder  
-                DefaultImagesDirectory = Path.Combine(pluginDirectory, Images);
-                Helper.ValidateDataDirectory(bundledImagesDirectory, DefaultImagesDirectory);
+                var bundledImagesDirectory = Path.Combine(pluginDirectory, Images);
 
                 // Custom images directory is in the WebSearch's data location folder 
-                var name = Path.GetFileNameWithoutExtension(_context.CurrentPluginMetadata.ExecuteFileName);
-                CustomImagesDirectory = Path.Combine(DataLocation.PluginSettingsDirectory, name, "CustomIcons");
+                var name = Path.GetFileNameWithoutExtension(Context.CurrentPluginMetadata.ExecuteFileName);
+                CustomImagesDirectory = Path.Combine(Context.API.GetSettingLocation(), "CustomIcons");
             };
         }
 
@@ -185,19 +181,19 @@ namespace Flow.Launcher.Plugin.WebSearch
 
         public Control CreateSettingPanel()
         {
-            return new SettingsControl(_context, _viewModel);
+            return new SettingsControl(Context, _viewModel);
         }
 
         #endregion
 
         public string GetTranslatedPluginTitle()
         {
-            return _context.API.GetTranslation("flowlauncher_plugin_websearch_plugin_name");
+            return Context.API.GetTranslation("flowlauncher_plugin_websearch_plugin_name");
         }
 
         public string GetTranslatedPluginDescription()
         {
-            return _context.API.GetTranslation("flowlauncher_plugin_websearch_plugin_description");
+            return Context.API.GetTranslation("flowlauncher_plugin_websearch_plugin_description");
         }
 
         public event ResultUpdatedEventHandler ResultsUpdated;

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -1,14 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using Flow.Launcher.Infrastructure;
-using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin.SharedCommands;
 

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSource.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSource.cs
@@ -1,9 +1,5 @@
 using System.IO;
-using System.Windows.Media;
 using JetBrains.Annotations;
-using Flow.Launcher.Infrastructure.Image;
-using Flow.Launcher.Infrastructure;
-using System.Reflection;
 using System.Text.Json.Serialization;
 
 namespace Flow.Launcher.Plugin.WebSearch

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Windows;
 using Microsoft.Win32;
-using Flow.Launcher.Core.Plugin;
 
 namespace Flow.Launcher.Plugin.WebSearch
 {
@@ -80,10 +79,10 @@ namespace Flow.Launcher.Plugin.WebSearch
         private void AddSearchSource()
         {
             var keyword = _searchSource.ActionKeyword;
-            if (!PluginManager.ActionKeywordRegistered(keyword))
+            if (!_context.API.ActionKeywordRegistered(keyword))
             {
                 var id = _context.CurrentPluginMetadata.ID;
-                PluginManager.AddActionKeyword(id, keyword);
+                _context.API.AddActionKeyword(id, keyword);
 
                 _searchSources.Add(_searchSource);
 
@@ -100,10 +99,11 @@ namespace Flow.Launcher.Plugin.WebSearch
         {
             var newKeyword = _searchSource.ActionKeyword;
             var oldKeyword = _oldSearchSource.ActionKeyword;
-            if (!PluginManager.ActionKeywordRegistered(newKeyword) || oldKeyword == newKeyword)
+            if (!_context.API.ActionKeywordRegistered(newKeyword) || oldKeyword == newKeyword)
             {
                 var id = _context.CurrentPluginMetadata.ID;
-                PluginManager.ReplaceActionKeyword(id, oldKeyword, newKeyword);
+                _context.API.RemoveActionKeyword(id, oldKeyword);
+                _context.API.AddActionKeyword(id, newKeyword);
 
                 var index = _searchSources.IndexOf(_oldSearchSource);
                 _searchSources[index] = _searchSource;

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceViewModel.cs
@@ -1,8 +1,6 @@
 using Flow.Launcher.Infrastructure.Image;
 using System;
-using System.Drawing;
 using System.IO;
-using System.Windows;
 using System.Windows.Media;
 
 namespace Flow.Launcher.Plugin.WebSearch

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceViewModel.cs
@@ -1,6 +1,7 @@
 using Flow.Launcher.Infrastructure.Image;
 using System;
 using System.IO;
+using System.Windows;
 using System.Windows.Media;
 
 namespace Flow.Launcher.Plugin.WebSearch

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceViewModel.cs
@@ -1,4 +1,3 @@
-using Flow.Launcher.Infrastructure.Image;
 using System;
 using System.IO;
 using System.Windows;
@@ -58,7 +57,7 @@ namespace Flow.Launcher.Plugin.WebSearch
 
         internal ImageSource LoadPreviewIcon(string pathToPreviewIconImage)
         {
-            return ImageLoader.Load(pathToPreviewIconImage);
+            return Main.Context.API.LoadImage(pathToPreviewIconImage);
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml.cs
@@ -1,7 +1,6 @@
 using Microsoft.Win32;
 using System.Windows;
 using System.Windows.Controls;
-using Flow.Launcher.Core.Plugin;
 using System.ComponentModel;
 using System.Windows.Data;
 
@@ -44,7 +43,7 @@ namespace Flow.Launcher.Plugin.WebSearch
                 if (result == MessageBoxResult.Yes)
                 {
                     var id = _context.CurrentPluginMetadata.ID;
-                    PluginManager.RemoveActionKeyword(id, selected.ActionKeyword);
+                    _context.API.RemoveActionKeyword(id, selected.ActionKeyword);
                     _settings.SearchSources.Remove(selected);
                 }
             }

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsViewModel.cs
@@ -1,21 +1,12 @@
-﻿using Flow.Launcher.Infrastructure.Storage;
-
-namespace Flow.Launcher.Plugin.WebSearch
+﻿namespace Flow.Launcher.Plugin.WebSearch
 {
     public class SettingsViewModel
     {
-        private readonly PluginJsonStorage<Settings> _storage;
-
         public SettingsViewModel(Settings settings)
         {
             Settings = settings;
         }
 
         public Settings Settings { get; }
-
-        public void Save()
-        {
-            _storage.Save();
-        }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Baidu.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Baidu.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Baidu.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Baidu.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Flow.Launcher.Infrastructure.Http;
-using Flow.Launcher.Infrastructure.Logger;
 using System.Net.Http;
 using System.Threading;
 
@@ -22,11 +20,11 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
             try
             {
                 const string api = "http://suggestion.baidu.com/su?json=1&wd=";
-                result = await Http.GetAsync(api + Uri.EscapeUriString(query), token).ConfigureAwait(false);
+                result = await Main.Context.API.HttpGetStringAsync(api + Uri.EscapeUriString(query), token).ConfigureAwait(false);
             }
             catch (Exception e) when (e is HttpRequestException || e.InnerException is TimeoutException)
             {
-                Log.Exception("|Baidu.Suggestions|Can't get suggestion from baidu", e);
+                Main.Context.API.LogException("Baidu.Suggestion", "Can't get suggestion from baidu", e);
                 return null;
             }
 
@@ -41,7 +39,7 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
                 }
                 catch (JsonException e)
                 {
-                    Log.Exception("|Baidu.Suggestions|can't parse suggestions", e);
+                    Main.Context.API.LogException("Baidu.Suggestions", "Can't parse suggestions", e);
                     return new List<string>();
                 }
 

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Bing.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Bing.cs
@@ -2,10 +2,7 @@
 using Flow.Launcher.Infrastructure.Logger;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Text.Json;
 using System.Linq;

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Bing.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Bing.cs
@@ -1,6 +1,4 @@
-﻿using Flow.Launcher.Infrastructure.Http;
-using Flow.Launcher.Infrastructure.Logger;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -18,8 +16,8 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
             try
             {
                 const string api = "https://api.bing.com/qsonhs.aspx?q=";
-                
-                using var resultStream = await Http.GetStreamAsync(api + Uri.EscapeUriString(query), token).ConfigureAwait(false);
+
+                using var resultStream = await Main.Context.API.HttpGetStreamAsync(api + Uri.EscapeUriString(query), token).ConfigureAwait(false);
 
                 using var json = (await JsonDocument.ParseAsync(resultStream, cancellationToken: token));
                 var root = json.RootElement.GetProperty("AS");
@@ -39,14 +37,14 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
             }
             catch (Exception e) when (e is HttpRequestException || e.InnerException is TimeoutException)
             {
-                Log.Exception("|Baidu.Suggestions|Can't get suggestion from baidu", e);
+                Main.Context.API.LogException("Bing.Suggestion", "Can't get suggestion from baidu", e);
                 return null;
             }
             catch (JsonException e)
             {
-                Log.Exception("|Bing.Suggestions|can't parse suggestions", e);
+                Main.Context.API.LogException("Baidu.Suggestion", "Can't parse suggestions from bing", e);
                 return new List<string>();
-            } 
+            }
         }
 
         public override string ToString()

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Google.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Google.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using Flow.Launcher.Infrastructure.Http;
 using Flow.Launcher.Infrastructure.Logger;
 using System.Net.Http;
 using System.Threading;
 using System.Text.Json;
-using System.IO;
 
 namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
 {

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Google.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Google.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Flow.Launcher.Infrastructure.Http;
-using Flow.Launcher.Infrastructure.Logger;
 using System.Net.Http;
 using System.Threading;
 using System.Text.Json;
@@ -18,7 +16,7 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
             {
                 const string api = "https://www.google.com/complete/search?output=chrome&q=";
 
-                using var resultStream = await Http.GetStreamAsync(api + Uri.EscapeUriString(query)).ConfigureAwait(false);
+                using var resultStream = await Main.Context.API.HttpGetStreamAsync(api + Uri.EscapeUriString(query), token).ConfigureAwait(false);
 
                 using var json = await JsonDocument.ParseAsync(resultStream, cancellationToken: token);
 
@@ -32,12 +30,12 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
             }
             catch (Exception e) when (e is HttpRequestException || e.InnerException is TimeoutException)
             {
-                Log.Exception("|Baidu.Suggestions|Can't get suggestion from baidu", e);
+                Main.Context.API.LogException("Google.Suggestions", "Can't get suggestion from Google", e);
                 return null;
             }
             catch (JsonException e)
             {
-                Log.Exception("|Google.Suggestions|can't parse suggestions", e);
+                Main.Context.API.LogException("Google.Suggestions", "Can't parse suggestion from Google", e);
                 return new List<string>();
             }
         }


### PR DESCRIPTION
A complete refactor branch. Currently all plugin is referencing the infrastructure, which creates a lot unnecessary build when modifying.