### PR TITLE
[dev] Change Icon back to field to maintain backward compatibility

### DIFF
--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -50,7 +50,7 @@ namespace Flow.Launcher.Plugin
         /// <summary>
         /// Delegate to Get Image Source
         /// </summary>
-        public IconDelegate Icon { get; set; }
+        public IconDelegate Icon;
 
         /// <summary>
         /// Information for Glyph Icon


### PR DESCRIPTION
It will break backward compatibility for plugin use Icon field (although I think not a lot use it).