### PR TITLE
Add Clipboard copy to jsonRPC API

### DIFF
--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -37,6 +37,12 @@ namespace Flow.Launcher.Plugin
         /// <exception cref="FileNotFoundException">Thrown when unable to find the file specified in the command </exception>
         /// <exception cref="Win32Exception">Thrown when error occurs during the execution of the command </exception>
         void ShellRun(string cmd, string filename = "cmd.exe");
+        
+        /// <summary>
+        /// Copy Text to clipboard
+        /// </summary>
+        /// <param name="Text">Text to save on clipboard</param>
+        public void CopyToClipboard(string text);
 
         /// <summary>
         /// Save everything, all of Flow Launcher and plugins' data and settings

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -114,6 +114,11 @@ namespace Flow.Launcher
             var startInfo = ShellCommand.SetProcessStartInfo(filename, arguments: args, createNoWindow: true);
             ShellCommand.Execute(startInfo);
         }
+        
+        public void CopyToClipboard(string text)
+        {
+            Clipboard.SetText(text);
+        }
 
         public void StartLoadingBar() => _mainVM.ProgressBarVisibility = Visibility.Visible;
 

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -117,7 +117,7 @@ namespace Flow.Launcher
         
         public void CopyToClipboard(string text)
         {
-            Clipboard.SetText(text);
+            Clipboard.SetDataObject(text);
         }
 
         public void StartLoadingBar() => _mainVM.ProgressBarVisibility = Visibility.Visible;


### PR DESCRIPTION
Simply adds a method for jsonRPC to call and place test into the system's clipboard.

```
print(json.dumps({"method": "flow.CopyToClipboard","parameters":["text"]}))
```
