### PR TITLE
Global TAB complete

### DIFF
--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -31,14 +31,7 @@ namespace Flow.Launcher.Plugin
         /// </summary>
         public string ActionKeywordAssigned { get; set; }
 
-        public string InsertText
-        {
-            get { return string.IsNullOrEmpty(_insertText) ? Title : _insertText; }
-            set
-            {
-                _insertText = value;
-            }
-        }
+        public string SuggestionText { get; set; } = string.Empty;
 
         public string IcoPath
         {

--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -13,6 +13,8 @@ namespace Flow.Launcher.Plugin
         
         private string _icoPath;
 
+        private string _insertText;
+
         /// <summary>
         /// Provides the title of the result. This is always required.
         /// </summary>
@@ -28,6 +30,15 @@ namespace Flow.Launcher.Plugin
         /// If result is triggered by global keyword: *, this should be empty.
         /// </summary>
         public string ActionKeywordAssigned { get; set; }
+
+        public string InsertText
+        {
+            get { return string.IsNullOrEmpty(_insertText) ? Title : _insertText; }
+            set
+            {
+                _insertText = value;
+            }
+        }
 
         public string IcoPath
         {

--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -29,7 +29,12 @@ namespace Flow.Launcher.Plugin
         /// </summary>
         public string ActionKeywordAssigned { get; set; }
 
-        public string SuggestionText { get; set; } = string.Empty;
+        /// <summary>
+        /// This holds the text which can be provided by plugin to help Flow autocomplete text
+        /// for user on the plugin result. If autocomplete action for example is tab, pressing tab will have 
+        /// the default constructed autocomplete text (result's Title), or the text provided here if not empty.
+        /// </summary>
+        public string AutoCompleteText { get; set; }
 
         public string IcoPath
         {

--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -13,8 +13,6 @@ namespace Flow.Launcher.Plugin
         
         private string _icoPath;
 
-        private string _insertText;
-
         /// <summary>
         /// Provides the title of the result. This is always required.
         /// </summary>

--- a/Flow.Launcher/Converters/QuerySuggestionBoxConverter.cs
+++ b/Flow.Launcher/Converters/QuerySuggestionBoxConverter.cs
@@ -43,13 +43,12 @@ namespace Flow.Launcher.Converters
                 if (!selectedResultPossibleSuggestion.StartsWith(queryText, StringComparison.CurrentCultureIgnoreCase))
                     return string.Empty;
 
-                // When user typed lower case and result title is uppercase, we still want to display suggestion
-
+                // construct autocomplete with suggestion
                 string _suggestion = queryText + selectedResultPossibleSuggestion.Substring(queryText.Length);
-                if (String.IsNullOrEmpty(selectedResult.SuggestionText))
-                {
-                    selectedItem.Result.SuggestionText = _suggestion;
-                }
+                if (string.IsNullOrEmpty(selectedResult.AutoCompleteText))
+                    selectedItem.Result.AutoCompleteText = _suggestion;
+
+                // When user typed lower case and result title is uppercase, we still want to display suggestion
                 return queryText + selectedResultPossibleSuggestion.Substring(queryText.Length);
             }
             catch (Exception e)

--- a/Flow.Launcher/Converters/QuerySuggestionBoxConverter.cs
+++ b/Flow.Launcher/Converters/QuerySuggestionBoxConverter.cs
@@ -43,13 +43,11 @@ namespace Flow.Launcher.Converters
                 if (!selectedResultPossibleSuggestion.StartsWith(queryText, StringComparison.CurrentCultureIgnoreCase))
                     return string.Empty;
 
-                // construct autocomplete with suggestion
-                string _suggestion = queryText + selectedResultPossibleSuggestion.Substring(queryText.Length);
-                if (string.IsNullOrEmpty(selectedResult.AutoCompleteText))
-                    selectedItem.QuerySuggestionText = _suggestion;
-
+                // For AutocompleteQueryCommand.
                 // When user typed lower case and result title is uppercase, we still want to display suggestion
-                return queryText + selectedResultPossibleSuggestion.Substring(queryText.Length);
+                selectedItem.QuerySuggestionText = queryText + selectedResultPossibleSuggestion.Substring(queryText.Length);
+                
+                return selectedItem.QuerySuggestionText;
             }
             catch (Exception e)
             {

--- a/Flow.Launcher/Converters/QuerySuggestionBoxConverter.cs
+++ b/Flow.Launcher/Converters/QuerySuggestionBoxConverter.cs
@@ -46,7 +46,7 @@ namespace Flow.Launcher.Converters
                 // construct autocomplete with suggestion
                 string _suggestion = queryText + selectedResultPossibleSuggestion.Substring(queryText.Length);
                 if (string.IsNullOrEmpty(selectedResult.AutoCompleteText))
-                    selectedItem.Result.AutoCompleteText = _suggestion;
+                    selectedItem.QuerySuggestionText = _suggestion;
 
                 // When user typed lower case and result title is uppercase, we still want to display suggestion
                 return queryText + selectedResultPossibleSuggestion.Substring(queryText.Length);

--- a/Flow.Launcher/Converters/QuerySuggestionBoxConverter.cs
+++ b/Flow.Launcher/Converters/QuerySuggestionBoxConverter.cs
@@ -44,6 +44,12 @@ namespace Flow.Launcher.Converters
                     return string.Empty;
 
                 // When user typed lower case and result title is uppercase, we still want to display suggestion
+
+                string _suggestion = queryText + selectedResultPossibleSuggestion.Substring(queryText.Length);
+                if (String.IsNullOrEmpty(selectedResult.SuggestionText))
+                {
+                    selectedItem.Result.SuggestionText = _suggestion;
+                }
                 return queryText + selectedResultPossibleSuggestion.Substring(queryText.Length);
             }
             catch (Exception e)

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -42,6 +42,13 @@
         <KeyBinding Key="F1" Command="{Binding StartHelpCommand}" />
         <KeyBinding Key="F5" Command="{Binding ReloadPluginDataCommand}" />
         <KeyBinding
+            Key="Tab"
+            Command="{Binding InsertSuggestion}"/>
+        <KeyBinding
+            Key="Tab"
+            Command="{Binding InsertSuggestion}"
+            Modifiers="Shift" />
+        <KeyBinding
             Key="I"
             Command="{Binding OpenSettingCommand}"
             Modifiers="Ctrl" />

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -44,7 +44,7 @@
         <KeyBinding Key="Tab" Command="{Binding ReplaceQueryWithResult}" />
         <KeyBinding
             Key="Tab"
-            Command="{Binding SelectPrevItemCommand}"
+            Command="{Binding ReplaceQueryWithResult}"
             Modifiers="Shift" />
         <KeyBinding
             Key="I"

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -43,10 +43,10 @@
         <KeyBinding Key="F5" Command="{Binding ReloadPluginDataCommand}" />
         <KeyBinding
             Key="Tab"
-            Command="{Binding InsertSuggestion}"/>
+            Command="{Binding AutocompleteQueryCommand}"/>
         <KeyBinding
             Key="Tab"
-            Command="{Binding InsertSuggestion}"
+            Command="{Binding AutocompleteQueryCommand}"
             Modifiers="Shift" />
         <KeyBinding
             Key="I"

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -41,11 +41,6 @@
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />
         <KeyBinding Key="F1" Command="{Binding StartHelpCommand}" />
         <KeyBinding Key="F5" Command="{Binding ReloadPluginDataCommand}" />
-        <KeyBinding Key="Tab" Command="{Binding ReplaceQueryWithResult}" />
-        <KeyBinding
-            Key="Tab"
-            Command="{Binding ReplaceQueryWithResult}"
-            Modifiers="Shift" />
         <KeyBinding
             Key="I"
             Command="{Binding OpenSettingCommand}"

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -41,7 +41,7 @@
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />
         <KeyBinding Key="F1" Command="{Binding StartHelpCommand}" />
         <KeyBinding Key="F5" Command="{Binding ReloadPluginDataCommand}" />
-        <KeyBinding Key="Tab" Command="{Binding SelectNextItemCommand}" />
+        <KeyBinding Key="Tab" Command="{Binding ReplaceQueryWithResult}" />
         <KeyBinding
             Key="Tab"
             Command="{Binding SelectPrevItemCommand}"

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -469,10 +469,6 @@ namespace Flow.Launcher
                         e.Handled = true;
                     }
                     break;
-                case Key.Tab:
-                    _viewModel.InsertSuggestion(QueryTextSuggestionBox.Text);
-                    e.Handled = true;
-                    break;
                 default:
                     break;
 

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -469,6 +469,10 @@ namespace Flow.Launcher
                         e.Handled = true;
                     }
                     break;
+                case Key.Tab:
+                    _viewModel.InsertSuggestion(QueryTextSuggestionBox.Text);
+                    e.Handled = true;
+                    break;
                 default:
                     break;
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -228,29 +228,6 @@ namespace Flow.Launcher.ViewModel
                 }
             });
 
-            ReplaceQueryWithResult = new RelayCommand(index =>
-            {
-                var results = SelectedResults;
-
-                if (index != null)
-                {
-                    results.SelectedIndex = int.Parse(index.ToString());
-                }
-
-                var result = results.SelectedItem?.Result;
-                if (result != null) // SelectedItem returns null if selection is empty.
-                {
-                    string _newText = String.Empty;
-                    _newText = result.Title;
-                    var SpecialKeyState = GlobalHotkey.Instance.CheckModifiers();
-                    if (SpecialKeyState.ShiftPressed)
-                    {
-                        _newText = result.SubTitle;
-                    }
-                    ChangeQueryText(_newText);
-                }
-            });
-
             LoadContextMenuCommand = new RelayCommand(_ =>
             {
                 if (SelectedIsFromQueryResults())
@@ -310,7 +287,6 @@ namespace Flow.Launcher.ViewModel
         public bool GameModeStatus { get; set; }
 
         private string _queryText;
-
         public string QueryText
         {
             get => _queryText;
@@ -339,7 +315,24 @@ namespace Flow.Launcher.ViewModel
             }
             QueryTextCursorMovedToEnd = true;
         }
+        public void InsertSuggestion(string suggestion)
+        {
+            var results = SelectedResults;
 
+            var result = results.SelectedItem?.Result;
+            if (result != null) // SelectedItem returns null if selection is empty.
+            {
+                suggestion = String.IsNullOrEmpty(suggestion) ? result.Title : suggestion;
+                string _newText = String.IsNullOrEmpty(result.SuggestionText) ? suggestion : result.SuggestionText;
+
+                var SpecialKeyState = GlobalHotkey.Instance.CheckModifiers();
+                if (SpecialKeyState.ShiftPressed)
+                {
+                    _newText = result.SubTitle;
+                }
+                ChangeQueryText(_newText);
+            }
+        }
         public bool LastQuerySelected { get; set; }
 
         // This is not a reliable indicator of the cursor's position, it is manually set for a specific purpose.

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -228,6 +228,24 @@ namespace Flow.Launcher.ViewModel
                 }
             });
 
+            InsertSuggestion = new RelayCommand(_ =>
+            {
+                var results = SelectedResults;
+
+                var result = results.SelectedItem?.Result;
+                if (result != null) // SelectedItem returns null if selection is empty.
+                {
+                    string _newText = String.IsNullOrEmpty(result.SuggestionText) ? result.Title : result.SuggestionText;
+
+                    var SpecialKeyState = GlobalHotkey.Instance.CheckModifiers();
+                    if (SpecialKeyState.ShiftPressed)
+                    {
+                        _newText = result.SubTitle;
+                    }
+                    ChangeQueryText(_newText);
+                }
+            });
+
             LoadContextMenuCommand = new RelayCommand(_ =>
             {
                 if (SelectedIsFromQueryResults())
@@ -315,24 +333,7 @@ namespace Flow.Launcher.ViewModel
             }
             QueryTextCursorMovedToEnd = true;
         }
-        public void InsertSuggestion(string suggestion)
-        {
-            var results = SelectedResults;
 
-            var result = results.SelectedItem?.Result;
-            if (result != null) // SelectedItem returns null if selection is empty.
-            {
-                suggestion = String.IsNullOrEmpty(suggestion) ? result.Title : suggestion;
-                string _newText = String.IsNullOrEmpty(result.SuggestionText) ? suggestion : result.SuggestionText;
-
-                var SpecialKeyState = GlobalHotkey.Instance.CheckModifiers();
-                if (SpecialKeyState.ShiftPressed)
-                {
-                    _newText = result.SubTitle;
-                }
-                ChangeQueryText(_newText);
-            }
-        }
         public bool LastQuerySelected { get; set; }
 
         // This is not a reliable indicator of the cursor's position, it is manually set for a specific purpose.
@@ -399,7 +400,7 @@ namespace Flow.Launcher.ViewModel
         public ICommand OpenSettingCommand { get; set; }
         public ICommand ReloadPluginDataCommand { get; set; }
         public ICommand ClearQueryCommand { get; private set; }
-        public ICommand ReplaceQueryWithResult { get; set; }
+        public ICommand InsertSuggestion { get; set; }
 
         public string OpenResultCommandModifiers { get; private set; }
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -240,7 +240,14 @@ namespace Flow.Launcher.ViewModel
                 var result = results.SelectedItem?.Result;
                 if (result != null) // SelectedItem returns null if selection is empty.
                 {
-                    ChangeQueryText(result.InsertText);
+                    string _newText = String.Empty;
+                    _newText = result.Title;
+                    var SpecialKeyState = GlobalHotkey.Instance.CheckModifiers();
+                    if (SpecialKeyState.ShiftPressed)
+                    {
+                        _newText = result.SubTitle;
+                    }
+                    ChangeQueryText(_newText);
                 }
             });
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -233,14 +233,24 @@ namespace Flow.Launcher.ViewModel
                 var result = SelectedResults.SelectedItem?.Result;
                 if (result != null) // SelectedItem returns null if selection is empty.
                 {
-                    string _newText = String.IsNullOrEmpty(result.AutoCompleteText) ? result.Title : result.AutoCompleteText;
+                    var autoCompleteText = result.Title;
+
+                    if (!string.IsNullOrEmpty(result.AutoCompleteText))
+                    {
+                        autoCompleteText = result.AutoCompleteText;
+                    }
+                    else if (!string.IsNullOrEmpty(SelectedResults.SelectedItem?.QuerySuggestionText))
+                    {
+                        autoCompleteText = SelectedResults.SelectedItem.QuerySuggestionText;
+                    }
 
                     var SpecialKeyState = GlobalHotkey.Instance.CheckModifiers();
                     if (SpecialKeyState.ShiftPressed)
                     {
-                        _newText = result.SubTitle;
+                        autoCompleteText = result.SubTitle;
                     }
-                    ChangeQueryText(_newText);
+
+                    ChangeQueryText(autoCompleteText);
                 }
             });
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -240,7 +240,7 @@ namespace Flow.Launcher.ViewModel
                 var result = results.SelectedItem?.Result;
                 if (result != null) // SelectedItem returns null if selection is empty.
                 {
-                    ChangeQueryText(result.Title, true);
+                    ChangeQueryText(result.Title);
                 }
             });
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -228,6 +228,22 @@ namespace Flow.Launcher.ViewModel
                 }
             });
 
+            ReplaceQueryWithResult = new RelayCommand(index =>
+            {
+                var results = SelectedResults;
+
+                if (index != null)
+                {
+                    results.SelectedIndex = int.Parse(index.ToString());
+                }
+
+                var result = results.SelectedItem?.Result;
+                if (result != null) // SelectedItem returns null if selection is empty.
+                {
+                    ChangeQueryText(result.Title, true);
+                }
+            });
+
             LoadContextMenuCommand = new RelayCommand(_ =>
             {
                 if (SelectedIsFromQueryResults())
@@ -383,6 +399,7 @@ namespace Flow.Launcher.ViewModel
         public ICommand OpenSettingCommand { get; set; }
         public ICommand ReloadPluginDataCommand { get; set; }
         public ICommand ClearQueryCommand { get; private set; }
+        public ICommand ReplaceQueryWithResult { get; set; }
 
         public string OpenResultCommandModifiers { get; private set; }
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -235,7 +235,7 @@ namespace Flow.Launcher.ViewModel
                 var result = results.SelectedItem?.Result;
                 if (result != null) // SelectedItem returns null if selection is empty.
                 {
-                    string _newText = String.IsNullOrEmpty(result.SuggestionText) ? result.Title : result.SuggestionText;
+                    string _newText = String.IsNullOrEmpty(result.AutoCompleteText) ? result.Title : result.AutoCompleteText;
 
                     var SpecialKeyState = GlobalHotkey.Instance.CheckModifiers();
                     if (SpecialKeyState.ShiftPressed)

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -228,7 +228,7 @@ namespace Flow.Launcher.ViewModel
                 }
             });
 
-            InsertSuggestion = new RelayCommand(_ =>
+            AutocompleteQueryCommand = new RelayCommand(_ =>
             {
                 var result = SelectedResults.SelectedItem?.Result;
                 if (result != null) // SelectedItem returns null if selection is empty.
@@ -408,7 +408,7 @@ namespace Flow.Launcher.ViewModel
         public ICommand OpenSettingCommand { get; set; }
         public ICommand ReloadPluginDataCommand { get; set; }
         public ICommand ClearQueryCommand { get; private set; }
-        public ICommand InsertSuggestion { get; set; }
+        public ICommand AutocompleteQueryCommand { get; set; }
 
         public string OpenResultCommandModifiers { get; private set; }
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -240,7 +240,7 @@ namespace Flow.Launcher.ViewModel
                 var result = results.SelectedItem?.Result;
                 if (result != null) // SelectedItem returns null if selection is empty.
                 {
-                    ChangeQueryText(result.Title);
+                    ChangeQueryText(result.InsertText);
                 }
             });
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -230,9 +230,7 @@ namespace Flow.Launcher.ViewModel
 
             InsertSuggestion = new RelayCommand(_ =>
             {
-                var results = SelectedResults;
-
-                var result = results.SelectedItem?.Result;
+                var result = SelectedResults.SelectedItem?.Result;
                 if (result != null) // SelectedItem returns null if selection is empty.
                 {
                     string _newText = String.IsNullOrEmpty(result.AutoCompleteText) ? result.Title : result.AutoCompleteText;

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -142,6 +142,8 @@ namespace Flow.Launcher.ViewModel
 
         public Result Result { get; }
 
+        public string QuerySuggestionText { get; set; }
+
         public override bool Equals(object obj)
         {
             return obj is ResultViewModel r && Result.Equals(r.Result);


### PR DESCRIPTION
Pressing <kbd>Tab</kbd> will replace the current Query with the selected result's `Title`.


https://user-images.githubusercontent.com/535299/144630236-62f19803-49a0-4fa2-b0da-217d28b71024.mp4

# Todo:
- [x] ~~Cycle to next result if query matches result~~ (Feels weird and unnatural and doesn't work very well)
- [x] Allow plugins to change inserted text
- [x] <kbd>Shift</kbd>+<kbd>Tab</kbd> to insert result subtitle
