### PR TITLE
Hide suggestions if query matches

### DIFF
--- a/Flow.Launcher/Converters/QuerySuggestionBoxConverter.cs
+++ b/Flow.Launcher/Converters/QuerySuggestionBoxConverter.cs
@@ -40,7 +40,7 @@ namespace Flow.Launcher.Converters
                 var selectedResultActionKeyword = string.IsNullOrEmpty(selectedResult.ActionKeywordAssigned) ? "" : selectedResult.ActionKeywordAssigned + " ";
                 var selectedResultPossibleSuggestion = selectedResultActionKeyword + selectedResult.Title;
 
-                if (!selectedResultPossibleSuggestion.StartsWith(queryText, StringComparison.CurrentCultureIgnoreCase))
+                if (!selectedResultPossibleSuggestion.StartsWith(queryText, StringComparison.CurrentCultureIgnoreCase) || queryText == selectedResultPossibleSuggestion)
                     return string.Empty;
 
                 // When user typed lower case and result title is uppercase, we still want to display suggestion


### PR DESCRIPTION
There's no need to display a suggestion when the query is the same as the suggestion. This helps alleviate issues on very long text.
Old:
![OLD](https://user-images.githubusercontent.com/535299/144367093-c6cd038b-eddc-4122-865a-f0e4502b36b8.png)
New:
![NEW](https://user-images.githubusercontent.com/535299/144367124-589bef06-a443-4a20-ad54-4e1201d7f737.png)

