### PR TITLE
Display hotkey in tray context menu

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -147,6 +147,9 @@ namespace Flow.Launcher
                     case nameof(Settings.Language):
                         UpdateNotifyIconText();
                         break;
+                    case nameof(Settings.Hotkey):
+                        UpdateNotifyIconText();
+                        break;
                 }
             };
         }
@@ -168,7 +171,7 @@ namespace Flow.Launcher
         private void UpdateNotifyIconText()
         {
             var menu = contextMenu;
-            ((MenuItem)menu.Items[1]).Header = InternationalizationManager.Instance.GetTranslation("iconTrayOpen");
+            ((MenuItem)menu.Items[1]).Header = InternationalizationManager.Instance.GetTranslation("iconTrayOpen") + " (" + _settings.Hotkey + ")";
             ((MenuItem)menu.Items[2]).Header = InternationalizationManager.Instance.GetTranslation("GameMode");
             ((MenuItem)menu.Items[3]).Header = InternationalizationManager.Instance.GetTranslation("iconTraySettings");
             ((MenuItem)menu.Items[4]).Header = InternationalizationManager.Instance.GetTranslation("iconTrayExit");
@@ -191,7 +194,7 @@ namespace Flow.Launcher
             };
             var open = new MenuItem
             {
-                Header = InternationalizationManager.Instance.GetTranslation("iconTrayOpen")
+                Header = InternationalizationManager.Instance.GetTranslation("iconTrayOpen") + " (" +_settings.Hotkey + ")"
             };
             var gamemode = new MenuItem
             {


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/6903107/146677448-059c92f9-274d-4eab-98e4-a9e9c4dd8104.png" width="400">

The trigger key is very important, but it is currently notified on the Wizard screen, and in the settings, you need to go to the hotkey tab to know the set key. Add display the trigger key so that you can know immediately when you open the tray menu.