### PR TITLE
Revise ttf/otf code

### DIFF
--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -62,8 +62,6 @@ namespace Flow.Launcher.ViewModel
             Settings = settings;
         }
 
-        
-
         private Settings Settings { get; }
 
         public Visibility ShowOpenResultHotkey =>


### PR DESCRIPTION
WPF requires font name after the font source. This patch adds support for that.