### PR TITLE
Fix incorrect text for "New Tab" and "New Window" buttons

### DIFF
--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -176,8 +176,8 @@
     <system:String x:Key="defaultBrowser_name">Browser</system:String>
     <system:String x:Key="defaultBrowser_profile_name">Browser Name</system:String>
     <system:String x:Key="defaultBrowser_path">Browser Path</system:String>
-    <system:String x:Key="defaultBrowser_newtab">New Window</system:String>
-    <system:String x:Key="defaultBrowser_newWindow">New Tab</system:String>
+    <system:String x:Key="defaultBrowser_newWindow">New Window</system:String>
+    <system:String x:Key="defaultBrowser_newTab">New Tab</system:String>
     <system:String x:Key="defaultBrowser_parameter">Private Mode</system:String>
 
     <!--  Priority Setting Dialog  -->

--- a/Flow.Launcher/Languages/ko.xaml
+++ b/Flow.Launcher/Languages/ko.xaml
@@ -175,8 +175,8 @@
     <system:String x:Key="defaultBrowser_name">브라우저</system:String>
     <system:String x:Key="defaultBrowser_profile_name">브라우저 이름</system:String>
     <system:String x:Key="defaultBrowser_path">브라우저 경로</system:String>
-    <system:String x:Key="defaultBrowser_newtab">새 창</system:String>
-    <system:String x:Key="defaultBrowser_newWindow">새 탭</system:String>
+    <system:String x:Key="defaultBrowser_newWindow">새 창</system:String>
+    <system:String x:Key="defaultBrowser_newTab">새 탭</system:String>
     <system:String x:Key="defaultBrowser_parameter">프라이빗 모드</system:String>
 
     <!--  Priority Setting Dialog  -->

--- a/Flow.Launcher/Languages/pt-pt.xaml
+++ b/Flow.Launcher/Languages/pt-pt.xaml
@@ -176,8 +176,8 @@
     <system:String x:Key="defaultBrowser_name">Navegador</system:String>
     <system:String x:Key="defaultBrowser_profile_name">Nome do navegador</system:String>
     <system:String x:Key="defaultBrowser_path">Caminho do navegador</system:String>
-    <system:String x:Key="defaultBrowser_newtab">Nova janela</system:String>
-    <system:String x:Key="defaultBrowser_newWindow">Novo separador</system:String>
+    <system:String x:Key="defaultBrowser_newWindow">Nova janela</system:String>
+    <system:String x:Key="defaultBrowser_newTab">Novo separador</system:String>
     <system:String x:Key="defaultBrowser_parameter">Modo privado</system:String>
 
     <!--  Priority Setting Dialog  -->

--- a/Flow.Launcher/Languages/sk.xaml
+++ b/Flow.Launcher/Languages/sk.xaml
@@ -174,8 +174,8 @@
     <system:String x:Key="defaultBrowser_name">Prehliadač</system:String>
     <system:String x:Key="defaultBrowser_profile_name">Názov prehliadača</system:String>
     <system:String x:Key="defaultBrowser_path">Cesta k prehliadaču</system:String>
-    <system:String x:Key="defaultBrowser_newtab">Nové okno</system:String>
-    <system:String x:Key="defaultBrowser_newWindow">Nová karta</system:String>
+    <system:String x:Key="defaultBrowser_newWindow">Nové okno</system:String>
+    <system:String x:Key="defaultBrowser_newTab">Nová karta</system:String>
     <system:String x:Key="defaultBrowser_parameter">Privátny režim</system:String>
 
     <!--  Priority Setting Dialog  -->

--- a/Flow.Launcher/ReportWindow.xaml.cs
+++ b/Flow.Launcher/ReportWindow.xaml.cs
@@ -52,8 +52,8 @@ namespace Flow.Launcher
             var link = new Hyperlink { IsEnabled = true };
             link.Inlines.Add(url);
             link.NavigateUri = new Uri(url);
-            link.RequestNavigate += (s, e) => SearchWeb.NewTabInBrowser(e.Uri.ToString());
-            link.Click += (s, e) => SearchWeb.NewTabInBrowser(url);
+            link.RequestNavigate += (s, e) => SearchWeb.OpenInBrowserTab(e.Uri.ToString());
+            link.Click += (s, e) => SearchWeb.OpenInBrowserTab(url);
 
             paragraph.Inlines.Add(textBeforeUrl);
             paragraph.Inlines.Add(link);

--- a/Flow.Launcher/SelectBrowserWindow.xaml
+++ b/Flow.Launcher/SelectBrowserWindow.xaml
@@ -196,7 +196,7 @@
                             VerticalAlignment="Center"
                             Orientation="Horizontal">
                             <RadioButton IsChecked="{Binding OpenInTab}" 
-                                         Content="{DynamicResource defaultBrowser_newWindow}"></RadioButton>
+                                         Content="{DynamicResource defaultBrowser_newTab}"></RadioButton>
                             <RadioButton IsChecked="{Binding OpenInNewWindow, Mode=OneTime}"
                                          Content="{DynamicResource defaultBrowser_newWindow}"></RadioButton>
                         </StackPanel>

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -232,7 +232,7 @@ namespace Flow.Launcher
                     var uri = new Uri(website);
                     if (Uri.CheckSchemeName(uri.Scheme))
                     {
-                        website.NewTabInBrowser();
+                        website.OpenInBrowserTab();
                     }
                 }
             }

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -333,7 +333,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                 {
                     if (e.SpecialKeyState.CtrlPressed)
                     {
-                        SearchWeb.NewTabInBrowser(plugin.UrlDownload);
+                        SearchWeb.OpenInBrowserTab(plugin.UrlDownload);
                         return ShouldHideWindow;
                     }
 
@@ -397,7 +397,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                             {
                                 if (e.SpecialKeyState.CtrlPressed)
                                 {
-                                    SearchWeb.NewTabInBrowser(x.Website);
+                                    SearchWeb.OpenInBrowserTab(x.Website);
                                     return ShouldHideWindow;
                                 }
 

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
@@ -6,7 +6,7 @@
   "Name": "Plugins Manager",
   "Description": "Management of installing, uninstalling or updating Flow Launcher plugins",
   "Author": "Jeremy Wu",
-  "Version": "1.11.1",
+  "Version": "1.11.2",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.PluginsManager.dll",


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/697917/147936388-60a07abb-89d0-4543-b5b9-7d9ed06b5c96.png)

The translation keys were flipped for tab/browser, and the `DynamicResource` was incorrectly set for the "New Tab" case.

Also resolved some compilation warnings.