### PR TITLE
Fix Toggle Switch Knob (White Circle) Positioning

### DIFF
--- a/Flow.Launcher/Resources/CustomControlTemplate.xaml
+++ b/Flow.Launcher/Resources/CustomControlTemplate.xaml
@@ -1469,6 +1469,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="ui:ToggleSwitch">
                     <Border
+                        Width="Auto"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
@@ -1498,7 +1499,7 @@
                                 Visibility="Collapsed" />
                             <Grid
                                 Grid.Row="1"
-                                MinWidth="{DynamicResource ToggleSwitchThemeMinWidth}"
+                                MinWidth="10"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Top">
 
@@ -1509,7 +1510,7 @@
                                 </Grid.RowDefinitions>
 
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="12" MaxWidth="12" />
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>

--- a/Flow.Launcher/Resources/CustomControlTemplate.xaml
+++ b/Flow.Launcher/Resources/CustomControlTemplate.xaml
@@ -1478,7 +1478,7 @@
                             <ui:SimpleVisualStateManager />
                         </VisualStateManager.CustomVisualStateManager>
 
-                        <Grid>
+                        <Grid HorizontalAlignment="Right">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />
@@ -1486,7 +1486,7 @@
 
                             <ui:ContentPresenterEx
                                 x:Name="HeaderContentPresenter"
-                                Grid.Row="1"
+                                Grid.Row="0"
                                 Margin="{DynamicResource ToggleSwitchTopHeaderMargin}"
                                 VerticalAlignment="Top"
                                 Content="{TemplateBinding Header}"
@@ -1497,11 +1497,9 @@
                                 TextWrapping="Wrap"
                                 Visibility="Collapsed" />
                             <Grid
-                                Grid.Row="0"
-                                Width="100"
+                                Grid.Row="1"
                                 MinWidth="{DynamicResource ToggleSwitchThemeMinWidth}"
-                                Margin="10,0,0,0"
-                                HorizontalAlignment="Left"
+                                HorizontalAlignment="Right"
                                 VerticalAlignment="Top">
 
                                 <Grid.RowDefinitions>
@@ -1511,7 +1509,7 @@
                                 </Grid.RowDefinitions>
 
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="12" MaxWidth="12" />
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
@@ -1520,6 +1518,7 @@
                                     Grid.RowSpan="3"
                                     Grid.ColumnSpan="3"
                                     Margin="0,5"
+                                    HorizontalAlignment="Right"
                                     ui:FocusVisualHelper.IsTemplateFocusTarget="True"
                                     Background="{DynamicResource ToggleSwitchContainerBackground}" />
                                 <ContentPresenter
@@ -1552,6 +1551,7 @@
                                     Grid.Column="2"
                                     Width="40"
                                     Height="20"
+                                    HorizontalAlignment="Right"
                                     Fill="{DynamicResource ToggleSwitchFillOff}"
                                     RadiusX="10"
                                     RadiusY="10"
@@ -1563,6 +1563,7 @@
                                     Grid.Column="2"
                                     Width="40"
                                     Height="20"
+                                    HorizontalAlignment="Right"
                                     Fill="{DynamicResource ToggleSwitchFillOn}"
                                     Opacity="0"
                                     RadiusX="10"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -992,7 +992,7 @@
                                                         <Border>
                                                             <Button
                                                                 x:Name="PriorityButton"
-                                                                Margin="0,0,0,0"
+                                                                Margin="0,0,18,0"
                                                                 VerticalAlignment="Center"
                                                                 Click="OnPluginPriorityClick"
                                                                 Content="{Binding Priority, UpdateSourceTrigger=PropertyChanged}"
@@ -1023,7 +1023,12 @@
                                                         </Border>
                                                     </StackPanel>
                                                     <DockPanel Grid.Column="3">
-                                                        <ui:ToggleSwitch HorizontalAlignment="Right" IsOn="{Binding PluginState}" />
+                                                        <ui:ToggleSwitch
+                                                            Margin="0,0,6,0"
+                                                            HorizontalAlignment="Right"
+                                                            IsOn="{Binding PluginState}"
+                                                            OffContent="{DynamicResource disable}"
+                                                            OnContent="{DynamicResource enable}" />
                                                     </DockPanel>
                                                 </Grid>
 

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -951,7 +951,7 @@
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="100" MinWidth="100" />
                                                         <ColumnDefinition Width="8*" />
-                                                        <ColumnDefinition MinWidth="100" />
+                                                        <ColumnDefinition Width="Auto" />
                                                         <ColumnDefinition Width="Auto" />
                                                     </Grid.ColumnDefinitions>
                                                     <StackPanel
@@ -992,7 +992,7 @@
                                                         <Border>
                                                             <Button
                                                                 x:Name="PriorityButton"
-                                                                Margin="0,0,18,0"
+                                                                Margin="0,0,22,0"
                                                                 VerticalAlignment="Center"
                                                                 Click="OnPluginPriorityClick"
                                                                 Content="{Binding Priority, UpdateSourceTrigger=PropertyChanged}"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -57,10 +57,7 @@
                                     MinWidth="20"
                                     MaxWidth="60" />
                                 <ColumnDefinition Width="8*" />
-                                <ColumnDefinition
-                                    Width="Auto"
-                                    MinWidth="40"
-                                    MaxWidth="550" />
+                                <ColumnDefinition Width="Auto" MinWidth="30" />
                             </Grid.ColumnDefinitions>
                         </Grid>
                     </ItemsPanelTemplate>
@@ -102,7 +99,7 @@
             TargetType="{x:Type CheckBox}">
             <Setter Property="Width" Value="24" />
             <Setter Property="Grid.Column" Value="2" />
-            <Setter Property="Margin" Value="0,4,0,4" />
+            <Setter Property="Margin" Value="0,4,10,4" />
             <Setter Property="LayoutTransform">
                 <Setter.Value>
                     <ScaleTransform ScaleX="1" ScaleY="1" />
@@ -110,11 +107,16 @@
             </Setter>
         </Style>
 
-        <Style x:Key="SideToggleSwitch" TargetType="{x:Type ui:ToggleSwitch}">
+        <Style
+            x:Key="SideToggleSwitch"
+            BasedOn="{StaticResource DefaultToggleSwitch}"
+            TargetType="{x:Type ui:ToggleSwitch}">
             <Setter Property="Grid.Column" Value="2" />
+            <Setter Property="Width" Value="Auto" />
+            <Setter Property="HorizontalAlignment" Value="Right" />
+            <Setter Property="HorizontalContentAlignment" Value="Right" />
             <Setter Property="OffContent" Value="{DynamicResource disable}" />
             <Setter Property="OnContent" Value="{DynamicResource enable}" />
-            <Setter Property="FlowDirection" Value="RightToLeft" />
             <Setter Property="Margin" Value="0,4,22,4" />
         </Style>
 
@@ -948,9 +950,9 @@
                                                     FlowDirection="LeftToRight">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="100" MinWidth="100" />
-                                                        <ColumnDefinition Width="3*" />
-                                                        <ColumnDefinition />
-                                                        <ColumnDefinition />
+                                                        <ColumnDefinition Width="8*" />
+                                                        <ColumnDefinition MinWidth="100" />
+                                                        <ColumnDefinition Width="Auto" />
                                                     </Grid.ColumnDefinitions>
                                                     <StackPanel
                                                         Grid.Column="0"
@@ -990,7 +992,7 @@
                                                         <Border>
                                                             <Button
                                                                 x:Name="PriorityButton"
-                                                                Margin="0,0,12,0"
+                                                                Margin="0,0,0,0"
                                                                 VerticalAlignment="Center"
                                                                 Click="OnPluginPriorityClick"
                                                                 Content="{Binding Priority, UpdateSourceTrigger=PropertyChanged}"
@@ -1021,11 +1023,7 @@
                                                         </Border>
                                                     </StackPanel>
                                                     <DockPanel Grid.Column="3">
-                                                        <ui:ToggleSwitch
-                                                            Margin="0"
-                                                            DockPanel.Dock="Right"
-                                                            IsOn="{Binding PluginState}"
-                                                            Style="{DynamicResource SideToggleSwitch}" />
+                                                        <ui:ToggleSwitch HorizontalAlignment="Right" IsOn="{Binding PluginState}" />
                                                     </DockPanel>
                                                 </Grid>
 
@@ -1955,7 +1953,7 @@
                                                 </StackPanel>
                                                 <Button
                                                     Grid.Column="2"
-                                                    Width="180"
+                                                    MinWidth="180"
                                                     Margin="0,0,18,0"
                                                     HorizontalAlignment="Center"
                                                     Click="OpenThemeFolder"


### PR DESCRIPTION
**Before** 
- The knob position of the toggle switch is wrong.
- This is a problem caused by the use of RTL for right alignment.

![image](https://user-images.githubusercontent.com/6903107/147947823-b279fbf1-e7be-4b8c-a903-c45e00362a4d.png)

- When the window size increases, the positions of the Priority button and the toggle switch operate incorrectly.

![image](https://user-images.githubusercontent.com/6903107/147948270-b3bd33a9-b209-49c1-abbe-4b98a1d30091.png)


**After**
- Toggle Switch with LTR

![image](https://user-images.githubusercontent.com/6903107/147947602-5f9bce69-7712-4c44-b633-5a4203d11477.png)

- Fix Toggle Switch Circle Positioning
- Change "Open Theme Folder" Button Width to Responsive
- Adjust Priority Button Position
- Even if the window size changes, it is aligned to the right.

![image](https://user-images.githubusercontent.com/6903107/147948406-cf29757e-6efd-4a7a-81e9-3b9b2cc78a3d.png)




**Test / Validate**
- When the toggle switch is turned on, the inner round circle (aka Knob) must be on the right.
- For languages with long toggle switch on/off labels, the area is automatically adjusted and all must be displayed. 
- The dot mark in Slovak language should be displayed on the right.
- When adjusting the size of the setting window, the Priority button and label should be displayed well.