### PR TITLE
stop trigger global hotkey when shell plugin is not enabled

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -317,7 +317,7 @@ namespace Flow.Launcher.Plugin.Shell
 
         bool API_GlobalKeyboardEvent(int keyevent, int vkcode, SpecialKeyState state)
         {
-            if (_settings.ReplaceWinR)
+            if (!context.CurrentPluginMetadata.Disabled && _settings.ReplaceWinR)
             {
                 if (keyevent == (int)KeyEvent.WM_KEYDOWN && vkcode == (int)Keys.R && state.WinPressed)
                 {

--- a/Plugins/Flow.Launcher.Plugin.Shell/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Shell/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Shell",
   "Description": "Provide executing commands from Flow Launcher",
   "Author": "qianlifeng",
-  "Version": "1.4.8",
+  "Version": "1.4.9",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Shell.dll",


### PR DESCRIPTION
temporary fix for #950 
We should stop init disabled plugin when startup. corresponding to idea of #391 