### PR TITLE
Improvements to PluginManager plugin

### DIFF
--- a/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
@@ -1,4 +1,4 @@
-﻿using Flow.Launcher.Infrastructure.Logger;
+using Flow.Launcher.Infrastructure.Logger;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -11,7 +11,7 @@ namespace Flow.Launcher.Core.ExternalPlugins
 {
     public static class PluginsManifest
     {
-        private const string manifestFileUrl = "https://raw.githubusercontent.com/Flow-Launcher/Flow.Launcher.PluginsManifest/plugin_api_v2/plugins.json";
+        private const string manifestFileUrl = "https://cdn.jsdelivr.net/gh/Flow-Launcher/Flow.Launcher.PluginsManifest@plugin_api_v2/plugins.json";
 
         private static HttpClient httpClient = new HttpClient();
 

--- a/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
@@ -1,4 +1,4 @@
-using Flow.Launcher.Infrastructure.Logger;
+﻿using Flow.Launcher.Infrastructure.Logger;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -21,24 +21,24 @@ namespace Flow.Launcher.Core.ExternalPlugins
 
         public static List<UserPlugin> UserPlugins { get; private set; } = new List<UserPlugin>();
 
-        public static async Task UpdateManifestAsync()
+        public static async Task UpdateManifestAsync(CancellationToken token = default)
         {
             try
             {
-                await manifestUpdateLock.WaitAsync().ConfigureAwait(false);
+                await manifestUpdateLock.WaitAsync(token).ConfigureAwait(false);
 
                 var request = new HttpRequestMessage(HttpMethod.Get, manifestFileUrl);
                 request.Headers.Add("If-None-Match", latestEtag);
 
-                var response = await httpClient.SendAsync(request).ConfigureAwait(false);
+                var response = await httpClient.SendAsync(request, token).ConfigureAwait(false);
 
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
                     Log.Info($"|PluginsManifest.{nameof(UpdateManifestAsync)}|Fetched plugins from manifest repo");
 
-                    var json = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    var json = await response.Content.ReadAsStreamAsync(token).ConfigureAwait(false);
 
-                    UserPlugins = await JsonSerializer.DeserializeAsync<List<UserPlugin>>(json).ConfigureAwait(false);
+                    UserPlugins = await JsonSerializer.DeserializeAsync<List<UserPlugin>>(json, cancellationToken: token).ConfigureAwait(false);
 
                     latestEtag = response.Headers.ETag.Tag;
                 }

--- a/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
@@ -1,3 +1,4 @@
+﻿using Flow.Launcher.Infrastructure.Http;
 using Flow.Launcher.Infrastructure.Logger;
 using System;
 using System.Collections.Generic;
@@ -12,8 +13,6 @@ namespace Flow.Launcher.Core.ExternalPlugins
     public static class PluginsManifest
     {
         private const string manifestFileUrl = "https://cdn.jsdelivr.net/gh/Flow-Launcher/Flow.Launcher.PluginsManifest@plugin_api_v2/plugins.json";
-
-        private static HttpClient httpClient = new HttpClient();
 
         private static readonly SemaphoreSlim manifestUpdateLock = new(1);
 
@@ -30,7 +29,7 @@ namespace Flow.Launcher.Core.ExternalPlugins
                 var request = new HttpRequestMessage(HttpMethod.Get, manifestFileUrl);
                 request.Headers.Add("If-None-Match", latestEtag);
 
-                var response = await httpClient.SendAsync(request, token).ConfigureAwait(false);
+                var response = await Http.SendAsync(request, token).ConfigureAwait(false);
 
                 if (response.StatusCode == HttpStatusCode.OK)
                 {

--- a/Flow.Launcher.Infrastructure/Http/Http.cs
+++ b/Flow.Launcher.Infrastructure/Http/Http.cs
@@ -159,7 +159,7 @@ namespace Flow.Launcher.Infrastructure.Http
         /// </summary>
         public static async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token = default)
         {
-            return await client.SendAsync(request, token);
+            return await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token);
         }
     }
 }

--- a/Flow.Launcher.Infrastructure/Http/Http.cs
+++ b/Flow.Launcher.Infrastructure/Http/Http.cs
@@ -153,5 +153,13 @@ namespace Flow.Launcher.Infrastructure.Http
             var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, token);
             return await response.Content.ReadAsStreamAsync();
         }
+
+        /// <summary>
+        /// Asynchrously send an HTTP request.
+        /// </summary>
+        public static async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token = default)
+        {
+            return await client.SendAsync(request, token);
+        }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/ContextMenu.cs
@@ -2,7 +2,7 @@
 using Flow.Launcher.Infrastructure.UserSettings;
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Flow.Launcher.Plugin.PluginsManager
 {
@@ -53,8 +53,8 @@ namespace Flow.Launcher.Plugin.PluginsManager
                     {
                         // standard UrlSourceCode format in PluginsManifest's plugins.json file: https://github.com/jjw24/Flow.Launcher.Plugin.Putty/tree/master
                         var link = pluginManifestInfo.UrlSourceCode.StartsWith("https://github.com") 
-                                                                ? pluginManifestInfo.UrlSourceCode.Replace("/tree/master", "/issues/new/choose") 
-                                                                : pluginManifestInfo.UrlSourceCode;
+                                        ? Regex.Replace(pluginManifestInfo.UrlSourceCode, @"\/tree\/\w+$", "") + "/issues/new/choose"
+                                        : pluginManifestInfo.UrlSourceCode;
 
                         Context.API.OpenUrl(link);
                         return true;

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
@@ -12,7 +12,7 @@ using System.Windows;
 
 namespace Flow.Launcher.Plugin.PluginsManager
 {
-    public class Main : ISettingProvider, IAsyncPlugin, IContextMenu, IPluginI18n, IAsyncReloadable
+    public class Main : ISettingProvider, IAsyncPlugin, IContextMenu, IPluginI18n
     {
         internal PluginInitContext Context { get; set; }
 
@@ -75,11 +75,6 @@ namespace Flow.Launcher.Plugin.PluginsManager
         public string GetTranslatedPluginDescription()
         {
             return Context.API.GetTranslation("plugin_pluginsmanager_plugin_description");
-        }
-
-        public async Task ReloadDataAsync()
-        {
-            await pluginManager.UpdateManifestAsync();
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
@@ -50,15 +50,12 @@ namespace Flow.Launcher.Plugin.PluginsManager
             if (string.IsNullOrWhiteSpace(query.Search))
                 return pluginManager.GetDefaultHotKeys();
 
-            return query.FirstSearch switch
+            return query.FirstSearch.ToLower() switch
             {
                 //search could be url, no need ToLower() when passed in
-                var s when s.Equals(Settings.HotKeyInstall, StringComparison.OrdinalIgnoreCase)
-                    => await pluginManager.RequestInstallOrUpdate(query.SecondToEndSearch, token),
-                var s when s.Equals(Settings.HotkeyUninstall, StringComparison.OrdinalIgnoreCase)
-                    => pluginManager.RequestUninstall(query.SecondToEndSearch),
-                var s when s.Equals(Settings.HotkeyUpdate, StringComparison.OrdinalIgnoreCase)
-                    => await pluginManager.RequestUpdate(query.SecondToEndSearch, token),
+                Settings.InstallCommand => await pluginManager.RequestInstallOrUpdate(query.SecondToEndSearch, token),
+                Settings.UninstallCommand => pluginManager.RequestUninstall(query.SecondToEndSearch),
+                Settings.UpdateCommand => await pluginManager.RequestUpdate(query.SecondToEndSearch, token),
                 _ => pluginManager.GetDefaultHotKeys().Where(hotkey =>
                 {
                     hotkey.Score = StringMatcher.FuzzySearch(query.Search, hotkey.Title).Score;

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
@@ -29,7 +29,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
             return new PluginsManagerSettings(viewModel);
         }
 
-        public Task InitAsync(PluginInitContext context)
+        public async Task InitAsync(PluginInitContext context)
         {
             Context = context;
             Settings = context.API.LoadSettingJsonStorage<Settings>();
@@ -37,7 +37,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
             contextMenu = new ContextMenu(Context);
             pluginManager = new PluginsManager(Context, Settings);
 
-            return Task.CompletedTask;
+            await pluginManager.UpdateManifestAsync();
         }
 
         public List<Result> LoadContextMenus(Result selectedResult)

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
@@ -47,23 +47,21 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
         public async Task<List<Result>> QueryAsync(Query query, CancellationToken token)
         {
-            var search = query.Search;
-
-            if (string.IsNullOrWhiteSpace(search))
+            if (string.IsNullOrWhiteSpace(query.Search))
                 return pluginManager.GetDefaultHotKeys();
 
-            return search switch
+            return query.FirstSearch switch
             {
                 //search could be url, no need ToLower() when passed in
-                var s when s.StartsWith(Settings.HotKeyInstall, StringComparison.OrdinalIgnoreCase)
-                    => await pluginManager.RequestInstallOrUpdate(search, token),
-                var s when s.StartsWith(Settings.HotkeyUninstall, StringComparison.OrdinalIgnoreCase)
-                    => pluginManager.RequestUninstall(search),
-                var s when s.StartsWith(Settings.HotkeyUpdate, StringComparison.OrdinalIgnoreCase)
-                    => await pluginManager.RequestUpdate(search, token),
+                var s when s.Equals(Settings.HotKeyInstall, StringComparison.OrdinalIgnoreCase)
+                    => await pluginManager.RequestInstallOrUpdate(query.SecondToEndSearch, token),
+                var s when s.Equals(Settings.HotkeyUninstall, StringComparison.OrdinalIgnoreCase)
+                    => pluginManager.RequestUninstall(query.SecondToEndSearch),
+                var s when s.Equals(Settings.HotkeyUpdate, StringComparison.OrdinalIgnoreCase)
+                    => await pluginManager.RequestUpdate(query.SecondToEndSearch, token),
                 _ => pluginManager.GetDefaultHotKeys().Where(hotkey =>
                 {
-                    hotkey.Score = StringMatcher.FuzzySearch(search, hotkey.Title).Score;
+                    hotkey.Score = StringMatcher.FuzzySearch(query.Search, hotkey.Title).Score;
                     return hotkey.Score > 0;
                 }).ToList()
             };

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -75,34 +75,34 @@ namespace Flow.Launcher.Plugin.PluginsManager
             {
                 new Result()
                 {
-                    Title = Settings.HotKeyInstall,
+                    Title = Settings.InstallCommand,
                     IcoPath = icoPath,
-                    AutoCompleteText = $"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.HotKeyInstall} ",
+                    AutoCompleteText = $"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.InstallCommand} ",
                     Action = _ =>
                     {
-                        Context.API.ChangeQuery($"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.HotKeyInstall} ");
+                        Context.API.ChangeQuery($"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.InstallCommand} ");
                         return false;
                     }
                 },
                 new Result()
                 {
-                    Title = Settings.HotkeyUninstall,
+                    Title = Settings.UninstallCommand,
                     IcoPath = icoPath,
-                    AutoCompleteText = $"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.HotkeyUninstall} ",
+                    AutoCompleteText = $"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.UninstallCommand} ",
                     Action = _ =>
                     {
-                        Context.API.ChangeQuery($"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.HotkeyUninstall} ");
+                        Context.API.ChangeQuery($"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.UninstallCommand} ");
                         return false;
                     }
                 },
                 new Result()
                 {
-                    Title = Settings.HotkeyUpdate,
+                    Title = Settings.UpdateCommand,
                     IcoPath = icoPath,
-                    AutoCompleteText = $"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.HotkeyUpdate} ",
+                    AutoCompleteText = $"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.UpdateCommand} ",
                     Action = _ =>
                     {
-                        Context.API.ChangeQuery($"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.HotkeyUpdate} ");
+                        Context.API.ChangeQuery($"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.UpdateCommand} ");
                         return false;
                     }
                 }
@@ -122,7 +122,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                         Context
                             .API
                             .ChangeQuery(
-                                $"{Context.CurrentPluginMetadata.ActionKeywords.FirstOrDefault()} {Settings.HotkeyUpdate} {plugin.Name}");
+                                $"{Context.CurrentPluginMetadata.ActionKeywords.FirstOrDefault()} {Settings.UpdateCommand} {plugin.Name}");
 
                     var mainWindow = Application.Current.MainWindow;
                     mainWindow.Show();

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -77,9 +77,10 @@ namespace Flow.Launcher.Plugin.PluginsManager
                 {
                     Title = Settings.HotKeyInstall,
                     IcoPath = icoPath,
+                    AutoCompleteText = $"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.HotKeyInstall} ",
                     Action = _ =>
                     {
-                        Context.API.ChangeQuery("pm install ");
+                        Context.API.ChangeQuery($"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.HotKeyInstall} ");
                         return false;
                     }
                 },
@@ -87,9 +88,10 @@ namespace Flow.Launcher.Plugin.PluginsManager
                 {
                     Title = Settings.HotkeyUninstall,
                     IcoPath = icoPath,
+                    AutoCompleteText = $"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.HotkeyUninstall} ",
                     Action = _ =>
                     {
-                        Context.API.ChangeQuery("pm uninstall ");
+                        Context.API.ChangeQuery($"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.HotkeyUninstall} ");
                         return false;
                     }
                 },
@@ -97,9 +99,10 @@ namespace Flow.Launcher.Plugin.PluginsManager
                 {
                     Title = Settings.HotkeyUpdate,
                     IcoPath = icoPath,
+                    AutoCompleteText = $"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.HotkeyUpdate} ",
                     Action = _ =>
                     {
-                        Context.API.ChangeQuery("pm update ");
+                        Context.API.ChangeQuery($"{Context.CurrentPluginMetadata.ActionKeyword} {Settings.HotkeyUpdate} ");
                         return false;
                     }
                 }

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -59,7 +59,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
             }
             else
             {
-                _downloadManifestTask = PluginsManifest.UpdateTask;
+                _downloadManifestTask = PluginsManifest.UpdateManifestAsync();
                 if (!silent)
                     _downloadManifestTask.ContinueWith(_ =>
                             Context.API.ShowMsg(Context.API.GetTranslation("plugin_pluginsmanager_update_failed_title"),
@@ -181,10 +181,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
         internal async ValueTask<List<Result>> RequestUpdate(string search, CancellationToken token)
         {
-            if (!PluginsManifest.UserPlugins.Any())
-            {
-                await UpdateManifestAsync();
-            }
+            await UpdateManifestAsync();
 
             token.ThrowIfCancellationRequested();
 
@@ -371,10 +368,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
         internal async ValueTask<List<Result>> RequestInstallOrUpdate(string searchName, CancellationToken token)
         {
-            if (!PluginsManifest.UserPlugins.Any())
-            {
-                await UpdateManifestAsync();
-            }
+            await UpdateManifestAsync();
 
             token.ThrowIfCancellationRequested();
 

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -51,7 +51,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
         private Task _downloadManifestTask = Task.CompletedTask;
 
-        internal Task UpdateManifestAsync(bool silent = false)
+        internal Task UpdateManifestAsync(CancellationToken token = default, bool silent = false)
         {
             if (_downloadManifestTask.Status == TaskStatus.Running)
             {
@@ -59,7 +59,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
             }
             else
             {
-                _downloadManifestTask = PluginsManifest.UpdateManifestAsync();
+                _downloadManifestTask = PluginsManifest.UpdateManifestAsync(token);
                 if (!silent)
                     _downloadManifestTask.ContinueWith(_ =>
                             Context.API.ShowMsg(Context.API.GetTranslation("plugin_pluginsmanager_update_failed_title"),
@@ -181,9 +181,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
         internal async ValueTask<List<Result>> RequestUpdate(string search, CancellationToken token)
         {
-            await UpdateManifestAsync();
-
-            token.ThrowIfCancellationRequested();
+            await UpdateManifestAsync(token);
 
             var autocompletedResults = AutoCompleteReturnAllResults(search,
                 Settings.HotkeyUpdate,
@@ -368,9 +366,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
         internal async ValueTask<List<Result>> RequestInstallOrUpdate(string searchName, CancellationToken token)
         {
-            await UpdateManifestAsync();
-
-            token.ThrowIfCancellationRequested();
+            await UpdateManifestAsync(token);
 
             var searchNameWithoutKeyword = searchName.Replace(Settings.HotKeyInstall, string.Empty, StringComparison.OrdinalIgnoreCase).Trim();
 

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Settings.cs
@@ -6,11 +6,11 @@ namespace Flow.Launcher.Plugin.PluginsManager
 {
     internal class Settings
     {
-        internal string HotKeyInstall { get; set; } = "install";
+        internal const string InstallCommand = "install";
 
-        internal string HotkeyUninstall { get; set; } = "uninstall";
+        internal const string UninstallCommand = "uninstall";
 
-        internal string HotkeyUpdate { get; set; } = "update";
+        internal const string UpdateCommand = "update";
 
         public bool WarnFromUnknownSource { get; set; } = true;
     }

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
@@ -6,7 +6,7 @@
   "Name": "Plugins Manager",
   "Description": "Management of installing, uninstalling or updating Flow Launcher plugins",
   "Author": "Jeremy Wu",
-  "Version": "1.11.2",
+  "Version": "1.12.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.PluginsManager.dll",


### PR DESCRIPTION
The main change introduced here is the use of conditional http requests when fetching the plugin manifest json. This allows us to always check for changes to the manifest repo when running one of `pm install`, `pm update`, with very little performance overhead (for me it is about 50ms). It also allows us to simplify the relevant code a bit.

Also some quick refactoring in `PluginsManager` and a couple quality-of-life enhancements:

1. typing `pm inst` and hitting tab would autocomplete to `pm install` without a space at the end (same for the other base commands)
2. fix incorrect link (for some plugins) when selecting to open an issue from the context menu

PS: I missed #682 until I started writing this PR text... my apologies. I see similarities, perhaps we can pick some of the missing changes into this PR?