### PR TITLE
Minor enhancements to query auto-completion

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -229,7 +229,7 @@ namespace Flow.Launcher.ViewModel
             AutocompleteQueryCommand = new RelayCommand(_ =>
             {
                 var result = SelectedResults.SelectedItem?.Result;
-                if (result != null) // SelectedItem returns null if selection is empty.
+                if (result != null && SelectedIsFromQueryResults()) // SelectedItem returns null if selection is empty.
                 {
                     var autoCompleteText = result.Title;
 

--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/Main.cs
@@ -25,6 +25,7 @@ namespace Flow.Launcher.Plugin.PluginIndicator
                               SubTitle = $"Activate {metadata.Name} plugin",
                               Score = 100,
                               IcoPath = metadata.IcoPath,
+                              AutoCompleteText = $"{keyword}{Plugin.Query.TermSeparator}",
                               Action = c =>
                               {
                                   context.API.ChangeQuery($"{keyword}{Plugin.Query.TermSeparator}");

--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Plugin Indicator",
   "Description": "Provide plugin actionword suggestion",
   "Author": "qianlifeng",
-  "Version": "1.1.3",
+  "Version": "1.1.4",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.PluginIndicator.dll",

--- a/Plugins/Flow.Launcher.Plugin.ProcessKiller/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.ProcessKiller/Main.cs
@@ -88,6 +88,7 @@ namespace Flow.Launcher.Plugin.ProcessKiller
                     TitleHighlightData = StringMatcher.FuzzySearch(termToSearch, p.ProcessName).MatchData,
                     Score = pr.Score,
                     ContextData = p.ProcessName,
+                    AutoCompleteText = $"{_context.CurrentPluginMetadata.ActionKeyword}{Plugin.Query.TermSeparator}{p.ProcessName}",
                     Action = (c) =>
                     {
                         processHelper.TryKill(p);

--- a/Plugins/Flow.Launcher.Plugin.ProcessKiller/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.ProcessKiller/plugin.json
@@ -4,7 +4,7 @@
     "Name":"Process Killer",
     "Description":"Kill running processes from Flow",
     "Author":"Flow-Launcher",
-    "Version":"1.2.4",
+    "Version":"1.2.5",
     "Language":"csharp",
     "Website":"https://github.com/Flow-Launcher/Flow.Launcher.Plugin.ProcessKiller",
     "IcoPath":"Images\\app.png",


### PR DESCRIPTION
Quick one to address some minor annoyances:

1. hitting Tab from a context menu seems to be only intended for accidents... I've ended up with "Set as topmost in this query" as my query text a few times 😂 I have disabled auto-completion in context menus since I don't see a use for it...
2. hitting Tab from a ProcessKiller result would append the process number to the query, which would no longer work be a valid `kill` query
3. hitting Tab from a PluginIndicator result would not append a space at the end