### PR TITLE
Allow plugins to capture hotkey actions on query window results

### DIFF
--- a/Flow.Launcher.Core/Plugin/ExecutablePlugin.cs
+++ b/Flow.Launcher.Core/Plugin/ExecutablePlugin.cs
@@ -21,12 +21,15 @@ namespace Flow.Launcher.Core.Plugin
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
-            
-            // required initialisation for below request calls 
+
+            // required initialisation for below request calls
             _startInfo.ArgumentList.Add(string.Empty);
         }
 
-        protected override Task<Stream> RequestAsync(JsonRPCRequestModel request, CancellationToken token = default)
+        protected override Task<Stream> RequestAsync(
+            JsonRPCRequestModel request,
+            CancellationToken token = default,
+            bool ignoreEmptyResponse = false)
         {
             // since this is not static, request strings will build up in ArgumentList if index is not specified
             _startInfo.ArgumentList[0] = request.ToString();

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -177,6 +177,15 @@ namespace Flow.Launcher.Core.Plugin
             {
                 return GlobalPlugins;
             }
+        }
+
+        public static async Task PublishPathSelectedFromResult(string selectedPath, string hotkey)
+        {
+            await Task.WhenAll(AllPlugins.Select(plugin => plugin.Plugin switch
+            {
+                IPathSelected p => p.PathSelected(selectedPath, hotkey),
+                _ => Task.CompletedTask,
+            }));
         }
 
         public static async Task<List<Result>> QueryForPluginAsync(PluginPair pair, Query query, CancellationToken token)

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -26,7 +26,6 @@ namespace Flow.Launcher.Core.Plugin
 
         public static IPublicAPI API { private set; get; }
 
-        // todo happlebao, this should not be public, the indicator function should be embeded 
         public static PluginsSettings Settings;
         private static List<PluginMetadata> _metadatas;
 
@@ -181,9 +180,14 @@ namespace Flow.Launcher.Core.Plugin
 
         public static async Task PublishPathSelectedFromResult(string selectedPath, string hotkey)
         {
-            await Task.WhenAll(AllPlugins.Select(plugin => plugin.Plugin switch
+            await Task.WhenAll(AllPlugins.Select(pluginPair => pluginPair.Plugin switch
             {
-                IPathSelected p => p.PathSelected(selectedPath, hotkey),
+                IPathSelected p
+                    when pluginPair
+                            .Metadata
+                            .Listeners
+                            .Any(x => x.ContainsKey(hotkey) && x.ContainsValue("IPathSelected"))
+                  => p.PathSelected(selectedPath, hotkey),
                 _ => Task.CompletedTask,
             }));
         }

--- a/Flow.Launcher.Core/Plugin/PythonPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/PythonPlugin.cs
@@ -37,11 +37,14 @@ namespace Flow.Launcher.Core.Plugin
             _startInfo.ArgumentList.Add("-B");
         }
 
-        protected override Task<Stream> RequestAsync(JsonRPCRequestModel request, CancellationToken token = default)
+        protected override Task<Stream> RequestAsync(
+            JsonRPCRequestModel request,
+            CancellationToken token = default,
+            bool ignoreEmptyResponse = false)
         {
             _startInfo.ArgumentList[2] = request.ToString();
 
-            return ExecuteAsync(_startInfo, token);
+            return ExecuteAsync(_startInfo, token, ignoreEmptyResponse: ignoreEmptyResponse);
         }
 
         protected override string Request(JsonRPCRequestModel rpcRequest, CancellationToken token = default)

--- a/Flow.Launcher.Plugin/Interfaces/IPathSelected.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPathSelected.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Flow.Launcher.Plugin
+{
+    public interface IPathSelected : IFeatures
+    {
+        Task PathSelected(string path, string hotkey);
+    }
+}

--- a/Flow.Launcher.Plugin/PluginMetadata.cs
+++ b/Flow.Launcher.Plugin/PluginMetadata.cs
@@ -35,8 +35,10 @@ namespace Flow.Launcher.Plugin
 
         public List<string> ActionKeywords { get; set; }
 
+        public List<Dictionary<string, string>> Listeners { get; set;}
+
         public string IcoPath { get; set;}
-        
+
         public override string ToString()
         {
             return Name;

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -39,7 +39,7 @@
     </Window.Resources>
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />
-        <KeyBinding Key="F1" Command="{Binding StartHelpCommand}" />
+        <KeyBinding Key="F1" Command="{Binding F1SelectedCommand}" />
         <KeyBinding Key="F5" Command="{Binding ReloadPluginDataCommand}" />
         <KeyBinding Key="Tab" Command="{Binding AutocompleteQueryCommand}" />
         <KeyBinding

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -187,6 +187,33 @@ namespace Flow.Launcher.ViewModel
 
             SelectPrevPageCommand = new RelayCommand(_ => { SelectedResults.SelectPrevPage(); });
 
+            F1SelectedCommand = new RelayCommand(_ =>
+            {
+                var results = SelectedResults;
+                var result = results.SelectedItem?.Result;
+
+                if (result is null)
+                    return;
+
+                var selectedPath = string.Empty;
+
+                if (File.Exists(result.Title) || Directory.Exists(result.Title))
+                {
+                    selectedPath = result.Title;
+                }
+                else if (File.Exists(result.SubTitle) || Directory.Exists(result.SubTitle))
+                {
+                    selectedPath = result.SubTitle;
+                }
+                else if (!string.IsNullOrEmpty(result.IcoPath))
+                {
+                    selectedPath = result.IcoPath;
+                }
+
+                PluginManager.PublishPathSelectedFromResult(selectedPath, "f1");
+
+            });
+
             SelectFirstResultCommand = new RelayCommand(_ => SelectedResults.SelectFirstResult());
 
             StartHelpCommand = new RelayCommand(_ =>
@@ -429,6 +456,8 @@ namespace Flow.Launcher.ViewModel
         public ICommand CopyToClipboard { get; set; }
 
         public ICommand AutocompleteQueryCommand { get; set; }
+
+        public ICommand F1SelectedCommand { get; set; }
 
         public string OpenResultCommandModifiers { get; private set; }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
@@ -11,7 +11,7 @@ using System.Windows.Controls;
 
 namespace Flow.Launcher.Plugin.Explorer
 {
-    public class Main : ISettingProvider, IAsyncPlugin, IContextMenu, IPluginI18n
+    public class Main : ISettingProvider, IAsyncPlugin, IContextMenu, IPluginI18n, IPathSelected
     {
         internal PluginInitContext Context { get; set; }
 
@@ -26,6 +26,13 @@ namespace Flow.Launcher.Plugin.Explorer
         public Control CreateSettingPanel()
         {
             return new ExplorerSettings(viewModel);
+        }
+
+        public Task PathSelected(string filePath, string hotkey)
+        {
+            //checked the hotkey if is ctrl+c, then 
+            //copy file to clipboard.
+            return Task.CompletedTask;
         }
 
         public Task InitAsync(PluginInitContext context)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
@@ -28,10 +28,11 @@ namespace Flow.Launcher.Plugin.Explorer
             return new ExplorerSettings(viewModel);
         }
 
-        public Task PathSelected(string filePath, string hotkey)
+        public Task PathSelected(string path, string hotkey)
         {
             //checked the hotkey if is ctrl+c, then 
             //copy file to clipboard.
+            Context.API.ShowMsg("Success", string.Format("You have selected path \"{0}\", with hotkey \"{1}\"", path, hotkey));
             return Task.CompletedTask;
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -7,6 +7,7 @@
     "*",
     "*"
   ],
+  "Listeners": [{"f1": "IPathSelected"}],
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",


### PR DESCRIPTION
**Goal:**
Allow plugins to capture hotkey presses on query window results, such as Ctrl+P, F1, Space, Ctrl+Backspace, Up or Down. 

This information is then passed onto each plugin, which will allow them to do some action based on the hotkey and information supplied.

This is a proof of concept PR, using F1 key press as an example to demonstrate when F1 is pressed on a result, the information of the selected result is translated to a path which is then passed onto each plugin. Only if the plugin inherits IPathSelected, will it be able to capture and use the path and hotkey information to do something further.
This example uses Explorer plugin, and works with JsonRPC plugins (i.e. Python, TS, JS and etc).

**What success looks like:**
1. Allow plugin to utilise QuickLook from #859 and previews should work on Up, Down or F1 hotkeys on the selected result.  
2. Allow Explorer or Everything plugin to utilise Ctrl+C on a selected result that is a file/folder and have it copied on to clipboard. 
3. JsonRPC plugins to also utilise the new feature.