### PR TITLE
Fix WindowsSettings plugin result scores higher than normal

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.WindowsSettings/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.WindowsSettings/plugin.json
@@ -4,7 +4,7 @@
   "Description": "Search settings inside Control Panel and Settings App",
   "Name": "Windows Settings",
   "Author": "TobiasSekan",
-  "Version": "2.0.1",
+  "Version": "2.0.2",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.WindowsSettings.dll",


### PR DESCRIPTION
WindowsSettings results are higher than normal due to intentional score bumping. This fix removes the bump for settings name matched results and for non-name matched results reduce by 10 points.

This means normal Windows settings results should rank the same order as all other plugin results, and the lower ranked non-name matched results behaviour is still kept.

**Before**, should actually show SourceTree program from Program plugin:
![image](https://user-images.githubusercontent.com/26427004/153694739-bc379f8a-d9ca-4969-b185-23a540c938d5.png)

**After**
![image](https://user-images.githubusercontent.com/26427004/153694706-9587aa58-ed61-4f65-9822-4da68f2ca856.png)


Addresses #1008