### PR TITLE
Fix Shared Assembly Issue

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginAssemblyLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginAssemblyLoader.cs
@@ -11,57 +11,37 @@ namespace Flow.Launcher.Core.Plugin
 {
     internal class PluginAssemblyLoader : AssemblyLoadContext
     {
-        private readonly AssemblyDependencyResolver dependencyResolver;
+        private readonly AssemblyDependencyResolver _dependencyResolver;
 
-        private readonly AssemblyName assemblyName;
-
-        private static readonly ConcurrentDictionary<string, byte> loadedAssembly;
-
-        static PluginAssemblyLoader()
-        {
-            var currentAssemblies = AppDomain.CurrentDomain.GetAssemblies();
-            loadedAssembly = new ConcurrentDictionary<string, byte>(
-                currentAssemblies.Select(x => new KeyValuePair<string, byte>(x.FullName, default)));
-
-            AppDomain.CurrentDomain.AssemblyLoad += (sender, args) =>
-            {
-                loadedAssembly[args.LoadedAssembly.FullName] = default;
-            };
-        }
+        private readonly AssemblyName _assemblyName;
 
         internal PluginAssemblyLoader(string assemblyFilePath)
         {
-            dependencyResolver = new AssemblyDependencyResolver(assemblyFilePath);
-            assemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(assemblyFilePath));
+            _dependencyResolver = new AssemblyDependencyResolver(assemblyFilePath);
+            _assemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(assemblyFilePath));
         }
 
         internal Assembly LoadAssemblyAndDependencies()
         {
-            return LoadFromAssemblyName(assemblyName);
+            return LoadFromAssemblyName(_assemblyName);
         }
 
         protected override Assembly Load(AssemblyName assemblyName)
         {
-            string assemblyPath = dependencyResolver.ResolveAssemblyToPath(assemblyName);
+            string assemblyPath = _dependencyResolver.ResolveAssemblyToPath(assemblyName);
 
             // When resolving dependencies, ignore assembly depenedencies that already exits with Flow.Launcher
             // Otherwise duplicate assembly will be loaded and some weird behavior will occur, such as WinRT.Runtime.dll
             // will fail due to loading multiple versions in process, each with their own static instance of registration state
-            if (assemblyPath == null || ExistsInReferencedPackage(assemblyName))
-                return null;
+            var existAssembly = Default.Assemblies.FirstOrDefault(x => x.FullName == assemblyName.FullName);
 
-            return LoadFromAssemblyPath(assemblyPath);
+            return existAssembly ?? (assemblyPath == null ? null : LoadFromAssemblyPath(assemblyPath));
         }
 
         internal Type FromAssemblyGetTypeOfInterface(Assembly assembly, Type type)
         {
             var allTypes = assembly.ExportedTypes;
             return allTypes.First(o => o.IsClass && !o.IsAbstract && o.GetInterfaces().Any(t => t == type));
-        }
-
-        internal bool ExistsInReferencedPackage(AssemblyName assemblyName)
-        {
-            return loadedAssembly.ContainsKey(assemblyName.FullName);
         }
     }
 }

--- a/Flow.Launcher.Core/Plugin/PluginAssemblyLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginAssemblyLoader.cs
@@ -11,24 +11,24 @@ namespace Flow.Launcher.Core.Plugin
 {
     internal class PluginAssemblyLoader : AssemblyLoadContext
     {
-        private readonly AssemblyDependencyResolver _dependencyResolver;
+        private readonly AssemblyDependencyResolver dependencyResolver;
 
-        private readonly AssemblyName _assemblyName;
+        private readonly AssemblyName assemblyName;
 
         internal PluginAssemblyLoader(string assemblyFilePath)
         {
-            _dependencyResolver = new AssemblyDependencyResolver(assemblyFilePath);
-            _assemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(assemblyFilePath));
+            dependencyResolver = new AssemblyDependencyResolver(assemblyFilePath);
+            assemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(assemblyFilePath));
         }
 
         internal Assembly LoadAssemblyAndDependencies()
         {
-            return LoadFromAssemblyName(_assemblyName);
+            return LoadFromAssemblyName(assemblyName);
         }
 
         protected override Assembly Load(AssemblyName assemblyName)
         {
-            string assemblyPath = _dependencyResolver.ResolveAssemblyToPath(assemblyName);
+            string assemblyPath = dependencyResolver.ResolveAssemblyToPath(assemblyName);
 
             // When resolving dependencies, ignore assembly depenedencies that already exits with Flow.Launcher
             // Otherwise duplicate assembly will be loaded and some weird behavior will occur, such as WinRT.Runtime.dll


### PR DESCRIPTION
This fixes the issue where multiple plugins using shared assembly like SQLite, where the ones loaded later will not be able to access the shared assembly.

Previous I check all the loaded assembly before allowing the pluginassemblyloader to load the assembly. However, this doesn't seem like a good practice, since this will prevent a assembly context to load the same assembly if another assembly context has already loaded it (which are isolated).

I have tested it for the winrt.dll situation as well. The default assembly loader will load the winrt.dll before we trigger a deferred load so all assembly should be good with that. However, I am curious whether we should match with Name instead of FullName.