### PR TITLE
Remove calling `.ToArray()` on a `ConcurrentDictionary`

### DIFF
--- a/Flow.Launcher.Infrastructure/Image/ImageCache.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageCache.cs
@@ -74,7 +74,7 @@ namespace Flow.Launcher.Infrastructure.Image
                         // To delete the images from the data dictionary based on the resizing of the Usage Dictionary
                         // Double Check to avoid concurrent remove
                         if (Data.Count > permissibleFactor * MaxCached)
-                            foreach (var key in Data.OrderBy(x => x.Value.usage).Take(Data.Count - MaxCached).Select(x => x.Key).ToArray())
+                            foreach (var key in Data.OrderBy(x => x.Value.usage).Take(Data.Count - MaxCached).Select(x => x.Key))
                                 Data.TryRemove(key, out _);
                         semaphore.Release();
                     }


### PR DESCRIPTION
This pull request fixes the race condition when calling `.ToArray()` on a `ConcurrentDictionary` in the `ImageCache` class.
Related issue: close #1039 