### PR TITLE
Release 1.9.3

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginAssemblyLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginAssemblyLoader.cs
@@ -11,57 +11,37 @@ namespace Flow.Launcher.Core.Plugin
 {
     internal class PluginAssemblyLoader : AssemblyLoadContext
     {
-        private readonly AssemblyDependencyResolver dependencyResolver;
+        private readonly AssemblyDependencyResolver _dependencyResolver;
 
-        private readonly AssemblyName assemblyName;
-
-        private static readonly ConcurrentDictionary<string, byte> loadedAssembly;
-
-        static PluginAssemblyLoader()
-        {
-            var currentAssemblies = AppDomain.CurrentDomain.GetAssemblies();
-            loadedAssembly = new ConcurrentDictionary<string, byte>(
-                currentAssemblies.Select(x => new KeyValuePair<string, byte>(x.FullName, default)));
-
-            AppDomain.CurrentDomain.AssemblyLoad += (sender, args) =>
-            {
-                loadedAssembly[args.LoadedAssembly.FullName] = default;
-            };
-        }
+        private readonly AssemblyName _assemblyName;
 
         internal PluginAssemblyLoader(string assemblyFilePath)
         {
-            dependencyResolver = new AssemblyDependencyResolver(assemblyFilePath);
-            assemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(assemblyFilePath));
+            _dependencyResolver = new AssemblyDependencyResolver(assemblyFilePath);
+            _assemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(assemblyFilePath));
         }
 
         internal Assembly LoadAssemblyAndDependencies()
         {
-            return LoadFromAssemblyName(assemblyName);
+            return LoadFromAssemblyName(_assemblyName);
         }
 
         protected override Assembly Load(AssemblyName assemblyName)
         {
-            string assemblyPath = dependencyResolver.ResolveAssemblyToPath(assemblyName);
+            string assemblyPath = _dependencyResolver.ResolveAssemblyToPath(assemblyName);
 
             // When resolving dependencies, ignore assembly depenedencies that already exits with Flow.Launcher
             // Otherwise duplicate assembly will be loaded and some weird behavior will occur, such as WinRT.Runtime.dll
             // will fail due to loading multiple versions in process, each with their own static instance of registration state
-            if (assemblyPath == null || ExistsInReferencedPackage(assemblyName))
-                return null;
+            var existAssembly = Default.Assemblies.FirstOrDefault(x => x.FullName == assemblyName.FullName);
 
-            return LoadFromAssemblyPath(assemblyPath);
+            return existAssembly ?? (assemblyPath == null ? null : LoadFromAssemblyPath(assemblyPath));
         }
 
         internal Type FromAssemblyGetTypeOfInterface(Assembly assembly, Type type)
         {
             var allTypes = assembly.ExportedTypes;
             return allTypes.First(o => o.IsClass && !o.IsAbstract && o.GetInterfaces().Any(t => t == type));
-        }
-
-        internal bool ExistsInReferencedPackage(AssemblyName assemblyName)
-        {
-            return loadedAssembly.ContainsKey(assemblyName.FullName);
         }
     }
 }

--- a/Flow.Launcher.Core/Plugin/PluginAssemblyLoader.cs
+++ b/Flow.Launcher.Core/Plugin/PluginAssemblyLoader.cs
@@ -11,24 +11,24 @@ namespace Flow.Launcher.Core.Plugin
 {
     internal class PluginAssemblyLoader : AssemblyLoadContext
     {
-        private readonly AssemblyDependencyResolver _dependencyResolver;
+        private readonly AssemblyDependencyResolver dependencyResolver;
 
-        private readonly AssemblyName _assemblyName;
+        private readonly AssemblyName assemblyName;
 
         internal PluginAssemblyLoader(string assemblyFilePath)
         {
-            _dependencyResolver = new AssemblyDependencyResolver(assemblyFilePath);
-            _assemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(assemblyFilePath));
+            dependencyResolver = new AssemblyDependencyResolver(assemblyFilePath);
+            assemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(assemblyFilePath));
         }
 
         internal Assembly LoadAssemblyAndDependencies()
         {
-            return LoadFromAssemblyName(_assemblyName);
+            return LoadFromAssemblyName(assemblyName);
         }
 
         protected override Assembly Load(AssemblyName assemblyName)
         {
-            string assemblyPath = _dependencyResolver.ResolveAssemblyToPath(assemblyName);
+            string assemblyPath = dependencyResolver.ResolveAssemblyToPath(assemblyName);
 
             // When resolving dependencies, ignore assembly depenedencies that already exits with Flow.Launcher
             // Otherwise duplicate assembly will be loaded and some weird behavior will occur, such as WinRT.Runtime.dll

--- a/Flow.Launcher.Infrastructure/Image/ImageCache.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageCache.cs
@@ -74,7 +74,7 @@ namespace Flow.Launcher.Infrastructure.Image
                         // To delete the images from the data dictionary based on the resizing of the Usage Dictionary
                         // Double Check to avoid concurrent remove
                         if (Data.Count > permissibleFactor * MaxCached)
-                            foreach (var key in Data.OrderBy(x => x.Value.usage).Take(Data.Count - MaxCached).Select(x => x.Key).ToArray())
+                            foreach (var key in Data.OrderBy(x => x.Value.usage).Take(Data.Count - MaxCached).Select(x => x.Key))
                                 Data.TryRemove(key, out _);
                         semaphore.Release();
                     }

--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -25,7 +25,7 @@ namespace Flow.Launcher.Helper
 
         internal static void OnToggleHotkey(object sender, HotkeyEventArgs args)
         {
-            if (!mainViewModel.GameModeStatus)
+            if (!mainViewModel.ShouldIgnoreHotkeys())
                 mainViewModel.ToggleFlowLauncher();
         }
 

--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -25,7 +25,7 @@ namespace Flow.Launcher.Helper
 
         internal static void OnToggleHotkey(object sender, HotkeyEventArgs args)
         {
-            if (!mainViewModel.ShouldIgnoreHotkeys())
+            if (!mainViewModel.ShouldIgnoreHotkeys() && !mainViewModel.GameModeStatus)
                 mainViewModel.ToggleFlowLauncher();
         }
 

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -176,8 +176,8 @@
     <system:String x:Key="defaultBrowser_name">Browser</system:String>
     <system:String x:Key="defaultBrowser_profile_name">Browser Name</system:String>
     <system:String x:Key="defaultBrowser_path">Browser Path</system:String>
-    <system:String x:Key="defaultBrowser_newtab">New Window</system:String>
-    <system:String x:Key="defaultBrowser_newWindow">New Tab</system:String>
+    <system:String x:Key="defaultBrowser_newWindow">New Window</system:String>
+    <system:String x:Key="defaultBrowser_newTab">New Tab</system:String>
     <system:String x:Key="defaultBrowser_parameter">Private Mode</system:String>
 
     <!--  Priority Setting Dialog  -->

--- a/Flow.Launcher/Languages/ko.xaml
+++ b/Flow.Launcher/Languages/ko.xaml
@@ -175,8 +175,8 @@
     <system:String x:Key="defaultBrowser_name">브라우저</system:String>
     <system:String x:Key="defaultBrowser_profile_name">브라우저 이름</system:String>
     <system:String x:Key="defaultBrowser_path">브라우저 경로</system:String>
-    <system:String x:Key="defaultBrowser_newtab">새 창</system:String>
-    <system:String x:Key="defaultBrowser_newWindow">새 탭</system:String>
+    <system:String x:Key="defaultBrowser_newWindow">새 창</system:String>
+    <system:String x:Key="defaultBrowser_newTab">새 탭</system:String>
     <system:String x:Key="defaultBrowser_parameter">프라이빗 모드</system:String>
 
     <!--  Priority Setting Dialog  -->

--- a/Flow.Launcher/Languages/pt-pt.xaml
+++ b/Flow.Launcher/Languages/pt-pt.xaml
@@ -176,8 +176,8 @@
     <system:String x:Key="defaultBrowser_name">Navegador</system:String>
     <system:String x:Key="defaultBrowser_profile_name">Nome do navegador</system:String>
     <system:String x:Key="defaultBrowser_path">Caminho do navegador</system:String>
-    <system:String x:Key="defaultBrowser_newtab">Nova janela</system:String>
-    <system:String x:Key="defaultBrowser_newWindow">Novo separador</system:String>
+    <system:String x:Key="defaultBrowser_newWindow">Nova janela</system:String>
+    <system:String x:Key="defaultBrowser_newTab">Novo separador</system:String>
     <system:String x:Key="defaultBrowser_parameter">Modo privado</system:String>
 
     <!--  Priority Setting Dialog  -->

--- a/Flow.Launcher/Languages/sk.xaml
+++ b/Flow.Launcher/Languages/sk.xaml
@@ -174,8 +174,8 @@
     <system:String x:Key="defaultBrowser_name">Prehliadač</system:String>
     <system:String x:Key="defaultBrowser_profile_name">Názov prehliadača</system:String>
     <system:String x:Key="defaultBrowser_path">Cesta k prehliadaču</system:String>
-    <system:String x:Key="defaultBrowser_newtab">Nové okno</system:String>
-    <system:String x:Key="defaultBrowser_newWindow">Nová karta</system:String>
+    <system:String x:Key="defaultBrowser_newWindow">Nové okno</system:String>
+    <system:String x:Key="defaultBrowser_newTab">Nová karta</system:String>
     <system:String x:Key="defaultBrowser_parameter">Privátny režim</system:String>
 
     <!--  Priority Setting Dialog  -->

--- a/Flow.Launcher/ReportWindow.xaml.cs
+++ b/Flow.Launcher/ReportWindow.xaml.cs
@@ -52,8 +52,8 @@ namespace Flow.Launcher
             var link = new Hyperlink { IsEnabled = true };
             link.Inlines.Add(url);
             link.NavigateUri = new Uri(url);
-            link.RequestNavigate += (s, e) => SearchWeb.NewTabInBrowser(e.Uri.ToString());
-            link.Click += (s, e) => SearchWeb.NewTabInBrowser(url);
+            link.RequestNavigate += (s, e) => SearchWeb.OpenInBrowserTab(e.Uri.ToString());
+            link.Click += (s, e) => SearchWeb.OpenInBrowserTab(url);
 
             paragraph.Inlines.Add(textBeforeUrl);
             paragraph.Inlines.Add(link);

--- a/Flow.Launcher/SelectBrowserWindow.xaml
+++ b/Flow.Launcher/SelectBrowserWindow.xaml
@@ -196,7 +196,7 @@
                             VerticalAlignment="Center"
                             Orientation="Horizontal">
                             <RadioButton IsChecked="{Binding OpenInTab}" 
-                                         Content="{DynamicResource defaultBrowser_newWindow}"></RadioButton>
+                                         Content="{DynamicResource defaultBrowser_newTab}"></RadioButton>
                             <RadioButton IsChecked="{Binding OpenInNewWindow, Mode=OneTime}"
                                          Content="{DynamicResource defaultBrowser_newWindow}"></RadioButton>
                         </StackPanel>

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -232,7 +232,7 @@ namespace Flow.Launcher
                     var uri = new Uri(website);
                     if (Uri.CheckSchemeName(uri.Scheme))
                     {
-                        website.NewTabInBrowser();
+                        website.OpenInBrowserTab();
                     }
                 }
             }

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -62,8 +62,6 @@ namespace Flow.Launcher.ViewModel
             Settings = settings;
         }
 
-        
-
         private Settings Settings { get; }
 
         public Visibility ShowOpenResultHotkey =>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -333,7 +333,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                 {
                     if (e.SpecialKeyState.CtrlPressed)
                     {
-                        SearchWeb.NewTabInBrowser(plugin.UrlDownload);
+                        SearchWeb.OpenInBrowserTab(plugin.UrlDownload);
                         return ShouldHideWindow;
                     }
 
@@ -397,7 +397,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                             {
                                 if (e.SpecialKeyState.CtrlPressed)
                                 {
-                                    SearchWeb.NewTabInBrowser(x.Website);
+                                    SearchWeb.OpenInBrowserTab(x.Website);
                                     return ShouldHideWindow;
                                 }
 

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -85,7 +85,8 @@ namespace Flow.Launcher.Plugin.WebSearch
 
                 ResultsUpdated?.Invoke(this, new ResultUpdatedEventArgs
                 {
-                    Results = results, Query = query
+                    Results = results,
+                    Query = query
                 });
 
                 await UpdateResultsFromSuggestionAsync(results, keyword, subtitle, searchSource, query, token).ConfigureAwait(false);

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -135,6 +135,7 @@ namespace Flow.Launcher.Plugin.WebSearch
                 SubTitle = subtitle,
                 Score = score,
                 IcoPath = searchSource.IconPath,
+                ActionKeywordAssigned = searchSource.ActionKeyword == SearchSourceGlobalPluginWildCardSign ? string.Empty : searchSource.ActionKeyword,
                 Action = c =>
                 {
                     _context.API.OpenUrl(searchSource.Url.Replace("{q}", Uri.EscapeDataString(o)));

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -166,9 +166,7 @@ namespace Flow.Launcher.Plugin.WebSearch
                 // Custom images directory is in the WebSearch's data location folder 
                 var name = Path.GetFileNameWithoutExtension(_context.CurrentPluginMetadata.ExecuteFileName);
                 CustomImagesDirectory = Path.Combine(DataLocation.PluginSettingsDirectory, name, "CustomIcons");
-            }
-
-            ;
+            };
         }
 
         #region ISettingProvider Members

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Baidu.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Baidu.cs
@@ -16,7 +16,7 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
     {
         private readonly Regex _reg = new Regex("window.baidu.sug\\((.*)\\)");
 
-        public override async Task<List<string>> Suggestions(string query, CancellationToken token)
+        public override async Task<List<string>> SuggestionsAsync(string query, CancellationToken token)
         {
             string result;
 
@@ -25,7 +25,7 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
                 const string api = "http://suggestion.baidu.com/su?json=1&wd=";
                 result = await Http.GetAsync(api + Uri.EscapeUriString(query), token).ConfigureAwait(false);
             }
-            catch (Exception e) when (e is HttpRequestException || e.InnerException is TimeoutException)
+            catch (Exception e) when (e is HttpRequestException or {InnerException: TimeoutException})
             {
                 Log.Exception("|Baidu.Suggestions|Can't get suggestion from baidu", e);
                 return null;

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Bing.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Bing.cs
@@ -15,7 +15,7 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
 {
     class Bing : SuggestionSource
     {
-        public override async Task<List<string>> Suggestions(string query, CancellationToken token)
+        public override async Task<List<string>> SuggestionsAsync(string query, CancellationToken token)
         {
 
             try
@@ -40,7 +40,7 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
 
 
             }
-            catch (Exception e) when (e is HttpRequestException || e.InnerException is TimeoutException)
+            catch (Exception e) when (e is HttpRequestException or {InnerException: TimeoutException})
             {
                 Log.Exception("|Baidu.Suggestions|Can't get suggestion from baidu", e);
                 return null;

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Google.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/Google.cs
@@ -14,7 +14,7 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
 {
     public class Google : SuggestionSource
     {
-        public override async Task<List<string>> Suggestions(string query, CancellationToken token)
+        public override async Task<List<string>> SuggestionsAsync(string query, CancellationToken token)
         {
             try
             {
@@ -32,7 +32,7 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
                 return results.EnumerateArray().Select(o => o.GetString()).ToList();
 
             }
-            catch (Exception e) when (e is HttpRequestException || e.InnerException is TimeoutException)
+            catch (Exception e) when (e is HttpRequestException or {InnerException: TimeoutException})
             {
                 Log.Exception("|Baidu.Suggestions|Can't get suggestion from baidu", e);
                 return null;

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/SuggestionSource.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/SuggestionSource.cs
@@ -6,6 +6,6 @@ namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
 {
     public abstract class SuggestionSource
     {
-        public abstract Task<List<string>> Suggestions(string query, CancellationToken token);
+        public abstract Task<List<string>> SuggestionsAsync(string query, CancellationToken token);
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.WindowsSettings/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.WindowsSettings/plugin.json
@@ -4,7 +4,7 @@
   "Description": "Search settings inside Control Panel and Settings App",
   "Name": "Windows Settings",
   "Author": "TobiasSekan",
-  "Version": "2.0.1",
+  "Version": "2.0.2",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.WindowsSettings.dll",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '1.9.2.{build}'
+version: '1.9.3.{build}'
 
 init:
 - ps: |


### PR DESCRIPTION
Release Notes
=========

## Bug fixes
- Addresses the issue where WindowsSettings plugin results appear higher than other results #1020 

- Fixed an issue where full screen mode does not disable hotkey when enabled #1037 

- Fixed some potential issues when loading plugins that use shared assembly #1036 

- Sorted out a race condition issue causing image loading on some results to fail #1040 

- Revised ttf/otf support #935 

- Resolved the issue where WebSearch plugin would crash if not connected to internet #977 

- Fixed incorrect text for "New Tab" and "New Window" buttons under Settings' default browser section #951 

- Fixed typos in plugin title and WindowsSettings name inside the context menu #1056  