### PR TITLE
Fix typo for plugin title in context menu and WindowsSettings name

### DIFF
--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -58,7 +58,7 @@
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->
-    <system:String x:Key="plugin">Plugins</system:String>
+    <system:String x:Key="plugin">Plugin</system:String>
     <system:String x:Key="browserMorePlugins">Find more plugins</system:String>
     <system:String x:Key="enable">On</system:String>
     <system:String x:Key="disable">Off</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WindowsSettings/Properties/Resources.resx
+++ b/Plugins/Flow.Launcher.Plugin.WindowsSettings/Properties/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1206,7 +1206,7 @@
     <value>Plugin to search for Windows settings</value>
   </data>
   <data name="PluginTitle" xml:space="preserve">
-    <value>Windows settings</value>
+    <value>Windows Settings</value>
   </data>
   <data name="PowerAndSleep" xml:space="preserve">
     <value>Power and sleep</value>


### PR DESCRIPTION
Fix typo for plugin title in context menu and WindowsSettings name, `Plugins` -> `Plugin` & `Windows settings` -> `Windows Settings`:

![image](https://user-images.githubusercontent.com/26427004/156344463-466be708-eed4-4967-8324-52960c7cfb8a.png)

Checked that the plugin string is only used by the context menu.