### PR TITLE
avoid exception in ChromiumBookmarkLoader.cs

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
@@ -37,7 +37,8 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
                 return new();
             foreach (var folder in rootElement.EnumerateObject())
             {
-                EnumerateFolderBookmark(folder.Value, bookmarks, source);
+                if (folder.Value.ValueKind == JsonValueKind.Object)
+                    EnumerateFolderBookmark(folder.Value, bookmarks, source);
             }
             return bookmarks;
         }


### PR DESCRIPTION
Every time I start Flow Launcher since the plugins refactor, the Bookmarks plugin has been throwing an exception.  The issue stems from it parsing the Bookmarks file, and assuming that every JsonElement in the "roots" element is a JsonValueKind.Object.  My Bookmarks file though has a JsonValueKind.String value off the roots key of `"sync_transaction_version": "20297",` along-side the bookmark_bar, other, and synced keys, which ARE objects.  When it calls EnumerateFolderBookmark with the value from the sync_transaction_version key, it gets into the method because the string value of `20297` IS a JsonElement, but then throws an exception on the folderElement.TryGetProperty("children", ...) call because you can't call TryGetProperty on a String, only Objects.  So... only try to Enumerate Objects.