### PR TITLE
Fix the use of index in path search

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -23,6 +23,8 @@
     <system:String x:Key="plugin_explorer_manageactionkeywords_header">Customise Action Keywords</system:String>
     <system:String x:Key="plugin_explorer_quickaccesslinks_header">Quick Access Links</system:String>
     <system:String x:Key="plugin_explorer_indexsearchexcludedpaths_header">Index Search Excluded Paths</system:String>
+    <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch">Use Index Search For Path Search</system:String>
+    <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch_tooltip">Turning this on will return indexed directories/files faster, but if a directory/file is not indexed it will not show up. If a directory/file has been added to Index Search Excluded Path then it will still show up even if this option is on</system:String>
     <system:String x:Key="plugin_explorer_manageindexoptions">Indexing Options</system:String>
     <system:String x:Key="plugin_explorer_actionkeywordview_search">Search:</system:String>
     <system:String x:Key="plugin_explorer_actionkeywordview_pathsearch">Path Search:</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -14,7 +14,7 @@ namespace Flow.Launcher.Plugin.Explorer
         // as at v1.7.0 this is to maintain backwards compatibility, need to be removed afterwards.
         public List<AccessLink> QuickFolderAccessLinks { get; set; } = new List<AccessLink>();
 
-        public bool UseWindowsIndexForDirectorySearch { get; set; } = true;
+        public bool UseWindowsIndexForDirectorySearch { get; set; } = false;
 
         public List<AccessLink> IndexSearchExcludedSubdirectoryPaths { get; set; } = new List<AccessLink>();
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -52,5 +52,16 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
         }
 
         internal bool IsNewActionKeywordGlobal(string newActionKeyword) => newActionKeyword == Query.GlobalPluginWildcardSign;
+
+        public bool UseWindowsIndexForDirectorySearch {
+            get
+            {
+                return Settings.UseWindowsIndexForDirectorySearch;
+            }
+            set
+            {
+                Settings.UseWindowsIndexForDirectorySearch = value;
+            }
+        }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -4,7 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:viewModels="clr-namespace:Flow.Launcher.Plugin.Explorer.ViewModels"
     xmlns:views="clr-namespace:Flow.Launcher.Plugin.Explorer.Views"
     d:DesignHeight="450"
     d:DesignWidth="800"
@@ -91,12 +90,20 @@
                     Margin="0,10,0,0"
                     Expanded="expExcludedPaths_Click"
                     Header="{DynamicResource plugin_explorer_indexsearchexcludedpaths_header}">
-                    <ListView
-                        x:Name="lbxExcludedPaths"
-                        AllowDrop="True"
-                        DragEnter="lbxAccessLinks_DragEnter"
-                        Drop="lbxAccessLinks_Drop"
-                        ItemTemplate="{StaticResource ListViewTemplateExcludedPaths}" />
+                    <StackPanel>
+                        <CheckBox
+                            Name="UseWindowsIndexForDirectorySearch"
+                            Margin="12,10,0,0"
+                            Content="{DynamicResource plugin_explorer_usewindowsindexfordirectorysearch}"
+                            IsChecked="{Binding UseWindowsIndexForDirectorySearch}"
+                            ToolTip="{DynamicResource plugin_explorer_usewindowsindexfordirectorysearch_tooltip}" />
+                        <ListView
+                            x:Name="lbxExcludedPaths"
+                            AllowDrop="True"
+                            DragEnter="lbxAccessLinks_DragEnter"
+                            Drop="lbxAccessLinks_Drop"
+                            ItemTemplate="{StaticResource ListViewTemplateExcludedPaths}" />
+                    </StackPanel>
                 </Expander>
             </StackPanel>
         </ScrollViewer>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
@@ -29,6 +29,8 @@ namespace Flow.Launcher.Plugin.Explorer.Views
 
             this.viewModel = viewModel;
 
+            DataContext = viewModel;
+
             lbxAccessLinks.ItemsSource = this.viewModel.Settings.QuickAccessLinks;
 
             lbxExcludedPaths.ItemsSource = this.viewModel.Settings.IndexSearchExcludedSubdirectoryPaths;


### PR DESCRIPTION
- By default path search should not use index, this solves the issue where if a path e.g. C:\blah\  is not included users should still able to pull it up with the path search.
- Allow option to enable/disable the use of index in path search via settings.

Related issue #1064 