### PR TITLE
Move Explorer's recursive directory search to Plugin project

### DIFF
--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using System.Windows;
 
 namespace Flow.Launcher.Plugin.SharedCommands
@@ -190,6 +192,49 @@ namespace Flow.Launcher.Plugin.SharedCommands
             }
 
             return previousDirectoryPath;
+        }
+
+        ///<summary>
+        /// Returns a dictionary list of sub-directories and files for a given path
+        ///</summary>
+        public static List<Dictionary<string, string>> DirectoryRecursiveSearch(
+            string searchPath,
+            EnumerationOptions enumerationOption,
+            string searchCriteria, CancellationToken token)
+        {
+            var results = new List<Dictionary<string, string>>();
+
+            var path = ReturnPreviousDirectoryIfIncompleteString(searchPath);
+
+            var directoryInfo = new DirectoryInfo(path);
+
+            foreach (var fileSystemInfo in directoryInfo.EnumerateFileSystemInfos(searchCriteria, enumerationOption))
+            {
+                if (fileSystemInfo is DirectoryInfo)
+                {
+                    results.Add(
+                    new Dictionary<string, string>()
+                    {
+                            { "Type", "Folder" },
+                            { "Name", fileSystemInfo.Name },
+                            { "Path", fileSystemInfo.FullName }
+                    });
+                }
+                else
+                {
+                    results.Add(
+                    new Dictionary<string, string>()
+                    {
+                            { "Type", "File" },
+                            { "Name", fileSystemInfo.Name },
+                            { "Path", fileSystemInfo.FullName }
+                    });
+                }
+
+                token.ThrowIfCancellationRequested();
+            }
+
+            return results;
         }
 
         ///<summary>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
@@ -56,22 +56,20 @@ namespace Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo
 
             try
             {
-                var directoryInfo = new System.IO.DirectoryInfo(path);
+                var searchResults = FilesFolders.DirectoryRecursiveSearch(path, enumerationOption, searchCriteria, token);
 
-                foreach (var fileSystemInfo in directoryInfo.EnumerateFileSystemInfos(searchCriteria, enumerationOption)
-                )
+                for (var count = 0; count < searchResults.Count; count++)
                 {
-                    if (fileSystemInfo is System.IO.DirectoryInfo)
+                    if (searchResults[count]["Type"] == "Folder")
                     {
-                        folderList.Add(ResultManager.CreateFolderResult(fileSystemInfo.Name, fileSystemInfo.FullName,
-                            fileSystemInfo.FullName, query, 0, true, false));
+                        folderList.Add(ResultManager.CreateFolderResult(searchResults[count]["Name"], searchResults[count]["Path"],
+                            searchResults[count]["Path"], query, 0, true, false));
                     }
                     else
                     {
-                        fileList.Add(ResultManager.CreateFileResult(fileSystemInfo.FullName, query, 0, true, false));
-                    }
+                        fileList.Add(ResultManager.CreateFileResult(searchResults[count]["Path"], query, 0, true, false));
 
-                    token.ThrowIfCancellationRequested();
+                    }
                 }
             }
             catch (Exception e)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -10,7 +10,7 @@
   "Name": "Explorer",
   "Description": "Search and manage files and folders. Explorer utilises Windows Index Search",
   "Author": "Jeremy Wu",
-  "Version": "1.11.2",
+  "Version": "1.12.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
Move Explorer's recursive directory search to Plugin project, this will allow Everything plugin to utilise the same directory recursive search code.

Tested search performance speed and behaviour still the same.

Related #1064 