### PR TITLE
Set Shell plugin's default replace Win R hotkey to off

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
@@ -6,7 +6,7 @@ namespace Flow.Launcher.Plugin.Shell
     {
         public Shell Shell { get; set; } = Shell.Cmd;
         
-        public bool ReplaceWinR { get; set; } = true;
+        public bool ReplaceWinR { get; set; } = false;
         
         public bool LeaveShellOpen { get; set; }
 


### PR DESCRIPTION
Set Shell plugin's default replace Win R hotkey to off, it has been confusing new users.