### PR TITLE
Add Stale issue workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/workflows/stale.yml
+++ b/.github/ISSUE_TEMPLATE/workflows/stale.yml
@@ -1,0 +1,25 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-stale: 30
+          days-before-close: 5
+          days-before-pr-close: -1
+          exempt-all-milestones: true

--- a/.github/ISSUE_TEMPLATE/workflows/stale.yml
+++ b/.github/ISSUE_TEMPLATE/workflows/stale.yml
@@ -1,6 +1,3 @@
-# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
-#
-# You can adjust the behavior by modifying this file.
 # For more information, see:
 # https://github.com/actions/stale
 name: Mark stale issues and pull requests

--- a/.github/ISSUE_TEMPLATE/workflows/stale.yml
+++ b/.github/ISSUE_TEMPLATE/workflows/stale.yml
@@ -20,3 +20,4 @@ jobs:
           days-before-close: 5
           days-before-pr-close: -1
           exempt-all-milestones: true
+          close-issue-message: 'This issue was closed because it has been stale for 5 days with no activity. If you feel this issue still needs attention please feel free to reopen.'


### PR DESCRIPTION
With this workflow Issues and PRs that have not received any updates will be marked with a `stale` label. 

Any Issues will be closed after 5 days if they are not updated after being marked. 
PRs will never be closed.
Any PR that has a milestone will be exempt from the stale label.