### PR TITLE
merge shobu13/windowsTerminalBasicSupport To Dev

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Shell/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Languages/en.xaml
@@ -5,6 +5,7 @@
     <system:String x:Key="flowlauncher_plugin_cmd_relace_winr">Replace Win+R</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_leave_cmd_open">Do not close Command Prompt after command execution</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_always_run_as_administrator">Always run as administrator</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_use_windows_terminal">Use Windows Terminal</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_run_as_different_user">Run as different user</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_plugin_name">Shell</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_plugin_description">Allows to execute system commands from Flow Launcher. Commands should start with ></system:String>

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -224,6 +224,20 @@ namespace Flow.Launcher.Plugin.Shell
                         break;
                     }
 
+                case Shell.Pwsh:
+                    {
+                        info.FileName = "pwsh.exe";
+                        if (_settings.LeaveShellOpen)
+                        {
+                            info.ArgumentList.Add("-NoExit");
+                        }
+
+                        info.ArgumentList.Add("-Command");
+                        info.ArgumentList.Add(command);
+
+                        break;
+                    }
+
                 case Shell.RunCommand:
                     {
                         var parts = command.Split(new[] { ' ' }, 2);
@@ -258,8 +272,16 @@ namespace Flow.Launcher.Plugin.Shell
                 wtInfo.FileName = "wt.exe";
                 wtInfo.ArgumentList.Add("-p");
                 wtInfo.ArgumentList.Add(_settings.WindowsTerminalProfile);
+
                 wtInfo.ArgumentList.Add(info.FileName);
-                wtInfo.ArgumentList.Add(info.FileName + " " + String.Join(" ", info.ArgumentList));
+
+                foreach (var argument in info.ArgumentList)
+                {
+                    wtInfo.ArgumentList.Add(argument);
+                }
+            
+                wtInfo.WorkingDirectory = info.WorkingDirectory;
+                wtInfo.Verb = info.Verb;
 
                 info = wtInfo;
             }

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -252,6 +252,18 @@ namespace Flow.Launcher.Plugin.Shell
                     throw new NotImplementedException();
             }
 
+            if (_settings.UseWindowsTerminal)
+            {
+                ProcessStartInfo wtInfo = new();
+                wtInfo.FileName = "wt.exe";
+                wtInfo.ArgumentList.Add("-p");
+                wtInfo.ArgumentList.Add(_settings.WindowsTerminalProfile);
+                wtInfo.ArgumentList.Add(info.FileName);
+                wtInfo.ArgumentList.Add(info.FileName + " " + String.Join(" ", info.ArgumentList));
+
+                info = wtInfo;
+            }
+
             info.UseShellExecute = true;
 
             _settings.AddCmdHistory(command);

--- a/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
@@ -41,7 +41,7 @@ namespace Flow.Launcher.Plugin.Shell
     {
         Cmd = 0,
         Powershell = 1,
-        RunCommand = 2,
-        WindowsTerminal = 3
+        Pwsh = 2,
+        RunCommand = 3
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
@@ -5,18 +5,24 @@ namespace Flow.Launcher.Plugin.Shell
     public class Settings
     {
         public Shell Shell { get; set; } = Shell.Cmd;
-        
+
         public bool ReplaceWinR { get; set; } = false;
-        
+
         public bool LeaveShellOpen { get; set; }
 
         public bool RunAsAdministrator { get; set; } = true;
+
+        public bool UseWindowsTerminal { get; set; } = false;
+
+        public string WindowsTerminalProfile { get; set; }
 
         public bool ShowOnlyMostUsedCMDs { get; set; }
 
         public int ShowOnlyMostUsedCMDsNumber { get; set; }
 
-        public Dictionary<string, int> CommandHistory { get; set; } = new Dictionary<string, int>();
+        public Dictionary<string, int> CommandHistory
+        { get; set;
+        } = new Dictionary<string, int>();
 
         public void AddCmdHistory(string cmdName)
         {
@@ -36,6 +42,6 @@ namespace Flow.Launcher.Plugin.Shell
         Cmd = 0,
         Powershell = 1,
         RunCommand = 2,
-
+        WindowsTerminal = 3
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml
@@ -53,6 +53,7 @@
             HorizontalAlignment="Left">
             <ComboBoxItem>CMD</ComboBoxItem>
             <ComboBoxItem>PowerShell</ComboBoxItem>
+            <ComboBoxItem>Pwsh</ComboBoxItem>
             <ComboBoxItem>RunCommand</ComboBoxItem>
         </ComboBox>
         <StackPanel Grid.Row="5" Orientation="Horizontal">

--- a/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml
@@ -15,6 +15,7 @@
             <RowDefinition />
             <RowDefinition />
             <RowDefinition />
+            <RowDefinition />
         </Grid.RowDefinitions>
         <CheckBox
             x:Name="ReplaceWinR"
@@ -34,16 +35,27 @@
             Margin="10,5,5,5"
             HorizontalAlignment="Left"
             Content="{DynamicResource flowlauncher_plugin_cmd_always_run_as_administrator}" />
+        <StackPanel Grid.Row="3" Orientation="Horizontal">
+            <CheckBox
+            x:Name="UseWindowsTerminal"
+            Margin="10,5,5,5"
+            Content="{DynamicResource flowlauncher_plugin_cmd_use_windows_terminal}" />
+            <TextBox
+                x:Name="WindowsTerminalProfile"
+                Margin="10,5,5,5"
+                HorizontalAlignment="Left" />
+        </StackPanel>
+
         <ComboBox
             x:Name="ShellComboBox"
-            Grid.Row="3"
+            Grid.Row="4"
             Margin="10,5,5,5"
             HorizontalAlignment="Left">
             <ComboBoxItem>CMD</ComboBoxItem>
             <ComboBoxItem>PowerShell</ComboBoxItem>
             <ComboBoxItem>RunCommand</ComboBoxItem>
         </ComboBox>
-        <StackPanel Grid.Row="4" Orientation="Horizontal">
+        <StackPanel Grid.Row="5" Orientation="Horizontal">
             <CheckBox
                 x:Name="ShowOnlyMostUsedCMDs"
                 Margin="10,5,5,5"

--- a/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml.cs
@@ -17,25 +17,34 @@ namespace Flow.Launcher.Plugin.Shell
         private void CMDSetting_OnLoaded(object sender, RoutedEventArgs re)
         {
             ReplaceWinR.IsChecked = _settings.ReplaceWinR;
-            
+
             LeaveShellOpen.IsChecked = _settings.LeaveShellOpen;
-            
+
             AlwaysRunAsAdministrator.IsChecked = _settings.RunAsAdministrator;
-            
+
+            UseWindowsTerminal.IsChecked = _settings.UseWindowsTerminal;
+
+            WindowsTerminalProfile.Text = _settings.WindowsTerminalProfile;
+
+            if ((bool) !UseWindowsTerminal.IsChecked)
+                WindowsTerminalProfile.IsEnabled = false;
+
             LeaveShellOpen.IsEnabled = _settings.Shell != Shell.RunCommand;
-            
+
             ShowOnlyMostUsedCMDs.IsChecked = _settings.ShowOnlyMostUsedCMDs;
-            
-            if ((bool)!ShowOnlyMostUsedCMDs.IsChecked)
+
+            if ((bool) !ShowOnlyMostUsedCMDs.IsChecked)
                 ShowOnlyMostUsedCMDsNumber.IsEnabled = false;
 
-            ShowOnlyMostUsedCMDsNumber.ItemsSource = new List<int>() { 5, 10, 20 };
+            ShowOnlyMostUsedCMDsNumber.ItemsSource =
+                new List<int>() { 5, 10, 20 };
 
             if (_settings.ShowOnlyMostUsedCMDsNumber == 0)
             {
                 ShowOnlyMostUsedCMDsNumber.SelectedIndex = 0;
 
-                _settings.ShowOnlyMostUsedCMDsNumber = (int)ShowOnlyMostUsedCMDsNumber.SelectedItem;
+                _settings.ShowOnlyMostUsedCMDsNumber =
+                    (int) ShowOnlyMostUsedCMDsNumber.SelectedItem;
             }
 
             LeaveShellOpen.Checked += (o, e) =>
@@ -56,6 +65,25 @@ namespace Flow.Launcher.Plugin.Shell
             AlwaysRunAsAdministrator.Unchecked += (o, e) =>
             {
                 _settings.RunAsAdministrator = false;
+            };
+
+            UseWindowsTerminal.Checked += (o, e) =>
+            {
+                _settings.UseWindowsTerminal = true;
+
+                WindowsTerminalProfile.IsEnabled = true;
+            };
+
+            UseWindowsTerminal.Unchecked += (o, e) =>
+            {
+                _settings.UseWindowsTerminal = false;
+
+                WindowsTerminalProfile.IsEnabled = false;
+            };
+
+            WindowsTerminalProfile.TextChanged += (o, e) =>
+            {
+                _settings.WindowsTerminalProfile = WindowsTerminalProfile.Text;
             };
 
             ReplaceWinR.Checked += (o, e) =>
@@ -89,12 +117,13 @@ namespace Flow.Launcher.Plugin.Shell
                 ShowOnlyMostUsedCMDsNumber.IsEnabled = false;
             };
 
-            ShowOnlyMostUsedCMDsNumber.SelectedItem = _settings.ShowOnlyMostUsedCMDsNumber;
+            ShowOnlyMostUsedCMDsNumber.SelectedItem =
+                _settings.ShowOnlyMostUsedCMDsNumber;
             ShowOnlyMostUsedCMDsNumber.SelectionChanged += (o, e) =>
             {
-                _settings.ShowOnlyMostUsedCMDsNumber = (int)ShowOnlyMostUsedCMDsNumber.SelectedItem;
+                _settings.ShowOnlyMostUsedCMDsNumber =
+                    (int) ShowOnlyMostUsedCMDsNumber.SelectedItem;
             };
-
         }
     }
 }


### PR DESCRIPTION
add a basic terminal for Windows Terminal, 
with the current version, you can set Windows Terminal as your default terminal emulator, but if you launch a command using Flow, Windows Terminal don't use your the matching profile, but a default profile instead.

So i've added a "use windows terminal" property to specify usage of WT, and a Textbox where you can input the Profile you want to use. 

Then, on query process, the plugin call WT, passing the Profile as -p option, followed by the actual query.