### PR TITLE
Remove All Cleartype Rendering

### DIFF
--- a/Flow.Launcher/Themes/Base.xaml
+++ b/Flow.Launcher/Themes/Base.xaml
@@ -1,15 +1,16 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib"
-                    xmlns:userSettings="clr-namespace:Flow.Launcher.Infrastructure.UserSettings;assembly=Flow.Launcher.Infrastructure">
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib"
+    xmlns:userSettings="clr-namespace:Flow.Launcher.Infrastructure.UserSettings;assembly=Flow.Launcher.Infrastructure">
 
-    <!-- Further font customisations are dynamically loaded in Theme.cs -->
+    <!--  Further font customisations are dynamically loaded in Theme.cs  -->
     <Style x:Key="BaseQueryBoxStyle" TargetType="{x:Type TextBox}">
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="FontSize" Value="28" />
         <Setter Property="FontWeight" Value="Regular" />
-        <Setter Property="Margin" Value="16 7 0 7" />
-        <Setter Property="Padding" Value="0 4 68 0" />
+        <Setter Property="Margin" Value="16,7,0,7" />
+        <Setter Property="Padding" Value="0,4,68,0" />
         <Setter Property="Background" Value="#2F2F2F" />
         <Setter Property="Height" Value="48" />
         <Setter Property="Foreground" Value="#E3E0E3" />
@@ -20,13 +21,22 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBox}">
-                    <Border x:Name="border" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
-                        <ScrollViewer x:Name="PART_ContentHost" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"
-                                      Background="{TemplateBinding Background}">
+                    <Border
+                        x:Name="border"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="True">
+                        <ScrollViewer
+                            x:Name="PART_ContentHost"
+                            Background="{TemplateBinding Background}"
+                            Focusable="false"
+                            HorizontalScrollBarVisibility="Hidden"
+                            VerticalScrollBarVisibility="Hidden">
                             <ScrollViewer.ContentTemplate>
                                 <DataTemplate>
-                                    <Grid Background="{Binding Background, ElementName=PART_ContentHost}" RenderOptions.ClearTypeHint="Enabled">
-                                        <ContentPresenter Content="{Binding Path=Content, ElementName=PART_ContentHost}"></ContentPresenter>
+                                    <Grid Background="{Binding Background, ElementName=PART_ContentHost}">
+                                        <ContentPresenter Content="{Binding Path=Content, ElementName=PART_ContentHost}" />
                                     </Grid>
                                 </DataTemplate>
                             </ScrollViewer.ContentTemplate>
@@ -37,47 +47,47 @@
         </Setter>
     </Style>
 
-    <!-- Further font customisations are dynamically loaded in Theme.cs -->
-    <Style x:Key="BaseQuerySuggestionBoxStyle" BasedOn="{StaticResource BaseQueryBoxStyle}" TargetType="{x:Type TextBox}">
+    <!--  Further font customisations are dynamically loaded in Theme.cs  -->
+    <Style
+        x:Key="BaseQuerySuggestionBoxStyle"
+        BasedOn="{StaticResource BaseQueryBoxStyle}"
+        TargetType="{x:Type TextBox}">
         <Setter Property="Foreground" Value="DarkGray" />
         <Setter Property="Height" Value="48" />
-        <Setter Property="Margin" Value="16 7 0 7" />
+        <Setter Property="Margin" Value="16,7,0,7" />
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Padding" Value="0 4 68 0" />
+        <Setter Property="Padding" Value="0,4,68,0" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
 
     <Style x:Key="BaseWindowBorderStyle" TargetType="{x:Type Border}">
         <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="Background" Value="#2F2F2F"></Setter>
-        <Setter Property="Padding" Value="0 0 0 0" />
+        <Setter Property="Background" Value="#2F2F2F" />
+        <Setter Property="Padding" Value="0,0,0,0" />
         <Setter Property="CornerRadius" Value="5" />
     </Style>
     <Style x:Key="BaseWindowStyle" TargetType="{x:Type Window}">
         <Setter Property="Width" Value="600" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
 
     <Style x:Key="WindowRadius" TargetType="{x:Type Border}">
         <Setter Property="CornerRadius" Value="5" />
     </Style>
-    
+
     <Style x:Key="BasePendingLineStyle" TargetType="{x:Type Line}">
         <Setter Property="Stroke" Value="Blue" />
     </Style>
 
-    
-    <!-- Item Style -->
+
+    <!--  Item Style  -->
     <Style x:Key="BaseItemTitleStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="#FFFFF8" />
         <Setter Property="FontSize" Value="16" />
         <Setter Property="FontWeight" Value="Medium" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
-    <Style x:Key="BaseItemSubTitleStyle" TargetType="{x:Type TextBlock}" >
+    <Style x:Key="BaseItemSubTitleStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="#D9D9D4" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
         <Setter Property="FontSize" Value="13" />
         <Setter Property="FontWeight" Value="Normal" />
         <Style.Triggers>
@@ -89,9 +99,8 @@
     <Style x:Key="BaseItemNumberStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalAlignment" Value="Center" />
-        <Setter Property="Margin" Value="3 0 0 0" />
+        <Setter Property="Margin" Value="3,0,0,0" />
         <Setter Property="FontSize" Value="22" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
     <Style x:Key="BaseGlyphStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="#ffffff" />
@@ -99,34 +108,31 @@
         <Setter Property="HorizontalAlignment" Value="Center" />
         <Setter Property="Width" Value="25" />
         <Setter Property="Height" Value="25" />
-        <Setter Property="FontSize" Value="25"/>
+        <Setter Property="FontSize" Value="25" />
     </Style>
-    <Style x:Key="BaseItemTitleSelectedStyle" TargetType="{x:Type TextBlock}" >
+    <Style x:Key="BaseItemTitleSelectedStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="#FFFFF8" />
         <Setter Property="FontSize" Value="16" />
         <Setter Property="FontWeight" Value="Normal" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
-    <Style x:Key="BaseItemSubTitleSelectedStyle" TargetType="{x:Type TextBlock}" >
+    <Style x:Key="BaseItemSubTitleSelectedStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="#D9D9D4" />
         <Setter Property="FontSize" Value="13" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
         <Style.Triggers>
             <DataTrigger Binding="{Binding ElementName=SubTitle, UpdateSourceTrigger=PropertyChanged, Path=Text.Length}" Value="0">
                 <Setter Property="Height" Value="0" />
             </DataTrigger>
         </Style.Triggers>
     </Style>
-    <Style x:Key="BaseItemImageSelectedStyle" TargetType="{x:Type Image}" >
-    </Style>
+    <Style x:Key="BaseItemImageSelectedStyle" TargetType="{x:Type Image}" />
 
     <Style x:Key="BaseListboxStyle" TargetType="{x:Type ListBox}">
-        <Setter Property="BorderBrush" Value="Transparent"/>
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
-        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
-        <Setter Property="Margin" Value="0 0 0 0" />
-        <Setter Property="Padding" Value="0 0 0 0" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="Margin" Value="0,0,0,0" />
+        <Setter Property="Padding" Value="0,0,0,0" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListBox">
@@ -135,12 +141,12 @@
                             <Style TargetType="ScrollViewer">
                                 <Style.Triggers>
                                     <Trigger Property="ComputedVerticalScrollBarVisibility" Value="Visible">
-                                        <Setter Property="Margin" Value="0 0 0 0" />
-                                        <Setter Property="Padding" Value="0 0 0 0" />
+                                        <Setter Property="Margin" Value="0,0,0,0" />
+                                        <Setter Property="Padding" Value="0,0,0,0" />
                                     </Trigger>
                                     <Trigger Property="ComputedVerticalScrollBarVisibility" Value="Collapsed">
-                                        <Setter Property="Margin" Value="0 0 0 0" />
-                                        <Setter Property="Padding" Value="0 0 0 0" />
+                                        <Setter Property="Margin" Value="0,0,0,0" />
+                                        <Setter Property="Padding" Value="0,0,0,0" />
                                     </Trigger>
                                 </Style.Triggers>
                             </Style>
@@ -152,7 +158,7 @@
         </Setter>
     </Style>
 
-    <!-- ScrollViewer Style -->
+    <!--  ScrollViewer Style  -->
     <ControlTemplate x:Key="ScrollViewerControlTemplate" TargetType="{x:Type ScrollViewer}">
         <Grid x:Name="Grid" Background="{TemplateBinding Background}">
             <Grid.ColumnDefinitions>
@@ -160,44 +166,50 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <!--content in the left of ScrollViewer, just default-->
-            <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
-                                        CanContentScroll="{TemplateBinding CanContentScroll}"
-                                        CanHorizontallyScroll="False"
-                                        CanVerticallyScroll="False"
-                                        ContentTemplate="{TemplateBinding ContentTemplate}"
-                                        Content="{TemplateBinding Content}"
-                                        Grid.Column="0"
-                                        Margin="0"
-                                        Grid.Row="0" />
+            <!--  content in the left of ScrollViewer, just default  -->
+            <ScrollContentPresenter
+                x:Name="PART_ScrollContentPresenter"
+                Grid.Row="0"
+                Grid.Column="0"
+                Margin="0"
+                CanContentScroll="{TemplateBinding CanContentScroll}"
+                CanHorizontallyScroll="False"
+                CanVerticallyScroll="False"
+                Content="{TemplateBinding Content}"
+                ContentTemplate="{TemplateBinding ContentTemplate}" />
 
-            <!--Scrollbar in thr rigth of ScrollViewer-->
-            <ScrollBar x:Name="PART_VerticalScrollBar"
-                           AutomationProperties.AutomationId="VerticalScrollBar"
-                           Cursor="Arrow"
-                           Grid.Column="0"
-                           HorizontalAlignment="Right"
-                           Margin="0 0 0 0"
-                           Maximum="{TemplateBinding ScrollableHeight}"
-                           Minimum="0"
-                           Grid.Row="0"
-                           Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-                           Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-                           ViewportSize="{TemplateBinding ViewportHeight}"
-                           Style="{DynamicResource ScrollBarStyle}" />
+            <!--  Scrollbar in thr rigth of ScrollViewer  -->
+            <ScrollBar
+                x:Name="PART_VerticalScrollBar"
+                Grid.Row="0"
+                Grid.Column="0"
+                Margin="0,0,0,0"
+                HorizontalAlignment="Right"
+                AutomationProperties.AutomationId="VerticalScrollBar"
+                Cursor="Arrow"
+                Maximum="{TemplateBinding ScrollableHeight}"
+                Minimum="0"
+                Style="{DynamicResource ScrollBarStyle}"
+                ViewportSize="{TemplateBinding ViewportHeight}"
+                Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
         </Grid>
     </ControlTemplate>
 
-    <!-- button style in the middle of the scrollbar -->
+    <!--  button style in the middle of the scrollbar  -->
     <Style x:Key="BaseThumbStyle" TargetType="{x:Type Thumb}">
-        <Setter Property="SnapsToDevicePixels" Value="True"/>
-        <Setter Property="OverridesDefaultStyle" Value="true"/>
-        <Setter Property="IsTabStop" Value="false"/>
-        <Setter Property="Focusable" Value="false"/>
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="IsTabStop" Value="false" />
+        <Setter Property="Focusable" Value="false" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">
-                    <Border CornerRadius="2" DockPanel.Dock="Right" Background="#898989" BorderBrush="Transparent" />
+                    <Border
+                        Background="#898989"
+                        BorderBrush="Transparent"
+                        CornerRadius="2"
+                        DockPanel.Dock="Right" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -207,16 +219,19 @@
         <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="false" />
         <Setter Property="Background" Value="Black" />
-        <!-- must set min width -->
-        <Setter Property="MinWidth" Value="0"/>
-        <Setter Property="Width" Value="5"/>
+        <!--  must set min width  -->
+        <Setter Property="MinWidth" Value="0" />
+        <Setter Property="Width" Value="5" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ScrollBar}">
                     <DockPanel>
-                        <Track x:Name="PART_Track" IsDirectionReversed="true" DockPanel.Dock="Right">
+                        <Track
+                            x:Name="PART_Track"
+                            DockPanel.Dock="Right"
+                            IsDirectionReversed="true">
                             <Track.Thumb>
-                                <Thumb Style="{DynamicResource ThumbStyle}"/>
+                                <Thumb Style="{DynamicResource ThumbStyle}" />
                             </Track.Thumb>
                         </Track>
                     </DockPanel>
@@ -224,8 +239,7 @@
             </Setter.Value>
         </Setter>
     </Style>
-    <Style x:Key="BaseSeparatorStyle" TargetType="Rectangle">
-    </Style>
+    <Style x:Key="BaseSeparatorStyle" TargetType="Rectangle" />
     <Style x:Key="HighlightStyle">
         <Setter Property="Inline.FontWeight" Value="Bold" />
     </Style>
@@ -249,12 +263,12 @@
     <Style x:Key="BaseSearchIconPosition" TargetType="{x:Type Canvas}">
         <Setter Property="Width" Value="32" />
         <Setter Property="Height" Value="32" />
-        <Setter Property="Margin" Value="0 2 18 0" />
+        <Setter Property="Margin" Value="0,2,18,0" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="HorizontalAlignment" Value="Right" />
     </Style>
-    
-    <!--for classic themes-->
+
+    <!--  for classic themes  -->
     <Style x:Key="SearchIconStyle" TargetType="{x:Type Path}">
         <Setter Property="Fill" Value="#555555" />
         <Setter Property="Width" Value="32" />
@@ -263,19 +277,24 @@
     <Style x:Key="SearchIconPosition" TargetType="{x:Type Canvas}">
         <Setter Property="Width" Value="32" />
         <Setter Property="Height" Value="32" />
-        <Setter Property="Margin" Value="0 2 18 0" />
+        <Setter Property="Margin" Value="0,2,18,0" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="HorizontalAlignment" Value="Right" />
     </Style>
-    <Style x:Key="ItemHotkeyStyle" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource BaseItemHotkeyStyle}">
+    <Style
+        x:Key="ItemHotkeyStyle"
+        BasedOn="{StaticResource BaseItemHotkeyStyle}"
+        TargetType="{x:Type TextBlock}">
         <Setter Property="FontSize" Value="15" />
         <Setter Property="Foreground" Value="#8f8f8f" />
         <Setter Property="Opacity" Value="0.5" />
     </Style>
-    <Style x:Key="ItemHotkeySelectedStyle" TargetType="{x:Type TextBlock}"  BasedOn="{StaticResource BaseItemHotkeySelecetedStyle}">
+    <Style
+        x:Key="ItemHotkeySelectedStyle"
+        BasedOn="{StaticResource BaseItemHotkeySelecetedStyle}"
+        TargetType="{x:Type TextBlock}">
         <Setter Property="FontSize" Value="15" />
         <Setter Property="Foreground" Value="#8f8f8f" />
         <Setter Property="Opacity" Value="0.5" />
     </Style>
 </ResourceDictionary>
-    


### PR DESCRIPTION
**What's the PR?**
- Fix for https://github.com/Flow-Launcher/Flow.Launcher/issues/1066
- For older versions, there is no problem with high resolution (over 1920x1080), but it appears to be a problem with typical FHD.
- Removed All CleartypeHint Rendering (RenderOptions.ClearTypeHint="Enabled")


I don't have a 1920x1080 monitor, so it's hard to test.
(It cannot be properly tested by changing the resolution.)
In my case with this PR, the higher resolution(over FHD) was no problem, and it looked okay on FHD. Other people's tests are needed.

**Refer**
- https://github.com/microsoft/PowerToys/issues/6462
- https://github.com/microsoft/PowerToys/pull/10568

**Test Case**
- In 1920x1080, the Chinese language shall be displayed smoothly.
- In higher resolution thatn 1920x1080, fonts should be clearly displayed in other DPIs (125%, 150%, 175%, 200%,...)
