### PR TITLE
Pass query without trimming whitespace

### DIFF
--- a/Flow.Launcher.Core/Plugin/QueryBuilder.cs
+++ b/Flow.Launcher.Core/Plugin/QueryBuilder.cs
@@ -16,7 +16,7 @@ namespace Flow.Launcher.Core.Plugin
                 return null;
             }
 
-            var rawQuery = string.Join(Query.TermSeparator, terms);
+            var rawQuery = text;
             string actionKeyword, search;
             string possibleActionKeyword = terms[0];
             string[] searchTerms;

--- a/Flow.Launcher.Core/Plugin/QueryBuilder.cs
+++ b/Flow.Launcher.Core/Plugin/QueryBuilder.cs
@@ -24,13 +24,13 @@ namespace Flow.Launcher.Core.Plugin
             if (nonGlobalPlugins.TryGetValue(possibleActionKeyword, out var pluginPair) && !pluginPair.Metadata.Disabled)
             { // use non global plugin for query
                 actionKeyword = possibleActionKeyword;
-                search = terms.Length > 1 ? rawQuery[(actionKeyword.Length + 1)..] : string.Empty;
+                search = terms.Length > 1 ? rawQuery[(actionKeyword.Length + 1)..].TrimStart() : string.Empty;
                 searchTerms = terms[1..];
             }
             else
             { // non action keyword
                 actionKeyword = string.Empty;
-                search = rawQuery;
+                search = rawQuery.TrimStart();
                 searchTerms = terms;
             }
 

--- a/Flow.Launcher.Test/QueryBuilderTest.cs
+++ b/Flow.Launcher.Test/QueryBuilderTest.cs
@@ -17,7 +17,7 @@ namespace Flow.Launcher.Test
 
             Query q = QueryBuilder.Build(">   file.txt    file2 file3", nonGlobalPlugins);
 
-            Assert.AreEqual("file.txt file2 file3", q.Search);
+            Assert.AreEqual("  file.txt    file2 file3", q.Search);
             Assert.AreEqual(">", q.ActionKeyword);
         }
 
@@ -31,7 +31,7 @@ namespace Flow.Launcher.Test
 
             Query q = QueryBuilder.Build(">   file.txt    file2 file3", nonGlobalPlugins);
 
-            Assert.AreEqual("> file.txt file2 file3", q.Search);
+            Assert.AreEqual(">   file.txt    file2 file3", q.Search);
         }
 
         [Test]

--- a/Flow.Launcher.Test/QueryBuilderTest.cs
+++ b/Flow.Launcher.Test/QueryBuilderTest.cs
@@ -17,7 +17,7 @@ namespace Flow.Launcher.Test
 
             Query q = QueryBuilder.Build(">   file.txt    file2 file3", nonGlobalPlugins);
 
-            Assert.AreEqual("  file.txt    file2 file3", q.Search);
+            Assert.AreEqual("file.txt    file2 file3", q.Search);
             Assert.AreEqual(">", q.ActionKeyword);
         }
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -569,7 +569,7 @@ namespace Flow.Launcher.ViewModel
             if (currentCancellationToken.IsCancellationRequested)
                 return;
 
-            var query = QueryBuilder.Build(QueryText.Trim(), PluginManager.NonGlobalPlugins);
+            var query = QueryBuilder.Build(QueryText, PluginManager.NonGlobalPlugins);
 
             // handle the exclusiveness of plugin using action keyword
             RemoveOldQueryResults(query);


### PR DESCRIPTION
Trailing whitespace can be very helpful for argument detection.

This PR removes any whitespace trimming from Query before being passed to the Plugin.