### PR TITLE
Update Stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,4 +20,5 @@ jobs:
           days-before-close: 7
           days-before-pr-close: -1
           exempt-all-milestones: true
+          close-issue-message: 'This issue was closed because it has been stale for 5 days with no activity. If you feel this issue still needs attention please feel free to reopen.'
           stale-pr-label: 'no-pr-activity'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,3 +22,4 @@ jobs:
           exempt-all-milestones: true
           close-issue-message: 'This issue was closed because it has been stale for 5 days with no activity. If you feel this issue still needs attention please feel free to reopen.'
           stale-pr-label: 'no-pr-activity'
+          exempt-issue-labels: 'keep-fresh'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/stale@v4
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          days-before-stale: 30
           days-before-close: 5
+          days-before-stale: 45
           days-before-pr-close: -1
           exempt-all-milestones: true
           close-issue-message: 'This issue was closed because it has been stale for 5 days with no activity. If you feel this issue still needs attention please feel free to reopen.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/stale@v4
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          days-before-close: 5
           days-before-stale: 45
+          days-before-close: 7
           days-before-pr-close: -1
           exempt-all-milestones: true
           close-issue-message: 'This issue was closed because it has been stale for 5 days with no activity. If you feel this issue still needs attention please feel free to reopen.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,3 +23,4 @@ jobs:
           close-issue-message: 'This issue was closed because it has been stale for 5 days with no activity. If you feel this issue still needs attention please feel free to reopen.'
           stale-pr-label: 'no-pr-activity'
           exempt-issue-labels: 'keep-fresh'
+          exempt-pr-labels: 'keep-fresh,awaiting-approval,work-in-progress'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,4 +20,4 @@ jobs:
           days-before-close: 7
           days-before-pr-close: -1
           exempt-all-milestones: true
-          close-issue-message: 'This issue was closed because it has been stale for 5 days with no activity. If you feel this issue still needs attention please feel free to reopen.'
+          stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
Changed some configuration on Stales Bot. 

1. Increase the number of days an issue/PR is marked stale to 45 days.
>Hopefully this will give some issues some breathing room to be resolved.
3. Increase the number of days until an issue is closed to 7 days (up from 5 days).
>Should give a more reasonable chance for anyone to respond before the issue is closed.
4. Ignore PRs that are in progress or awaiting approval
5. Ignore Issues and PRs that are marked with a "keep fresh" label.
> Give some control to the team on whats marked stale or not.