### PR TITLE
Force reload theme resources when changing fonts etc in settings 

### DIFF
--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -85,7 +85,7 @@ namespace Flow.Launcher.Core.Resource
 
                 Settings.Theme = theme;
 
-                // #625, #637 - reload all resources even if the theme itself hasn't changed in order to pickup changes
+                // reload all resources even if the theme itself hasn't changed in order to pickup changes
                 // to things like fonts
                 UpdateResourceDictionary(GetResourceDictionary());
 

--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -85,10 +85,13 @@ namespace Flow.Launcher.Core.Resource
 
                 Settings.Theme = theme;
 
+                // #625, #637 - reload all resources even if the theme itself hasn't changed in order to pickup changes
+                // to things like fonts
+                UpdateResourceDictionary(GetResourceDictionary());
+
                 //always allow re-loading default theme, in case of failure of switching to a new theme from default theme
                 if (_oldTheme != theme || theme == defaultTheme)
                 {
-                    UpdateResourceDictionary(GetResourceDictionary());
                     _oldTheme = Path.GetFileNameWithoutExtension(_oldResource.Source.AbsolutePath);
                 }
 


### PR DESCRIPTION
Fixes #625 & #637 

This will mean that changing some settings will be a bit slower than before, especially when enabling blur which will reload resources twice but this is negligible and only hits in settings.