### PR TITLE
Release 1.9.4

### DIFF
--- a/Flow.Launcher.Core/Flow.Launcher.Core.csproj
+++ b/Flow.Launcher.Core/Flow.Launcher.Core.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Droplex" Version="1.4.0" />
+    <PackageReference Include="Droplex" Version="1.4.1" />
     <PackageReference Include="FSharp.Core" Version="5.0.2" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.1.3" />
     <PackageReference Include="squirrel.windows" Version="1.5.2" />

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -91,7 +91,7 @@
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
     <PackageReference Include="ModernWpfUI" Version="0.9.4" />
     <PackageReference Include="NHotkey.Wpf" Version="2.1.0" />
-    <PackageReference Include="NuGet.CommandLine" Version="5.4.0">
+    <PackageReference Include="NuGet.CommandLine" Version="5.7.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -55,7 +55,7 @@
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->
-    <system:String x:Key="plugin">Plugins</system:String>
+    <system:String x:Key="plugin">Plugin</system:String>
     <system:String x:Key="browserMorePlugins">Find more plugins</system:String>
     <system:String x:Key="enable">On</system:String>
     <system:String x:Key="disable">Off</system:String>

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -927,7 +927,9 @@
                                 ScrollViewer.CanContentScroll="False"
                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                 SelectedItem="{Binding SelectedPlugin}"
-                                SnapsToDevicePixels="True">
+                                SelectionChanged="SelectedPluginChanged"
+                                SnapsToDevicePixels="True"
+                                Name="Plugins">
                                 <ListBox.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <StackPanel Margin="0,0,0,18" />
@@ -1116,7 +1118,8 @@
                                                             Margin="0"
                                                             Padding="1"
                                                             VerticalAlignment="Stretch"
-                                                            Content="{Binding SettingControl}" />
+                                                            Content="{Binding SettingControl}" 
+                                                            SizeChanged="ItemSizeChanged"/>
                                                     </StackPanel>
 
                                                     <StackPanel>

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -13,12 +13,15 @@ using ModernWpf;
 using System;
 using System.IO;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Interop;
+using System.Windows.Media;
 using System.Windows.Navigation;
 using Button = System.Windows.Controls.Button;
 using Control = System.Windows.Controls.Control;
+using ListViewItem = System.Windows.Controls.ListViewItem;
 using MessageBox = System.Windows.MessageBox;
 using TextBox = System.Windows.Controls.TextBox;
 using ThemeManager = ModernWpf.ThemeManager;
@@ -44,6 +47,7 @@ namespace Flow.Launcher
         }
 
         #region General
+
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             RefreshMaximizeRestoreButton();
@@ -247,6 +251,7 @@ namespace Flow.Launcher
                     PluginManager.API.OpenDirectory(directory);
             }
         }
+
         #endregion
 
         #region Proxy
@@ -307,7 +312,7 @@ namespace Flow.Launcher
 
         private void OnExternalPluginInstallClick(object sender, RoutedEventArgs e)
         {
-            if(sender is Button { DataContext: UserPlugin plugin })
+            if (sender is Button { DataContext: UserPlugin plugin })
             {
                 var pluginsManagerPlugin = PluginManager.GetPluginForId("9f8f9b14-2518-4907-b211-35ab6290dee7");
                 var actionKeyword = pluginsManagerPlugin.Metadata.ActionKeywords.Count == 0 ? "" : pluginsManagerPlugin.Metadata.ActionKeywords[0];
@@ -326,7 +331,7 @@ namespace Flow.Launcher
             textBox.MoveFocus(tRequest);
         }
 
-        private void ColorSchemeSelectedIndexChanged(object sender, EventArgs e) 
+        private void ColorSchemeSelectedIndexChanged(object sender, EventArgs e)
             => ThemeManager.Current.ApplicationTheme = settings.ColorScheme switch
             {
                 Constant.Light => ApplicationTheme.Light,
@@ -370,5 +375,13 @@ namespace Flow.Launcher
             RefreshMaximizeRestoreButton();
         }
 
+        private void SelectedPluginChanged(object sender, SelectionChangedEventArgs e)
+        {
+            Plugins.ScrollIntoView(Plugins.SelectedItem);
+        }
+        private void ItemSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            Plugins.ScrollIntoView(Plugins.SelectedItem);
+        }
     }
 }

--- a/Flow.Launcher/Themes/Base.xaml
+++ b/Flow.Launcher/Themes/Base.xaml
@@ -1,15 +1,16 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib"
-                    xmlns:userSettings="clr-namespace:Flow.Launcher.Infrastructure.UserSettings;assembly=Flow.Launcher.Infrastructure">
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib"
+    xmlns:userSettings="clr-namespace:Flow.Launcher.Infrastructure.UserSettings;assembly=Flow.Launcher.Infrastructure">
 
-    <!-- Further font customisations are dynamically loaded in Theme.cs -->
+    <!--  Further font customisations are dynamically loaded in Theme.cs  -->
     <Style x:Key="BaseQueryBoxStyle" TargetType="{x:Type TextBox}">
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="FontSize" Value="28" />
         <Setter Property="FontWeight" Value="Regular" />
-        <Setter Property="Margin" Value="16 7 0 7" />
-        <Setter Property="Padding" Value="0 4 68 0" />
+        <Setter Property="Margin" Value="16,7,0,7" />
+        <Setter Property="Padding" Value="0,4,68,0" />
         <Setter Property="Background" Value="#2F2F2F" />
         <Setter Property="Height" Value="48" />
         <Setter Property="Foreground" Value="#E3E0E3" />
@@ -20,13 +21,22 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBox}">
-                    <Border x:Name="border" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
-                        <ScrollViewer x:Name="PART_ContentHost" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"
-                                      Background="{TemplateBinding Background}">
+                    <Border
+                        x:Name="border"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        SnapsToDevicePixels="True">
+                        <ScrollViewer
+                            x:Name="PART_ContentHost"
+                            Background="{TemplateBinding Background}"
+                            Focusable="false"
+                            HorizontalScrollBarVisibility="Hidden"
+                            VerticalScrollBarVisibility="Hidden">
                             <ScrollViewer.ContentTemplate>
                                 <DataTemplate>
-                                    <Grid Background="{Binding Background, ElementName=PART_ContentHost}" RenderOptions.ClearTypeHint="Enabled">
-                                        <ContentPresenter Content="{Binding Path=Content, ElementName=PART_ContentHost}"></ContentPresenter>
+                                    <Grid Background="{Binding Background, ElementName=PART_ContentHost}">
+                                        <ContentPresenter Content="{Binding Path=Content, ElementName=PART_ContentHost}" />
                                     </Grid>
                                 </DataTemplate>
                             </ScrollViewer.ContentTemplate>
@@ -37,47 +47,47 @@
         </Setter>
     </Style>
 
-    <!-- Further font customisations are dynamically loaded in Theme.cs -->
-    <Style x:Key="BaseQuerySuggestionBoxStyle" BasedOn="{StaticResource BaseQueryBoxStyle}" TargetType="{x:Type TextBox}">
+    <!--  Further font customisations are dynamically loaded in Theme.cs  -->
+    <Style
+        x:Key="BaseQuerySuggestionBoxStyle"
+        BasedOn="{StaticResource BaseQueryBoxStyle}"
+        TargetType="{x:Type TextBox}">
         <Setter Property="Foreground" Value="DarkGray" />
         <Setter Property="Height" Value="48" />
-        <Setter Property="Margin" Value="16 7 0 7" />
+        <Setter Property="Margin" Value="16,7,0,7" />
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Padding" Value="0 4 68 0" />
+        <Setter Property="Padding" Value="0,4,68,0" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
 
     <Style x:Key="BaseWindowBorderStyle" TargetType="{x:Type Border}">
         <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="Background" Value="#2F2F2F"></Setter>
-        <Setter Property="Padding" Value="0 0 0 0" />
+        <Setter Property="Background" Value="#2F2F2F" />
+        <Setter Property="Padding" Value="0,0,0,0" />
         <Setter Property="CornerRadius" Value="5" />
     </Style>
     <Style x:Key="BaseWindowStyle" TargetType="{x:Type Window}">
         <Setter Property="Width" Value="600" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
 
     <Style x:Key="WindowRadius" TargetType="{x:Type Border}">
         <Setter Property="CornerRadius" Value="5" />
     </Style>
-    
+
     <Style x:Key="BasePendingLineStyle" TargetType="{x:Type Line}">
         <Setter Property="Stroke" Value="Blue" />
     </Style>
 
-    
-    <!-- Item Style -->
+
+    <!--  Item Style  -->
     <Style x:Key="BaseItemTitleStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="#FFFFF8" />
         <Setter Property="FontSize" Value="16" />
         <Setter Property="FontWeight" Value="Medium" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
-    <Style x:Key="BaseItemSubTitleStyle" TargetType="{x:Type TextBlock}" >
+    <Style x:Key="BaseItemSubTitleStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="#D9D9D4" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
         <Setter Property="FontSize" Value="13" />
         <Setter Property="FontWeight" Value="Normal" />
         <Style.Triggers>
@@ -89,9 +99,8 @@
     <Style x:Key="BaseItemNumberStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalAlignment" Value="Center" />
-        <Setter Property="Margin" Value="3 0 0 0" />
+        <Setter Property="Margin" Value="3,0,0,0" />
         <Setter Property="FontSize" Value="22" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
     <Style x:Key="BaseGlyphStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="#ffffff" />
@@ -99,34 +108,31 @@
         <Setter Property="HorizontalAlignment" Value="Center" />
         <Setter Property="Width" Value="25" />
         <Setter Property="Height" Value="25" />
-        <Setter Property="FontSize" Value="25"/>
+        <Setter Property="FontSize" Value="25" />
     </Style>
-    <Style x:Key="BaseItemTitleSelectedStyle" TargetType="{x:Type TextBlock}" >
+    <Style x:Key="BaseItemTitleSelectedStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="#FFFFF8" />
         <Setter Property="FontSize" Value="16" />
         <Setter Property="FontWeight" Value="Normal" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
     </Style>
-    <Style x:Key="BaseItemSubTitleSelectedStyle" TargetType="{x:Type TextBlock}" >
+    <Style x:Key="BaseItemSubTitleSelectedStyle" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="#D9D9D4" />
         <Setter Property="FontSize" Value="13" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled"/>
         <Style.Triggers>
             <DataTrigger Binding="{Binding ElementName=SubTitle, UpdateSourceTrigger=PropertyChanged, Path=Text.Length}" Value="0">
                 <Setter Property="Height" Value="0" />
             </DataTrigger>
         </Style.Triggers>
     </Style>
-    <Style x:Key="BaseItemImageSelectedStyle" TargetType="{x:Type Image}" >
-    </Style>
+    <Style x:Key="BaseItemImageSelectedStyle" TargetType="{x:Type Image}" />
 
     <Style x:Key="BaseListboxStyle" TargetType="{x:Type ListBox}">
-        <Setter Property="BorderBrush" Value="Transparent"/>
-        <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
-        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
-        <Setter Property="Margin" Value="0 0 0 0" />
-        <Setter Property="Padding" Value="0 0 0 0" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="Margin" Value="0,0,0,0" />
+        <Setter Property="Padding" Value="0,0,0,0" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListBox">
@@ -135,12 +141,12 @@
                             <Style TargetType="ScrollViewer">
                                 <Style.Triggers>
                                     <Trigger Property="ComputedVerticalScrollBarVisibility" Value="Visible">
-                                        <Setter Property="Margin" Value="0 0 0 0" />
-                                        <Setter Property="Padding" Value="0 0 0 0" />
+                                        <Setter Property="Margin" Value="0,0,0,0" />
+                                        <Setter Property="Padding" Value="0,0,0,0" />
                                     </Trigger>
                                     <Trigger Property="ComputedVerticalScrollBarVisibility" Value="Collapsed">
-                                        <Setter Property="Margin" Value="0 0 0 0" />
-                                        <Setter Property="Padding" Value="0 0 0 0" />
+                                        <Setter Property="Margin" Value="0,0,0,0" />
+                                        <Setter Property="Padding" Value="0,0,0,0" />
                                     </Trigger>
                                 </Style.Triggers>
                             </Style>
@@ -152,7 +158,7 @@
         </Setter>
     </Style>
 
-    <!-- ScrollViewer Style -->
+    <!--  ScrollViewer Style  -->
     <ControlTemplate x:Key="ScrollViewerControlTemplate" TargetType="{x:Type ScrollViewer}">
         <Grid x:Name="Grid" Background="{TemplateBinding Background}">
             <Grid.ColumnDefinitions>
@@ -160,44 +166,50 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <!--content in the left of ScrollViewer, just default-->
-            <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
-                                        CanContentScroll="{TemplateBinding CanContentScroll}"
-                                        CanHorizontallyScroll="False"
-                                        CanVerticallyScroll="False"
-                                        ContentTemplate="{TemplateBinding ContentTemplate}"
-                                        Content="{TemplateBinding Content}"
-                                        Grid.Column="0"
-                                        Margin="0"
-                                        Grid.Row="0" />
+            <!--  content in the left of ScrollViewer, just default  -->
+            <ScrollContentPresenter
+                x:Name="PART_ScrollContentPresenter"
+                Grid.Row="0"
+                Grid.Column="0"
+                Margin="0"
+                CanContentScroll="{TemplateBinding CanContentScroll}"
+                CanHorizontallyScroll="False"
+                CanVerticallyScroll="False"
+                Content="{TemplateBinding Content}"
+                ContentTemplate="{TemplateBinding ContentTemplate}" />
 
-            <!--Scrollbar in thr rigth of ScrollViewer-->
-            <ScrollBar x:Name="PART_VerticalScrollBar"
-                           AutomationProperties.AutomationId="VerticalScrollBar"
-                           Cursor="Arrow"
-                           Grid.Column="0"
-                           HorizontalAlignment="Right"
-                           Margin="0 0 0 0"
-                           Maximum="{TemplateBinding ScrollableHeight}"
-                           Minimum="0"
-                           Grid.Row="0"
-                           Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-                           Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}"
-                           ViewportSize="{TemplateBinding ViewportHeight}"
-                           Style="{DynamicResource ScrollBarStyle}" />
+            <!--  Scrollbar in thr rigth of ScrollViewer  -->
+            <ScrollBar
+                x:Name="PART_VerticalScrollBar"
+                Grid.Row="0"
+                Grid.Column="0"
+                Margin="0,0,0,0"
+                HorizontalAlignment="Right"
+                AutomationProperties.AutomationId="VerticalScrollBar"
+                Cursor="Arrow"
+                Maximum="{TemplateBinding ScrollableHeight}"
+                Minimum="0"
+                Style="{DynamicResource ScrollBarStyle}"
+                ViewportSize="{TemplateBinding ViewportHeight}"
+                Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
         </Grid>
     </ControlTemplate>
 
-    <!-- button style in the middle of the scrollbar -->
+    <!--  button style in the middle of the scrollbar  -->
     <Style x:Key="BaseThumbStyle" TargetType="{x:Type Thumb}">
-        <Setter Property="SnapsToDevicePixels" Value="True"/>
-        <Setter Property="OverridesDefaultStyle" Value="true"/>
-        <Setter Property="IsTabStop" Value="false"/>
-        <Setter Property="Focusable" Value="false"/>
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="IsTabStop" Value="false" />
+        <Setter Property="Focusable" Value="false" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">
-                    <Border CornerRadius="2" DockPanel.Dock="Right" Background="#898989" BorderBrush="Transparent" />
+                    <Border
+                        Background="#898989"
+                        BorderBrush="Transparent"
+                        CornerRadius="2"
+                        DockPanel.Dock="Right" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -207,16 +219,19 @@
         <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="false" />
         <Setter Property="Background" Value="Black" />
-        <!-- must set min width -->
-        <Setter Property="MinWidth" Value="0"/>
-        <Setter Property="Width" Value="5"/>
+        <!--  must set min width  -->
+        <Setter Property="MinWidth" Value="0" />
+        <Setter Property="Width" Value="5" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ScrollBar}">
                     <DockPanel>
-                        <Track x:Name="PART_Track" IsDirectionReversed="true" DockPanel.Dock="Right">
+                        <Track
+                            x:Name="PART_Track"
+                            DockPanel.Dock="Right"
+                            IsDirectionReversed="true">
                             <Track.Thumb>
-                                <Thumb Style="{DynamicResource ThumbStyle}"/>
+                                <Thumb Style="{DynamicResource ThumbStyle}" />
                             </Track.Thumb>
                         </Track>
                     </DockPanel>
@@ -224,8 +239,7 @@
             </Setter.Value>
         </Setter>
     </Style>
-    <Style x:Key="BaseSeparatorStyle" TargetType="Rectangle">
-    </Style>
+    <Style x:Key="BaseSeparatorStyle" TargetType="Rectangle" />
     <Style x:Key="HighlightStyle">
         <Setter Property="Inline.FontWeight" Value="Bold" />
     </Style>
@@ -249,12 +263,12 @@
     <Style x:Key="BaseSearchIconPosition" TargetType="{x:Type Canvas}">
         <Setter Property="Width" Value="32" />
         <Setter Property="Height" Value="32" />
-        <Setter Property="Margin" Value="0 2 18 0" />
+        <Setter Property="Margin" Value="0,2,18,0" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="HorizontalAlignment" Value="Right" />
     </Style>
-    
-    <!--for classic themes-->
+
+    <!--  for classic themes  -->
     <Style x:Key="SearchIconStyle" TargetType="{x:Type Path}">
         <Setter Property="Fill" Value="#555555" />
         <Setter Property="Width" Value="32" />
@@ -263,19 +277,24 @@
     <Style x:Key="SearchIconPosition" TargetType="{x:Type Canvas}">
         <Setter Property="Width" Value="32" />
         <Setter Property="Height" Value="32" />
-        <Setter Property="Margin" Value="0 2 18 0" />
+        <Setter Property="Margin" Value="0,2,18,0" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="HorizontalAlignment" Value="Right" />
     </Style>
-    <Style x:Key="ItemHotkeyStyle" TargetType="{x:Type TextBlock}" BasedOn="{StaticResource BaseItemHotkeyStyle}">
+    <Style
+        x:Key="ItemHotkeyStyle"
+        BasedOn="{StaticResource BaseItemHotkeyStyle}"
+        TargetType="{x:Type TextBlock}">
         <Setter Property="FontSize" Value="15" />
         <Setter Property="Foreground" Value="#8f8f8f" />
         <Setter Property="Opacity" Value="0.5" />
     </Style>
-    <Style x:Key="ItemHotkeySelectedStyle" TargetType="{x:Type TextBlock}"  BasedOn="{StaticResource BaseItemHotkeySelecetedStyle}">
+    <Style
+        x:Key="ItemHotkeySelectedStyle"
+        BasedOn="{StaticResource BaseItemHotkeySelecetedStyle}"
+        TargetType="{x:Type TextBlock}">
         <Setter Property="FontSize" Value="15" />
         <Setter Property="Foreground" Value="#8f8f8f" />
         <Setter Property="Opacity" Value="0.5" />
     </Style>
 </ResourceDictionary>
-    

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -625,7 +625,7 @@ namespace Flow.Launcher.ViewModel
 
         private void RemoveOldQueryResults(Query query)
         {
-            if (_lastQuery.ActionKeyword != query.ActionKeyword)
+            if (_lastQuery?.ActionKeyword != query?.ActionKeyword)
             {
                 Results.Clear();
             }

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
@@ -37,7 +37,8 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
                 return new();
             foreach (var folder in rootElement.EnumerateObject())
             {
-                EnumerateFolderBookmark(folder.Value, bookmarks, source);
+                if (folder.Value.ValueKind == JsonValueKind.Object)
+                    EnumerateFolderBookmark(folder.Value, bookmarks, source);
             }
             return bookmarks;
         }

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
@@ -90,7 +90,6 @@ namespace Flow.Launcher.Plugin.Caculator
                             IcoPath = "Images/calculator.png",
                             Score = 300,
                             SubTitle = Context.API.GetTranslation("flowlauncher_plugin_calculator_copy_number_to_clipboard"),
-                            CopyText = newResult,
                             Action = c =>
                             {
                                 try

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
@@ -6,7 +6,6 @@ using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 using Mages.Core;
-using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin.Caculator.ViewModels;
 using Flow.Launcher.Plugin.Caculator.Views;
 
@@ -25,6 +24,9 @@ namespace Flow.Launcher.Plugin.Caculator
                         @")+$", RegexOptions.Compiled);
         private static readonly Regex RegBrackets = new Regex(@"[\(\)\[\]]", RegexOptions.Compiled);
         private static Engine MagesEngine;
+        private const string comma = ",";
+        private const string dot = ".";
+
         private PluginInitContext Context { get; set; }
 
         private static Settings _settings;
@@ -35,7 +37,7 @@ namespace Flow.Launcher.Plugin.Caculator
             Context = context;
             _settings = context.API.LoadSettingJsonStorage<Settings>();
             _viewModel = new SettingsViewModel(_settings);
-            
+
             MagesEngine = new Engine(new Configuration
             {
                 Scope = new Dictionary<string, object>
@@ -54,7 +56,19 @@ namespace Flow.Launcher.Plugin.Caculator
 
             try
             {
-                var expression = query.Search.Replace(",", ".");
+                string expression;
+
+                switch (_settings.DecimalSeparator)
+                {
+                    case DecimalSeparator.Comma:
+                    case DecimalSeparator.UseSystemLocale when CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator == ",":
+                        expression = query.Search.Replace(",", ".");
+                        break;
+                    default:
+                        expression = query.Search;
+                        break;
+                }
+
                 var result = MagesEngine.Interpret(expression);
 
                 if (result?.ToString() == "NaN")
@@ -76,6 +90,7 @@ namespace Flow.Launcher.Plugin.Caculator
                             IcoPath = "Images/calculator.png",
                             Score = 300,
                             SubTitle = Context.API.GetTranslation("flowlauncher_plugin_calculator_copy_number_to_clipboard"),
+                            CopyText = newResult,
                             Action = c =>
                             {
                                 try
@@ -119,6 +134,10 @@ namespace Flow.Launcher.Plugin.Caculator
                 return false;
             }
 
+            if ((query.Search.Contains(dot) && GetDecimalSeparator() != dot) ||
+                (query.Search.Contains(comma) && GetDecimalSeparator() != comma))
+                return false;
+
             return true;
         }
 
@@ -142,8 +161,8 @@ namespace Flow.Launcher.Plugin.Caculator
             switch (_settings.DecimalSeparator)
             {
                 case DecimalSeparator.UseSystemLocale: return systemDecimalSeperator;
-                case DecimalSeparator.Dot: return ".";
-                case DecimalSeparator.Comma: return ",";
+                case DecimalSeparator.Dot: return dot;
+                case DecimalSeparator.Comma: return comma;
                 default: return systemDecimalSeperator;
             }
         }

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Settings.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace Flow.Launcher.Plugin.Caculator
 {
     public class Settings

--- a/Plugins/Flow.Launcher.Plugin.Calculator/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Calculator",
   "Description": "Provide mathematical calculations.(Try 5*3-2 in Flow Launcher)",
   "Author": "cxfksword",
-  "Version": "1.1.9",
+  "Version": "1.1.10",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Caculator.dll",

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -15,6 +15,7 @@
     <system:String x:Key="plugin_explorer_windowsSearchServiceFix">To fix this, start the Windows Search service. Select here to remove this warning</system:String>
     <system:String x:Key="plugin_explorer_alternative">The warning message has been switched off. As an alternative for searching files and folders, would you like to install Everything plugin?{0}{0}Select 'Yes' to install Everything plugin, or 'No' to return</system:String>
     <system:String x:Key="plugin_explorer_alternative_title">Explorer Alternative</system:String>
+    <system:String x:Key="plugin_explorer_directoryinfosearch_error">Error occurred during search: {0}</system:String>
 
     <!--Controls-->
     <system:String x:Key="plugin_explorer_delete">Delete</system:String>
@@ -23,6 +24,8 @@
     <system:String x:Key="plugin_explorer_manageactionkeywords_header">Customise Action Keywords</system:String>
     <system:String x:Key="plugin_explorer_quickaccesslinks_header">Quick Access Links</system:String>
     <system:String x:Key="plugin_explorer_indexsearchexcludedpaths_header">Index Search Excluded Paths</system:String>
+    <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch">Use Index Search For Path Search</system:String>
+    <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch_tooltip">Turning this on will return indexed directories/files faster, but if a directory/file is not indexed it will not show up. If a directory/file has been added to Index Search Excluded Path then it will still show up even if this option is on</system:String>
     <system:String x:Key="plugin_explorer_manageindexoptions">Indexing Options</system:String>
     <system:String x:Key="plugin_explorer_actionkeywordview_search">Search:</system:String>
     <system:String x:Key="plugin_explorer_actionkeywordview_pathsearch">Path Search:</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
@@ -1,4 +1,4 @@
-﻿using Flow.Launcher.Infrastructure.Logger;
+using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Plugin.SharedCommands;
 using System;
 using System.Collections.Generic;
@@ -58,8 +58,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo
             {
                 var directoryInfo = new System.IO.DirectoryInfo(path);
 
-                foreach (var fileSystemInfo in directoryInfo.EnumerateFileSystemInfos(searchCriteria, enumerationOption)
-                )
+                foreach (var fileSystemInfo in directoryInfo.EnumerateFileSystemInfos(searchCriteria, enumerationOption))
                 {
                     if (fileSystemInfo is System.IO.DirectoryInfo)
                     {
@@ -76,8 +75,17 @@ namespace Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo
             }
             catch (Exception e)
             {
-                Log.Exception("Flow.Plugin.Explorer.", nameof(DirectoryInfoSearch), e);
-                results.Add(new Result {Title = e.Message, Score = 501});
+                Log.Exception(nameof(DirectoryInfoSearch), "Error occured while searching path", e);
+                
+                results.Add(
+                    new Result
+                    {
+                        Title = string.Format(SearchManager.Context.API.GetTranslation(
+                                                "plugin_explorer_directoryinfosearch_error"),
+                                                e.Message),
+                        Score = 501, 
+                        IcoPath = Constants.ExplorerIconImagePath
+                    });
 
                 return results;
             }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -14,7 +14,7 @@ namespace Flow.Launcher.Plugin.Explorer
         // as at v1.7.0 this is to maintain backwards compatibility, need to be removed afterwards.
         public List<AccessLink> QuickFolderAccessLinks { get; set; } = new List<AccessLink>();
 
-        public bool UseWindowsIndexForDirectorySearch { get; set; } = true;
+        public bool UseWindowsIndexForDirectorySearch { get; set; } = false;
 
         public List<AccessLink> IndexSearchExcludedSubdirectoryPaths { get; set; } = new List<AccessLink>();
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -52,5 +52,16 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
         }
 
         internal bool IsNewActionKeywordGlobal(string newActionKeyword) => newActionKeyword == Query.GlobalPluginWildcardSign;
+
+        public bool UseWindowsIndexForDirectorySearch {
+            get
+            {
+                return Settings.UseWindowsIndexForDirectorySearch;
+            }
+            set
+            {
+                Settings.UseWindowsIndexForDirectorySearch = value;
+            }
+        }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -89,6 +89,7 @@
                 <Expander
                     x:Name="expExcludedPaths"
                     Margin="0,10,0,0"
+                    Collapsed="expExcludedPaths_Collapsed"
                     Expanded="expExcludedPaths_Click"
                     Header="{DynamicResource plugin_explorer_indexsearchexcludedpaths_header}">
                     <ListView

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -4,7 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:viewModels="clr-namespace:Flow.Launcher.Plugin.Explorer.ViewModels"
     xmlns:views="clr-namespace:Flow.Launcher.Plugin.Explorer.Views"
     d:DesignHeight="450"
     d:DesignWidth="800"
@@ -92,12 +91,20 @@
                     Collapsed="expExcludedPaths_Collapsed"
                     Expanded="expExcludedPaths_Click"
                     Header="{DynamicResource plugin_explorer_indexsearchexcludedpaths_header}">
-                    <ListView
-                        x:Name="lbxExcludedPaths"
-                        AllowDrop="True"
-                        DragEnter="lbxAccessLinks_DragEnter"
-                        Drop="lbxAccessLinks_Drop"
-                        ItemTemplate="{StaticResource ListViewTemplateExcludedPaths}" />
+                    <StackPanel>
+                        <CheckBox
+                            Name="UseWindowsIndexForDirectorySearch"
+                            Margin="12,10,0,0"
+                            Content="{DynamicResource plugin_explorer_usewindowsindexfordirectorysearch}"
+                            IsChecked="{Binding UseWindowsIndexForDirectorySearch}"
+                            ToolTip="{DynamicResource plugin_explorer_usewindowsindexfordirectorysearch_tooltip}" />
+                        <ListView
+                            x:Name="lbxExcludedPaths"
+                            AllowDrop="True"
+                            DragEnter="lbxAccessLinks_DragEnter"
+                            Drop="lbxAccessLinks_Drop"
+                            ItemTemplate="{StaticResource ListViewTemplateExcludedPaths}" />
+                    </StackPanel>
                 </Expander>
             </StackPanel>
         </ScrollViewer>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
@@ -29,6 +29,8 @@ namespace Flow.Launcher.Plugin.Explorer.Views
 
             this.viewModel = viewModel;
 
+            DataContext = viewModel;
+
             lbxAccessLinks.ItemsSource = this.viewModel.Settings.QuickAccessLinks;
 
             lbxExcludedPaths.ItemsSource = this.viewModel.Settings.IndexSearchExcludedSubdirectoryPaths;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
@@ -60,9 +60,7 @@ namespace Flow.Launcher.Plugin.Explorer.Views
 
             lbxExcludedPaths.Items.SortDescriptions.Add(new SortDescription("Path", ListSortDirection.Ascending));
 
-            btnDelete.Visibility = Visibility.Hidden;
-            btnEdit.Visibility = Visibility.Hidden;
-            btnAdd.Visibility = Visibility.Hidden;
+            SetButtonVisibilityToHidden();
 
             if (expAccessLinks.IsExpanded || expExcludedPaths.IsExpanded || expActionKeywords.IsExpanded)
             {
@@ -123,8 +121,8 @@ namespace Flow.Launcher.Plugin.Explorer.Views
 
         private void expActionKeywords_Collapsed(object sender, RoutedEventArgs e)
         {
-            if (!expActionKeywords.IsExpanded)
-                expActionKeywords.Height = double.NaN;
+            expActionKeywords.Height = double.NaN;
+            SetButtonVisibilityToHidden();
         }
 
         private void expAccessLinks_Click(object sender, RoutedEventArgs e)
@@ -143,8 +141,8 @@ namespace Flow.Launcher.Plugin.Explorer.Views
 
         private void expAccessLinks_Collapsed(object sender, RoutedEventArgs e)
         {
-            if (!expAccessLinks.IsExpanded)
-                expAccessLinks.Height = double.NaN;
+            expAccessLinks.Height = double.NaN;
+            SetButtonVisibilityToHidden();
         }
 
         private void expExcludedPaths_Click(object sender, RoutedEventArgs e)
@@ -159,6 +157,11 @@ namespace Flow.Launcher.Plugin.Explorer.Views
                 expActionKeywords.IsExpanded = false;
 
             RefreshView();
+        }
+
+        private void expExcludedPaths_Collapsed(object sender, RoutedEventArgs e)
+        {
+            SetButtonVisibilityToHidden();
         }
 
         private void btnDelete_Click(object sender, RoutedEventArgs e)
@@ -308,6 +311,13 @@ namespace Flow.Launcher.Plugin.Explorer.Views
         private void btnOpenIndexingOptions_Click(object sender, RoutedEventArgs e)
         {
             viewModel.OpenWindowsIndexingOptions();
+        }
+
+        public void SetButtonVisibilityToHidden()
+        {
+            btnDelete.Visibility = Visibility.Hidden;
+            btnEdit.Visibility = Visibility.Hidden;
+            btnAdd.Visibility = Visibility.Hidden;
         }
     }
 

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -61,24 +61,26 @@ namespace Flow.Launcher.Plugin.Shell
 
                     if (basedir != null)
                     {
-                        var autocomplete = Directory.GetFileSystemEntries(basedir).
-                            Select(o => dir + Path.GetFileName(o)).
-                            Where(o => o.StartsWith(cmd, StringComparison.OrdinalIgnoreCase) &&
-                                       !results.Any(p => o.Equals(p.Title, StringComparison.OrdinalIgnoreCase)) &&
-                                       !results.Any(p => o.Equals(p.Title, StringComparison.OrdinalIgnoreCase))).ToList();
+                        var autocomplete = 
+                            Directory.GetFileSystemEntries(basedir)
+                                .Select(o => dir + Path.GetFileName(o))
+                                .Where(o => o.StartsWith(cmd, StringComparison.OrdinalIgnoreCase) &&
+                            !results.Any(p => o.Equals(p.Title, StringComparison.OrdinalIgnoreCase)) &&
+                            !results.Any(p => o.Equals(p.Title, StringComparison.OrdinalIgnoreCase))).ToList();
+                        
                         autocomplete.Sort();
+                        
                         results.AddRange(autocomplete.ConvertAll(m => new Result
                         {
                             Title = m,
                             IcoPath = Image,
                             Action = c =>
                             {
-                                var runAsAdministrator = (
+                                var runAsAdministrator =
                                     c.SpecialKeyState.CtrlPressed &&
                                     c.SpecialKeyState.ShiftPressed &&
                                     !c.SpecialKeyState.AltPressed &&
-                                    !c.SpecialKeyState.WinPressed
-                                );
+                                    !c.SpecialKeyState.WinPressed;
 
                                 Execute(Process.Start, PrepareProcessStartInfo(m, runAsAdministrator));
                                 return true;
@@ -113,12 +115,11 @@ namespace Flow.Launcher.Plugin.Shell
                         IcoPath = Image,
                         Action = c =>
                         {
-                            var runAsAdministrator = (
+                            var runAsAdministrator =
                                 c.SpecialKeyState.CtrlPressed &&
                                 c.SpecialKeyState.ShiftPressed &&
                                 !c.SpecialKeyState.AltPressed &&
-                                !c.SpecialKeyState.WinPressed
-                            );
+                                !c.SpecialKeyState.WinPressed;
 
                             Execute(Process.Start, PrepareProcessStartInfo(m.Key, runAsAdministrator));
                             return true;
@@ -143,12 +144,11 @@ namespace Flow.Launcher.Plugin.Shell
                 IcoPath = Image,
                 Action = c =>
                 {
-                    var runAsAdministrator = (
+                    var runAsAdministrator =
                         c.SpecialKeyState.CtrlPressed &&
                         c.SpecialKeyState.ShiftPressed &&
                         !c.SpecialKeyState.AltPressed &&
-                        !c.SpecialKeyState.WinPressed
-                    );
+                        !c.SpecialKeyState.WinPressed;
 
                     Execute(Process.Start, PrepareProcessStartInfo(cmd, runAsAdministrator));
                     return true;
@@ -168,12 +168,11 @@ namespace Flow.Launcher.Plugin.Shell
                     IcoPath = Image,
                     Action = c =>
                     {
-                        var runAsAdministrator = (
+                        var runAsAdministrator =
                             c.SpecialKeyState.CtrlPressed &&
                             c.SpecialKeyState.ShiftPressed &&
                             !c.SpecialKeyState.AltPressed &&
-                            !c.SpecialKeyState.WinPressed
-                        );
+                            !c.SpecialKeyState.WinPressed;
 
                         Execute(Process.Start, PrepareProcessStartInfo(m.Key, runAsAdministrator));
                         return true;
@@ -203,8 +202,21 @@ namespace Flow.Launcher.Plugin.Shell
                 case Shell.Cmd:
                     {
                         info.FileName = "cmd.exe";
-                        info.ArgumentList.Add(_settings.LeaveShellOpen ? "/k" : "/c");
-                        info.ArgumentList.Add(command);
+                        info.Arguments = $"{(_settings.LeaveShellOpen ? "/k" : "/c")} {command}";
+
+                        //// Use info.Arguments instead of info.ArgumentList to enable users better control over the arguments they are writing.
+                        //// Previous code using ArgumentList, commands needed to be seperated correctly:                      
+                        //// Incorrect:
+                        // info.ArgumentList.Add(_settings.LeaveShellOpen ? "/k" : "/c");
+                        // info.ArgumentList.Add(command); //<== info.ArgumentList.Add("mkdir \"c:\\test new\"");
+
+                        //// Correct version should be:
+                        //info.ArgumentList.Add(_settings.LeaveShellOpen ? "/k" : "/c");
+                        //info.ArgumentList.Add("mkdir");
+                        //info.ArgumentList.Add(@"c:\test new");
+
+                        //https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist?view=net-6.0#remarks
+
                         break;
                     }
 
@@ -366,7 +378,7 @@ namespace Flow.Launcher.Plugin.Shell
                     Title = context.API.GetTranslation("flowlauncher_plugin_cmd_run_as_different_user"),
                     Action = c =>
                     {
-                        Task.Run(() =>Execute(ShellCommand.RunAsDifferentUser, PrepareProcessStartInfo(selectedResult.Title)));
+                        Task.Run(() => Execute(ShellCommand.RunAsDifferentUser, PrepareProcessStartInfo(selectedResult.Title)));
                         return true;
                     },
                     IcoPath = "Images/user.png"

--- a/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
@@ -6,7 +6,7 @@ namespace Flow.Launcher.Plugin.Shell
     {
         public Shell Shell { get; set; } = Shell.Cmd;
         
-        public bool ReplaceWinR { get; set; } = true;
+        public bool ReplaceWinR { get; set; } = false;
         
         public bool LeaveShellOpen { get; set; }
 

--- a/Plugins/Flow.Launcher.Plugin.WindowsSettings/Properties/Resources.resx
+++ b/Plugins/Flow.Launcher.Plugin.WindowsSettings/Properties/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1206,7 +1206,7 @@
     <value>Plugin to search for Windows settings</value>
   </data>
   <data name="PluginTitle" xml:space="preserve">
-    <value>Windows settings</value>
+    <value>Windows Settings</value>
   </data>
   <data name="PowerAndSleep" xml:space="preserve">
     <value>Power and sleep</value>

--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -71,7 +71,7 @@ function Pack-Squirrel-Installer ($path, $version, $output) {
     Write-Host "Packing: $spec"
     Write-Host "Input path:  $input"
     # making version static as multiple versions can exist in the nuget folder and in the case a breaking change is introduced.
-    New-Alias Nuget $env:USERPROFILE\.nuget\packages\NuGet.CommandLine\5.4.0\tools\NuGet.exe -Force
+    New-Alias Nuget $env:USERPROFILE\.nuget\packages\NuGet.CommandLine\5.7.2\tools\NuGet.exe -Force
     # dotnet pack is not used because ran into issues, need to test installation and starting up if to use it.
     nuget pack $spec -Version $version -BasePath $input -OutputDirectory $output -Properties Configuration=Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ deploy:
   - provider: NuGet
     artifact: Plugin nupkg
     api_key:
-      secure: M0FYTgnThhthw9FPAI51CR0l5/te1VSh914YbCtOfDTTLYgbA/Ii9R91sc5l5bAN
+      secure: EwKxUgjI8VGouFq9fdhI68+uj42amAhwE65JixIbqx8VlqLbyEuW97CLjBBOIL0r
     on:
       APPVEYOR_REPO_TAG: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '1.9.3.{build}'
+version: '1.9.4.{build}'
 
 init:
 - ps: |


### PR DESCRIPTION
Release Notes
=========

## Bug fixes
- Bumped NuGet.CommandLine from 5.4.0 to 5.7.2 #1241

- Fixed shell cmd command when used with quotes and spaces #1205

- Fixed occasional NullReferenceException error #1204

- Updated Python download mirrors #1187

- Fixed font-anti-aliasing #1119

- Fixed decimal separator when used as part of the query #1108

- Fixed plugins inside settings window to expand correctly and fill the entire window when required #1098

- Updated Shell plugin's default setting for replacing Win R hotkey to off #1087

- Fixed incorrect button visibility in Explorer plugin's setting panel #1077

- Updated Explorer's path search to not use index by default when searching inside directories #1076

- Fixed a silent error thrown when Chromium bookmarks are loaded #1071 

- Fixed typos in context menu result's plugin title and WindowsSettings' name #1056

- Fixed the occasional error 'No process is associated with this object' #1005