### PR TITLE
[Dev] add check query length when calling backspace command action

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -517,6 +517,7 @@ namespace Flow.Launcher
                     if (specialKeyState.CtrlPressed)
                     {
                         if (_viewModel.SelectedIsFromQueryResults()
+                            && QueryTextBox.Text.Length > 0
                             && QueryTextBox.CaretIndex == QueryTextBox.Text.Length)
                         {
                             var queryWithoutActionKeyword = 


### PR DESCRIPTION
When browsing directories and using ctrl backspace to go back up one directory, flow will throw error if ctrl backspace is pressed when there is no query text.

Currently error exists in Dev branch.