### PR TITLE
[Dev] Add icons to About tab

### DIFF
--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -14,7 +14,7 @@
     xmlns:vm="clr-namespace:Flow.Launcher.ViewModel"
     Title="{DynamicResource flowlauncher_settings}"
     Width="1000"
-    Height="650"
+    Height="700"
     MinWidth="900"
     MinHeight="600"
     d:DataContext="{d:DesignInstance vm:SettingWindowViewModel}"
@@ -2487,6 +2487,26 @@
                                     </ItemsControl>
                                 </Border>
 
+                                <Border Height="62" Style="{DynamicResource SettingGroupBox}">
+                                    <ItemsControl Style="{StaticResource SettingGrid}">
+                                        <StackPanel Style="{StaticResource TextPanel}">
+                                            <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="Icons" />
+                                        </StackPanel>
+                                        <TextBlock
+                                            Margin="0,0,-12,0"
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource SideTextAbout}">
+                                            <Hyperlink NavigateUri="https://icons8.com" RequestNavigate="OnRequestNavigate">
+                                                <Run Text="icons8.com" />
+                                            </Hyperlink>
+
+                                        </TextBlock>
+                                        <TextBlock Style="{StaticResource Glyph}">
+                                            &#xE8FE;
+                                        </TextBlock>
+                                    </ItemsControl>
+                                </Border>
+
                                 <Border Style="{DynamicResource SettingGroupBox}">
                                     <ItemsControl Style="{StaticResource SettingGrid}">
                                         <StackPanel Style="{StaticResource TextPanel}">
@@ -2513,19 +2533,7 @@
                                     </ItemsControl>
                                 </Border>
                                 <TextBlock
-                                    Margin="14,14,0,0"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Bottom"
-                                    FontSize="12"
-                                    Foreground="{DynamicResource Color15B}"
-                                    TextWrapping="WrapWithOverflow">
-                                    <Hyperlink NavigateUri="https://icons8.com" RequestNavigate="OnRequestNavigate">
-                                        <Run Text="Icons by icons8.com" />
-                                    </Hyperlink>
-                                </TextBlock>
-
-                                <TextBlock
-                                    Margin="14,4,0,0"
+                                    Margin="14,20,0,0"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Bottom"
                                     DockPanel.Dock="Bottom"


### PR DESCRIPTION
Move 'icons by icons8.com' to the About tab instead of a hyper link.

**Before**
![image](https://user-images.githubusercontent.com/26427004/184373576-b325c2ef-947a-4068-ac7a-1d504b2d32a6.png)

**After**
![image](https://user-images.githubusercontent.com/26427004/184373363-7c5e93df-87d6-4734-80e5-d9795255c9ba.png)

Related https://github.com/Flow-Launcher/Flow.Launcher/pull/843