### PR TITLE
[Dev] Unregister Cancellation Event by disposing the delegate

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -280,7 +280,7 @@ namespace Flow.Launcher.Core.Plugin
             switch (sourceBuffer.Length, errorBuffer.Length)
             {
                 case (0, 0):
-                    var errorMessage = Encoding.UTF8.GetString(errorBuffer.GetBuffer(), 0, (int)errorBuffer.Position);
+                    const string errorMessage = "Empty JSON-RPC Response.";
                     Log.Warn($"|{nameof(JsonRPCPlugin)}.{nameof(ExecuteAsync)}|{errorMessage}");
                     break;
                 case (_, not 0):

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -277,7 +277,7 @@ namespace Flow.Launcher.Core.Plugin
                 return Stream.Null;
             }
 
-            switch (sourceBuffer.Length, errorBuffer.Position)
+            switch (sourceBuffer.Length, errorBuffer.Length)
             {
                 case (0, 0):
                     var errorMessage = Encoding.UTF8.GetString(errorBuffer.GetBuffer(), 0, (int)errorBuffer.Position);

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -1,34 +1,26 @@
-﻿using Accessibility;
-using Flow.Launcher.Core.Resource;
+﻿using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Infrastructure;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
-using ICSharpCode.SharpZipLib.Zip;
-using JetBrains.Annotations;
 using Microsoft.IO;
-using System.Text.Json.Serialization;
 using System.Windows;
 using System.Windows.Controls;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using CheckBox = System.Windows.Controls.CheckBox;
 using Control = System.Windows.Controls.Control;
-using Label = System.Windows.Controls.Label;
 using Orientation = System.Windows.Controls.Orientation;
 using TextBox = System.Windows.Controls.TextBox;
 using UserControl = System.Windows.Controls.UserControl;
-using System.Windows.Data;
 
 namespace Flow.Launcher.Core.Plugin
 {


### PR DESCRIPTION
1. Unregister `kill` callback by disposing the registered event.
2. Fix Error Message not being read