### PR TITLE
Rounded icon mask field

### DIFF
--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -66,6 +66,10 @@ namespace Flow.Launcher.Plugin
                 }
             }
         }
+        /// <summary>
+        /// Determines if Icon has a border radius
+        /// </summary>
+        public bool RoundedIcon { get; set; } = false;
 
         /// <summary>
         /// Delegate function, see <see cref="Icon"/>

--- a/Flow.Launcher/ResultListBox.xaml
+++ b/Flow.Launcher/ResultListBox.xaml
@@ -82,8 +82,8 @@
                             BorderThickness="0">
                             <Image
                                 x:Name="ImageIcon"
-                                Width="32"
-                                Height="32"
+                                Width="{Binding IconXY}"
+                                Height="{Binding IconXY}"
                                 Margin="0,0,0,0"
                                 HorizontalAlignment="Center"
                                 Source="{Binding Image, TargetNullValue={x:Null}}"

--- a/Flow.Launcher/ResultListBox.xaml
+++ b/Flow.Launcher/ResultListBox.xaml
@@ -88,7 +88,11 @@
                                 HorizontalAlignment="Center"
                                 Source="{Binding Image, TargetNullValue={x:Null}}"
                                 Stretch="Uniform"
-                                Visibility="{Binding ShowIcon}" />
+                                Visibility="{Binding ShowIcon}">
+                                <Image.Clip>
+                                    <EllipseGeometry RadiusX="{Binding IconRadius}" RadiusY="{Binding IconRadius}" Center="16 16"/>
+                                </Image.Clip>
+                            </Image>
                         </Border>
                         <Border
                             Margin="9,0,0,0"

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -84,6 +84,19 @@ namespace Flow.Launcher.ViewModel
             }
         }
 
+        public double IconRadius
+        {
+            get
+            {
+                if (Result.RoundedIcon)
+                {
+                    return IconXY / 2;
+                }
+                return IconXY;
+            }
+
+        }
+
         public Visibility ShowGlyph
         {
             get

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -165,6 +165,8 @@ namespace Flow.Launcher.ViewModel
 
         public string QuerySuggestionText { get; set; }
 
+        public double IconXY { get; set; } = 32;
+
         public override bool Equals(object obj)
         {
             return obj is ResultViewModel r && Result.Equals(r.Result);


### PR DESCRIPTION
Allows plugins to apply a rounded mask to a result icon.

Plugin need only provide the field `RoundedIcon` with a Boolean. Defaults to `False`

Some API's provide a square icon but intend to be displayed with rounded edges. This will help display images correctly.

Before:
![image](https://user-images.githubusercontent.com/535299/187388782-0ea0506e-107b-4a2f-ba45-a0d91f5d17af.png)

After:
![image](https://user-images.githubusercontent.com/535299/187388798-851d695f-2bef-4523-9039-0ba0018ef0d8.png)

