### PR TITLE
Adjust Max Width Window Size

### DIFF
--- a/Flow.Launcher/ResultListBox.xaml
+++ b/Flow.Launcher/ResultListBox.xaml
@@ -42,7 +42,6 @@
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
                         Cursor="Hand"
-                        ShowGridLines="True"
                         UseLayoutRounding="False">
                         <Grid.Resources>
                             <converter:HighlightTextConverter x:Key="HighlightTextConverter" />

--- a/Flow.Launcher/ResultListBox.xaml
+++ b/Flow.Launcher/ResultListBox.xaml
@@ -30,7 +30,7 @@
 
     <ListBox.ItemTemplate>
         <DataTemplate>
-            <Button>
+            <Button HorizontalAlignment="Stretch">
                 <Button.Template>
                     <ControlTemplate>
                         <ContentPresenter Content="{TemplateBinding Button.Content}" />
@@ -39,9 +39,10 @@
                 <Button.Content>
                     <Grid
                         Margin="0"
-                        HorizontalAlignment="Left"
+                        HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
                         Cursor="Hand"
+                        ShowGridLines="True"
                         UseLayoutRounding="False">
                         <Grid.Resources>
                             <converter:HighlightTextConverter x:Key="HighlightTextConverter" />
@@ -50,7 +51,7 @@
                         </Grid.Resources>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="60" />
-                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="9*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <StackPanel
@@ -129,12 +130,9 @@
                             <TextBlock
                                 x:Name="SubTitle"
                                 Grid.Row="1"
-                                MinWidth="750"
                                 Style="{DynamicResource ItemSubTitleStyle}"
                                 Text="{Binding Result.SubTitle}"
-                                ToolTip="{Binding ShowSubTitleToolTip}">
-                    
-                            </TextBlock>
+                                ToolTip="{Binding ShowSubTitleToolTip}" />
 
                         </Grid>
 

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -597,9 +597,7 @@
                                     <StackPanel Style="{StaticResource TextPanel}">
                                         <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource startFlowLauncherOnSystemStartup}" />
                                     </StackPanel>
-                                    <CheckBox
-                                        IsChecked="{Binding StartFlowLauncherOnSystemStartup}"
-                                        Style="{DynamicResource SideControlCheckBox}" />
+                                    <CheckBox IsChecked="{Binding StartFlowLauncherOnSystemStartup}" Style="{DynamicResource SideControlCheckBox}" />
                                     <TextBlock Style="{StaticResource Glyph}">
                                         &#xe8fc;
                                     </TextBlock>
@@ -1621,7 +1619,7 @@
                                                     Margin="0,0,18,0"
                                                     IsMoveToPointEnabled="True"
                                                     IsSnapToTickEnabled="True"
-                                                    Maximum="900"
+                                                    Maximum="1920"
                                                     Minimum="400"
                                                     TickFrequency="10"
                                                     Value="{Binding WindowWidthSize, Mode=TwoWay}" />
@@ -1792,9 +1790,9 @@
                                                             Margin="20,0,0,0"
                                                             HorizontalAlignment="Left"
                                                             VerticalAlignment="Top"
+                                                            IsSynchronizedWithCurrentItem="False"
                                                             ItemsSource="{Binding Source={StaticResource SortedFonts}}"
-                                                            SelectedItem="{Binding SelectedQueryBoxFont}"
-                                                            IsSynchronizedWithCurrentItem="False" />
+                                                            SelectedItem="{Binding SelectedQueryBoxFont}" />
                                                         <ComboBox
                                                             Width="130"
                                                             Margin="10,0,0,0"
@@ -1843,9 +1841,9 @@
                                                             Margin="20,-2,0,0"
                                                             HorizontalAlignment="Left"
                                                             VerticalAlignment="Top"
+                                                            IsSynchronizedWithCurrentItem="False"
                                                             ItemsSource="{Binding Source={StaticResource SortedFonts}}"
-                                                            SelectedItem="{Binding SelectedResultFont}"
-                                                            IsSynchronizedWithCurrentItem="False" />
+                                                            SelectedItem="{Binding SelectedResultFont}" />
                                                         <ComboBox
                                                             Width="130"
                                                             Margin="10,-2,0,0"


### PR DESCRIPTION
- Change Max Width to 1920 from 900 (Window Size Slider in setting window)
- Adjust Result Item Layout

**Check List**
- Even if you increase the window size, the item layout must be displayed normally.
- The shortcut (alt+1 things) display should be displayed normally when turned on and off.

**ETC**
- 1920 is a temporary. I hope the width will be changed based on the Monitor's Width.  