### PR TITLE
Fixed QueryTextbox Binding event

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -173,7 +173,7 @@
                         Background="Transparent"
                         PreviewDragOver="OnPreviewDragOver"
                         Style="{DynamicResource QueryBoxStyle}"
-                        Text="{Binding QueryText, Mode=TwoWay, UpdateSourceTrigger=Explicit}"
+                        Text="{Binding QueryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                         PreviewKeyUp="QueryTextBox_KeyUp"
                         Visibility="Visible">
                         <TextBox.CommandBindings>

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -173,7 +173,8 @@
                         Background="Transparent"
                         PreviewDragOver="OnPreviewDragOver"
                         Style="{DynamicResource QueryBoxStyle}"
-                        Text="{Binding QueryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        Text="{Binding QueryText, Mode=TwoWay, UpdateSourceTrigger=Explicit}"
+                        PreviewKeyUp="QueryTextBox_KeyUp"
                         Visibility="Visible">
                         <TextBox.CommandBindings>
                             <CommandBinding Command="ApplicationCommands.Copy" Executed="OnCopy" />

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -561,7 +561,10 @@ namespace Flow.Launcher
         private void QueryTextBox_KeyUp(object sender, KeyEventArgs e)
         {
             if(_viewModel.QueryText != QueryTextBox.Text)
-                _viewModel.QueryText = QueryTextBox.Text;
+            {
+                BindingExpression be = QueryTextBox.GetBindingExpression(System.Windows.Controls.TextBox.TextProperty);
+                be.UpdateSource();
+            }
         }
     }
 }

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows;
@@ -20,6 +20,7 @@ using Flow.Launcher.Infrastructure;
 using System.Windows.Media;
 using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Plugin.SharedCommands;
+using System.Windows.Data;
 
 namespace Flow.Launcher
 {
@@ -554,6 +555,12 @@ namespace Flow.Launcher
             {
                 ModernWpf.ThemeManager.Current.ApplicationTheme = ModernWpf.ApplicationTheme.Dark;
             }
+        }
+
+        private void QueryTextBox_KeyUp(object sender, KeyEventArgs e)
+        {
+            BindingExpression be = QueryTextBox.GetBindingExpression(System.Windows.Controls.TextBox.TextProperty);
+            be.UpdateSource();
         }
     }
 }

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -21,6 +21,7 @@ using System.Windows.Media;
 using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Plugin.SharedCommands;
 using System.Windows.Data;
+using System.Diagnostics;
 
 namespace Flow.Launcher
 {
@@ -559,8 +560,7 @@ namespace Flow.Launcher
 
         private void QueryTextBox_KeyUp(object sender, KeyEventArgs e)
         {
-            BindingExpression be = QueryTextBox.GetBindingExpression(System.Windows.Controls.TextBox.TextProperty);
-            be.UpdateSource();
+            _viewModel.ChangeQueryText(QueryTextBox.Text);
         }
     }
 }

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -560,7 +560,8 @@ namespace Flow.Launcher
 
         private void QueryTextBox_KeyUp(object sender, KeyEventArgs e)
         {
-            _viewModel.ChangeQueryText(QueryTextBox.Text);
+            if(_viewModel.QueryText != QueryTextBox.Text)
+                _viewModel.QueryText = QueryTextBox.Text;
         }
     }
 }


### PR DESCRIPTION
Fixed an error when typing QueryTextBox in specific language.
For example, if the user enters "안녕하세요" and presses the Enter key immediately, it will be searched as "안녕하세".