### PR TITLE
Fixed Progressbar Binding Error (ProgressBar Value is Not Nullable)

### DIFF
--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -201,7 +201,12 @@ namespace Flow.Launcher.Plugin
         /// <summary>
         /// Progress bar display. Providing an int value between 0-100 will trigger the progress bar to be displayed on the result
         /// </summary>
-        public int? ProgressBar { get; set; }
+        public int ProgressBarValue { get; set; }
+
+        /// <summary>
+        /// Progress bar visibility Check
+        /// </summary>
+        public bool IsProgressBarVisible { get; set; } = false;
 
         /// <summary>
         /// Optionally set the color of the progress bar

--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -201,12 +201,7 @@ namespace Flow.Launcher.Plugin
         /// <summary>
         /// Progress bar display. Providing an int value between 0-100 will trigger the progress bar to be displayed on the result
         /// </summary>
-        public int ProgressBarValue { get; set; }
-
-        /// <summary>
-        /// Progress bar visibility Check
-        /// </summary>
-        public bool IsProgressBarVisible { get; set; } = false;
+        public int? ProgressBar { get; set; }
 
         /// <summary>
         /// Optionally set the color of the progress bar

--- a/Flow.Launcher/ResultListBox.xaml
+++ b/Flow.Launcher/ResultListBox.xaml
@@ -28,10 +28,6 @@
     mc:Ignorable="d">
     <!--  IsSynchronizedWithCurrentItem: http://stackoverflow.com/a/7833798/2833083  -->
 
-    <ListBox.Resources>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
-    </ListBox.Resources>
-    
     <ListBox.ItemTemplate>
         <DataTemplate>
             <Button HorizontalAlignment="Stretch">
@@ -118,9 +114,18 @@
                             <ProgressBar
                                 x:Name="progressbarResult"
                                 Foreground="{Binding Result.ProgressBarColor}"
-                                Style="{DynamicResource ProgressBarResult}"
-                                Value="{Binding Result.ProgressBarValue}"
-                                Visibility="{Binding Result.IsProgressBarVisible, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                Value="{Binding ResultProgress, Mode=OneWay}">
+                                <ProgressBar.Style>
+                                    <Style TargetType="ProgressBar" BasedOn="{StaticResource ProgressBarResult}">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Result.ProgressBar}" Value="{x:Null}">
+                                                <Setter Property="Visibility" Value="Collapsed"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ProgressBar.Style>
+                            </ProgressBar>
                             <TextBlock
                                 x:Name="Title"
                                 VerticalAlignment="Center"

--- a/Flow.Launcher/ResultListBox.xaml
+++ b/Flow.Launcher/ResultListBox.xaml
@@ -115,7 +115,7 @@
                                 x:Name="progressbarResult"
                                 Foreground="{Binding Result.ProgressBarColor}"
                                 Style="{DynamicResource ProgressBarResult}"
-                                Value="{Binding Result.ProgressBar}" />
+                                Value="{Binding Result.ProgressBarValue}" />
                             <TextBlock
                                 x:Name="Title"
                                 VerticalAlignment="Center"

--- a/Flow.Launcher/ResultListBox.xaml
+++ b/Flow.Launcher/ResultListBox.xaml
@@ -28,6 +28,10 @@
     mc:Ignorable="d">
     <!--  IsSynchronizedWithCurrentItem: http://stackoverflow.com/a/7833798/2833083  -->
 
+    <ListBox.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+    </ListBox.Resources>
+    
     <ListBox.ItemTemplate>
         <DataTemplate>
             <Button HorizontalAlignment="Stretch">
@@ -115,7 +119,8 @@
                                 x:Name="progressbarResult"
                                 Foreground="{Binding Result.ProgressBarColor}"
                                 Style="{DynamicResource ProgressBarResult}"
-                                Value="{Binding Result.ProgressBarValue}" />
+                                Value="{Binding Result.ProgressBarValue}"
+                                Visibility="{Binding Result.IsProgressBarVisible, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                             <TextBlock
                                 x:Name="Title"
                                 VerticalAlignment="Center"

--- a/Flow.Launcher/Themes/Base.xaml
+++ b/Flow.Launcher/Themes/Base.xaml
@@ -4,6 +4,8 @@
     xmlns:system="clr-namespace:System;assembly=mscorlib"
     xmlns:userSettings="clr-namespace:Flow.Launcher.Infrastructure.UserSettings;assembly=Flow.Launcher.Infrastructure">
 
+    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+
     <!--  Further font customisations are dynamically loaded in Theme.cs  -->
     <Style x:Key="BaseQueryBoxStyle" TargetType="{x:Type TextBox}">
         <Setter Property="BorderThickness" Value="0" />
@@ -89,11 +91,7 @@
         <Setter Property="Minimum" Value="0" />
         <Setter Property="Visibility" Value="Visible" />
         <Setter Property="Foreground" Value="#26a0da " />
-        <Style.Triggers>
-            <DataTrigger Binding="{Binding Result.ProgressBar}" Value="{x:Null}">
-                <Setter Property="Visibility" Value="Collapsed" />
-            </DataTrigger>
-        </Style.Triggers>
+        <Setter Property="Visibility" Value="{Binding Result.IsProgressBarVisible, Converter={StaticResource BooleanToVisibilityConverter}}"/>
     </Style>
 
     <Style x:Key="BaseItemTitleStyle" TargetType="{x:Type TextBlock}">

--- a/Flow.Launcher/Themes/Base.xaml
+++ b/Flow.Launcher/Themes/Base.xaml
@@ -3,9 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:system="clr-namespace:System;assembly=mscorlib"
     xmlns:userSettings="clr-namespace:Flow.Launcher.Infrastructure.UserSettings;assembly=Flow.Launcher.Infrastructure">
-
-    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
-
+    
     <!--  Further font customisations are dynamically loaded in Theme.cs  -->
     <Style x:Key="BaseQueryBoxStyle" TargetType="{x:Type TextBox}">
         <Setter Property="BorderThickness" Value="0" />
@@ -91,7 +89,6 @@
         <Setter Property="Minimum" Value="0" />
         <Setter Property="Visibility" Value="Visible" />
         <Setter Property="Foreground" Value="#26a0da " />
-        <Setter Property="Visibility" Value="{Binding Result.IsProgressBarVisible, Converter={StaticResource BooleanToVisibilityConverter}}"/>
     </Style>
 
     <Style x:Key="BaseItemTitleStyle" TargetType="{x:Type TextBlock}">

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -162,6 +162,16 @@ namespace Flow.Launcher.ViewModel
         }
 
         public Result Result { get; }
+        public int ResultProgress
+        {
+            get
+            {
+                if (Result.ProgressBar == null)
+                    return 0;
+
+                return Result.ProgressBar.Value;
+            }
+        }
 
         public string QuerySuggestionText { get; set; }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -100,8 +100,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 AutoCompleteText = GetPathWithActionKeyword(path, ResultType.Folder),
                 IcoPath = path,
                 Score = 500,
-                ProgressBarValue = progressValue,
-                IsProgressBarVisible = true,
+                ProgressBar = progressValue,
                 ProgressBarColor = progressBarColor,
                 Action = c =>
                 {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -80,7 +80,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         internal static Result CreateDriveSpaceDisplayResult(string path, bool windowsIndexed = false)
         {
             var progressBarColor = "#26a0da";
-            int? progressValue = null;
+            int progressValue = 0;
             var title = string.Empty; // hide title when use progress bar,
             var driveLetter = path.Substring(0, 1).ToUpper();
             var driveName = driveLetter + ":\\";
@@ -100,7 +100,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 AutoCompleteText = GetPathWithActionKeyword(path, ResultType.Folder),
                 IcoPath = path,
                 Score = 500,
-                ProgressBar = progressValue,
+                ProgressBarValue = progressValue,
+                IsProgressBarVisible = true,
                 ProgressBarColor = progressBarColor,
                 Action = c =>
                 {


### PR DESCRIPTION
When the item in the ResultListBox was added, fixed progressbar binding error.


```
System.Windows.Data Error: 40 : BindingExpression path error: 'ProgressBarVisibility' property not found on 'object' ''Result' (HashCode=1859780700)'. BindingExpression:Path=Result.ProgressBarVisibility; DataItem='ResultViewModel' (HashCode=1859780700); target element is 'ProgressBar' (Name=''); target property is 'Visibility' (type 'Visibility')
```