### PR TITLE
Fix opening url twice when clicking on exception report link

### DIFF
--- a/Flow.Launcher/ReportWindow.xaml.cs
+++ b/Flow.Launcher/ReportWindow.xaml.cs
@@ -77,7 +77,6 @@ namespace Flow.Launcher
             };
             link.Inlines.Add(url);
             link.NavigateUri = new Uri(url);
-            link.RequestNavigate += (s, e) => SearchWeb.OpenInBrowserTab(e.Uri.ToString());
             link.Click += (s, e) => SearchWeb.OpenInBrowserTab(url);
 
             paragraph.Inlines.Add(textBeforeUrl);


### PR DESCRIPTION
To repro:

1. Cause an exception
2. Ctrl + click on the exception report window link
3. Observe the link is opened twice in two browser tabs
(If you can debugging locally, you can install GitHub Quick Launcher and type query 'gr' and exception window will pop up. This exception is not an issue with the plugin, but because flow is not run from the expected Local AppData location.)

![image](https://user-images.githubusercontent.com/26427004/190639191-c3f496e2-0967-4029-8c06-e8f7c35efead.png)

