### PR TITLE
Spanish & Spanish Latin America languages release for v1.9.5

### DIFF
--- a/Flow.Launcher/Languages/es-419.xaml
+++ b/Flow.Launcher/Languages/es-419.xaml
@@ -1,0 +1,290 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+    <!--  MainWindow  -->
+    <system:String x:Key="registerHotkeyFailed">Error al registrar la tecla de acceso directo: {0}</system:String>
+    <system:String x:Key="couldnotStartCmd">No se pudo iniciar {0}</system:String>
+    <system:String x:Key="invalidFlowLauncherPluginFileFormat">Formato de archivo de plugin Flow Launcher inválido</system:String>
+    <system:String x:Key="setAsTopMostInThisQuery">Establecer como superior en esta consulta</system:String>
+    <system:String x:Key="cancelTopMostInThisQuery">Quitar como superior en esta consulta</system:String>
+    <system:String x:Key="executeQuery">Ejecutar consulta: {0}</system:String>
+    <system:String x:Key="lastExecuteTime">Fecha de última ejecución: {0}</system:String>
+    <system:String x:Key="iconTrayOpen">Abrir</system:String>
+    <system:String x:Key="iconTraySettings">Ajustes</system:String>
+    <system:String x:Key="iconTrayAbout">Acerca de</system:String>
+    <system:String x:Key="iconTrayExit">Salir</system:String>
+    <system:String x:Key="closeWindow">Cerrar</system:String>
+    <system:String x:Key="copy">Copiar</system:String>
+    <system:String x:Key="cut">Cortar</system:String>
+    <system:String x:Key="paste">Pegar</system:String>
+    <system:String x:Key="fileTitle">Archivo</system:String>
+    <system:String x:Key="folderTitle">Carpeta</system:String>
+    <system:String x:Key="textTitle">Texto</system:String>
+    <system:String x:Key="GameMode">Modo de juego</system:String>
+    <system:String x:Key="GameModeToolTip">Suspender el uso de las teclas de acceso directo.</system:String>
+
+    <!--  Setting General  -->
+    <system:String x:Key="flowlauncher_settings">Ajustes de Flow Launcher</system:String>
+    <system:String x:Key="general">General</system:String>
+    <system:String x:Key="portableMode">Modo portable</system:String>
+    <system:String x:Key="portableModeToolTIp">Almacena todos los ajustes y datos de usuario en una sola carpeta (útil cuando se utiliza con unidades extraíbles o servicios en la nube).</system:String>
+    <system:String x:Key="startFlowLauncherOnSystemStartup">Iniciar Flow Launcher al arrancar el sistema</system:String>
+    <system:String x:Key="setAutoStartFailed">Error setting launch on startup</system:String>
+    <system:String x:Key="hideFlowLauncherWhenLoseFocus">Ocultar Flow Launcher cuando se pierde el enfoque</system:String>
+    <system:String x:Key="dontPromptUpdateMsg">No mostrar notificaciones de nuevas versiones</system:String>
+    <system:String x:Key="rememberLastLocation">Recordar última ubicación de inicio</system:String>
+    <system:String x:Key="language">Idioma</system:String>
+    <system:String x:Key="lastQueryMode">Estilo de la última consulta</system:String>
+    <system:String x:Key="lastQueryModeToolTip">Mostrar/Ocultar resultados anteriores cuando Flow Launcher es reactivado.</system:String>
+    <system:String x:Key="LastQueryPreserved">Conservar última consulta</system:String>
+    <system:String x:Key="LastQuerySelected">Seleccionar última consulta</system:String>
+    <system:String x:Key="LastQueryEmpty">Borrar última consulta</system:String>
+    <system:String x:Key="maxShowResults">Máximo de resultados mostrados</system:String>
+    <system:String x:Key="ignoreHotkeysOnFullscreen">Ignorar atajos de teclado en modo pantalla completa</system:String>
+    <system:String x:Key="ignoreHotkeysOnFullscreenToolTip">Deshabilitar Flow Launcher cuando una aplicación de pantalla completa está activa (Recomendado para juegos).</system:String>
+    <system:String x:Key="defaultFileManager">Gestor de archivos predeterminado</system:String>
+    <system:String x:Key="defaultFileManagerToolTip">Seleccione el gestor de archivos a utilizar al abrir la carpeta.</system:String>
+    <system:String x:Key="defaultBrowser">Navegador web predeterminado</system:String>
+    <system:String x:Key="defaultBrowserToolTip">Configuración para Nueva Pestaña, Nueva Ventana, Modo Privado.</system:String>
+    <system:String x:Key="pythonDirectory">Directorio de Python</system:String>
+    <system:String x:Key="autoUpdates">Actualización automática</system:String>
+    <system:String x:Key="selectPythonDirectory">Seleccionar</system:String>
+    <system:String x:Key="hideOnStartup">Ocultar Flow Launcher al arrancar el sistema</system:String>
+    <system:String x:Key="hideNotifyIcon">Ocultar icono de la bandeja</system:String>
+    <system:String x:Key="querySearchPrecision">Precisión de la búsqueda</system:String>
+    <system:String x:Key="querySearchPrecisionToolTip">Cambia la puntuación mínima de similitud requerida para resultados.</system:String>
+    <system:String x:Key="ShouldUsePinyin">Debe usar Pinyin</system:String>
+    <system:String x:Key="ShouldUsePinyinToolTip">Permite el uso de Pinyin para la búsqueda. Pinyin es el sistema estándar de ortografía romanizada para traducir chino</system:String>
+    <system:String x:Key="shadowEffectNotAllowed">El efecto de sombra no está permitido mientras el tema actual tenga el efecto de desenfoque habilitado</system:String>
+
+    <!--  Setting Plugin  -->
+    <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="browserMorePlugins">Encontrar más plugins</system:String>
+    <system:String x:Key="enable">Activado</system:String>
+    <system:String x:Key="disable">Desactivado</system:String>
+    <system:String x:Key="actionKeywordsTitle">Ajuste de palabra clave</system:String>
+    <system:String x:Key="actionKeywords">Palabra clave</system:String>
+    <system:String x:Key="currentActionKeywords">Palabra clave actual</system:String>
+    <system:String x:Key="newActionKeyword">Nueva palabra clave</system:String>
+    <system:String x:Key="actionKeywordsTooltip">Cambiar palabras clave</system:String>
+    <system:String x:Key="currentPriority">Prioridad Actual</system:String>
+    <system:String x:Key="newPriority">Nueva Prioridad</system:String>
+    <system:String x:Key="priority">Prioridad</system:String>
+    <system:String x:Key="pluginDirectory">Directorio de Plugins</system:String>
+    <system:String x:Key="author">por</system:String>
+    <system:String x:Key="plugin_init_time">Tiempo de inicio:</system:String>
+    <system:String x:Key="plugin_query_time">Tiempo de consulta:</system:String>
+    <system:String x:Key="plugin_query_version">| Versión</system:String>
+    <system:String x:Key="plugin_query_web">Sitio web</system:String>
+
+
+    <!--  Setting Plugin Store  -->
+    <system:String x:Key="pluginStore">Tienda de Plugins</system:String>
+    <system:String x:Key="refresh">Recargar</system:String>
+    <system:String x:Key="install">Instalar</system:String>
+
+    <!--  Setting Theme  -->
+    <system:String x:Key="theme">Tema</system:String>
+    <system:String x:Key="browserMoreThemes">Galería de Temas</system:String>
+    <system:String x:Key="howToCreateTheme">Cómo crear un tema</system:String>
+    <system:String x:Key="hiThere">Hola</system:String>
+    <system:String x:Key="queryBoxFont">Fuente del cuadro de consulta</system:String>
+    <system:String x:Key="resultItemFont">Fuente de los resultados</system:String>
+    <system:String x:Key="windowMode">Modo Ventana</system:String>
+    <system:String x:Key="opacity">Opacidad</system:String>
+    <system:String x:Key="theme_load_failure_path_not_exists">Tema {0} no existe, se usará al tema predeterminado</system:String>
+    <system:String x:Key="theme_load_failure_parse_error">Error al cargar el tema {0}, se usará al tema predeterminado</system:String>
+    <system:String x:Key="ThemeFolder">Carpeta de Temas</system:String>
+    <system:String x:Key="OpenThemeFolder">Abrir Carpeta de Temas</system:String>
+    <system:String x:Key="ColorScheme">Esquemas de Colores</system:String>
+    <system:String x:Key="ColorSchemeSystem">Determinado por el Sistema</system:String>
+    <system:String x:Key="ColorSchemeLight">Claro</system:String>
+    <system:String x:Key="ColorSchemeDark">Oscuro</system:String>
+    <system:String x:Key="SoundEffect">Efectos de Sonido</system:String>
+    <system:String x:Key="SoundEffectTip">Reproducir un sonido al abrir la ventana de búsqueda</system:String>
+    <system:String x:Key="Animation">Animación</system:String>
+    <system:String x:Key="AnimationTip">Usar Animación en la Interfaz</system:String>
+
+    <!--  Setting Hotkey  -->
+    <system:String x:Key="hotkey">Tecla Rápida</system:String>
+    <system:String x:Key="flowlauncherHotkey">Tecla de acceso a Flow Launcher</system:String>
+    <system:String x:Key="flowlauncherHotkeyToolTip">Introduzca el acceso directo para mostrar/ocultar Flow Launcher.</system:String>
+    <system:String x:Key="openResultModifiers">Abrir Tecla de Modificación de Resultado</system:String>
+    <system:String x:Key="openResultModifiersToolTip">Seleccione una tecla de modificación para abrir el resultado seleccionado vía teclado.</system:String>
+    <system:String x:Key="showOpenResultHotkey">Mostrar tecla de acceso directo</system:String>
+    <system:String x:Key="showOpenResultHotkeyToolTip">Mostrar tecla rápida de selección con resultados.</system:String>
+    <system:String x:Key="customQueryHotkey">Tecla Rápida de Consulta Personalizada</system:String>
+    <system:String x:Key="customQuery">Consulta</system:String>
+    <system:String x:Key="delete">Eliminar</system:String>
+    <system:String x:Key="edit">Editar</system:String>
+    <system:String x:Key="add">Añadir</system:String>
+    <system:String x:Key="pleaseSelectAnItem">Por favor, seleccione un elemento</system:String>
+    <system:String x:Key="deleteCustomHotkeyWarning">¿Está seguro que desea eliminar la tecla de acceso directo del plugin {0}?</system:String>
+    <system:String x:Key="queryWindowShadowEffect">Efecto de sombra de ventana de búsqueda</system:String>
+    <system:String x:Key="shadowEffectCPUUsage">El efecto sombra tiene un uso sustancial de GPU. No se recomienda si el rendimiento de su computadora es limitado.</system:String>
+    <system:String x:Key="windowWidthSize">Tamaño de Ancho de Ventana</system:String>
+    <system:String x:Key="useGlyphUI">Usar Iconos de Segoe Fluent</system:String>
+    <system:String x:Key="useGlyphUIEffect">Usar iconos de Segoe Fluent para resultados de consultas que sean soportados</system:String>
+
+    <!--  Setting Proxy  -->
+    <system:String x:Key="proxy">Proxy HTTP</system:String>
+    <system:String x:Key="enableProxy">Habilitar Proxy HTTP</system:String>
+    <system:String x:Key="server">Servidor HTTP</system:String>
+    <system:String x:Key="port">Puerto</system:String>
+    <system:String x:Key="userName">Nombre de Usuario</system:String>
+    <system:String x:Key="password">Contraseña</system:String>
+    <system:String x:Key="testProxy">Probar Proxy</system:String>
+    <system:String x:Key="save">Guardar</system:String>
+    <system:String x:Key="serverCantBeEmpty">El campo del servidor no puede estar vacío</system:String>
+    <system:String x:Key="portCantBeEmpty">El campo de puerto no puede estar vacío</system:String>
+    <system:String x:Key="invalidPortFormat">Formato de puerto inválido</system:String>
+    <system:String x:Key="saveProxySuccessfully">Configuración de proxy guardada correctamente</system:String>
+    <system:String x:Key="proxyIsCorrect">Proxy configurado correctamente</system:String>
+    <system:String x:Key="proxyConnectFailed">Conexión con proxy fallida</system:String>
+
+    <!--  Setting About  -->
+    <system:String x:Key="about">Acerca de</system:String>
+    <system:String x:Key="website">Sitio web</system:String>
+    <system:String x:Key="github">GitHub</system:String>
+    <system:String x:Key="docs">Documentación</system:String>
+    <system:String x:Key="version">Versión</system:String>
+    <system:String x:Key="about_activate_times">Has activado Flow Launcher {0} veces</system:String>
+    <system:String x:Key="checkUpdates">Buscar actualizaciones</system:String>
+    <system:String x:Key="newVersionTips">La nueva versión {0} está disponible, ¿desea reiniciar Flow Launcher para usar la actualización?</system:String>
+    <system:String x:Key="checkUpdatesFailed">Falló la comprobación de actualizaciones, compruebe su conexión y configuración de proxy a api.github.com.</system:String>
+    <system:String x:Key="downloadUpdatesFailed">
+        Falló la descarga de actualizaciones, por favor compruebe su conexión y configuración de proxy agithub-cloud.s3.amazonaws.com,
+        o vaya a https://github.com/Flow-Launcher/Flow.Launcher/releases para descargar actualizaciones manualmente.
+    </system:String>
+    <system:String x:Key="releaseNotes">Notas de la versión</system:String>
+    <system:String x:Key="documentation">Consejos de Uso</system:String>
+    <system:String x:Key="devtool">Herramientas de desarrollo</system:String>
+    <system:String x:Key="settingfolder">Carpeta de Configuración</system:String>
+    <system:String x:Key="logfolder">Carpeta de registros</system:String>
+    <system:String x:Key="welcomewindow">Asistente</system:String>
+
+    <!--  FileManager Setting Dialog  -->
+    <system:String x:Key="fileManagerWindow">Seleccionar Gestor de Archivos</system:String>
+    <system:String x:Key="fileManager_tips">Por favor, especifique la ubicación del gestor de archivos que utiliza y añada argumentos si es necesario. Los argumentos por defecto son &quot;%d&quot;, y se introduce una ruta en esa ubicación. Por ejemplo, si se requiere un comando como &quot;totalcmd.exe /A c:\windows&quot;, el argumento es /A &quot;%d&quot;.</system:String>
+    <system:String x:Key="fileManager_tips2">&quot;%f&quot; es un argumento que representa la ruta del archivo. Se utiliza para enfatizar el nombre de archivo/carpeta al abrir una ubicación específica de archivo en un gestor de archivos de terceros. Este argumento sólo está disponible en el elemento &quot;Arg para Archivo&quot;. Si el gestor de archivos no tiene esa función, puede utilizar &quot;%d&quot;.</system:String>
+    <system:String x:Key="fileManager_name">Gestor de Archivos</system:String>
+    <system:String x:Key="fileManager_profile_name">Nombre de Perfil</system:String>
+    <system:String x:Key="fileManager_path">Ruta del Gestor de Archivos</system:String>
+    <system:String x:Key="fileManager_directory_arg">Arg para Carpeta</system:String>
+    <system:String x:Key="fileManager_file_arg">Arg para Archivo</system:String>
+
+    <!--  DefaultBrowser Setting Dialog  -->
+    <system:String x:Key="defaultBrowserTitle">Navegador Web Predeterminado</system:String>
+    <system:String x:Key="defaultBrowser_tips">La configuración predeterminada sigue la configuración por defecto del navegador del sistema operativo. Si se especifica por separado, Flow utiliza ese navegador.</system:String>
+    <system:String x:Key="defaultBrowser_name">Navegador</system:String>
+    <system:String x:Key="defaultBrowser_profile_name">Nombre del Navegador</system:String>
+    <system:String x:Key="defaultBrowser_path">Ruta del Navegador</system:String>
+    <system:String x:Key="defaultBrowser_newWindow">Nueva Ventana</system:String>
+    <system:String x:Key="defaultBrowser_newTab">Nueva Pestaña</system:String>
+    <system:String x:Key="defaultBrowser_parameter">Modo Privado</system:String>
+
+    <!--  Priority Setting Dialog  -->
+    <system:String x:Key="changePriorityWindow">Cambiar Prioridad</system:String>
+    <system:String x:Key="priority_tips">Mayor el número, mayor la clasificación del resultado. Intente establecerlo como 5. Si desea que los resultados sean inferiores a cualquier otro plugin, proporcione un número negativo</system:String>
+    <system:String x:Key="invalidPriority">¡Por favor, proporcione un entero válido para la prioridad!</system:String>
+
+    <!--  Action Keyword Setting Dialog  -->
+    <system:String x:Key="oldActionKeywords">Palabra Clave Antigua</system:String>
+    <system:String x:Key="newActionKeywords">Nueva Palabra Clave</system:String>
+    <system:String x:Key="cancel">Cancelar</system:String>
+    <system:String x:Key="done">Hecho</system:String>
+    <system:String x:Key="cannotFindSpecifiedPlugin">No se puede encontrar el plugin especificado</system:String>
+    <system:String x:Key="newActionKeywordsCannotBeEmpty">La nueva palabra clave no puede estar vacía</system:String>
+    <system:String x:Key="newActionKeywordsHasBeenAssigned">Esta palabra clave ya está asignada a otro plugin, por favor elija una diferente</system:String>
+    <system:String x:Key="success">Éxito</system:String>
+    <system:String x:Key="completedSuccessfully">Completado con éxito</system:String>
+    <system:String x:Key="actionkeyword_tips">Introduzca la palabra clave que desea utilizar para iniciar el plugin. Utilice * si no desea especificar ninguno, y el plugin se activará sin ninguna palabra clave.</system:String>
+
+    <!--  Custom Query Hotkey Dialog  -->
+    <system:String x:Key="customeQueryHotkeyTitle">Tecla de Acceso Personalizada</system:String>
+    <system:String x:Key="customeQueryHotkeyTips">Presione la tecla de acceso personalizada para insertar automáticamente la consulta especificada.</system:String>
+    <system:String x:Key="preview">Vista previa</system:String>
+    <system:String x:Key="hotkeyIsNotUnavailable">Tecla no disponible, por favor seleccione una nueva tecla de acceso directo</system:String>
+    <system:String x:Key="invalidPluginHotkey">Tecla de acceso directo al plugin inválida</system:String>
+    <system:String x:Key="update">Actualizar</system:String>
+
+    <!--  Hotkey Control  -->
+    <system:String x:Key="hotkeyUnavailable">Tecla No Disponible</system:String>
+
+    <!--  Crash Reporter  -->
+    <system:String x:Key="reportWindow_version">Versión</system:String>
+    <system:String x:Key="reportWindow_time">Hora</system:String>
+    <system:String x:Key="reportWindow_reproduce">Por favor, díganos cómo falló la aplicación para que podamos arreglarla</system:String>
+    <system:String x:Key="reportWindow_send_report">Enviar Reporte</system:String>
+    <system:String x:Key="reportWindow_cancel">Cancelar</system:String>
+    <system:String x:Key="reportWindow_general">General</system:String>
+    <system:String x:Key="reportWindow_exceptions">Excepciones</system:String>
+    <system:String x:Key="reportWindow_exception_type">Tipo de Excepción</system:String>
+    <system:String x:Key="reportWindow_source">Fuente</system:String>
+    <system:String x:Key="reportWindow_stack_trace">Traza de Pila</system:String>
+    <system:String x:Key="reportWindow_sending">Enviando</system:String>
+    <system:String x:Key="reportWindow_report_succeed">Informe enviado correctamente</system:String>
+    <system:String x:Key="reportWindow_report_failed">Error al enviar el informe</system:String>
+    <system:String x:Key="reportWindow_flowlauncher_got_an_error">Flow Launcher ha tenido un error</system:String>
+
+    <!--  General Notice  -->
+    <system:String x:Key="pleaseWait">Por favor espere...</system:String>
+
+    <!--  update  -->
+    <system:String x:Key="update_flowlauncher_update_check">Buscando nueva actualización</system:String>
+    <system:String x:Key="update_flowlauncher_already_on_latest">Ya esta instalada la última versión de Flow Launcher</system:String>
+    <system:String x:Key="update_flowlauncher_update_found">Actualización encontrada</system:String>
+    <system:String x:Key="update_flowlauncher_updating">Actualizando...</system:String>
+    <system:String x:Key="update_flowlauncher_fail_moving_portable_user_profile_data">
+        Flow Launcher no pudo mover los datos de su perfil de usuario a la nueva versión de actualización.
+        Por favor, mueva manualmente la carpeta de datos de su perfil de {0} a {1}
+    </system:String>
+    <system:String x:Key="update_flowlauncher_new_update">Nueva Actualización</system:String>
+    <system:String x:Key="update_flowlauncher_update_new_version_available">La nueva versión {0} de Flow Launcher ya está disponible</system:String>
+    <system:String x:Key="update_flowlauncher_update_error">Ocurrió un error mientras se instalaban actualizaciones de software</system:String>
+    <system:String x:Key="update_flowlauncher_update">Actualizar</system:String>
+    <system:String x:Key="update_flowlauncher_update_cancel">Cancelar</system:String>
+    <system:String x:Key="update_flowlauncher_fail">Error al actualizar</system:String>
+    <system:String x:Key="update_flowlauncher_check_connection">Compruebe su conexión e intente actualizar la configuración del proxy a github-cloud.s3.amazonaws.com.</system:String>
+    <system:String x:Key="update_flowlauncher_update_restart_flowlauncher_tip">Esta actualización reiniciará Flow Launcher</system:String>
+    <system:String x:Key="update_flowlauncher_update_update_files">Los siguientes archivos serán actualizados</system:String>
+    <system:String x:Key="update_flowlauncher_update_files">Actualizar archivos</system:String>
+    <system:String x:Key="update_flowlauncher_update_update_description">Actualizar descripción</system:String>
+
+    <!--  Welcome Window  -->
+    <system:String x:Key="Skip">Omitir</system:String>
+    <system:String x:Key="Welcome_Page1_Title">Bienvenido a Flow Launcher</system:String>
+    <system:String x:Key="Welcome_Page1_Text01">¡Hola, esta es la primera vez que ejecutas Flow Launcher!</system:String>
+    <system:String x:Key="Welcome_Page1_Text02">Antes de comenzar, este asistente ayudará a configurar Flow Launcher. Puedes saltarlo si quieres. Por favor, elige un idioma</system:String>
+    <system:String x:Key="Welcome_Page2_Title">Busca y ejecuta todos los archivos y aplicaciones en tu PC</system:String>
+    <system:String x:Key="Welcome_Page2_Text01">Busca todo desde aplicaciones, archivos, marcadores, YouTube, Twitter y mucho más. Todo desde la comodidad de tu teclado sin tocar nunca el ratón.</system:String>
+    <system:String x:Key="Welcome_Page2_Text02">Flow Launcher comienza con la tecla de acceso directo de abajo, pruébala ahora. Para cambiarla, haga clic en la entrada y presione la tecla de acceso directo deseada.</system:String>
+    <system:String x:Key="Welcome_Page3_Title">Teclas De Acceso Directo</system:String>
+    <system:String x:Key="Welcome_Page4_Title">Palabra Clave y Comandos</system:String>
+    <system:String x:Key="Welcome_Page4_Text01">Busca en la web, inicia aplicaciones o haz uso de varias funciones a través de plugins en Flow Launcher. Algunas funciones necesitan una palabra clave, y si es necesario, pueden ser usadas sin palabras clave. Pruebe consultar lo siguiente en Flow Launcher.</system:String>
+    <system:String x:Key="Welcome_Page5_Title">Comencemos Flow Launcher</system:String>
+    <system:String x:Key="Welcome_Page5_Text01">Finalizado. Disfruta de Flow Launcher. No olvides la tecla de acceso directo para empezar :)</system:String>
+
+    <!--  General Guide & Hotkey  -->
+
+    <system:String x:Key="HotkeyUpDownDesc">Atrás / Menú Contextual</system:String>
+    <system:String x:Key="HotkeyLeftRightDesc">Navegación de Elemento</system:String>
+    <system:String x:Key="HotkeyShiftEnterDesc">Abrir Menú Contextual</system:String>
+    <system:String x:Key="HotkeyCtrlEnterDesc">Abrir Carpeta Contenedora</system:String>
+    <system:String x:Key="HotkeyCtrlShiftEnterDesc">Ejecutar como administrador</system:String>
+    <system:String x:Key="HotkeyCtrlHDesc">Historial de Consultas</system:String>
+    <system:String x:Key="HotkeyESCDesc">Volver al Resultado en el Menú Contextual</system:String>
+    <system:String x:Key="HotkeyTabDesc">Autocompletar</system:String>
+    <system:String x:Key="HotkeyRunDesc">Abrir / Ejecutar Elemento Seleccionado</system:String>
+    <system:String x:Key="HotkeyCtrlIDesc">Abrir Ventana de Ajustes</system:String>
+    <system:String x:Key="HotkeyF5Desc">Recargar Datos del Plugin</system:String>
+
+    <system:String x:Key="RecommendWeather">Clima</system:String>
+    <system:String x:Key="RecommendWeatherDesc">Clima en los Resultados de Google</system:String>
+    <system:String x:Key="RecommendShell">&gt; ping 8.8.8.8</system:String>
+    <system:String x:Key="RecommendShellDesc">Comando de Shell</system:String>
+    <system:String x:Key="RecommendBluetooth">Bluetooth</system:String>
+    <system:String x:Key="RecommendBluetoothDesc">Bluetooth en configuración de Windows</system:String>
+    <system:String x:Key="RecommendAcronyms">sn</system:String>
+    <system:String x:Key="RecommendAcronymsDesc">Notas adhesivas</system:String>
+
+</ResourceDictionary>

--- a/Flow.Launcher/Languages/es.xaml
+++ b/Flow.Launcher/Languages/es.xaml
@@ -1,0 +1,290 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+    <!--  MainWindow  -->
+    <system:String x:Key="registerHotkeyFailed">No se ha podido registrar el atajo de teclado: {0}</system:String>
+    <system:String x:Key="couldnotStartCmd">No se ha podido iniciar {0}</system:String>
+    <system:String x:Key="invalidFlowLauncherPluginFileFormat">Formato de archivo del plugin Flow Launcher no válido</system:String>
+    <system:String x:Key="setAsTopMostInThisQuery">Establecer como primer resultado en esta consulta</system:String>
+    <system:String x:Key="cancelTopMostInThisQuery">Cancelar como primer resultado en esta consulta</system:String>
+    <system:String x:Key="executeQuery">Ejecutar consulta: {0}</system:String>
+    <system:String x:Key="lastExecuteTime">Hora de la última ejecución: {0}</system:String>
+    <system:String x:Key="iconTrayOpen">Abrir</system:String>
+    <system:String x:Key="iconTraySettings">Configuración</system:String>
+    <system:String x:Key="iconTrayAbout">Acerca de</system:String>
+    <system:String x:Key="iconTrayExit">Salir</system:String>
+    <system:String x:Key="closeWindow">Cerrar</system:String>
+    <system:String x:Key="copy">Copiar</system:String>
+    <system:String x:Key="cut">Cortar</system:String>
+    <system:String x:Key="paste">Pegar</system:String>
+    <system:String x:Key="fileTitle">Archivo</system:String>
+    <system:String x:Key="folderTitle">Carpeta</system:String>
+    <system:String x:Key="textTitle">Texto</system:String>
+    <system:String x:Key="GameMode">Modo Juego</system:String>
+    <system:String x:Key="GameModeToolTip">Suspende el uso de atajos de teclado.</system:String>
+
+    <!--  Setting General  -->
+    <system:String x:Key="flowlauncher_settings">Configuración de Flow Launcher</system:String>
+    <system:String x:Key="general">General</system:String>
+    <system:String x:Key="portableMode">Modo Portable</system:String>
+    <system:String x:Key="portableModeToolTIp">Guarda toda la configuración y datos de usuario en una carpeta (Útil cuando se utiliza con unidades extraíbles o servicios en la nube).</system:String>
+    <system:String x:Key="startFlowLauncherOnSystemStartup">Cargar Flow Launcher al iniciar el sistema</system:String>
+    <system:String x:Key="setAutoStartFailed">Error de configuración de arranque al iniciar</system:String>
+    <system:String x:Key="hideFlowLauncherWhenLoseFocus">Ocultar Flow Launcher cuando se pierde el foco</system:String>
+    <system:String x:Key="dontPromptUpdateMsg">No mostrar notificaciones de nuevas versiones</system:String>
+    <system:String x:Key="rememberLastLocation">Recordar última posición de Flow Launcher</system:String>
+    <system:String x:Key="language">Idioma</system:String>
+    <system:String x:Key="lastQueryMode">Estilo de la última consulta</system:String>
+    <system:String x:Key="lastQueryModeToolTip">Muestra/Oculta resultados anteriores cuando Flow Launcher es reactivado.</system:String>
+    <system:String x:Key="LastQueryPreserved">Mantener la última consulta</system:String>
+    <system:String x:Key="LastQuerySelected">Seleccionar la última consulta</system:String>
+    <system:String x:Key="LastQueryEmpty">Limpiar la última consulta</system:String>
+    <system:String x:Key="maxShowResults">Número máximo de resultados mostrados</system:String>
+    <system:String x:Key="ignoreHotkeysOnFullscreen">Ignorar atajos de teclado en modo pantalla completa</system:String>
+    <system:String x:Key="ignoreHotkeysOnFullscreenToolTip">Desactiva Flow Launcher cuando una aplicación de pantalla completa está activa (Recomendado para juegos).</system:String>
+    <system:String x:Key="defaultFileManager">Administrador de archivos predeterminado</system:String>
+    <system:String x:Key="defaultFileManagerToolTip">Selecciona el administrador de archivos que se desea utilizar para abrir la carpeta.</system:String>
+    <system:String x:Key="defaultBrowser">Navegador web predeterminado</system:String>
+    <system:String x:Key="defaultBrowserToolTip">Configuración para Nueva Pestaña, Nueva Ventana, Modo Privado.</system:String>
+    <system:String x:Key="pythonDirectory">Carpeta de Python</system:String>
+    <system:String x:Key="autoUpdates">Actualización automática</system:String>
+    <system:String x:Key="selectPythonDirectory">Seleccionar</system:String>
+    <system:String x:Key="hideOnStartup">Ocultar Flow Launcher al inicio</system:String>
+    <system:String x:Key="hideNotifyIcon">Ocultar icono de la bandeja del sistema</system:String>
+    <system:String x:Key="querySearchPrecision">Precisión en la búsqueda de consultas</system:String>
+    <system:String x:Key="querySearchPrecisionToolTip">Cambia la puntuación mínima requerida para la coincidencia de los resultados.</system:String>
+    <system:String x:Key="ShouldUsePinyin">Utilizar Pinyin</system:String>
+    <system:String x:Key="ShouldUsePinyinToolTip">Permite utilizar Pinyin para la búsqueda. Pinyin es el sistema estándar de ortografía romanizado para traducir chino</system:String>
+    <system:String x:Key="shadowEffectNotAllowed">El efecto de sombra no está permitido mientras el tema actual tenga el efecto de desenfoque activado</system:String>
+
+    <!--  Setting Plugin  -->
+    <system:String x:Key="plugin">Complemento</system:String>
+    <system:String x:Key="browserMorePlugins">Buscar más complementos</system:String>
+    <system:String x:Key="enable">Activado</system:String>
+    <system:String x:Key="disable">Desactivado</system:String>
+    <system:String x:Key="actionKeywordsTitle">Configuración de la palabra clave de acción</system:String>
+    <system:String x:Key="actionKeywords">Palabra clave de acción</system:String>
+    <system:String x:Key="currentActionKeywords">Palabra clave de acción actual</system:String>
+    <system:String x:Key="newActionKeyword">Nueva palabra clave de acción</system:String>
+    <system:String x:Key="actionKeywordsTooltip">Cambia las palabras clave de acción</system:String>
+    <system:String x:Key="currentPriority">Prioridad actual</system:String>
+    <system:String x:Key="newPriority">Nueva prioridad</system:String>
+    <system:String x:Key="priority">Prioridad</system:String>
+    <system:String x:Key="pluginDirectory">Carpeta de complementos</system:String>
+    <system:String x:Key="author">por</system:String>
+    <system:String x:Key="plugin_init_time">Tiempo de inicio:</system:String>
+    <system:String x:Key="plugin_query_time">Tiempo de consulta:</system:String>
+    <system:String x:Key="plugin_query_version">| Versión</system:String>
+    <system:String x:Key="plugin_query_web">Sitio web</system:String>
+
+
+    <!--  Setting Plugin Store  -->
+    <system:String x:Key="pluginStore">Tienda de complementos</system:String>
+    <system:String x:Key="refresh">Refrescar</system:String>
+    <system:String x:Key="install">Instalar</system:String>
+
+    <!--  Setting Theme  -->
+    <system:String x:Key="theme">Tema</system:String>
+    <system:String x:Key="browserMoreThemes">Galería de temas</system:String>
+    <system:String x:Key="howToCreateTheme">Cómo crear un tema</system:String>
+    <system:String x:Key="hiThere">Hola</system:String>
+    <system:String x:Key="queryBoxFont">Fuente del texto del cuadro de consulta</system:String>
+    <system:String x:Key="resultItemFont">Fuente del texto de los resultados</system:String>
+    <system:String x:Key="windowMode">Modo Ventana</system:String>
+    <system:String x:Key="opacity">Opacidad</system:String>
+    <system:String x:Key="theme_load_failure_path_not_exists">El tema {0} no existe, activando el tema por defecto</system:String>
+    <system:String x:Key="theme_load_failure_parse_error">Fallo al cargar el tema {0}, activando el tema predeterminado</system:String>
+    <system:String x:Key="ThemeFolder">Carpeta de temas</system:String>
+    <system:String x:Key="OpenThemeFolder">Abrir carpeta de temas</system:String>
+    <system:String x:Key="ColorScheme">Esquema de colores</system:String>
+    <system:String x:Key="ColorSchemeSystem">Predeterminado del sistema</system:String>
+    <system:String x:Key="ColorSchemeLight">Claro</system:String>
+    <system:String x:Key="ColorSchemeDark">Oscuro</system:String>
+    <system:String x:Key="SoundEffect">Efecto de sonido</system:String>
+    <system:String x:Key="SoundEffectTip">Reproduce un pequeño sonido cuando se abre el cuadro de búsqueda</system:String>
+    <system:String x:Key="Animation">Animación</system:String>
+    <system:String x:Key="AnimationTip">Usar animación en la Interfaz de Usuario</system:String>
+
+    <!--  Setting Hotkey  -->
+    <system:String x:Key="hotkey">Atajo de teclado</system:String>
+    <system:String x:Key="flowlauncherHotkey">Atajo de teclado de Flow Launcher</system:String>
+    <system:String x:Key="flowlauncherHotkeyToolTip">Introduzca el atajo de teclado para mostrar/ocultar Flow Launcher.</system:String>
+    <system:String x:Key="openResultModifiers">Tecla modificadora para abrir resultado</system:String>
+    <system:String x:Key="openResultModifiersToolTip">Seleccione una tecla modificadora para abrir el resultado seleccionado con el teclado.</system:String>
+    <system:String x:Key="showOpenResultHotkey">Mostrar atajo de teclado</system:String>
+    <system:String x:Key="showOpenResultHotkeyToolTip">Muestra atajo de teclado de selección junto a los resultados.</system:String>
+    <system:String x:Key="customQueryHotkey">Atajo de teclado de consulta personalizada</system:String>
+    <system:String x:Key="customQuery">Consulta</system:String>
+    <system:String x:Key="delete">Eliminar</system:String>
+    <system:String x:Key="edit">Editar</system:String>
+    <system:String x:Key="add">Añadir</system:String>
+    <system:String x:Key="pleaseSelectAnItem">Por favor, seleccione un elemento</system:String>
+    <system:String x:Key="deleteCustomHotkeyWarning">¿Está seguro que desea eliminar el atajo de teclado del complemento {0}?</system:String>
+    <system:String x:Key="queryWindowShadowEffect">Efecto de sombra de la ventana de consultas</system:String>
+    <system:String x:Key="shadowEffectCPUUsage">El efecto de sombra hace un uso sustancial de la GPU. No se recomienda para ordenadores de rendimiento limitado.</system:String>
+    <system:String x:Key="windowWidthSize">Tamaño del ancho de la ventana</system:String>
+    <system:String x:Key="useGlyphUI">Usar iconos Segoe Fluent</system:String>
+    <system:String x:Key="useGlyphUIEffect">Usa iconos Segoe Fluent para los resultados de la consulta cuando sean compatibles</system:String>
+
+    <!--  Setting Proxy  -->
+    <system:String x:Key="proxy">Proxy HTTP</system:String>
+    <system:String x:Key="enableProxy">Habilitar proxy HTTP</system:String>
+    <system:String x:Key="server">Servidor HTTP</system:String>
+    <system:String x:Key="port">Puerto</system:String>
+    <system:String x:Key="userName">Nombre de usuario</system:String>
+    <system:String x:Key="password">Contraseña</system:String>
+    <system:String x:Key="testProxy">Probar proxy</system:String>
+    <system:String x:Key="save">Guardar</system:String>
+    <system:String x:Key="serverCantBeEmpty">El campo del servidor no puede estar vacío</system:String>
+    <system:String x:Key="portCantBeEmpty">El campo puerto no puede estar vacío</system:String>
+    <system:String x:Key="invalidPortFormat">Formato de puerto no válido</system:String>
+    <system:String x:Key="saveProxySuccessfully">Configuración del proxy guardada correctamente</system:String>
+    <system:String x:Key="proxyIsCorrect">Proxy configurado correctamente</system:String>
+    <system:String x:Key="proxyConnectFailed">La conexión con el proxy ha fallado</system:String>
+
+    <!--  Setting About  -->
+    <system:String x:Key="about">Acerca de</system:String>
+    <system:String x:Key="website">Sitio web</system:String>
+    <system:String x:Key="github">GitHub</system:String>
+    <system:String x:Key="docs">Documentación</system:String>
+    <system:String x:Key="version">Versión</system:String>
+    <system:String x:Key="about_activate_times">Ha activado Flow Launcher {0} veces</system:String>
+    <system:String x:Key="checkUpdates">Buscar actualizaciones</system:String>
+    <system:String x:Key="newVersionTips">La nueva versión {0} está disponible, ¿desea reiniciar Flow Launcher para actualizar?</system:String>
+    <system:String x:Key="checkUpdatesFailed">La comprobación de las actualizaciones ha fallado, por favor, compruebe la configuración de su proxy y conexión a api.github.com.</system:String>
+    <system:String x:Key="downloadUpdatesFailed">
+        La descarga de las actualizaciones ha fallado, por favor, compruebe la configuración de su proxy y conexión a github-cloud.s3.amazonaws.com,
+        o diríjase a https://github.com/Flow-Launcher/Flow.Launcher/releases para descargar actualizaciones manualmente.
+    </system:String>
+    <system:String x:Key="releaseNotes">Notas de la versión</system:String>
+    <system:String x:Key="documentation">Consejos de uso</system:String>
+    <system:String x:Key="devtool">Herramientas de desarrolador</system:String>
+    <system:String x:Key="settingfolder">Carpeta de configuración</system:String>
+    <system:String x:Key="logfolder">Carpeta de registros</system:String>
+    <system:String x:Key="welcomewindow">Asistente</system:String>
+
+    <!--  FileManager Setting Dialog  -->
+    <system:String x:Key="fileManagerWindow">Seleccionar administrador de archivos</system:String>
+    <system:String x:Key="fileManager_tips">Por favor, especifique la ubicación del administrador de archivos que desea utilizar y añada argumentos si es necesario. El argumento por defecto es &quot;%d&quot;, introduciendo una ruta en esa ubicación. Por ejemplo, si se requiere un comando como &quot;totalcmd.exe /A c:\windows&quot;, el argumento es /A &quot;%d&quot;.</system:String>
+    <system:String x:Key="fileManager_tips2">&quot;%f&quot; es un argumento que representa la ruta del archivo. Se utiliza para especificar el nombre de archivo/carpeta al abrir una ubicación específica con administradores de archivos de terceros. Este argumento sólo está disponible en el elemento &quot;Argumentos del archivo&quot;. Si el administrador de archivos no tiene esa función, puede utilizar &quot;%d&quot;.</system:String>
+    <system:String x:Key="fileManager_name">Administrador de archivos</system:String>
+    <system:String x:Key="fileManager_profile_name">Nombre del perfil</system:String>
+    <system:String x:Key="fileManager_path">Ruta del administrador de archivos</system:String>
+    <system:String x:Key="fileManager_directory_arg">Argumentos de la carpeta</system:String>
+    <system:String x:Key="fileManager_file_arg">Argumentos del archivo</system:String>
+
+    <!--  DefaultBrowser Setting Dialog  -->
+    <system:String x:Key="defaultBrowserTitle">Navegador web predeterminado</system:String>
+    <system:String x:Key="defaultBrowser_tips">La configuración por defecto utiliza el navegador predeterminado del sistema operativo. Si se indica uno específicamente, Flow Launcher utilizará este otro navegador.</system:String>
+    <system:String x:Key="defaultBrowser_name">Navegador</system:String>
+    <system:String x:Key="defaultBrowser_profile_name">Nombre del navegador</system:String>
+    <system:String x:Key="defaultBrowser_path">Ruta del navegador</system:String>
+    <system:String x:Key="defaultBrowser_newWindow">Nueva ventana</system:String>
+    <system:String x:Key="defaultBrowser_newTab">Nueva pestaña</system:String>
+    <system:String x:Key="defaultBrowser_parameter">Modo privado</system:String>
+
+    <!--  Priority Setting Dialog  -->
+    <system:String x:Key="changePriorityWindow">Cambiar la prioridad</system:String>
+    <system:String x:Key="priority_tips">A mayor número, más alto aparecerá el resultado. Inténtelo con 5. Si quiere que los resultados aparezcan más abajo que los de cualquier otro complemento, utilice un número negativo</system:String>
+    <system:String x:Key="invalidPriority">¡Por favor, proporcione un número entero válido para la prioridad!</system:String>
+
+    <!--  Action Keyword Setting Dialog  -->
+    <system:String x:Key="oldActionKeywords">Antigua palabra clave de acción</system:String>
+    <system:String x:Key="newActionKeywords">Nueva palabra clave de acción</system:String>
+    <system:String x:Key="cancel">Cancelar</system:String>
+    <system:String x:Key="done">Aceptar</system:String>
+    <system:String x:Key="cannotFindSpecifiedPlugin">No se puede encontrar el complemento especificado</system:String>
+    <system:String x:Key="newActionKeywordsCannotBeEmpty">La nueva palabra clave de acción no puede estar vacía</system:String>
+    <system:String x:Key="newActionKeywordsHasBeenAssigned">Esta nueva palabra clave de acción ya está asignada a otro complemento, por favor elija una diferente</system:String>
+    <system:String x:Key="success">Correcto</system:String>
+    <system:String x:Key="completedSuccessfully">Finalizado correctamente</system:String>
+    <system:String x:Key="actionkeyword_tips">Introduzca la palabra clave que desea utilizar para iniciar el complemento. Utilice * si no desea especificar ninguna, y el complemento se activará sin ninguna palabra clave.</system:String>
+
+    <!--  Custom Query Hotkey Dialog  -->
+    <system:String x:Key="customeQueryHotkeyTitle">Atajo de teclado de consulta personalizada</system:String>
+    <system:String x:Key="customeQueryHotkeyTips">Pulse el atajo de teclado personalizado para insertar automáticamente la consulta especificada.</system:String>
+    <system:String x:Key="preview">Vista previa</system:String>
+    <system:String x:Key="hotkeyIsNotUnavailable">El atajo de teclado no está disponible, por favor seleccione uno nuevo</system:String>
+    <system:String x:Key="invalidPluginHotkey">Atajo de teclado de complemento no válido</system:String>
+    <system:String x:Key="update">Actualizar</system:String>
+
+    <!--  Hotkey Control  -->
+    <system:String x:Key="hotkeyUnavailable">Atajo de teclado no disponible</system:String>
+
+    <!--  Crash Reporter  -->
+    <system:String x:Key="reportWindow_version">Versión</system:String>
+    <system:String x:Key="reportWindow_time">Hora</system:String>
+    <system:String x:Key="reportWindow_reproduce">Por favor, informe del fallo de la aplicación para poder solucionarlo</system:String>
+    <system:String x:Key="reportWindow_send_report">Enviar informe</system:String>
+    <system:String x:Key="reportWindow_cancel">Cancelar</system:String>
+    <system:String x:Key="reportWindow_general">General</system:String>
+    <system:String x:Key="reportWindow_exceptions">Excepciones</system:String>
+    <system:String x:Key="reportWindow_exception_type">Tipo de excepción</system:String>
+    <system:String x:Key="reportWindow_source">Origen</system:String>
+    <system:String x:Key="reportWindow_stack_trace">Rastreo de Pila</system:String>
+    <system:String x:Key="reportWindow_sending">Enviando</system:String>
+    <system:String x:Key="reportWindow_report_succeed">Informe enviado correctamente</system:String>
+    <system:String x:Key="reportWindow_report_failed">No se ha podido enviar el informe</system:String>
+    <system:String x:Key="reportWindow_flowlauncher_got_an_error">Flow Launcher ha tenido un error</system:String>
+
+    <!--  General Notice  -->
+    <system:String x:Key="pleaseWait">Por favor espere...</system:String>
+
+    <!--  update  -->
+    <system:String x:Key="update_flowlauncher_update_check">Comprobando actualizaciones</system:String>
+    <system:String x:Key="update_flowlauncher_already_on_latest">Ya tiene la última versión de Flow Launcher</system:String>
+    <system:String x:Key="update_flowlauncher_update_found">Actualización encontrada</system:String>
+    <system:String x:Key="update_flowlauncher_updating">Actualizando...</system:String>
+    <system:String x:Key="update_flowlauncher_fail_moving_portable_user_profile_data">
+        Flow Launcher no pudo mover sus datos de perfil de usuario a la nueva versión de actualización.
+        Por favor, mueva manualmente la carpeta de datos de su perfil de {0} a {1}
+    </system:String>
+    <system:String x:Key="update_flowlauncher_new_update">Nueva actualización</system:String>
+    <system:String x:Key="update_flowlauncher_update_new_version_available">La nueva versión {0} de Flow Launcher está disponible</system:String>
+    <system:String x:Key="update_flowlauncher_update_error">Se ha producido un error al intentar instalar actualizaciones de software</system:String>
+    <system:String x:Key="update_flowlauncher_update">Actualizar</system:String>
+    <system:String x:Key="update_flowlauncher_update_cancel">Cancelar</system:String>
+    <system:String x:Key="update_flowlauncher_fail">La actualización ha fallado</system:String>
+    <system:String x:Key="update_flowlauncher_check_connection">Compruebe su conexión e intente actualizar la configuración del proxy a github-cloud.s3.amazonaws.com.</system:String>
+    <system:String x:Key="update_flowlauncher_update_restart_flowlauncher_tip">Esta actualización reiniciará Flow Launcher</system:String>
+    <system:String x:Key="update_flowlauncher_update_update_files">Se actualizarán los siguientes archivos</system:String>
+    <system:String x:Key="update_flowlauncher_update_files">Actualizar archivos</system:String>
+    <system:String x:Key="update_flowlauncher_update_update_description">Actualizar descripción</system:String>
+
+    <!--  Welcome Window  -->
+    <system:String x:Key="Skip">Omitir</system:String>
+    <system:String x:Key="Welcome_Page1_Title">Bienvenido a Flow Launcher</system:String>
+    <system:String x:Key="Welcome_Page1_Text01">Hola, ¡Esta es la primera vez que ejecuta Flow Launcher!</system:String>
+    <system:String x:Key="Welcome_Page1_Text02">Antes de empezar, este asistente le ayudará a configurar Flow Launcher. Puede omitirlo si lo desea. Por favor, elija un idioma</system:String>
+    <system:String x:Key="Welcome_Page2_Title">Busque y ejecute todos los archivos y aplicaciones del equipo</system:String>
+    <system:String x:Key="Welcome_Page2_Text01">Busque todo, desde aplicaciones, archivos, marcadores, YouTube, Twitter y más. Todo desde la comodidad del teclado y sin tener que tocar el ratón.</system:String>
+    <system:String x:Key="Welcome_Page2_Text02">Flow Launcher se inicia con el atajo de teclado que se muestra a continuación, anímese y pruébelo ahora. Para cambiarlo, haga clic en la caja de texto y presione la nueva combinación de teclas.</system:String>
+    <system:String x:Key="Welcome_Page3_Title">Atajos de teclado</system:String>
+    <system:String x:Key="Welcome_Page4_Title">Palabra clave de acción y comandos</system:String>
+    <system:String x:Key="Welcome_Page4_Text01">Busque en la web, inicie aplicaciones o ejecute diversas funciones mediante los complementos de Flow Launcher. Algunas funciones comienzan con una palabra clave de acción y, si es necesario, pueden utilizarse sin ellas. Pruebe las siguientes consultas en Flow Launcher.</system:String>
+    <system:String x:Key="Welcome_Page5_Title">Iniciemos Flow Launcher</system:String>
+    <system:String x:Key="Welcome_Page5_Text01">Terminado. Disfruta de Flow Launcher. No olvides el atajo de teclado para empezar :)</system:String>
+
+    <!--  General Guide & Hotkey  -->
+
+    <system:String x:Key="HotkeyUpDownDesc">Atrás / Menú contextual</system:String>
+    <system:String x:Key="HotkeyLeftRightDesc">Navegación entre elementos</system:String>
+    <system:String x:Key="HotkeyShiftEnterDesc">Abrir menú contextual</system:String>
+    <system:String x:Key="HotkeyCtrlEnterDesc">Abrir carpeta contenedora</system:String>
+    <system:String x:Key="HotkeyCtrlShiftEnterDesc">Ejecutar como administrador</system:String>
+    <system:String x:Key="HotkeyCtrlHDesc">Historial de consultas</system:String>
+    <system:String x:Key="HotkeyESCDesc">Volver al resultado en menú contextual</system:String>
+    <system:String x:Key="HotkeyTabDesc">Autocompletar</system:String>
+    <system:String x:Key="HotkeyRunDesc">Abrir / Ejecutar elemento seleccionado</system:String>
+    <system:String x:Key="HotkeyCtrlIDesc">Abrir ventana de configuración</system:String>
+    <system:String x:Key="HotkeyF5Desc">Recargar datos del complemento</system:String>
+
+    <system:String x:Key="RecommendWeather">El tiempo</system:String>
+    <system:String x:Key="RecommendWeatherDesc">El tiempo en los resultados de Google</system:String>
+    <system:String x:Key="RecommendShell">&gt; ping 8.8.8.8</system:String>
+    <system:String x:Key="RecommendShellDesc">Comando de terminal</system:String>
+    <system:String x:Key="RecommendBluetooth">Bluetooth</system:String>
+    <system:String x:Key="RecommendBluetoothDesc">Bluetooth en la configuración de Windows</system:String>
+    <system:String x:Key="RecommendAcronyms">sn</system:String>
+    <system:String x:Key="RecommendAcronymsDesc">Notas adhesivas</system:String>
+
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Languages/es-419.xaml
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Languages/es-419.xaml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <!--  Plugin Info  -->
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_plugin_name">Marcadores del Navegador</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_plugin_description">Busca en los marcadores de tu navegador</system:String>
+
+    <!--  Settings  -->
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_bookmarkDataSetting">Datos de Marcadores</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_settings_openBookmarks">Abrir marcadores en:</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_settings_newWindow">Nueva ventana</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_settings_newTab">Nueva pestaña</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_settings_setBrowserFromPath">Establecer navegador desde ruta:</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_settings_choose">Elegir</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_copyurl_title">Copiar url</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_copyurl_subtitle">Copiar la url del marcador al portapapeles</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_loadBrowserFrom">Cargar navegador desde:</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_browserName">Nombre del Navegador</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_browserBookmarkDataDirectory">Ruta del Directorio de Datos</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_addBrowserBookmark">Añadir</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_removeBrowserBookmark">Eliminar</system:String>
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Languages/es.xaml
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Languages/es.xaml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <!--  Plugin Info  -->
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_plugin_name">Marcadores del navegador</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_plugin_description">Busque en sus marcadores del navegador</system:String>
+
+    <!--  Settings  -->
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_bookmarkDataSetting">Datos de marcador</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_settings_openBookmarks">Abrir marcadores en:</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_settings_newWindow">Nueva ventana</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_settings_newTab">Nueva pestaña</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_settings_setBrowserFromPath">Establecer navegador desde ruta:</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_settings_choose">Elegir</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_copyurl_title">Copiar url</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_copyurl_subtitle">Copia la url del marcador al portapapeles</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_loadBrowserFrom">Cargar navegador desde:</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_browserName">Nombre del navegador</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_browserBookmarkDataDirectory">Ruta del directorio de datos</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_addBrowserBookmark">Añadir</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_removeBrowserBookmark">Eliminar</system:String>
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Languages/es-419.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Languages/es-419.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="flowlauncher_plugin_caculator_plugin_name">Calculadora</system:String>
+    <system:String x:Key="flowlauncher_plugin_caculator_plugin_description">Permite hacer cálculos matemáticos. (Pruebe con 5*3-2 en Flow Launcher)</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_not_a_number">No es un número (NaN)</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_expression_not_complete">Expresión incorrecta o incompleta (¿Olvidó algún paréntesis?)</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_copy_number_to_clipboard">Copiar este número al portapapeles</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_output_decimal_seperator">Separador decimal</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_output_decimal_seperator_help">El separador decimal que se usará en el resultado.</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_decimal_seperator_use_system_locale">Usar configuración del sistema</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_decimal_seperator_comma">Coma (,)</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_decimal_seperator_dot">Punto (.)</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_max_decimal_places">Número máximo de decimales</system:String>
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Languages/es.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Languages/es.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="flowlauncher_plugin_caculator_plugin_name">Calculadora</system:String>
+    <system:String x:Key="flowlauncher_plugin_caculator_plugin_description">Permite hacer cálculos matemáticos. (Pruebe 5*3-2 en Flow Launcher)</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_not_a_number">No es un número (NaN)</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_expression_not_complete">Expresión incorrecta o incompleta (¿Ha olvidado algunos paréntesis?)</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_copy_number_to_clipboard">Copiar este número al portapapeles</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_output_decimal_seperator">Separador decimal</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_output_decimal_seperator_help">El separador decimal que se utilizará en la salida.</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_decimal_seperator_use_system_locale">Usar configuración regional del sistema</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_decimal_seperator_comma">Coma (,)</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_decimal_seperator_dot">Punto (.)</system:String>
+    <system:String x:Key="flowlauncher_plugin_calculator_max_decimal_places">Número máximo de decimales</system:String>
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/es-419.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/es-419.xaml
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <!--Dialogues-->
+    <system:String x:Key="plugin_explorer_make_selection_warning">Por favor, seleccione primero</system:String>
+    <system:String x:Key="plugin_explorer_select_folder_link_warning">Please select a folder link</system:String>
+    <system:String x:Key="plugin_explorer_delete_folder_link">Are you sure you want to delete {0}?</system:String>
+    <system:String x:Key="plugin_explorer_deletefilefolderconfirm">Are you sure you want to permanently delete this {0}?</system:String>
+    <system:String x:Key="plugin_explorer_deletefilefoldersuccess">Deletion successful</system:String>
+    <system:String x:Key="plugin_explorer_deletefilefoldersuccess_detail">Successfully deleted the {0}</system:String>
+    <system:String x:Key="plugin_explorer_globalActionKeywordInvalid">Assigning the global action keyword could bring up too many results during search. Please choose a specific action keyword</system:String>
+    <system:String x:Key="plugin_explorer_quickaccess_globalActionKeywordInvalid">Quick Access can not be set to the global action keyword when enabled. Please choose a specific action keyword</system:String>
+    <system:String x:Key="plugin_explorer_windowsSearchServiceNotRunning">The required service for Windows Index Search does not appear to be running</system:String>
+    <system:String x:Key="plugin_explorer_windowsSearchServiceFix">To fix this, start the Windows Search service. Select here to remove this warning</system:String>
+    <system:String x:Key="plugin_explorer_alternative">The warning message has been switched off. As an alternative for searching files and folders, would you like to install Everything plugin?{0}{0}Select 'Yes' to install Everything plugin, or 'No' to return</system:String>
+    <system:String x:Key="plugin_explorer_alternative_title">Explorer Alternative</system:String>
+    <system:String x:Key="plugin_explorer_directoryinfosearch_error">Error occurred during search: {0}</system:String>
+
+    <!--Controls-->
+    <system:String x:Key="plugin_explorer_delete">Eliminar</system:String>
+    <system:String x:Key="plugin_explorer_edit">Editar</system:String>
+    <system:String x:Key="plugin_explorer_add">Añadir</system:String>
+    <system:String x:Key="plugin_explorer_manageactionkeywords_header">Customise Action Keywords</system:String>
+    <system:String x:Key="plugin_explorer_quickaccesslinks_header">Quick Access Links</system:String>
+    <system:String x:Key="plugin_explorer_indexsearchexcludedpaths_header">Index Search Excluded Paths</system:String>
+    <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch">Use Index Search For Path Search</system:String>
+    <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch_tooltip">Turning this on will return indexed directories/files faster, but if a directory/file is not indexed it will not show up. If a directory/file has been added to Index Search Excluded Path then it will still show up even if this option is on</system:String>
+    <system:String x:Key="plugin_explorer_manageindexoptions">Indexing Options</system:String>
+    <system:String x:Key="plugin_explorer_actionkeywordview_search">Search:</system:String>
+    <system:String x:Key="plugin_explorer_actionkeywordview_pathsearch">Path Search:</system:String>
+    <system:String x:Key="plugin_explorer_actionkeywordview_filecontentsearch">File Content Search:</system:String>
+    <system:String x:Key="plugin_explorer_actionkeywordview_indexsearch">Index Search:</system:String>
+    <system:String x:Key="plugin_explorer_actionkeywordview_quickaccess">Quick Access:</system:String>
+    <system:String x:Key="plugin_explorer_actionkeyword_current">Current Action Keyword</system:String>
+    <system:String x:Key="plugin_explorer_actionkeyword_done">Hecho</system:String>
+    <system:String x:Key="plugin_explorer_actionkeyword_enabled">Enabled</system:String>
+    <system:String x:Key="plugin_explorer_actionkeyword_enabled_tooltip">When disabled Flow will not execute this search option, and will additionally revert back to '*' to free up the action keyword</system:String>
+
+    <!--Plugin Infos-->
+    <system:String x:Key="plugin_explorer_plugin_name">Explorer</system:String>
+    <system:String x:Key="plugin_explorer_plugin_description">Search and manage files and folders. Explorer utilises Windows Index Search</system:String>
+
+    <!--Context menu items-->
+    <system:String x:Key="plugin_explorer_copypath">Copy path</system:String>
+    <system:String x:Key="plugin_explorer_copyfilefolder">Copy</system:String>
+    <system:String x:Key="plugin_explorer_deletefilefolder">Eliminar</system:String>
+    <system:String x:Key="plugin_explorer_path">Path:</system:String>
+    <system:String x:Key="plugin_explorer_deletefilefolder_subtitle">Delete the selected</system:String>
+    <system:String x:Key="plugin_explorer_runasdifferentuser">Run as different user</system:String>
+    <system:String x:Key="plugin_explorer_runasdifferentuser_subtitle">Run the selected using a different user account</system:String>
+    <system:String x:Key="plugin_explorer_opencontainingfolder">Open containing folder</system:String>
+    <system:String x:Key="plugin_explorer_opencontainingfolder_subtitle">Opens the location that contains the file or folder</system:String>
+    <system:String x:Key="plugin_explorer_openwitheditor">Open With Editor:</system:String>
+    <system:String x:Key="plugin_explorer_excludefromindexsearch">Exclude current and sub-directories from Index Search</system:String>
+    <system:String x:Key="plugin_explorer_excludedfromindexsearch_msg">Excluded from Index Search</system:String>
+    <system:String x:Key="plugin_explorer_openindexingoptions">Open Windows Indexing Options</system:String>
+    <system:String x:Key="plugin_explorer_openindexingoptions_subtitle">Manage indexed files and folders</system:String>
+    <system:String x:Key="plugin_explorer_openindexingoptions_errormsg">Failed to open Windows Indexing Options</system:String>
+    <system:String x:Key="plugin_explorer_add_to_quickaccess_title">Add to Quick Access</system:String>
+    <system:String x:Key="plugin_explorer_add_to_quickaccess_subtitle">Add the current {0} to Quick Access</system:String>
+    <system:String x:Key="plugin_explorer_addfilefoldersuccess">Successfully Added</system:String>
+    <system:String x:Key="plugin_explorer_addfilefoldersuccess_detail">Successfully added to Quick Access</system:String>
+    <system:String x:Key="plugin_explorer_removefilefoldersuccess">Successfully Removed</system:String>
+    <system:String x:Key="plugin_explorer_removefilefoldersuccess_detail">Successfully removed from Quick Access</system:String>
+    <system:String x:Key="plugin_explorer_contextmenu_titletooltip">Add to Quick Access so it can be opened with Explorer's Search Activation action keyword</system:String>
+    <system:String x:Key="plugin_explorer_contextmenu_remove_titletooltip">Remove from Quick Access</system:String>
+    <system:String x:Key="plugin_explorer_remove_from_quickaccess_title">Remove from Quick Access</system:String>
+    <system:String x:Key="plugin_explorer_remove_from_quickaccess_subtitle">Remove the current {0} from Quick Access</system:String>
+
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/es.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/es.xaml
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <!--Dialogues-->
+    <system:String x:Key="plugin_explorer_make_selection_warning">Por favor haga una selección primero</system:String>
+    <system:String x:Key="plugin_explorer_select_folder_link_warning">Por favor, seleccione un enlace de carpeta</system:String>
+    <system:String x:Key="plugin_explorer_delete_folder_link">¿Está seguro que desea eliminar {0}?</system:String>
+    <system:String x:Key="plugin_explorer_deletefilefolderconfirm">¿Está seguro de que desea eliminar permanentemente este {0}?</system:String>
+    <system:String x:Key="plugin_explorer_deletefilefoldersuccess">Eliminado correctamente</system:String>
+    <system:String x:Key="plugin_explorer_deletefilefoldersuccess_detail">El {0} fué eliminado correctamente</system:String>
+    <system:String x:Key="plugin_explorer_globalActionKeywordInvalid">Asignar la palabra clave de acción global podría generar demasiados resultados durante la búsqueda. Por favor, elija una palabra clave de acción específica</system:String>
+    <system:String x:Key="plugin_explorer_quickaccess_globalActionKeywordInvalid">El acceso rápido no puede usar la palabra clave de acción global cuando está habilitado. Por favor, elija una palabra clave específica</system:String>
+    <system:String x:Key="plugin_explorer_windowsSearchServiceNotRunning">El servicio requerido de indexación de búsqueda de Windows no parece estar ejecutándose</system:String>
+    <system:String x:Key="plugin_explorer_windowsSearchServiceFix">Para solucionar esto, inicie el servicio de búsqueda de Windows. Seleccione aquí para eliminar esta advertencia</system:String>
+    <system:String x:Key="plugin_explorer_alternative">El mensaje de advertencia se ha desactivado. Como alternativa para buscar archivos y carpetas, ¿desea instalar el complemento Everything?{0}{0}Seleccione 'Sí' para instalar el complemento Everything, o 'No' para volver</system:String>
+    <system:String x:Key="plugin_explorer_alternative_title">Explorador alternativo</system:String>
+    <system:String x:Key="plugin_explorer_directoryinfosearch_error">Se ha producido un error durante la búsqueda: {0}</system:String>
+
+    <!--Controls-->
+    <system:String x:Key="plugin_explorer_delete">Eliminar</system:String>
+    <system:String x:Key="plugin_explorer_edit">Editar</system:String>
+    <system:String x:Key="plugin_explorer_add">Añadir</system:String>
+    <system:String x:Key="plugin_explorer_manageactionkeywords_header">Personalizar palabras clave de acción</system:String>
+    <system:String x:Key="plugin_explorer_quickaccesslinks_header">Enlaces de acceso rápido</system:String>
+    <system:String x:Key="plugin_explorer_indexsearchexcludedpaths_header">Rutas excluídas del índice de búsqueda</system:String>
+    <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch">Usar búsqueda indexada para buscar rutas</system:String>
+    <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch_tooltip">Al activar esta opción, los directorios/archivos indexados se mostrarán más rápidamente, pero si un directorio/archivo no está indexado, no se mostrará. Si se ha agregado un directorio/archivo a la ruta de exclusión del índice de búsqueda se seguirá mostrando incluso si la opción está activada</system:String>
+    <system:String x:Key="plugin_explorer_manageindexoptions">Opciones de indexación</system:String>
+    <system:String x:Key="plugin_explorer_actionkeywordview_search">Buscar:</system:String>
+    <system:String x:Key="plugin_explorer_actionkeywordview_pathsearch">Ruta de búsqueda:</system:String>
+    <system:String x:Key="plugin_explorer_actionkeywordview_filecontentsearch">Búsqueda de contenido de archivo:</system:String>
+    <system:String x:Key="plugin_explorer_actionkeywordview_indexsearch">Buscar índice:</system:String>
+    <system:String x:Key="plugin_explorer_actionkeywordview_quickaccess">Acceso rápido:</system:String>
+    <system:String x:Key="plugin_explorer_actionkeyword_current">Palabra clave de acción actual</system:String>
+    <system:String x:Key="plugin_explorer_actionkeyword_done">Aceptar</system:String>
+    <system:String x:Key="plugin_explorer_actionkeyword_enabled">Activado</system:String>
+    <system:String x:Key="plugin_explorer_actionkeyword_enabled_tooltip">Cuando esté desactivado, Flow no ejecutará esta opción de búsqueda, y además volverá a '*' para liberar la palabra clave de acción</system:String>
+
+    <!--Plugin Infos-->
+    <system:String x:Key="plugin_explorer_plugin_name">Explorador</system:String>
+    <system:String x:Key="plugin_explorer_plugin_description">Busca y gestiona archivos y carpetas. El explorador utiliza el índice de búsqueda de Windows</system:String>
+
+    <!--Context menu items-->
+    <system:String x:Key="plugin_explorer_copypath">Copiar ruta</system:String>
+    <system:String x:Key="plugin_explorer_copyfilefolder">Copiar</system:String>
+    <system:String x:Key="plugin_explorer_deletefilefolder">Eliminar</system:String>
+    <system:String x:Key="plugin_explorer_path">Ruta:</system:String>
+    <system:String x:Key="plugin_explorer_deletefilefolder_subtitle">Elimina el seleccionado</system:String>
+    <system:String x:Key="plugin_explorer_runasdifferentuser">Ejecutar como usuario diferente</system:String>
+    <system:String x:Key="plugin_explorer_runasdifferentuser_subtitle">Ejecuta la selección usando una cuenta de usuario diferente</system:String>
+    <system:String x:Key="plugin_explorer_opencontainingfolder">Abrir carpeta contenedora</system:String>
+    <system:String x:Key="plugin_explorer_opencontainingfolder_subtitle">Abre la ubicación que contiene el archivo o carpeta</system:String>
+    <system:String x:Key="plugin_explorer_openwitheditor">Abrir con el editor:</system:String>
+    <system:String x:Key="plugin_explorer_excludefromindexsearch">Excluir la carpeta actual y sus subcarpetas del índice de búsqueda</system:String>
+    <system:String x:Key="plugin_explorer_excludedfromindexsearch_msg">Excluido del índice de búsqueda</system:String>
+    <system:String x:Key="plugin_explorer_openindexingoptions">Abrir opciones de indexación de Windows</system:String>
+    <system:String x:Key="plugin_explorer_openindexingoptions_subtitle">Administra archivos y carpetas indexados</system:String>
+    <system:String x:Key="plugin_explorer_openindexingoptions_errormsg">No se ha podido abrir las opciones de indexación de Windows</system:String>
+    <system:String x:Key="plugin_explorer_add_to_quickaccess_title">Añadir al acceso rápido</system:String>
+    <system:String x:Key="plugin_explorer_add_to_quickaccess_subtitle">Añade el {0} actual al acceso rápido</system:String>
+    <system:String x:Key="plugin_explorer_addfilefoldersuccess">Añadido correctamente</system:String>
+    <system:String x:Key="plugin_explorer_addfilefoldersuccess_detail">Añadido correctamente al acceso rápido</system:String>
+    <system:String x:Key="plugin_explorer_removefilefoldersuccess">Eliminado correctamente</system:String>
+    <system:String x:Key="plugin_explorer_removefilefoldersuccess_detail">Eliminado correctamente del acceso rápido</system:String>
+    <system:String x:Key="plugin_explorer_contextmenu_titletooltip">Añade al acceso rápido para que se pueda abrir con la palabra clave de acción que activa la búsqueda del explorador</system:String>
+    <system:String x:Key="plugin_explorer_contextmenu_remove_titletooltip">Eliminar del acceso rápido</system:String>
+    <system:String x:Key="plugin_explorer_remove_from_quickaccess_title">Eliminar del acceso rápido</system:String>
+    <system:String x:Key="plugin_explorer_remove_from_quickaccess_subtitle">Elimina el {0} actual del acceso rápido</system:String>
+
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/Languages/es-419.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/Languages/es-419.xaml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="flowlauncher_plugin_pluginindicator_plugin_name">Indicador de Plugins</system:String>
+    <system:String x:Key="flowlauncher_plugin_pluginindicator_plugin_description">Sugiere palabras clave de plugins</system:String>
+    
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/Languages/es.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/Languages/es.xaml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="flowlauncher_plugin_pluginindicator_plugin_name">Indicador de complementos</system:String>
+    <system:String x:Key="flowlauncher_plugin_pluginindicator_plugin_description">Proporciona sugerencias de palabras de acción para los complementos</system:String>
+    
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/es-419.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/es-419.xaml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <!--Dialogues-->
+    <system:String x:Key="plugin_pluginsmanager_downloading_plugin">Downloading plugin</system:String>
+    <system:String x:Key="plugin_pluginsmanager_download_success">Successfully downloaded</system:String>
+    <system:String x:Key="plugin_pluginsmanager_download_error">Error: Unable to download the plugin</system:String>
+    <system:String x:Key="plugin_pluginsmanager_uninstall_prompt">{0} by {1} {2}{3}Would you like to uninstall this plugin? After the uninstallation Flow will automatically restart.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_prompt">{0} by {1} {2}{3}Would you like to install this plugin? After the installation Flow will automatically restart.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_title">Plugin Install</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_from_web">Download and install {0}</system:String>
+    <system:String x:Key="plugin_pluginsmanager_uninstall_title">Plugin Uninstall</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_success_restart">Plugin successfully installed. Restarting Flow, please wait...</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_errormetadatafile">Unable to find the plugin.json metadata file from the extracted zip file.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_error_duplicate">Error: A plugin which has the same or greater version with {0} already exists.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_error_title">Error installing plugin</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_error_subtitle">Error occured while trying to install {0}</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_noresult_title">No update available</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_noresult_subtitle">All plugins are up to date</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_prompt">{0} by {1} {2}{3}Would you like to update this plugin? After the update Flow will automatically restart.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_title">Plugin Update</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_exists">This plugin has an update, would you like to see it?</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_alreadyexists">This plugin is already installed</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_failed_title">Plugin Manifest Download Failed</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_failed_subtitle">Please check if you can connect to github.com. This error means you may not be able to install or update plugins.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_unknown_source_warning_title">Installing from an unknown source</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_unknown_source_warning">You are installing this plugin from an unknown source and it may contain potential risks!{0}{0}Please ensure you understand where this plugin is from and that it is safe.{0}{0}Would you like to continue still?{0}{0}(You can switch off this warning via settings)</system:String>
+
+    <!--Controls-->
+    
+    <!--Plugin Infos-->
+    <system:String x:Key="plugin_pluginsmanager_plugin_name">Plugins Manager</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_description">Management of installing, uninstalling or updating Flow Launcher plugins</system:String>
+    <system:String x:Key="plugin_pluginsmanager_unknown_author">Unknown Author</system:String>
+
+    <!--Context menu items-->
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_openwebsite_title">Open website</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_openwebsite_subtitle">Visit the plugin's website</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_gotosourcecode_title">See source code</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_gotosourcecode_subtitle">See the plugin's source code</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_newissue_title">Suggest an enhancement or submit an issue</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_newissue_subtitle">Suggest an enhancement or submit an issue to the plugin developer</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_pluginsmanifest_title">Go to Flow's plugins repository</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_pluginsmanifest_subtitle">Visit the PluginsManifest repository to see community-made plugin submissions</system:String>
+
+    <!--Settings menu items-->
+    <system:String x:Key="plugin_pluginsmanager_plugin_settings_unknown_source">Install from unknown source warning</system:String>
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/es.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/es.xaml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <!--Dialogues-->
+    <system:String x:Key="plugin_pluginsmanager_downloading_plugin">Descargando complemento</system:String>
+    <system:String x:Key="plugin_pluginsmanager_download_success">Descargado correctamente</system:String>
+    <system:String x:Key="plugin_pluginsmanager_download_error">Error: No se puede descargar el complemento</system:String>
+    <system:String x:Key="plugin_pluginsmanager_uninstall_prompt">{0} por {1} {2}{3}¿Desea desinstalar este complemento? Después de la desinstalación Flow se reiniciará automáticamente.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_prompt">{0} por {1} {2}{3}¿Desea instalar este complemento? Después de la instalación Flow se reiniciará automáticamente.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_title">Instalar complemento</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_from_web">Descargar e instalar {0}</system:String>
+    <system:String x:Key="plugin_pluginsmanager_uninstall_title">Desinstalar complemento</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_success_restart">Complemento instalado correctamente. Reiniciando Flow, por favor espere...</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_errormetadatafile">No se ha podido encontrar el archivo de metadatos plugin.json del archivo zip extraído.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_error_duplicate">Error: Ya existe un complemento que tiene la misma o mayor versión con {0}.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_error_title">Error al instalar el complemento</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_error_subtitle">Se ha producido un error al intentar instalar {0}</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_noresult_title">No hay actualizaciones disponibles</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_noresult_subtitle">Todos los complementos están actualizados</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_prompt">{0} por {1} {2}{3}¿Desea actualizar este complemento? Después de la actualización Flow se reiniciará automáticamente.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_title">Actualizar complemento</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_exists">Este complemento tiene una actualización, ¿desea verla?</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_alreadyexists">Este complemento ya está instalado</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_failed_title">La descarga del manifiesto del complemento ha fallado</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_failed_subtitle">Por favor, compruebe que puede establecer conexión con github.com. Este error significa que es posible que no pueda instalar o actualizar complementos.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_unknown_source_warning_title">Instalando desde una fuente desconocida</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_unknown_source_warning">¡Está instalando este complemento desde una fuente desconocida y puede contener riesgos potenciales!{0}{0}Por favor, asegúrese de saber de dónde procede este complemento y de que es seguro.{0}{0}¿Aún así desea continuar?{0}{0}(Puede desactivar esta advertencia en la configuración)</system:String>
+
+    <!--Controls-->
+    
+    <!--Plugin Infos-->
+    <system:String x:Key="plugin_pluginsmanager_plugin_name">Administrador de complementos</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_description">Administración de instalación, desinstalación o actualización de los complementos de Flow Launcher</system:String>
+    <system:String x:Key="plugin_pluginsmanager_unknown_author">Autor desconocido</system:String>
+
+    <!--Context menu items-->
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_openwebsite_title">Abrir sitio web</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_openwebsite_subtitle">Visite el sitio web del complemento</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_gotosourcecode_title">Ver código fuente</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_gotosourcecode_subtitle">Ver el código fuente del complemento</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_newissue_title">Sugerir una mejora o enviar una incidencia</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_newissue_subtitle">Sugerir una mejora o enviar una incidencia al desarrollador del complemento</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_pluginsmanifest_title">Ir al repositorio de complementos de Flow</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_contextmenu_pluginsmanifest_subtitle">Visite el repositorio PluginsManifest para ver complementos hechos por la comunidad</system:String>
+
+    <!--Settings menu items-->
+    <system:String x:Key="plugin_pluginsmanager_plugin_settings_unknown_source">Aviso de instalación desde fuentes desconocidas</system:String>
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.ProcessKiller/Languages/es-419.xaml
+++ b/Plugins/Flow.Launcher.Plugin.ProcessKiller/Languages/es-419.xaml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="flowlauncher_plugin_processkiller_plugin_name">Terminar procesos</system:String>
+    <system:String x:Key="flowlauncher_plugin_processkiller_plugin_description">Cierra procesos en ejecución desde Flow Launcher</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_processkiller_kill_all">termina todas las instancias de &quot;{0}&quot;</system:String>
+    <system:String x:Key="flowlauncher_plugin_processkiller_kill_all_count">terminar {0} procesos</system:String>
+    <system:String x:Key="flowlauncher_plugin_processkiller_kill_instances">termina todas las instancias</system:String>
+
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.ProcessKiller/Languages/es.xaml
+++ b/Plugins/Flow.Launcher.Plugin.ProcessKiller/Languages/es.xaml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="flowlauncher_plugin_processkiller_plugin_name">Finalizador de procesos</system:String>
+    <system:String x:Key="flowlauncher_plugin_processkiller_plugin_description">Finalizar procesos en ejecución desde Flow Launcher</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_processkiller_kill_all">finalizar todas las instancias de &quot;{0}&quot;</system:String>
+    <system:String x:Key="flowlauncher_plugin_processkiller_kill_all_count">finalizar {0} procesos</system:String>
+    <system:String x:Key="flowlauncher_plugin_processkiller_kill_instances">finalizar todas las instancias</system:String>
+
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/es-419.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/es-419.xaml
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <!--  Program setting  -->
+    <system:String x:Key="flowlauncher_plugin_program_delete">Eliminar</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_edit">Editar</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_add">Añadir</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_name">Nombre</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable">Habilitar</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_disable">Deshabilitar</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_location">Ubicación</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_all_programs">Todos los programas</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_suffixes">Sufijos de archivo</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_reindex">Reindex</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_indexing">Indexing</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_index_start">Index Start Menu</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_index_start_tooltip">When enabled, Flow will load programs from the start menu</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_index_registry">Index Registry</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_index_registry_tooltip">When enabled, Flow will load programs from the registry</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable_hidelnkpath">Hide app path</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable_hidelnkpath_tooltip">For executable files such as UWP or lnk, hide the file path from being visible</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable_description">Search in Program Description</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable_description_tooltip">Disabling this will also stop Flow from searching via the program desciption</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_suffixes_header">Suffixes</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_max_depth_header">Max Depth</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_directory">Directory</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_browse">Browse</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_file_suffixes">File Suffixes:</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_max_search_depth">Maximum Search Depth (-1 is unlimited):</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_pls_select_program_source">Please select a program source</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_delete_program_source">Are you sure you want to delete the selected program sources?</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_update">OK</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_only_index_tip">Flow Launcher will only index files that end with the following suffixes. (Each suffix should split by ';' )</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_update_file_suffixes">Successfully updated file suffixes</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_suffixes_cannot_empty">File suffixes can't be empty</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_run_as_different_user">Run As Different User</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_run_as_administrator">Run As Administrator</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_open_containing_folder">Open containing folder</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_disable_program">Disable this program from displaying</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_plugin_name">Program</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_plugin_description">Search programs in Flow Launcher</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_invalid_path">Invalid Path</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_customizedexplorer">Customized Explorer</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_args">Args</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_tooltip_customizedexplorer">You can customized the explorer used for opening the container folder by inputing the Environmental Variable of the explorer you want to use. It will be useful to use CMD to test whether the Environmental Variable is avaliable.</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_tooltip_args">Enter the customized args you want to add for your customized explorer. %s for parent directory, %f for full path (which only works for win32). Check the explorer's website for details.</system:String>
+
+    <!--  Dialogs  -->
+    <system:String x:Key="flowlauncher_plugin_program_disable_dlgtitle_success">Success</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_disable_dlgtitle_success_message">Successfully disabled this program from displaying in your query</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_run_as_administrator_not_supported_message">This app is not intended to be run as administrator</system:String>
+
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/es.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/es.xaml
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <!--  Program setting  -->
+    <system:String x:Key="flowlauncher_plugin_program_delete">Eliminar</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_edit">Editar</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_add">Añadir</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_name">Nombre</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable">Activar</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_disable">Desactivar</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_location">Ubicación</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_all_programs">Todos los programas</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_suffixes">Extensiones de archivo</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_reindex">Re-indexar</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_indexing">Indexando</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_index_start">Indexar menú de inicio</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_index_start_tooltip">Cuando esté activado, Flow cargará los programas desde el menú de inicio</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_index_registry">Indexar registro</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_index_registry_tooltip">Cuando esté activado, Flow cargará los programas desde el registro</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable_hidelnkpath">Ocultar ruta de aplicación</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable_hidelnkpath_tooltip">Para los archivos ejecutables como UWP o lnk, oculta la ruta del archivo para que no sea visible</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable_description">Busca en la descripción del programa</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable_description_tooltip">Si se desactiva, también se evitará que Flow busque a través de la descripción del programa</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_suffixes_header">Extensiones</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_max_depth_header">Profundidad máxima</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_directory">Carpeta</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_browse">Navegar</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_file_suffixes">Extensiones de archivo:</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_max_search_depth">Profundidad de búsqueda máxima (-1 es sin límite):</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_pls_select_program_source">Por favor, seleccione la ruta del programa</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_delete_program_source">¿Está seguro que desea eliminar las fuentes del programa seleccionadas?</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_update">Aceptar</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_only_index_tip">Flow Launcher sólo indexará los archivos que terminen con las siguientes extensiones. (Separar cada extensión con ';' )</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_update_file_suffixes">Extensiones de archivo actualizadas correctamente</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_suffixes_cannot_empty">Las extensiones de archivo no pueden estar vacías</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_run_as_different_user">Ejecutar como usuario diferente</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_run_as_administrator">Ejecutar como administrador</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_open_containing_folder">Abrir carpeta contenedora</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_disable_program">Desactivar la visualización de este programa</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_plugin_name">Programa</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_plugin_description">Busca programas en Flow Launcher</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_invalid_path">Ruta no válida</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_program_customizedexplorer">Explorador personalizado</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_args">Argumentos</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_tooltip_customizedexplorer">Puede personalizar el explorador utilizado para abrir la carpeta contenedor introduciendo la Variable de entorno del explorador que desea utilizar. Será útil usar CMD para probar si la Variable de entorno está disponible.</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_tooltip_args">Introduzca los argumentos personalizados que desea agregar para el explorador personalizado. %s para carpeta contenedora, %f para ruta completa (solo funciona para win32). Consulte la página web del explorador para obtener más detalles.</system:String>
+
+    <!--  Dialogs  -->
+    <system:String x:Key="flowlauncher_plugin_program_disable_dlgtitle_success">Correcto</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_disable_dlgtitle_success_message">Programa desactivado correctamente en las búsquedas</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_run_as_administrator_not_supported_message">Esta aplicación no fué diseñada para ser ejecutada como administrador</system:String>
+
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Shell/Languages/es-419.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Languages/es-419.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="flowlauncher_plugin_cmd_relace_winr">Reemplazar Win+R</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_leave_cmd_open">No cerrar Símbolo del Sistema tras ejecutar el comando</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_always_run_as_administrator">Siempre ejecutar como administrador</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_run_as_different_user">Ejecutar como otro usuario</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_plugin_name">Shell</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_plugin_description">Permite ejecutar comandos del sistema desde Flow Launcher. Los comandos deben comenzar con &gt;</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_cmd_has_been_executed_times">este comando ha sido ejecutado {0} veces</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_execute_through_shell">ejecutar comando a través del shell de comandos</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_run_as_administrator">Ejecutar como administrador</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_copy">Copiar comando</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_history">Sólo mostrar el número de comandos más usados:</system:String>
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Shell/Languages/es.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Languages/es.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="flowlauncher_plugin_cmd_relace_winr">Reemplazar Win+R</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_leave_cmd_open">No cerrar el símbolo del sistema después de la ejecución del comando</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_always_run_as_administrator">Ejecutar siempre como administrador</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_run_as_different_user">Ejecutar como usuario diferente</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_plugin_name">Terminal</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_plugin_description">Permite ejecutar comandos del sistema desde Flow Launcher. Los comandos deben comenzar con &gt;</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_cmd_has_been_executed_times">este comando ha sido ejecutado {0} veces</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_execute_through_shell">ejecutar comando en la terminal</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_run_as_administrator">Ejecutar como administrador</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_copy">Copiar el comando</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_history">Mostrar sólo el número de comandos más usados:</system:String>
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Sys/Languages/es-419.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Languages/es-419.xaml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <!--Command List-->
+    <system:String x:Key="flowlauncher_plugin_sys_command">Command</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_desc">Description</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_sys_shutdown_computer">Shutdown Computer</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_restart_computer">Restart Computer</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_restart_advanced">Restart the computer with Advanced Boot Options for Safe and Debugging modes, as well as other options</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_log_off">Log off</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_lock">Lock this computer</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_exit">Close Flow Launcher</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_restart">Restart Flow Launcher</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_setting">Tweak this app</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_sleep">Put computer to sleep</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_emptyrecyclebin">Empty recycle bin</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_hibernate">Hibernate computer</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_save_all_settings">Save all Flow Launcher settings</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_reload_plugin_data">Refreshes plugin data with new content</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_open_log_location">Open Flow Launcher's log location</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_check_for_update">Check for new Flow Launcher update</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_open_docs_tips">Visit Flow Launcher's documentation for more help and how to use tips</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_open_userdata_location">Open the location where Flow Launcher's settings are stored</system:String>
+
+    <!--Dialogs-->
+    <system:String x:Key="flowlauncher_plugin_sys_dlgtitle_success">Success</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_dlgtext_all_settings_saved">All Flow Launcher settings saved</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_dlgtext_all_applicableplugins_reloaded">Reloaded all applicable plugin data</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_dlgtext_shutdown_computer">Are you sure you want to shut the computer down?</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_dlgtext_restart_computer">Are you sure you want to restart the computer?</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_dlgtext_restart_computer_advanced">Are you sure you want to restart the computer with Advanced Boot Options?</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_sys_plugin_name">System Commands</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_plugin_description">Provides System related commands. e.g. shutdown, lock, settings etc.</system:String>
+
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Sys/Languages/es.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Languages/es.xaml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <!--Command List-->
+    <system:String x:Key="flowlauncher_plugin_sys_command">Comando</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_desc">Descripción</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_sys_shutdown_computer">Apagar el equipo</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_restart_computer">Reiniciar el equipo</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_restart_advanced">Reiniciar el equipo con opciones avanzadas de arranque para el modo seguro y de depuración, entre otras opciones</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_log_off">Cerrar sesión</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_lock">Bloquear el equipo</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_exit">Cerrar Flow Launcher</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_restart">Reiniciar Flow Launcher</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_setting">Ajustar esta aplicación</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_sleep">Suspender el equipo</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_emptyrecyclebin">Vaciar papelera de reciclaje</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_hibernate">Hibernar el equipo</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_save_all_settings">Guardar configuración de Flow Launcher</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_reload_plugin_data">Refresca los datos del complemento con nuevo contenido</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_open_log_location">Abrir ubicación de los archivos de registro de Flow Launcher</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_check_for_update">Buscar actualizaciones de Flow Launcher</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_open_docs_tips">Visite la documentación de Flow Launcher para más ayuda y consejos de uso</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_open_userdata_location">Abrir la ubicación donde se almacena la configuración de Flow Launcher</system:String>
+
+    <!--Dialogs-->
+    <system:String x:Key="flowlauncher_plugin_sys_dlgtitle_success">Correcto</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_dlgtext_all_settings_saved">Toda la configuración de Flow Launcher ha sido guardada</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_dlgtext_all_applicableplugins_reloaded">Se recargaron todos los datos del complemento</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_dlgtext_shutdown_computer">¿Está seguro de que desea apagar el equipo?</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_dlgtext_restart_computer">¿Está seguro de que desea reiniciar el equipo?</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_dlgtext_restart_computer_advanced">¿Está seguro de que desea reiniciar el equipo con opciones de arranque avanzadas?</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_sys_plugin_name">Comandos del sistema</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_plugin_description">Proporciona comandos relacionados con el sistema. Por ejemplo, apagar, bloquear, configurar, etc.</system:String>
+
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Url/Languages/es-419.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Url/Languages/es-419.xaml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="flowlauncher_plugin_url_open_search_in">Abrir búsqueda en:</system:String>
+    <system:String x:Key="flowlauncher_plugin_new_window">Nueva Ventana</system:String>
+    <system:String x:Key="flowlauncher_plugin_new_tab">Nueva Pestaña</system:String>
+    
+    <system:String x:Key="flowlauncher_plugin_url_open_url">Abrir url:{0}</system:String>
+    <system:String x:Key="flowlauncher_plugin_url_canot_open_url">No se puede abrir la url:{0}</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_url_plugin_name">URL</system:String>
+    <system:String x:Key="flowlauncher_plugin_url_plugin_description">Abre la URL escrita desde Flow Launcher</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_url_plugin_set_tip">Por favor, establezca la ruta de su navegador:</system:String>
+    <system:String x:Key="flowlauncher_plugin_url_plugin_choose">Elija</system:String>
+    <system:String x:Key="flowlauncher_plugin_url_plugin_filter">Aplicación(*.exe)|*.exe|Todos los archivos|*.*</system:String>
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Url/Languages/es.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Url/Languages/es.xaml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="flowlauncher_plugin_url_open_search_in">Abrir búsqueda en:</system:String>
+    <system:String x:Key="flowlauncher_plugin_new_window">Nueva ventana</system:String>
+    <system:String x:Key="flowlauncher_plugin_new_tab">Nueva pestaña</system:String>
+    
+    <system:String x:Key="flowlauncher_plugin_url_open_url">Abrir url:{0}</system:String>
+    <system:String x:Key="flowlauncher_plugin_url_canot_open_url">No se puede abrir la url:{0}</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_url_plugin_name">URL</system:String>
+    <system:String x:Key="flowlauncher_plugin_url_plugin_description">Abre la URL escrita desde Flow Launcher</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_url_plugin_set_tip">Por favor, establezca la ruta del navegador:</system:String>
+    <system:String x:Key="flowlauncher_plugin_url_plugin_choose">Elegir</system:String>
+    <system:String x:Key="flowlauncher_plugin_url_plugin_filter">Aplicación(*.exe)|*.exe|Todos los archivos|*.*</system:String>
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/es-419.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/es-419.xaml
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="flowlauncher_plugin_websearch_window_title">Configuración de fuente de búsqueda</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_open_search_in">Abrir búsqueda en:</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_new_window">Nueva Ventana</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_new_tab">Nueva Pestaña</system:String>
+    <system:String x:Key="flowlaucnher_plugin_websearch_set_browser_path">Establecer navegador desde ruta:</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_choose">Elegir</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_delete">Eliminar</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_edit">Editar</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_add">Añadir</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirmar</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_action_keyword">Palabra clave</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_url">URL</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_search">Buscar</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enable_suggestion">Autocompletar la búsqueda: </system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enable_suggestion_provider">Autocompletar datos de: </system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_pls_select_web_search">Por favor, seleccione una búsqueda</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_delete_warning">¿Seguro que desea eliminar {0}?</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_guide_1">Si quiere utilizar un motor de búsqueda, puede añadirlo a Flow. Por ejemplo, puede seguir el formato de la url en la barra de direcciones si desea buscar 'casino' en Netflix: &quot;https://www. etflix.com/search?q=Casino. Para ello, cambie el término de búsqueda 'Casino' de la siguiente manera.</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_guide_2">https://www.netflix.com/search?q={q}</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_guide_3">Agréguela al campo de URL. Ahora puede buscar en Netflix con Flow usando cualquier término de búsqueda.</system:String>
+   
+
+    <!--web search edit-->
+    <system:String x:Key="flowlauncher_plugin_websearch_title">Título</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enable">Habilitar</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_select_icon">Seleccionar icono</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_icon">Ícono</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_cancel">Cancelar</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_invalid_web_search">Búsqueda web inválida</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_input_title">Por favor ingrese un título</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_input_action_keyword">Por favor ingrese una palabra clave</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_input_url">Por favor, introduzca una URL</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_action_keyword_exist">La palabra clave ya existe, por favor ingrese una diferente</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_succeed">Éxitoso</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_iconpath_hint">Sugerencia: No es necesario colocar imágenes personalizadas en este directorio, si la versión de Flow se actualiza se perderán. Flow copiará automáticamente cualquier imagen fuera de este directorio a la ubicación de imagen personalizada de WebSearch.</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_websearch_plugin_name">Búsqueda web</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_plugin_description">Permite realizar búsquedas en la web</system:String>
+
+</ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/es.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/es.xaml
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:String x:Key="flowlauncher_plugin_websearch_window_title">Configuración de las fuentes de búsqueda</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_open_search_in">Abrir búsqueda en:</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_new_window">Nueva ventana</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_new_tab">Nueva pestaña</system:String>
+    <system:String x:Key="flowlaucnher_plugin_websearch_set_browser_path">Establecer navegador desde ruta:</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_choose">Elegir</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_delete">Eliminar</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_edit">Editar</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_add">Añadir</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirmar</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_action_keyword">Palabra clave de acción</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_url">URL</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_search">Buscar</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enable_suggestion">Usar autocompletado en consultas de búsqueda: </system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enable_suggestion_provider">Autocompletar datos desde: </system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_pls_select_web_search">Por favor, seleccione una búsqueda web</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_delete_warning">¿Está seguro que desea eliminar {0}?</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_guide_1">Si dispone de un servicio de búsqueda web que desea utilizar, puede añadirlo a Flow. Por ejemplo, si desea buscar 'casino' en Netflix puede utilizar el siguiente formato url en la barra de direcciones: &quot;https://www.netflix.com/search?q=Casino. Para ello, cambie el término de búsqueda 'Casino' de la siguiente manera.</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_guide_2">https://www.netflix.com/search?q={q}</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_guide_3">Añadirla a la sección URL, abajo indicada. Ahora puede buscar en Netflix utilizando cualquier término de búsqueda.</system:String>
+   
+
+    <!--web search edit-->
+    <system:String x:Key="flowlauncher_plugin_websearch_title">Título</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enable">Activar</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_select_icon">Seleccionar icono</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_icon">Icono</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_cancel">Cancelar</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_invalid_web_search">Búsqueda web no válida</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_input_title">Por favor, introduzca un título</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_input_action_keyword">Por favor, introduzca una palabra clave de acción</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_input_url">Por favor, introduzca una URL</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_action_keyword_exist">La palabra clave de acción ya está en uso, por favor, introduzca una diferente</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_succeed">Correcto</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_iconpath_hint">Sugerencia: No es necesario copiar imágenes personalizadas en esta carpeta, cuando Flow sea actualizado se perderán. Flow copiará automáticamente cualquier imagen externa a esta carpeta en la ubicación de imágenes personalizada de WebSearch.</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_websearch_plugin_name">Búsquedas Web</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_plugin_description">Permite realizar búsquedas web</system:String>
+
+</ResourceDictionary>


### PR DESCRIPTION
These are all language files for Spanish & Spanish Latin America added to the dev branch at the time of this PR, copied across for v1.9.5 release.

I purposely left out the language files in Windows Settings plugin because the changes are too drastic.

Expected:
Should not have any differences in the language files between this branch and dev branch.

Tested:
Selected both Spanish and Spanish Latin America and observed that the language has changed on each screen including plugin settings.