### PR TITLE
Use Search instead of SearchTerm[0] in PluginIndicator

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/Main.cs
@@ -16,7 +16,7 @@ namespace Flow.Launcher.Plugin.PluginIndicator
                 return new List<Result>();
 
             var results = from keyword in PluginManager.NonGlobalPlugins.Keys
-                          where keyword.StartsWith(query.SearchTerms[0])
+                          where keyword.StartsWith(query.Search)
                           let metadata = PluginManager.NonGlobalPlugins[keyword].Metadata
                           where !metadata.Disabled
                           select new Result


### PR DESCRIPTION
The error may happen when user set an action keyword to plugin indicator, in which the query may have empty Search and empty SearchTerms.

fix #1371