### PR TITLE
check query for null

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -166,18 +166,18 @@ namespace Flow.Launcher.Core.Plugin
 
         public static ICollection<PluginPair> ValidPluginsForQuery(Query query)
         {
-            if (NonGlobalPlugins.ContainsKey(query.ActionKeyword))
-            {
-                var plugin = NonGlobalPlugins[query.ActionKeyword];
-                return new List<PluginPair>
-                {
-                    plugin
-                };
-            }
-            else
-            {
+            if (query is null)
+                return Array.Empty<PluginPair>();
+            
+            if (!NonGlobalPlugins.ContainsKey(query.ActionKeyword))
                 return GlobalPlugins;
-            }
+            
+            
+            var plugin = NonGlobalPlugins[query.ActionKeyword];
+            return new List<PluginPair>
+            {
+                plugin
+            };
         }
 
         public static async Task<List<Result>> QueryForPluginAsync(PluginPair pair, Query query, CancellationToken token)


### PR DESCRIPTION
Defensive coding. The error suggests there's something here that can be null, which can only be the query. However, I am not sure when it will happen since the reporter doesn't provide way to consistent reproduce the error.

fix #1366