### PR TITLE
Search Source Setting guide text

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/en.xaml
@@ -1,6 +1,7 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <system:String x:Key="flowlauncher_plugin_websearch_window_title">Search Source Setting</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_open_search_in">Open search in:</system:String>
@@ -15,16 +16,21 @@
     <system:String x:Key="flowlauncher_plugin_websearch_action_keyword">Action Keyword</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_url">URL</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_search">Search</system:String>
-    <system:String x:Key="flowlauncher_plugin_websearch_enable_suggestion">Use Search Query Autocomplete: </system:String>
-    <system:String x:Key="flowlauncher_plugin_websearch_enable_suggestion_provider">Autocomplete Data from: </system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enable_suggestion">Use Search Query Autocomplete:</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enable_suggestion_provider">Autocomplete Data from:</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_pls_select_web_search">Please select a web search</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_delete_warning">Are you sure you want to delete {0}?</system:String>
-    <system:String x:Key="flowlauncher_plugin_websearch_guide_1">If you have a web search service you want to use, you can add it to Flow. For example, you can follow the url format in the address bar if you want to search 'casino' on Netflix: "https://www.netflix.com/search?q=Casino". To do this, change the search term 'Casino' as follows.</system:String>
-    <system:String x:Key="flowlauncher_plugin_websearch_guide_2">https://www.netflix.com/search?q={q}</system:String>
-    <system:String x:Key="flowlauncher_plugin_websearch_guide_3">Add it to the URL section below. You can now search Netflix with Flow using any search terms.</system:String>
-   
+    <system:String x:Key="flowlauncher_plugin_websearch_guide_1">If you want to add a search for a particular website to Flow, first enter a dummy text string in the search bar of that website, and launch the search. Now copy the contents of the browser's address bar, and paste it in the URL field below. Replace your test string with {q}. For example, if you search for casino on Netflix, its address bar reads</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_guide_2">https://www.netflix.com/search?q=Casino</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_guide_3">
+        Now copy this entrire string and paste it in the URL field below.
+        Then replace casino with {q}.
+        Thus, the generic formula for a search on Netflix is https://www.netflix.com/search?q={q}
+    </system:String>
 
-    <!--web search edit-->
+
+
+    <!--  web search edit  -->
     <system:String x:Key="flowlauncher_plugin_websearch_title">Title</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enable">Enable</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_select_icon">Select Icon</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
@@ -75,10 +75,11 @@
                                 Text="{DynamicResource flowlauncher_plugin_websearch_guide_1}"
                                 TextAlignment="Left"
                                 TextWrapping="WrapWithOverflow" />
-                            <TextBlock
+                            <TextBox
                                 Margin="0,12,0,12"
                                 FontSize="14"
                                 FontWeight="SemiBold"
+                                IsReadOnly="True"
                                 Text="{DynamicResource flowlauncher_plugin_websearch_guide_2}"
                                 TextAlignment="Center"
                                 TextWrapping="WrapWithOverflow" />


### PR DESCRIPTION
from https://github.com/Flow-Launcher/Flow.Launcher/issues/1309

**Before (and other languages)** 
<img src="https://user-images.githubusercontent.com/6903107/192970344-d094c45c-4c2b-413a-8b74-998233fc328e.png" width="400">

**After**
<img src="https://user-images.githubusercontent.com/6903107/192970113-4c2b640e-361a-4b8f-b871-e19fb440bea8.png" width="400">

Currently, the text is separated into three paragraphs, and inline bold cannot be used. To produce as requested, the design must be changed to four paragraphs, and all existing translations must be changed.

Therefore, it becomes the current editing form, and it is necessary to check if it is okay. Other languages will remain in their existing form, leaving each language worker at their discretion to translate according to the layout.