### PR TITLE
Fix Blurry Context menu in query box

### DIFF
--- a/Flow.Launcher/Resources/CustomControlTemplate.xaml
+++ b/Flow.Launcher/Resources/CustomControlTemplate.xaml
@@ -2724,7 +2724,8 @@
                         Background="{DynamicResource CustomContextBackground}"
                         BorderBrush="{DynamicResource CustomContextBorder}"
                         BorderThickness="1"
-                        CornerRadius="8">
+                        CornerRadius="8"
+                        UseLayoutRounding="True">
                         <Border.Effect>
                             <DropShadowEffect
                                 BlurRadius="12"


### PR DESCRIPTION
**What's the PR**
- It's a small difference, but the font in the Context menu that opens in Querybox looks blurry.
- Fix the issue

**Before**
![image](https://user-images.githubusercontent.com/6903107/192982872-522ce114-d51c-4d21-a0d9-62baec31a05f.png)

**After**
![image](https://user-images.githubusercontent.com/6903107/192983090-94f5c812-db62-4c52-b9a2-12633fec7da8.png)

**References**
- https://stackoverflow.com/questions/21538296/wpf-dropshadow-on-button-causes-blurry-text
- The same style is shared by the Tray menu, but there is no problem.