### PR TITLE
Use translation provided in launcher instead of in Program plugin

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/AddProgramSource.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/AddProgramSource.xaml
@@ -97,7 +97,7 @@
                     Margin="5,0,0,0"
                     HorizontalAlignment="Right"
                     Click="ButtonAdd_OnClick"
-                    Content="{DynamicResource flowlauncher_plugin_program_update}"
+                    Content="{DynamicResource done}"
                     Style="{DynamicResource AccentButtonStyle}" />
             </StackPanel>
         </Border>

--- a/Plugins/Flow.Launcher.Plugin.Program/ProgramSuffixes.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/ProgramSuffixes.xaml
@@ -92,7 +92,7 @@
                     Margin="5,0,0,0"
                     HorizontalAlignment="Right"
                     Click="ButtonBase_OnClick"
-                    Content="{DynamicResource flowlauncher_plugin_program_update}"
+                    Content="{DynamicResource done}"
                     Style="{DynamicResource AccentButtonStyle}" />
             </StackPanel>
         </Border>

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
@@ -162,13 +162,13 @@
                     MinWidth="100"
                     Margin="10"
                     Click="btnEditProgramSource_OnClick"
-                    Content="{DynamicResource flowlauncher_plugin_program_edit}" />
+                    Content="{DynamicResource edit}" />
                 <Button
                     x:Name="btnAddProgramSource"
                     MinWidth="100"
                     Margin="10,10,0,10"
                     Click="btnAddProgramSource_OnClick"
-                    Content="{DynamicResource flowlauncher_plugin_program_add}" />
+                    Content="{DynamicResource add}" />
             </StackPanel>
         </DockPanel>
     </Grid>


### PR DESCRIPTION
Some texts (e.g "edit", "OK") in Program plugin use translations provided in the plugin. No need to translate it again in the plugin.

BTW how to delete all unused translations? 