### PR TITLE
Fix #1476

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
@@ -43,6 +43,9 @@
 
     <system:String x:Key="flowlauncher_plugin_program_suffixes_excutable_types">File Suffixes</system:String>
     <system:String x:Key="flowlauncher_plugin_program_suffixes_URL_types">URL Protocols</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_suffixes_URL_steam">Steam Games</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_suffixes_URL_epic">Epic Games</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_suffixes_URL_http">Http/Https</system:String>
     <system:String x:Key="flowlauncher_plugin_program_suffixes_custom_urls">Custom URL Protocols</system:String>
     <system:String x:Key="flowlauncher_plugin_program_suffixes_custom_file_types">Custom File Suffixes</system:String>
     <system:String x:Key="flowlauncher_plugin_program_suffixes_tooltip">

--- a/Plugins/Flow.Launcher.Plugin.Program/ProgramSuffixes.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/ProgramSuffixes.xaml
@@ -193,9 +193,9 @@
                                 FontSize="16"
                                 FontWeight="SemiBold"
                                 Text="{DynamicResource flowlauncher_plugin_program_suffixes_URL_types}" />
-                            <CheckBox Name="steam" Margin="10,0,0,0" IsChecked="{Binding ProtocolsStatus[steam]}">Steam Games</CheckBox>
-                            <CheckBox Name="epic" Margin="10,0,0,0" IsChecked="{Binding ProtocolsStatus[epic]}">Epic Games</CheckBox>
-                            <CheckBox Name="http" Margin="10,0,0,0" IsChecked="{Binding ProtocolsStatus[http]}">Http/Https</CheckBox>
+                            <CheckBox Name="steam" Margin="10,0,0,0" IsChecked="{Binding ProtocolsStatus[steam]}" Content="{DynamicResource flowlauncher_plugin_program_suffixes_URL_steam}"></CheckBox>
+                            <CheckBox Name="epic" Margin="10,0,0,0" IsChecked="{Binding ProtocolsStatus[epic]}" Content="{DynamicResource flowlauncher_plugin_program_suffixes_URL_epic}"></CheckBox>
+                            <CheckBox Name="http" Margin="10,0,0,0" IsChecked="{Binding ProtocolsStatus[http]}" Content="{DynamicResource flowlauncher_plugin_program_suffixes_URL_http}"></CheckBox>
                             <CheckBox
                                 Name="CustomProtocol"
                                 Margin="10,0,0,0"


### PR DESCRIPTION
1. Currently #1476 doesn't index custom suffixes added before that PR due to renaming `string[] ProgramSuffixes`. Users will lose all custom suffixes in the settings. This has been fixed.
2. Adjusted some texts.