### PR TITLE
Enable non-C# plugins to use StringMatcher's scoring

### DIFF
--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -111,6 +111,11 @@ namespace Flow.Launcher.Plugin
         public int Score { get; set; }
 
         /// <summary>
+        /// String to use in fuzzy score matching
+        /// </summary>
+        public string FuzzyMatchString { get; set; }
+
+        /// <summary>
         /// A list of indexes for the characters to be highlighted in Title
         /// </summary>
         public IList<int> TitleHighlightData { get; set; }

--- a/Flow.Launcher/ViewModel/ResultsViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultsViewModel.cs
@@ -197,7 +197,7 @@ namespace Flow.Launcher.ViewModel
             if (!resultsForUpdates.Any())
                 return Results;
 
-            return Results.Where(r => r != null && !resultsForUpdates.Any(u => u.ID == r.Result.PluginID)).Where(
+            return Results.Where(r => r != null && !resultsForUpdates.Any(u => u.ID == r.Result.PluginID)).Concat(resultsForUpdates.SelectMany(u => u.Results, (u, r) => new ResultViewModel(r, _settings))).Where(
                 r =>
                 {
                     if (r.Result.FuzzyMatchString == null)
@@ -212,7 +212,7 @@ namespace Flow.Launcher.ViewModel
                     r.Result.Score = match.Score;
                     return true;
 
-                }).Concat(resultsForUpdates.SelectMany(u => u.Results, (u, r) => new ResultViewModel(r, _settings)))
+                })
                   .OrderByDescending(rv => rv.Result.Score)
                   .ToList();
         }

--- a/Flow.Launcher/ViewModel/ResultsViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultsViewModel.cs
@@ -200,7 +200,7 @@ namespace Flow.Launcher.ViewModel
             return Results.Where(r => r != null && !resultsForUpdates.Any(u => u.ID == r.Result.PluginID)).Concat(resultsForUpdates.SelectMany(u => u.Results, (u, r) => new ResultViewModel(r, _settings))).Where(
                 r =>
                 {
-                    if (r.Result.FuzzyMatchString == null)
+                    if (r.Result.FuzzyMatchString == null || r.Result.OriginQuery.Search == string.Empty)
                     {
                         return true;
                     }

--- a/Flow.Launcher/ViewModel/ResultsViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultsViewModel.cs
@@ -200,7 +200,6 @@ namespace Flow.Launcher.ViewModel
             return Results.Where(r => r != null && !resultsForUpdates.Any(u => u.ID == r.Result.PluginID)).Where(
                 r =>
                 {
-                    r.Result.SubTitle = r.Result.Score.ToString();
                     if (r.Result.FuzzyMatchString == null)
                     {
                         return true;
@@ -210,7 +209,6 @@ namespace Flow.Launcher.ViewModel
                     if (!match.IsSearchPrecisionScoreMet()) return false;
 
                     r.Result.Score = match.Score;
-                    r.Result.SubTitle = r.Result.Score.ToString();
                     return true;
 
                 }).Concat(resultsForUpdates.SelectMany(u => u.Results, (u, r) => new ResultViewModel(r, _settings)))

--- a/Flow.Launcher/ViewModel/ResultsViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultsViewModel.cs
@@ -207,6 +207,7 @@ namespace Flow.Launcher.ViewModel
                     var match = StringMatcher.FuzzySearch(r.Result.OriginQuery.Search, r.Result.FuzzyMatchString);
 
                     if (!match.IsSearchPrecisionScoreMet()) return false;
+                    r.Result.TitleHighlightData = match.MatchData;
 
                     r.Result.Score = match.Score;
                     return true;


### PR DESCRIPTION
Provides a new field called `FuzzyMatchString` that will override a results score with Flow's `StringMatcher.FuzzSearch` by matching the current query with the new field. 

Otherwise the field is `null` and ignored.

- [x] Fuzzymatch results
- [x] Hide results tht dont meet cutoff
- [x] Add text highlighting based on match?
- [x] Fix scores not applying if query text is the same

