### PR TITLE
Fix memory leaks with Plugin store layout

### DIFF
--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -98,6 +98,7 @@
     </PackageReference>
     <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" />
     <PackageReference Include="SharpVectors" Version="1.7.6" />
+    <PackageReference Include="VirtualizingWrapPanel" Version="1.5.7" />
   </ItemGroup>
 
   <ItemGroup>
@@ -120,7 +121,7 @@
     <!-- Work around https://github.com/dotnet/wpf/issues/6792 -->
 
     <ItemGroup>
-      <FilteredAnalyzer Include="@(Analyzer->Distinct())" />
+      <FilteredAnalyzer Include="@(Analyzer-&gt;Distinct())" />
       <Analyzer Remove="@(Analyzer)" />
       <Analyzer Include="@(FilteredAnalyzer)" />
     </ItemGroup>

--- a/Flow.Launcher/Resources/Dark.xaml
+++ b/Flow.Launcher/Resources/Dark.xaml
@@ -69,6 +69,8 @@
     <SolidColorBrush x:Key="CustomContextDisabled" Color="#868686" />
     <SolidColorBrush x:Key="ContextSeparator" Color="#3c3c3c" />
 
+    <SolidColorBrush x:Key="HoverStoreGrid2">#272727</SolidColorBrush>
+
     <Color x:Key="Color01">#202020</Color>
     <Color x:Key="Color02">#2b2b2b</Color>
     <Color x:Key="Color03">#1d1d1d</Color>

--- a/Flow.Launcher/Resources/Light.xaml
+++ b/Flow.Launcher/Resources/Light.xaml
@@ -62,6 +62,8 @@
     <SolidColorBrush x:Key="CustomContextDisabled" Color="#868686" />
     <SolidColorBrush x:Key="ContextSeparator" Color="#dadada" />
 
+    <SolidColorBrush x:Key="HoverStoreGrid2">#f6f6f6</SolidColorBrush>
+
     <Color x:Key="Color01">#f3f3f3</Color>
     <Color x:Key="Color02">#ffffff</Color>
     <Color x:Key="Color03">#e5e5e5</Color>

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -607,10 +607,10 @@
                     <ScrollViewer
                         Margin="0,0,0,0"
                         Background="{DynamicResource Color01B}"
-                        CanContentScroll="True"
+                        CanContentScroll="False"
                         VirtualizingPanel.ScrollUnit="Pixel"
                         VirtualizingStackPanel.IsVirtualizing="True">
-                        <StackPanel Margin="5,18,25,30" Orientation="Vertical">
+                        <VirtualizingStackPanel Margin="5,18,25,30" Orientation="Vertical">
                             <TextBlock
                                 Grid.Row="2"
                                 Margin="0,5,0,5"
@@ -917,7 +917,7 @@
                                     </TextBlock>
                                 </ItemsControl>
                             </Border>
-                        </StackPanel>
+                        </VirtualizingStackPanel>
                     </ScrollViewer>
                 </TabItem>
                 <TabItem KeyDown="OnPluginSettingKeydown">
@@ -1396,7 +1396,6 @@
                                 FontSize="14"
                                 KeyDown="PluginStoreFilterTxb_OnKeyDown"
                                 LostFocus="RefreshPluginStoreEventHandler"
-                         
                                 Text=""
                                 TextAlignment="Left"
                                 ToolTip="{DynamicResource searchpluginToolTip}"
@@ -1517,8 +1516,8 @@
                                         HorizontalContentAlignment="Stretch"
                                         VerticalContentAlignment="Stretch"
                                         BorderThickness="0"
-                                        FocusVisualStyle="{StaticResource StoreItemFocusVisualStyleKey}"
-                                        Click="StoreListItem_Click">
+                                        Click="StoreListItem_Click"
+                                        FocusVisualStyle="{StaticResource StoreItemFocusVisualStyleKey}">
                                         <ui:FlyoutService.Flyout>
                                             <ui:Flyout x:Name="InstallFlyout" Placement="Bottom">
                                                 <Grid MinWidth="200">
@@ -1679,8 +1678,8 @@
                             Margin="0,0,0,0"
                             Padding="6,0,24,0"
                             ScrollViewer.CanContentScroll="True"
-                            VirtualizingStackPanel.ScrollUnit="Pixel"
-                            VirtualizingStackPanel.IsVirtualizing="True">
+                            VirtualizingStackPanel.IsVirtualizing="True"
+                            VirtualizingStackPanel.ScrollUnit="Pixel">
                             <Grid Margin="0,0,0,0">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="0" />
@@ -2257,8 +2256,8 @@
                         Margin="0,0,0,0"
                         Padding="0,0,6,0"
                         ScrollViewer.CanContentScroll="True"
-                        VirtualizingStackPanel.ScrollUnit="Pixel"
-                        VirtualizingStackPanel.IsVirtualizing="True">
+                        VirtualizingStackPanel.IsVirtualizing="True"
+                        VirtualizingStackPanel.ScrollUnit="Pixel">
                         <Border>
                             <Grid Margin="5,18,18,10">
                                 <Grid.RowDefinitions>
@@ -2553,8 +2552,8 @@
                         Margin="0,0,0,0"
                         Padding="5,0,24,0"
                         ScrollViewer.CanContentScroll="True"
-                        VirtualizingStackPanel.ScrollUnit="Pixel"
-                        VirtualizingStackPanel.IsVirtualizing="True">
+                        VirtualizingStackPanel.IsVirtualizing="True"
+                        VirtualizingStackPanel.ScrollUnit="Pixel">
                         <Border>
 
                             <StackPanel>
@@ -2727,8 +2726,8 @@
                             Margin="0,0,0,0"
                             Background="{DynamicResource Color01B}"
                             ScrollViewer.CanContentScroll="True"
-                            VirtualizingStackPanel.ScrollUnit="Pixel"
-                            VirtualizingStackPanel.IsVirtualizing="True">
+                            VirtualizingStackPanel.IsVirtualizing="True"
+                            VirtualizingStackPanel.ScrollUnit="Pixel">
                             <StackPanel Margin="5,14,25,30" Orientation="Vertical">
                                 <TextBlock
                                     Grid.Row="2"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -11,6 +11,7 @@
     xmlns:ui="http://schemas.modernwpf.com/2019"
     xmlns:userSettings="clr-namespace:Flow.Launcher.Infrastructure.UserSettings;assembly=Flow.Launcher.Infrastructure"
     xmlns:vm="clr-namespace:Flow.Launcher.ViewModel"
+    xmlns:wpftk="clr-namespace:WpfToolkit.Controls;assembly=VirtualizingWrapPanel"
     Title="{DynamicResource flowlauncher_settings}"
     Width="{Binding SettingWindowWidth, Mode=TwoWay}"
     Height="{Binding SettingWindowHeight, Mode=TwoWay}"
@@ -1051,7 +1052,7 @@
                                 VirtualizingStackPanel.VirtualizationMode="Recycling">
                                 <ListBox.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <StackPanel Margin="0,0,0,18" />
+                                        <VirtualizingStackPanel Margin="0,0,0,18" />
                                     </ItemsPanelTemplate>
                                 </ListBox.ItemsPanel>
                                 <ListBox.ItemTemplate>
@@ -1511,7 +1512,7 @@
                                 </ListBox.GroupStyle>
                                 <ListBox.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <WrapPanel Margin="0,0,0,10" />
+                                        <wpftk:VirtualizingWrapPanel />
                                     </ItemsPanelTemplate>
                                 </ListBox.ItemsPanel>
                                 <ListBox.ItemTemplate>

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -484,7 +484,6 @@
                 Width="16"
                 Height="16"
                 Margin="10,4,4,4"
-                RenderOptions.BitmapScalingMode="HighQuality"
                 Source="/Images/app.png" />
             <TextBlock
                 Grid.Column="1"
@@ -1047,7 +1046,9 @@
                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                 SelectedItem="{Binding SelectedPlugin}"
                                 SnapsToDevicePixels="True"
-                                Style="{DynamicResource PluginListStyle}">
+                                Style="{DynamicResource PluginListStyle}"
+                                VirtualizingStackPanel.IsVirtualizing="True"
+                                VirtualizingStackPanel.VirtualizationMode="Recycling">
                                 <ListBox.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <StackPanel Margin="0,0,0,18" />
@@ -1477,7 +1478,9 @@
                                 ItemsSource="{Binding ExternalPlugins}"
                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                 SelectionMode="Single"
-                                Style="{DynamicResource StoreListStyle}">
+                                Style="{DynamicResource StoreListStyle}"
+                                VirtualizingStackPanel.IsVirtualizing="True"
+                                VirtualizingStackPanel.VirtualizationMode="Recycling">
                                 <ListBox.GroupStyle>
                                     <GroupStyle>
                                         <GroupStyle.ContainerStyle>
@@ -1587,7 +1590,6 @@
                                                         Margin="20,20,6,0"
                                                         HorizontalAlignment="Left"
                                                         VerticalAlignment="Top"
-                                                        RenderOptions.BitmapScalingMode="HighQuality"
                                                         Source="{Binding IcoPath, IsAsync=True}"
                                                         Stretch="Uniform" />
                                                 </StackPanel>
@@ -1756,7 +1758,8 @@
                         <ScrollViewer
                             Margin="0,0,0,0"
                             Padding="6,0,24,0"
-                            ScrollViewer.CanContentScroll="False">
+                            ScrollViewer.CanContentScroll="False"
+                            VirtualizingStackPanel.IsVirtualizing="True">
                             <Grid Margin="0,0,0,0">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="0" />

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -1493,7 +1493,9 @@
                                                                         FontSize="16"
                                                                         FontWeight="Bold"
                                                                         Text="{Binding Name, Converter={StaticResource TextConverter}}" />
+
                                                                     <ItemsPresenter />
+
                                                                 </StackPanel>
 
                                                             </Grid>
@@ -1506,13 +1508,7 @@
                                 </ListBox.GroupStyle>
                                 <ListBox.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <UniformGrid
-                                            Margin="0,0,17,18"
-                                            HorizontalAlignment="Left"
-                                            VerticalAlignment="Top"
-                                            Columns="3"
-                                            IsItemsHost="True"
-                                            SnapsToDevicePixels="True" />
+                                        <WrapPanel Margin="0,0,0,10" />
                                     </ItemsPanelTemplate>
                                 </ListBox.ItemsPanel>
                                 <ListBox.ItemTemplate>
@@ -1520,7 +1516,9 @@
                                         <!--  Hover Layout Style  -->
 
                                         <ToggleButton
-                                            Width="{Binding ActualWidth, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}}"
+                                            x:Name="StoreListItem"
+                                            Width="216"
+                                            Height="164"
                                             HorizontalAlignment="Left"
                                             HorizontalContentAlignment="left"
                                             Background="Transparent"
@@ -1543,10 +1541,7 @@
                                                 </ControlTemplate>
                                             </ToggleButton.Template>
 
-                                            <Grid
-                                                Height="160"
-                                                HorizontalAlignment="Left"
-                                                VerticalAlignment="Top">
+                                            <Grid HorizontalAlignment="Left" VerticalAlignment="Top">
                                                 <Grid.RowDefinitions>
                                                     <RowDefinition Height="56" />
                                                     <RowDefinition Height="*" />
@@ -1598,7 +1593,6 @@
                                                 </StackPanel>
                                                 <StackPanel
                                                     Grid.Row="1"
-                                                    Width="{Binding ActualWidth, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}}"
                                                     Margin="0,6,0,0"
                                                     VerticalAlignment="Top"
                                                     Panel.ZIndex="0">
@@ -1656,10 +1650,10 @@
                                                         VerticalAlignment="Stretch"
                                                         Panel.ZIndex="1">
                                                         <Grid.Background>
-                                                            <SolidColorBrush Opacity=".95" Color="{DynamicResource HoverStoreGrid}" />
+                                                            <SolidColorBrush Opacity="1" Color="{DynamicResource HoverStoreGrid}" />
                                                         </Grid.Background>
                                                         <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition Width="{Binding ActualWidth, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}}" />
+                                                            <ColumnDefinition Width="{Binding Path=ActualWidth, ElementName=StoreListItem}" />
                                                         </Grid.ColumnDefinitions>
 
                                                         <StackPanel

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -1402,6 +1402,7 @@
                                 Text="{DynamicResource pluginStore}"
                                 TextAlignment="left" />
                         </Border>
+
                         <DockPanel
                             Grid.Row="0"
                             Grid.Column="1"
@@ -1462,279 +1463,271 @@
                                 DockPanel.Dock="Right"
                                 FontSize="13" />
                         </DockPanel>
-                        <Border
+                        <ListView
+                            x:Name="StoreListBox"
                             Grid.Row="1"
                             Grid.Column="0"
                             Grid.ColumnSpan="2"
-                            Padding="0,0,0,0">
-                            <ListBox
-                                x:Name="StoreListBox"
-                                Width="Auto"
-                                Margin="5,1,0,0"
-                                Padding="0,0,0,0"
-                                HorizontalAlignment="Stretch"
-                                VerticalContentAlignment="Center"
-                                Background="{DynamicResource Color01B}"
-                                ItemContainerStyle="{StaticResource StoreList}"
-                                ItemsSource="{Binding ExternalPlugins}"
-                                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                SelectionMode="Single"
-                                Style="{DynamicResource StoreListStyle}"
-                                VirtualizingStackPanel.IsVirtualizing="True"
-                                VirtualizingStackPanel.VirtualizationMode="Recycling">
-                                <ListBox.GroupStyle>
-                                    <GroupStyle>
-                                        <GroupStyle.ContainerStyle>
-                                            <Style TargetType="{x:Type GroupItem}">
-                                                <Setter Property="Template">
-                                                    <Setter.Value>
-                                                        <ControlTemplate>
-                                                            <Grid>
-                                                                <StackPanel Orientation="Vertical">
-                                                                    <TextBlock
-                                                                        Margin="0,0,0,10"
-                                                                        VerticalAlignment="Top"
-                                                                        FontSize="16"
-                                                                        FontWeight="Bold"
-                                                                        Text="{Binding Name, Converter={StaticResource TextConverter}}" />
+                            Margin="0,2,0,0"
+                            Padding="0,0,18,0"
+                            ItemContainerStyle="{StaticResource StoreList}"
+                            ItemsSource="{Binding ExternalPlugins}"
+                            ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                            ScrollViewer.VerticalScrollBarVisibility="Auto"
+                            VirtualizingPanel.CacheLength="1,1"
+                            VirtualizingPanel.CacheLengthUnit="Page"
+                            VirtualizingPanel.IsVirtualizingWhenGrouping="True"
+                            VirtualizingPanel.ScrollUnit="Pixel"
+                            VirtualizingPanel.VirtualizationMode="Standard">
+                            <ListView.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <wpftk:VirtualizingWrapPanel
+                                        Margin="0,0,0,10"
+                                        MouseWheelDelta="48"
+                                        Orientation="Vertical"
+                                        ScrollLineDelta="16"
+                                        SpacingMode="Uniform"
+                                        StretchItems="True" />
+                                </ItemsPanelTemplate>
+                            </ListView.ItemsPanel>
+                            <ListView.GroupStyle>
+                                <GroupStyle HidesIfEmpty="True">
+                                    <GroupStyle.HeaderTemplate>
+                                        <DataTemplate>
+                                            <TextBlock
+                                                HorizontalAlignment="Left"
+                                                FontSize="14"
+                                                FontWeight="Bold"
+                                                Text="{Binding Name, Converter={StaticResource TextConverter}}" />
+                                        </DataTemplate>
+                                    </GroupStyle.HeaderTemplate>
+                                    <GroupStyle.Panel>
+                                        <ItemsPanelTemplate>
+                                            <VirtualizingStackPanel Orientation="{Binding Orientation, Mode=OneWay}" />
+                                        </ItemsPanelTemplate>
+                                    </GroupStyle.Panel>
+                                </GroupStyle>
+                            </ListView.GroupStyle>
 
-                                                                    <ItemsPresenter />
+                            <ListView.ItemTemplate>
+                                <DataTemplate>
+                                    <!--  Hover Layout Style  -->
 
-                                                                </StackPanel>
+                                    <ToggleButton
+                                        x:Name="StoreListItem"
+                                        Width="216"
+                                        Height="164"
+                                        HorizontalAlignment="Left"
+                                        HorizontalContentAlignment="left"
+                                        Background="Transparent"
+                                        IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}, Path=IsSelected}"
+                                        Style="{StaticResource StoreItem}">
+                                        <ToggleButton.Template>
+                                            <ControlTemplate TargetType="{x:Type ButtonBase}">
+                                                <ContentPresenter
+                                                    x:Name="contentPresenter"
+                                                    Margin="{TemplateBinding Padding}"
+                                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                    Content="{TemplateBinding Content}"
+                                                    ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                    Focusable="False"
+                                                    RecognizesAccessKey="True"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                                <ControlTemplate.Triggers />
+                                            </ControlTemplate>
+                                        </ToggleButton.Template>
 
-                                                            </Grid>
-                                                        </ControlTemplate>
-                                                    </Setter.Value>
-                                                </Setter>
-                                            </Style>
-                                        </GroupStyle.ContainerStyle>
-                                    </GroupStyle>
-                                </ListBox.GroupStyle>
-                                <ListBox.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <wpftk:VirtualizingWrapPanel />
-                                    </ItemsPanelTemplate>
-                                </ListBox.ItemsPanel>
-                                <ListBox.ItemTemplate>
-                                    <DataTemplate>
-                                        <!--  Hover Layout Style  -->
-
-                                        <ToggleButton
-                                            x:Name="StoreListItem"
-                                            Width="216"
-                                            Height="164"
-                                            HorizontalAlignment="Left"
-                                            HorizontalContentAlignment="left"
-                                            Background="Transparent"
-                                            IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}, Path=IsSelected}"
-                                            Style="{StaticResource StoreItem}">
-                                            <ToggleButton.Template>
-                                                <ControlTemplate TargetType="{x:Type ButtonBase}">
-                                                    <ContentPresenter
-                                                        x:Name="contentPresenter"
-                                                        Margin="{TemplateBinding Padding}"
-                                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                        Content="{TemplateBinding Content}"
-                                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                        Focusable="False"
-                                                        RecognizesAccessKey="True"
-                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                                                    <ControlTemplate.Triggers />
-                                                </ControlTemplate>
-                                            </ToggleButton.Template>
-
-                                            <Grid HorizontalAlignment="Left" VerticalAlignment="Top">
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="56" />
-                                                    <RowDefinition Height="*" />
-                                                </Grid.RowDefinitions>
-                                                <StackPanel
-                                                    Grid.Row="0"
-                                                    Grid.RowSpan="2"
-                                                    Grid.Column="0"
-                                                    Grid.ColumnSpan="2"
-                                                    Margin="0,0,2,0"
+                                        <Grid HorizontalAlignment="Left" VerticalAlignment="Top">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="56" />
+                                                <RowDefinition Height="*" />
+                                            </Grid.RowDefinitions>
+                                            <StackPanel
+                                                Grid.Row="0"
+                                                Grid.RowSpan="2"
+                                                Grid.Column="0"
+                                                Grid.ColumnSpan="2"
+                                                Margin="0,0,2,0"
+                                                HorizontalAlignment="Right"
+                                                Orientation="Horizontal">
+                                                <Border
+                                                    x:Name="LabelUpdate"
+                                                    Height="12"
+                                                    Margin="0,10,8,0"
+                                                    Padding="6,2,6,2"
                                                     HorizontalAlignment="Right"
-                                                    Orientation="Horizontal">
-                                                    <Border
-                                                        x:Name="LabelUpdate"
-                                                        Height="12"
-                                                        Margin="0,10,8,0"
-                                                        Padding="6,2,6,2"
-                                                        HorizontalAlignment="Right"
-                                                        VerticalAlignment="Top"
-                                                        Background="#45BD59"
-                                                        CornerRadius="36"
-                                                        ToolTip="{DynamicResource LabelUpdateToolTip}"
-                                                        Visibility="{Binding LabelUpdate, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                                </StackPanel>
-
-                                                <StackPanel
-                                                    Grid.Row="0"
-                                                    Margin="0,0,0,0"
-                                                    VerticalAlignment="Top">
-                                                    <StackPanel.Style>
-                                                        <Style>
-                                                            <Setter Property="StackPanel.Visibility" Value="Visible" />
-                                                            <Style.Triggers>
-                                                                <DataTrigger Binding="{Binding Mode=TwoWay, Path=IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem, Mode=FindAncestor}}" Value="true">
-                                                                    <Setter Property="StackPanel.Opacity" Value="1" />
-                                                                </DataTrigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </StackPanel.Style>
-                                                    <Image
-                                                        Width="32"
-                                                        Height="32"
-                                                        Margin="20,20,6,0"
-                                                        HorizontalAlignment="Left"
-                                                        VerticalAlignment="Top"
-                                                        Source="{Binding IcoPath, IsAsync=True}"
-                                                        Stretch="Uniform" />
-                                                </StackPanel>
-                                                <StackPanel
-                                                    Grid.Row="1"
-                                                    Margin="0,6,0,0"
                                                     VerticalAlignment="Top"
-                                                    Panel.ZIndex="0">
-                                                    <StackPanel.Style>
-                                                        <Style>
-                                                            <Setter Property="StackPanel.Visibility" Value="Visible" />
-                                                            <Style.Triggers>
-                                                                <DataTrigger Binding="{Binding Mode=TwoWay, Path=IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem, Mode=FindAncestor}}" Value="true">
-                                                                    <Setter Property="StackPanel.Opacity" Value="1" />
-                                                                </DataTrigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </StackPanel.Style>
-                                                    <TextBlock
-                                                        Padding="20,0,20,0"
-                                                        VerticalAlignment="Top"
-                                                        FontWeight="SemiBold"
-                                                        Foreground="{DynamicResource Color05B}"
-                                                        Text="{Binding Name}"
-                                                        TextWrapping="WrapWithOverflow"
-                                                        ToolTip="{Binding Version}" />
-                                                    <TextBlock
-                                                        Margin="0,6,0,0"
-                                                        Padding="20,0,22,20"
+                                                    Background="#45BD59"
+                                                    CornerRadius="36"
+                                                    ToolTip="{DynamicResource LabelUpdateToolTip}"
+                                                    Visibility="{Binding LabelUpdate, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                            </StackPanel>
+
+                                            <StackPanel
+                                                Grid.Row="0"
+                                                Margin="0,0,0,0"
+                                                VerticalAlignment="Top">
+                                                <StackPanel.Style>
+                                                    <Style>
+                                                        <Setter Property="StackPanel.Visibility" Value="Visible" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Mode=TwoWay, Path=IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem, Mode=FindAncestor}}" Value="true">
+                                                                <Setter Property="StackPanel.Opacity" Value="1" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </StackPanel.Style>
+                                                <Image
+                                                    Width="32"
+                                                    Height="32"
+                                                    Margin="20,20,6,0"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Top"
+                                                    Source="{Binding IcoPath, IsAsync=True}"
+                                                    Stretch="Uniform" />
+                                            </StackPanel>
+                                            <StackPanel
+                                                Grid.Row="1"
+                                                Margin="0,6,0,0"
+                                                VerticalAlignment="Top"
+                                                Panel.ZIndex="0">
+                                                <StackPanel.Style>
+                                                    <Style>
+                                                        <Setter Property="StackPanel.Visibility" Value="Visible" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Mode=TwoWay, Path=IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem, Mode=FindAncestor}}" Value="true">
+                                                                <Setter Property="StackPanel.Opacity" Value="1" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </StackPanel.Style>
+                                                <TextBlock
+                                                    Padding="20,0,20,0"
+                                                    VerticalAlignment="Top"
+                                                    FontWeight="SemiBold"
+                                                    Foreground="{DynamicResource Color05B}"
+                                                    Text="{Binding Name}"
+                                                    TextWrapping="WrapWithOverflow"
+                                                    ToolTip="{Binding Version}" />
+                                                <TextBlock
+                                                    Margin="0,6,0,0"
+                                                    Padding="20,0,22,20"
+                                                    Foreground="{DynamicResource Color04B}"
+                                                    TextWrapping="WrapWithOverflow">
+                                                    <Run
+                                                        FontSize="12"
                                                         Foreground="{DynamicResource Color04B}"
-                                                        TextWrapping="WrapWithOverflow">
-                                                        <Run
-                                                            FontSize="12"
-                                                            Foreground="{DynamicResource Color04B}"
-                                                            Text="{Binding Description, Mode=OneWay}" />
-                                                    </TextBlock>
+                                                        Text="{Binding Description, Mode=OneWay}" />
+                                                </TextBlock>
 
-                                                </StackPanel>
-                                                <StackPanel
-                                                    Grid.RowSpan="2"
-                                                    Grid.Column="0"
-                                                    Grid.ColumnSpan="2"
+                                            </StackPanel>
+                                            <StackPanel
+                                                Grid.RowSpan="2"
+                                                Grid.Column="0"
+                                                Grid.ColumnSpan="2"
+                                                HorizontalAlignment="Stretch"
+                                                VerticalAlignment="Stretch">
+                                                <StackPanel.Style>
+                                                    <Style>
+                                                        <Setter Property="StackPanel.Visibility" Value="Collapsed" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Mode=TwoWay, Path=IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem, Mode=FindAncestor}}" Value="true">
+                                                                <Setter Property="StackPanel.Visibility" Value="Visible" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </StackPanel.Style>
+
+
+                                                <Grid
+                                                    Height="180"
                                                     HorizontalAlignment="Stretch"
-                                                    VerticalAlignment="Stretch">
-                                                    <StackPanel.Style>
-                                                        <Style>
-                                                            <Setter Property="StackPanel.Visibility" Value="Collapsed" />
-                                                            <Style.Triggers>
-                                                                <DataTrigger Binding="{Binding Mode=TwoWay, Path=IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem, Mode=FindAncestor}}" Value="true">
-                                                                    <Setter Property="StackPanel.Visibility" Value="Visible" />
-                                                                </DataTrigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </StackPanel.Style>
+                                                    VerticalAlignment="Stretch"
+                                                    Panel.ZIndex="1">
+                                                    <Grid.Background>
+                                                        <SolidColorBrush Opacity="1" Color="{DynamicResource HoverStoreGrid}" />
+                                                    </Grid.Background>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="{Binding Path=ActualWidth, ElementName=StoreListItem}" />
+                                                    </Grid.ColumnDefinitions>
 
-
-                                                    <Grid
-                                                        Height="180"
+                                                    <StackPanel
+                                                        Grid.Row="0"
+                                                        Grid.Column="0"
                                                         HorizontalAlignment="Stretch"
-                                                        VerticalAlignment="Stretch"
-                                                        Panel.ZIndex="1">
-                                                        <Grid.Background>
-                                                            <SolidColorBrush Opacity="1" Color="{DynamicResource HoverStoreGrid}" />
-                                                        </Grid.Background>
-                                                        <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition Width="{Binding Path=ActualWidth, ElementName=StoreListItem}" />
-                                                        </Grid.ColumnDefinitions>
-
-                                                        <StackPanel
-                                                            Grid.Row="0"
-                                                            Grid.Column="0"
-                                                            HorizontalAlignment="Stretch"
-                                                            VerticalAlignment="Top">
-                                                            <StackPanel Orientation="Vertical">
-                                                                <TextBlock
-                                                                    Margin="20,20,20,0"
-                                                                    Padding="0,0,0,0"
-                                                                    FontWeight="Bold"
-                                                                    Foreground="{DynamicResource Color05B}"
-                                                                    Text="{Binding Name}"
-                                                                    TextWrapping="WrapWithOverflow"
-                                                                    ToolTip="{Binding Name}" />
-                                                                <TextBlock
-                                                                    Margin="20,4,20,0"
-                                                                    Padding="0,0,20,0"
-                                                                    Foreground="{DynamicResource Color05B}"
-                                                                    Text="{Binding Version}"
-                                                                    TextWrapping="WrapWithOverflow"
-                                                                    ToolTip="{Binding Version}" />
-                                                            </StackPanel>
-                                                            <StackPanel Margin="20,6,20,0" Orientation="Vertical">
-                                                                <TextBlock Padding="0,0,0,0" TextWrapping="Wrap">
-                                                                    <Hyperlink
-                                                                        Foreground="{DynamicResource Color04B}"
-                                                                        NavigateUri="{Binding Website}"
-                                                                        RequestNavigate="OnRequestNavigate">
-                                                                        <Run FontSize="12" Text="{Binding Author, Mode=OneWay}" />
-                                                                    </Hyperlink>
-                                                                </TextBlock>
-                                                            </StackPanel>
+                                                        VerticalAlignment="Top">
+                                                        <StackPanel Orientation="Vertical">
+                                                            <TextBlock
+                                                                Margin="20,20,20,0"
+                                                                Padding="0,0,0,0"
+                                                                FontWeight="Bold"
+                                                                Foreground="{DynamicResource Color05B}"
+                                                                Text="{Binding Name}"
+                                                                TextWrapping="WrapWithOverflow"
+                                                                ToolTip="{Binding Name}" />
+                                                            <TextBlock
+                                                                Margin="20,4,20,0"
+                                                                Padding="0,0,20,0"
+                                                                Foreground="{DynamicResource Color05B}"
+                                                                Text="{Binding Version}"
+                                                                TextWrapping="WrapWithOverflow"
+                                                                ToolTip="{Binding Version}" />
                                                         </StackPanel>
-                                                        <Grid Grid.Row="0" Grid.Column="1">
-                                                            <StackPanel
-                                                                Margin="0,70,20,0"
+                                                        <StackPanel Margin="20,6,20,0" Orientation="Vertical">
+                                                            <TextBlock Padding="0,0,0,0" TextWrapping="Wrap">
+                                                                <Hyperlink
+                                                                    Foreground="{DynamicResource Color04B}"
+                                                                    NavigateUri="{Binding Website}"
+                                                                    RequestNavigate="OnRequestNavigate">
+                                                                    <Run FontSize="12" Text="{Binding Author, Mode=OneWay}" />
+                                                                </Hyperlink>
+                                                            </TextBlock>
+                                                        </StackPanel>
+                                                    </StackPanel>
+                                                    <Grid Grid.Row="0" Grid.Column="1">
+                                                        <StackPanel
+                                                            Margin="0,70,20,0"
+                                                            HorizontalAlignment="Right"
+                                                            Orientation="Horizontal">
+                                                            <Button
+                                                                MinHeight="40"
+                                                                Padding="15,5,15,5"
                                                                 HorizontalAlignment="Right"
-                                                                Orientation="Horizontal">
-                                                                <Button
-                                                                    MinHeight="40"
-                                                                    Padding="15,5,15,5"
-                                                                    HorizontalAlignment="Right"
-                                                                    VerticalAlignment="Center"
-                                                                    Click="OnExternalPluginInstallClick"
-                                                                    Content="{DynamicResource installbtn}"
-                                                                    Visibility="{Binding LabelInstalled, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter='!'}" />
-                                                                <Button
-                                                                    MinHeight="40"
-                                                                    Margin="5,0,0,0"
-                                                                    Padding="15,5,15,5"
-                                                                    HorizontalAlignment="Right"
-                                                                    VerticalAlignment="Center"
-                                                                    Click="OnExternalPluginUninstallClick"
-                                                                    Content="{DynamicResource uninstallbtn}"
-                                                                    Visibility="{Binding LabelInstalled, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                                                <Button
-                                                                    MinHeight="40"
-                                                                    Margin="5,0,0,0"
-                                                                    Padding="15,5,15,5"
-                                                                    HorizontalAlignment="Right"
-                                                                    VerticalAlignment="Center"
-                                                                    Click="OnExternalPluginUpdateClick"
-                                                                    Content="{DynamicResource updatebtn}"
-                                                                    Visibility="{Binding LabelUpdate, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                                                <!--  Hide Install Button when installed Item  -->
-                                                            </StackPanel>
-                                                        </Grid>
+                                                                VerticalAlignment="Center"
+                                                                Click="OnExternalPluginInstallClick"
+                                                                Content="{DynamicResource installbtn}"
+                                                                Visibility="{Binding LabelInstalled, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter='!'}" />
+                                                            <Button
+                                                                MinHeight="40"
+                                                                Margin="5,0,0,0"
+                                                                Padding="15,5,15,5"
+                                                                HorizontalAlignment="Right"
+                                                                VerticalAlignment="Center"
+                                                                Click="OnExternalPluginUninstallClick"
+                                                                Content="{DynamicResource uninstallbtn}"
+                                                                Visibility="{Binding LabelInstalled, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                            <Button
+                                                                MinHeight="40"
+                                                                Margin="5,0,0,0"
+                                                                Padding="15,5,15,5"
+                                                                HorizontalAlignment="Right"
+                                                                VerticalAlignment="Center"
+                                                                Click="OnExternalPluginUpdateClick"
+                                                                Content="{DynamicResource updatebtn}"
+                                                                Visibility="{Binding LabelUpdate, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                            <!--  Hide Install Button when installed Item  -->
+                                                        </StackPanel>
                                                     </Grid>
-                                                </StackPanel>
-                                            </Grid>
+                                                </Grid>
+                                            </StackPanel>
+                                        </Grid>
 
-                                        </ToggleButton>
-                                    </DataTemplate>
-                                </ListBox.ItemTemplate>
-                            </ListBox>
-                        </Border>
+                                    </ToggleButton>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
                     </Grid>
                 </TabItem>
                 <!--#endregion-->

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -130,6 +130,7 @@
             <Setter Property="Margin" Value="0,0,-18,0" />
         </Style>
 
+
         <Style x:Key="logo" TargetType="{x:Type TabItem}">
             <!--#region Logo Style-->
             <Setter Property="Margin" Value="0" />
@@ -243,11 +244,7 @@
         </Style>
 
         <!--  Plugin Store Item when Selected layout for nothing  -->
-        <Style x:Key="StoreItem" TargetType="{x:Type ToggleButton}">
-            <Style.Triggers>
-                <Trigger Property="IsChecked" Value="True" />
-            </Style.Triggers>
-        </Style>
+        <Style x:Key="StoreItem" TargetType="{x:Type ToggleButton}" />
 
         <Style x:Key="PluginList" TargetType="ListBoxItem">
             <Setter Property="Background" Value="{DynamicResource Color00B}" />
@@ -320,11 +317,12 @@
         </Style>
 
         <!--#region PluginStore Style-->
-        <Style x:Key="StoreList" TargetType="ListBoxItem">
-            <Setter Property="Background" Value="{DynamicResource Color02B}" />
+        <Style x:Key="StoreList" TargetType="ListViewItem">
             <Setter Property="Padding" Value="0,0,0,0" />
-            <Setter Property="Margin" Value="0,0,8,5" />
-            <Setter Property="BorderBrush" Value="{DynamicResource Color03B}" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+
+            <Setter Property="Margin" Value="0,0,8,8" />
+            <Setter Property="VerticalContentAlignment" Value="Stretch" />
             <!--#region Template for blue highlight win10-->
             <Setter Property="Template">
                 <Setter.Value>
@@ -336,7 +334,8 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="5"
-                            SnapsToDevicePixels="True">
+                            SnapsToDevicePixels="True"
+                            UseLayoutRounding="True">
                             <ContentPresenter
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -346,6 +345,24 @@
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
                         <ControlTemplate.Triggers>
+
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsSelected" Value="False" />
+                                </MultiTrigger.Conditions>
+                                <Setter TargetName="Bd" Property="Margin" Value="0,0,0,0" />
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Color00B}" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Color03B}" />
+                            </MultiTrigger>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsSelected" Value="True" />
+                                </MultiTrigger.Conditions>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Color07B}" />
+                                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Color03B}" />
+                                <Setter TargetName="Bd" Property="CornerRadius" Value="5" />
+                                <Setter TargetName="Bd" Property="Margin" Value="0,0,0,0" />
+                            </MultiTrigger>
                             <MultiTrigger>
                                 <MultiTrigger.Conditions>
                                     <Condition Property="IsMouseOver" Value="True" />
@@ -353,29 +370,6 @@
                                 <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Color07B}" />
                                 <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Color03B}" />
                                 <Setter TargetName="Bd" Property="CornerRadius" Value="5" />
-
-                            </MultiTrigger>
-                            <MultiTrigger>
-                                <MultiTrigger.Conditions>
-                                    <Condition Property="Selector.IsSelectionActive" Value="False" />
-                                    <Condition Property="IsSelected" Value="True" />
-                                </MultiTrigger.Conditions>
-                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Color02B}" />
-                                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Color03B}" />
-                                <Setter TargetName="Bd" Property="Margin" Value="0,0,0,0" />
-
-
-                            </MultiTrigger>
-                            <MultiTrigger>
-                                <MultiTrigger.Conditions>
-                                    <Condition Property="Selector.IsSelectionActive" Value="True" />
-                                    <Condition Property="IsSelected" Value="True" />
-                                </MultiTrigger.Conditions>
-                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Color02B}" />
-                                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Color03B}" />
-                                <Setter TargetName="Bd" Property="CornerRadius" Value="5" />
-                                <Setter TargetName="Bd" Property="Margin" Value="0,0,0,0" />
-
 
                             </MultiTrigger>
                             <Trigger Property="IsEnabled" Value="False">
@@ -1407,6 +1401,7 @@
                             Grid.Row="0"
                             Grid.Column="1"
                             Margin="5,24,0,0">
+
                             <TextBox
                                 Name="pluginStoreFilterTxb"
                                 Width="150"
@@ -1483,7 +1478,9 @@
                             <ListView.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <wpftk:VirtualizingWrapPanel
+                                        x:Name="ItemWrapPanel"
                                         Margin="0,0,0,10"
+                                        ItemSize="216,194"
                                         MouseWheelDelta="48"
                                         Orientation="Vertical"
                                         ScrollLineDelta="16"
@@ -1493,15 +1490,30 @@
                             </ListView.ItemsPanel>
                             <ListView.GroupStyle>
                                 <GroupStyle HidesIfEmpty="True">
-                                    <GroupStyle.HeaderTemplate>
-                                        <DataTemplate>
-                                            <TextBlock
-                                                HorizontalAlignment="Left"
-                                                FontSize="14"
-                                                FontWeight="Bold"
-                                                Text="{Binding Name, Converter={StaticResource TextConverter}}" />
-                                        </DataTemplate>
-                                    </GroupStyle.HeaderTemplate>
+                                    <GroupStyle.ContainerStyle>
+                                        <Style TargetType="{x:Type GroupItem}">
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate>
+                                                        <Grid>
+                                                            <StackPanel Orientation="Vertical">
+                                                                <TextBlock
+                                                                    Margin="0,0,0,10"
+                                                                    VerticalAlignment="Top"
+                                                                    FontSize="16"
+                                                                    FontWeight="Bold"
+                                                                    Text="{Binding Name, Converter={StaticResource TextConverter}}" />
+
+                                                                <ItemsPresenter />
+
+                                                            </StackPanel>
+
+                                                        </Grid>
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Style>
+                                    </GroupStyle.ContainerStyle>
                                     <GroupStyle.Panel>
                                         <ItemsPanelTemplate>
                                             <VirtualizingStackPanel Orientation="{Binding Orientation, Mode=OneWay}" />
@@ -1510,17 +1522,15 @@
                                 </GroupStyle>
                             </ListView.GroupStyle>
 
-                            <ListView.ItemTemplate>
+                            <ListBox.ItemTemplate>
                                 <DataTemplate>
                                     <!--  Hover Layout Style  -->
 
                                     <ToggleButton
                                         x:Name="StoreListItem"
-                                        Width="216"
-                                        Height="164"
+                                        Width="200"
                                         HorizontalAlignment="Left"
                                         HorizontalContentAlignment="left"
-                                        Background="Transparent"
                                         IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}, Path=IsSelected}"
                                         Style="{StaticResource StoreItem}">
                                         <ToggleButton.Template>
@@ -1727,9 +1737,10 @@
 
                                     </ToggleButton>
                                 </DataTemplate>
-                            </ListView.ItemTemplate>
+                            </ListBox.ItemTemplate>
                         </ListView>
                     </Grid>
+
                 </TabItem>
                 <!--#endregion-->
 

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -358,7 +358,7 @@
                                 <MultiTrigger.Conditions>
                                     <Condition Property="IsSelected" Value="True" />
                                 </MultiTrigger.Conditions>
-                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Color07B}" />
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource HoverStoreGrid2}" />
                                 <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Color03B}" />
                                 <Setter TargetName="Bd" Property="CornerRadius" Value="5" />
                                 <Setter TargetName="Bd" Property="Margin" Value="0,0,0,0" />
@@ -367,7 +367,7 @@
                                 <MultiTrigger.Conditions>
                                     <Condition Property="IsMouseOver" Value="True" />
                                 </MultiTrigger.Conditions>
-                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Color07B}" />
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource HoverStoreGrid2}" />
                                 <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Color03B}" />
                                 <Setter TargetName="Bd" Property="CornerRadius" Value="5" />
 
@@ -1463,7 +1463,7 @@
                             Grid.Row="1"
                             Grid.Column="0"
                             Grid.ColumnSpan="2"
-                            Margin="0,2,0,0"
+                            Margin="5,2,0,0"
                             Padding="0,0,18,0"
                             ItemContainerStyle="{StaticResource StoreList}"
                             ItemsSource="{Binding ExternalPlugins}"
@@ -1497,10 +1497,11 @@
                                                         <Grid>
                                                             <StackPanel Orientation="Vertical">
                                                                 <TextBlock
-                                                                    Margin="0,0,0,10"
+                                                                    Margin="2,0,0,10"
                                                                     VerticalAlignment="Top"
                                                                     FontSize="16"
                                                                     FontWeight="Bold"
+                                                                    Foreground="{DynamicResource Color05B}"
                                                                     Text="{Binding Name, Converter={StaticResource TextConverter}}" />
 
                                                                 <ItemsPresenter />
@@ -1581,10 +1582,13 @@
                                                     ToolTip="{Binding Version}" />
                                                 <TextBlock
                                                     Grid.Column="0"
-                                                    Margin="18,10,18,10"
+                                                    Height="60"
+                                                    Margin="18,6,18,0"
+                                                    Padding="0,0,0,10"
                                                     FontSize="12"
                                                     Foreground="{DynamicResource Color04B}"
                                                     Text="{Binding Description, Mode=OneWay}"
+                                                    TextTrimming="WordEllipsis"
                                                     TextWrapping="Wrap" />
                                             </StackPanel>
 

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -320,7 +320,7 @@
         <Style x:Key="StoreList" TargetType="ListViewItem">
             <Setter Property="Padding" Value="0,0,0,0" />
             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
             <Setter Property="Margin" Value="0,0,8,8" />
             <Setter Property="VerticalContentAlignment" Value="Stretch" />
             <!--#region Template for blue highlight win10-->
@@ -1468,7 +1468,6 @@
                             ItemContainerStyle="{StaticResource StoreList}"
                             ItemsSource="{Binding ExternalPlugins}"
                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                            ScrollViewer.VerticalScrollBarVisibility="Auto"
                             SelectionMode="Single"
                             VirtualizingPanel.CacheLength="1,1"
                             VirtualizingPanel.CacheLengthUnit="Page"
@@ -1480,7 +1479,7 @@
                                     <wpftk:VirtualizingWrapPanel
                                         x:Name="ItemWrapPanel"
                                         Margin="0,0,0,10"
-                                        ItemSize="216,194"
+                                        ItemSize="216,184"
                                         MouseWheelDelta="48"
                                         Orientation="Vertical"
                                         ScrollLineDelta="16"
@@ -1522,19 +1521,21 @@
                                 </GroupStyle>
                             </ListView.GroupStyle>
 
-                            <ListBox.ItemTemplate>
+                            <ListView.ItemTemplate>
                                 <DataTemplate>
                                     <!--  Hover Layout Style  -->
 
                                     <ToggleButton
                                         x:Name="StoreListItem"
-                                        Width="200"
-                                        HorizontalAlignment="Left"
-                                        HorizontalContentAlignment="left"
-                                        IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}, Path=IsSelected}"
-                                        Style="{StaticResource StoreItem}">
+                                        Margin="0"
+                                        Padding="0"
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Stretch"
+                                        HorizontalContentAlignment="Stretch"
+                                        VerticalContentAlignment="Stretch"
+                                        IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}, Path=IsSelected}">
                                         <ToggleButton.Template>
-                                            <ControlTemplate TargetType="{x:Type ButtonBase}">
+                                            <ControlTemplate x:Name="StoreListItemTemplate" TargetType="{x:Type ButtonBase}">
                                                 <ContentPresenter
                                                     x:Name="contentPresenter"
                                                     Margin="{TemplateBinding Padding}"
@@ -1550,94 +1551,45 @@
                                             </ControlTemplate>
                                         </ToggleButton.Template>
 
-                                        <Grid HorizontalAlignment="Left" VerticalAlignment="Top">
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition Height="56" />
-                                                <RowDefinition Height="*" />
-                                            </Grid.RowDefinitions>
-                                            <StackPanel
-                                                Grid.Row="0"
-                                                Grid.RowSpan="2"
-                                                Grid.Column="0"
-                                                Grid.ColumnSpan="2"
-                                                Margin="0,0,2,0"
+                                        <Grid x:Name="StoreListItemGrid" Width="204">
+                                            <Border
+                                                x:Name="LabelUpdate"
+                                                Height="12"
+                                                Margin="0,10,8,0"
+                                                Padding="6,2,6,2"
                                                 HorizontalAlignment="Right"
-                                                Orientation="Horizontal">
-                                                <Border
-                                                    x:Name="LabelUpdate"
-                                                    Height="12"
-                                                    Margin="0,10,8,0"
-                                                    Padding="6,2,6,2"
-                                                    HorizontalAlignment="Right"
-                                                    VerticalAlignment="Top"
-                                                    Background="#45BD59"
-                                                    CornerRadius="36"
-                                                    ToolTip="{DynamicResource LabelUpdateToolTip}"
-                                                    Visibility="{Binding LabelUpdate, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                            </StackPanel>
-
-                                            <StackPanel
-                                                Grid.Row="0"
-                                                Margin="0,0,0,0"
-                                                VerticalAlignment="Top">
-                                                <StackPanel.Style>
-                                                    <Style>
-                                                        <Setter Property="StackPanel.Visibility" Value="Visible" />
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding Mode=TwoWay, Path=IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem, Mode=FindAncestor}}" Value="true">
-                                                                <Setter Property="StackPanel.Opacity" Value="1" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </StackPanel.Style>
+                                                VerticalAlignment="Top"
+                                                Background="#45BD59"
+                                                CornerRadius="36"
+                                                ToolTip="{DynamicResource LabelUpdateToolTip}"
+                                                Visibility="{Binding LabelUpdate, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                            <StackPanel>
                                                 <Image
+                                                    Grid.Column="0"
                                                     Width="32"
                                                     Height="32"
-                                                    Margin="20,20,6,0"
+                                                    Margin="18,24,0,0"
                                                     HorizontalAlignment="Left"
-                                                    VerticalAlignment="Top"
-                                                    Source="{Binding IcoPath, IsAsync=True}"
-                                                    Stretch="Uniform" />
-                                            </StackPanel>
-                                            <StackPanel
-                                                Grid.Row="1"
-                                                Margin="0,6,0,0"
-                                                VerticalAlignment="Top"
-                                                Panel.ZIndex="0">
-                                                <StackPanel.Style>
-                                                    <Style>
-                                                        <Setter Property="StackPanel.Visibility" Value="Visible" />
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding Mode=TwoWay, Path=IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem, Mode=FindAncestor}}" Value="true">
-                                                                <Setter Property="StackPanel.Opacity" Value="1" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </StackPanel.Style>
+                                                    Source="{Binding IcoPath, IsAsync=True}" />
                                                 <TextBlock
-                                                    Padding="20,0,20,0"
-                                                    VerticalAlignment="Top"
+                                                    Grid.Column="0"
+                                                    Margin="18,10,18,0"
                                                     FontWeight="SemiBold"
                                                     Foreground="{DynamicResource Color05B}"
                                                     Text="{Binding Name}"
-                                                    TextWrapping="WrapWithOverflow"
+                                                    TextWrapping="Wrap"
                                                     ToolTip="{Binding Version}" />
                                                 <TextBlock
-                                                    Margin="0,6,0,0"
-                                                    Padding="20,0,22,20"
+                                                    Grid.Column="0"
+                                                    Margin="18,10,18,10"
+                                                    FontSize="12"
                                                     Foreground="{DynamicResource Color04B}"
-                                                    TextWrapping="WrapWithOverflow">
-                                                    <Run
-                                                        FontSize="12"
-                                                        Foreground="{DynamicResource Color04B}"
-                                                        Text="{Binding Description, Mode=OneWay}" />
-                                                </TextBlock>
-
+                                                    Text="{Binding Description, Mode=OneWay}"
+                                                    TextWrapping="Wrap" />
                                             </StackPanel>
+
                                             <StackPanel
-                                                Grid.RowSpan="2"
                                                 Grid.Column="0"
-                                                Grid.ColumnSpan="2"
                                                 HorizontalAlignment="Stretch"
                                                 VerticalAlignment="Stretch">
                                                 <StackPanel.Style>
@@ -1653,7 +1605,7 @@
 
 
                                                 <Grid
-                                                    Height="180"
+                                                    Height="{Binding ElementName=StoreListItem, Path=ActualHeight}"
                                                     HorizontalAlignment="Stretch"
                                                     VerticalAlignment="Stretch"
                                                     Panel.ZIndex="1">
@@ -1661,7 +1613,7 @@
                                                         <SolidColorBrush Opacity="1" Color="{DynamicResource HoverStoreGrid}" />
                                                     </Grid.Background>
                                                     <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="{Binding Path=ActualWidth, ElementName=StoreListItem}" />
+                                                        <ColumnDefinition />
                                                     </Grid.ColumnDefinitions>
 
                                                     <StackPanel
@@ -1699,20 +1651,21 @@
                                                     </StackPanel>
                                                     <Grid Grid.Row="0" Grid.Column="1">
                                                         <StackPanel
-                                                            Margin="0,70,20,0"
+                                                            Margin="0,105,5,0"
                                                             HorizontalAlignment="Right"
                                                             Orientation="Horizontal">
                                                             <Button
                                                                 MinHeight="40"
+                                                                Margin="5,0,5,0"
                                                                 Padding="15,5,15,5"
-                                                                HorizontalAlignment="Right"
+                                                                HorizontalAlignment="Stretch"
                                                                 VerticalAlignment="Center"
                                                                 Click="OnExternalPluginInstallClick"
                                                                 Content="{DynamicResource installbtn}"
                                                                 Visibility="{Binding LabelInstalled, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter='!'}" />
                                                             <Button
                                                                 MinHeight="40"
-                                                                Margin="5,0,0,0"
+                                                                Margin="5,0,5,0"
                                                                 Padding="15,5,15,5"
                                                                 HorizontalAlignment="Right"
                                                                 VerticalAlignment="Center"
@@ -1721,7 +1674,7 @@
                                                                 Visibility="{Binding LabelInstalled, Converter={StaticResource BoolToVisibilityConverter}}" />
                                                             <Button
                                                                 MinHeight="40"
-                                                                Margin="5,0,0,0"
+                                                                Margin="5,0,5,0"
                                                                 Padding="15,5,15,5"
                                                                 HorizontalAlignment="Right"
                                                                 VerticalAlignment="Center"
@@ -1734,10 +1687,9 @@
                                                 </Grid>
                                             </StackPanel>
                                         </Grid>
-
                                     </ToggleButton>
                                 </DataTemplate>
-                            </ListBox.ItemTemplate>
+                            </ListView.ItemTemplate>
                         </ListView>
                     </Grid>
 

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -1040,6 +1040,7 @@
                                 ScrollViewer.CanContentScroll="True"
                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                 SelectedItem="{Binding SelectedPlugin}"
+                                SnapsToDevicePixels="True"
                                 Style="{DynamicResource PluginListStyle}"
                                 VirtualizingStackPanel.IsVirtualizing="True"
                                 VirtualizingPanel.ScrollUnit="Pixel"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -1483,7 +1483,7 @@
                                         MouseWheelDelta="48"
                                         Orientation="Vertical"
                                         ScrollLineDelta="16"
-                                        SpacingMode="Uniform"
+                                        SpacingMode="None"
                                         StretchItems="True" />
                                 </ItemsPanelTemplate>
                             </ListView.ItemsPanel>
@@ -1651,8 +1651,8 @@
                                                     </StackPanel>
                                                     <Grid Grid.Row="0" Grid.Column="1">
                                                         <StackPanel
-                                                            Margin="0,105,5,0"
-                                                            HorizontalAlignment="Right"
+                                                            Margin="12,105,5,5"
+                                                            HorizontalAlignment="Center"
                                                             Orientation="Horizontal">
                                                             <Button
                                                                 MinHeight="40"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -48,6 +48,18 @@
             </CollectionViewSource.SortDescriptions>
         </CollectionViewSource>
 
+        <Style x:Key="StoreItemFocusVisualStyleKey">
+            <Setter Property="Control.Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Rectangle
+                            Margin="0"
+                            Stroke="Black"
+                            StrokeThickness="2" />
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
         <Style x:Key="SettingGrid" TargetType="ItemsControl">
             <Setter Property="Focusable" Value="False" />
             <Setter Property="Margin" Value="0" />
@@ -344,38 +356,6 @@
                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
-                        <ControlTemplate.Triggers>
-
-                            <MultiTrigger>
-                                <MultiTrigger.Conditions>
-                                    <Condition Property="IsSelected" Value="False" />
-                                </MultiTrigger.Conditions>
-                                <Setter TargetName="Bd" Property="Margin" Value="0,0,0,0" />
-                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource Color00B}" />
-                                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Color03B}" />
-                            </MultiTrigger>
-                            <MultiTrigger>
-                                <MultiTrigger.Conditions>
-                                    <Condition Property="IsSelected" Value="True" />
-                                </MultiTrigger.Conditions>
-                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource HoverStoreGrid2}" />
-                                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Color03B}" />
-                                <Setter TargetName="Bd" Property="CornerRadius" Value="5" />
-                                <Setter TargetName="Bd" Property="Margin" Value="0,0,0,0" />
-                            </MultiTrigger>
-                            <MultiTrigger>
-                                <MultiTrigger.Conditions>
-                                    <Condition Property="IsMouseOver" Value="True" />
-                                </MultiTrigger.Conditions>
-                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource HoverStoreGrid2}" />
-                                <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource Color03B}" />
-                                <Setter TargetName="Bd" Property="CornerRadius" Value="5" />
-
-                            </MultiTrigger>
-                            <Trigger Property="IsEnabled" Value="False">
-                                <Setter TargetName="Bd" Property="TextElement.Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
-                            </Trigger>
-                        </ControlTemplate.Triggers>
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
@@ -1042,8 +1022,8 @@
                                 SelectedItem="{Binding SelectedPlugin}"
                                 SnapsToDevicePixels="True"
                                 Style="{DynamicResource PluginListStyle}"
-                                VirtualizingStackPanel.IsVirtualizing="True"
                                 VirtualizingPanel.ScrollUnit="Pixel"
+                                VirtualizingStackPanel.IsVirtualizing="True"
                                 VirtualizingStackPanel.VirtualizationMode="Recycling">
                                 <ListBox.ItemsPanel>
                                     <ItemsPanelTemplate>
@@ -1464,12 +1444,13 @@
                             Grid.Row="1"
                             Grid.Column="0"
                             Grid.ColumnSpan="2"
-                            Margin="5,2,0,0"
+                            Margin="4,0,0,0"
                             Padding="0,0,18,0"
                             ItemContainerStyle="{StaticResource StoreList}"
                             ItemsSource="{Binding ExternalPlugins}"
                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                             SelectionMode="Single"
+                            Style="{DynamicResource StoreListStyle}"
                             VirtualizingPanel.CacheLength="1,1"
                             VirtualizingPanel.CacheLengthUnit="Page"
                             VirtualizingPanel.IsVirtualizingWhenGrouping="True"
@@ -1504,11 +1485,8 @@
                                                                     FontWeight="Bold"
                                                                     Foreground="{DynamicResource Color05B}"
                                                                     Text="{Binding Name, Converter={StaticResource TextConverter}}" />
-
                                                                 <ItemsPresenter />
-
                                                             </StackPanel>
-
                                                         </Grid>
                                                     </ControlTemplate>
                                                 </Setter.Value>
@@ -1526,8 +1504,7 @@
                             <ListView.ItemTemplate>
                                 <DataTemplate>
                                     <!--  Hover Layout Style  -->
-
-                                    <ToggleButton
+                                    <Button
                                         x:Name="StoreListItem"
                                         Margin="0"
                                         Padding="0"
@@ -1535,44 +1512,115 @@
                                         VerticalAlignment="Stretch"
                                         HorizontalContentAlignment="Stretch"
                                         VerticalContentAlignment="Stretch"
-                                        IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}, Path=IsSelected}">
-                                        <ToggleButton.Template>
-                                            <ControlTemplate x:Name="StoreListItemTemplate" TargetType="{x:Type ButtonBase}">
-                                                <ContentPresenter
-                                                    x:Name="contentPresenter"
-                                                    Margin="{TemplateBinding Padding}"
-                                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                    Content="{TemplateBinding Content}"
-                                                    ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                    Focusable="False"
-                                                    RecognizesAccessKey="True"
-                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                                                <ControlTemplate.Triggers />
-                                            </ControlTemplate>
-                                        </ToggleButton.Template>
+                                        BorderThickness="0"
+                                        FocusVisualStyle="{StaticResource StoreItemFocusVisualStyleKey}">
+                                        <ui:FlyoutService.Flyout>
+                                            <ui:Flyout x:Name="InstallFlyout" Placement="Bottom">
+                                                <Grid MinWidth="200">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition />
+                                                        <RowDefinition />
+                                                    </Grid.RowDefinitions>
+                                                    <VirtualizingStackPanel
+                                                        Grid.Row="0"
+                                                        Grid.Column="0"
+                                                        Margin="5,0,0,0"
+                                                        Orientation="Horizontal">
+                                                        <TextBlock
+                                                            Margin="0,0,5,0"
+                                                            VerticalAlignment="Center"
+                                                            FontSize="14"
+                                                            FontWeight="Bold"
+                                                            Foreground="{DynamicResource Color05B}"
+                                                            Text="{Binding Name}"
+                                                            TextWrapping="Wrap"
+                                                            ToolTip="{Binding Name}" />
+                                                        <TextBlock
+                                                            VerticalAlignment="Center"
+                                                            FontSize="12"
+                                                            Foreground="{DynamicResource Color05B}"
+                                                            Text="{Binding Version}"
+                                                            TextWrapping="Wrap"
+                                                            ToolTip="{Binding Version}" />
+                                                    </VirtualizingStackPanel>
+                                                    <TextBlock
+                                                        Grid.Row="1"
+                                                        Grid.Column="0"
+                                                        Margin="5,4,0,0"
+                                                        TextWrapping="Wrap">
+                                                        <Hyperlink
+                                                            Foreground="{DynamicResource Color04B}"
+                                                            NavigateUri="{Binding Website}"
+                                                            RequestNavigate="OnRequestNavigate">
+                                                            <Run FontSize="12" Text="{Binding Author, Mode=OneWay}" />
+                                                        </Hyperlink>
+                                                    </TextBlock>
 
-                                        <Grid x:Name="StoreListItemGrid" Width="204">
-                                            <Border
-                                                x:Name="LabelUpdate"
-                                                Height="12"
-                                                Margin="0,10,8,0"
-                                                Padding="6,2,6,2"
-                                                HorizontalAlignment="Right"
-                                                VerticalAlignment="Top"
-                                                Background="#45BD59"
-                                                CornerRadius="36"
-                                                ToolTip="{DynamicResource LabelUpdateToolTip}"
-                                                Visibility="{Binding LabelUpdate, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                            <StackPanel>
-                                                <Image
-                                                    Grid.Column="0"
-                                                    Width="32"
-                                                    Height="32"
-                                                    Margin="18,24,0,0"
-                                                    HorizontalAlignment="Left"
-                                                    Source="{Binding IcoPath, IsAsync=True}" />
+                                                    <VirtualizingStackPanel
+                                                        Grid.Row="0"
+                                                        Grid.RowSpan="2"
+                                                        Grid.Column="1"
+                                                        Margin="20,0,0,0"
+                                                        HorizontalAlignment="Right"
+                                                        Orientation="Horizontal">
+                                                        <Button
+                                                            MinHeight="42"
+                                                            Margin="5,0,5,0"
+                                                            Padding="15,5,15,5"
+                                                            HorizontalAlignment="Stretch"
+                                                            VerticalAlignment="Center"
+                                                            Click="OnExternalPluginInstallClick"
+                                                            Content="{DynamicResource installbtn}"
+                                                            Visibility="{Binding LabelInstalled, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter='!'}" />
+                                                        <Button
+                                                            MinHeight="42"
+                                                            Margin="5,0,5,0"
+                                                            Padding="15,5,15,5"
+                                                            HorizontalAlignment="Right"
+                                                            VerticalAlignment="Center"
+                                                            Click="OnExternalPluginUninstallClick"
+                                                            Content="{DynamicResource uninstallbtn}"
+                                                            Visibility="{Binding LabelInstalled, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                        <Button
+                                                            MinHeight="42"
+                                                            Margin="5,0,5,0"
+                                                            Padding="15,5,15,5"
+                                                            HorizontalAlignment="Right"
+                                                            VerticalAlignment="Center"
+                                                            Click="OnExternalPluginUpdateClick"
+                                                            Content="{DynamicResource updatebtn}"
+                                                            Style="{DynamicResource AccentButtonStyle}"
+                                                            Visibility="{Binding LabelUpdate, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                    </VirtualizingStackPanel>
+                                                </Grid>
+                                            </ui:Flyout>
+                                        </ui:FlyoutService.Flyout>
+                                        <Grid>
+                                            <StackPanel Width="200">
+                                                <StackPanel Orientation="Horizontal">
+                                                    <Image
+                                                        Grid.Column="0"
+                                                        Width="32"
+                                                        Height="32"
+                                                        Margin="18,24,0,0"
+                                                        HorizontalAlignment="Left"
+                                                        Source="{Binding IcoPath, IsAsync=True}" />
+                                                    <Border
+                                                        x:Name="LabelUpdate"
+                                                        Height="12"
+                                                        Margin="10,24,0,0"
+                                                        Padding="6,2,6,2"
+                                                        HorizontalAlignment="Left"
+                                                        VerticalAlignment="Top"
+                                                        Background="#45BD59"
+                                                        CornerRadius="36"
+                                                        ToolTip="{DynamicResource LabelUpdateToolTip}"
+                                                        Visibility="{Binding LabelUpdate, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                </StackPanel>
                                                 <TextBlock
                                                     Grid.Column="0"
                                                     Margin="18,10,18,0"
@@ -1591,108 +1639,11 @@
                                                     Text="{Binding Description, Mode=OneWay}"
                                                     TextTrimming="WordEllipsis"
                                                     TextWrapping="Wrap" />
+
                                             </StackPanel>
 
-                                            <StackPanel
-                                                Grid.Column="0"
-                                                HorizontalAlignment="Stretch"
-                                                VerticalAlignment="Stretch">
-                                                <StackPanel.Style>
-                                                    <Style>
-                                                        <Setter Property="StackPanel.Visibility" Value="Collapsed" />
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding Mode=TwoWay, Path=IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem, Mode=FindAncestor}}" Value="true">
-                                                                <Setter Property="StackPanel.Visibility" Value="Visible" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </StackPanel.Style>
-
-
-                                                <Grid
-                                                    Height="{Binding ElementName=StoreListItem, Path=ActualHeight}"
-                                                    HorizontalAlignment="Stretch"
-                                                    VerticalAlignment="Stretch"
-                                                    Panel.ZIndex="1">
-                                                    <Grid.Background>
-                                                        <SolidColorBrush Opacity="1" Color="{DynamicResource HoverStoreGrid}" />
-                                                    </Grid.Background>
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition />
-                                                    </Grid.ColumnDefinitions>
-
-                                                    <StackPanel
-                                                        Grid.Row="0"
-                                                        Grid.Column="0"
-                                                        HorizontalAlignment="Stretch"
-                                                        VerticalAlignment="Top">
-                                                        <StackPanel Orientation="Vertical">
-                                                            <TextBlock
-                                                                Margin="20,20,20,0"
-                                                                Padding="0,0,0,0"
-                                                                FontWeight="Bold"
-                                                                Foreground="{DynamicResource Color05B}"
-                                                                Text="{Binding Name}"
-                                                                TextWrapping="WrapWithOverflow"
-                                                                ToolTip="{Binding Name}" />
-                                                            <TextBlock
-                                                                Margin="20,4,20,0"
-                                                                Padding="0,0,20,0"
-                                                                Foreground="{DynamicResource Color05B}"
-                                                                Text="{Binding Version}"
-                                                                TextWrapping="WrapWithOverflow"
-                                                                ToolTip="{Binding Version}" />
-                                                        </StackPanel>
-                                                        <StackPanel Margin="20,6,20,0" Orientation="Vertical">
-                                                            <TextBlock Padding="0,0,0,0" TextWrapping="Wrap">
-                                                                <Hyperlink
-                                                                    Foreground="{DynamicResource Color04B}"
-                                                                    NavigateUri="{Binding Website}"
-                                                                    RequestNavigate="OnRequestNavigate">
-                                                                    <Run FontSize="12" Text="{Binding Author, Mode=OneWay}" />
-                                                                </Hyperlink>
-                                                            </TextBlock>
-                                                        </StackPanel>
-                                                    </StackPanel>
-                                                    <Grid Grid.Row="0" Grid.Column="1">
-                                                        <StackPanel
-                                                            Margin="12,105,5,5"
-                                                            HorizontalAlignment="Center"
-                                                            Orientation="Horizontal">
-                                                            <Button
-                                                                MinHeight="40"
-                                                                Margin="5,0,5,0"
-                                                                Padding="15,5,15,5"
-                                                                HorizontalAlignment="Stretch"
-                                                                VerticalAlignment="Center"
-                                                                Click="OnExternalPluginInstallClick"
-                                                                Content="{DynamicResource installbtn}"
-                                                                Visibility="{Binding LabelInstalled, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter='!'}" />
-                                                            <Button
-                                                                MinHeight="40"
-                                                                Margin="5,0,5,0"
-                                                                Padding="15,5,15,5"
-                                                                HorizontalAlignment="Right"
-                                                                VerticalAlignment="Center"
-                                                                Click="OnExternalPluginUninstallClick"
-                                                                Content="{DynamicResource uninstallbtn}"
-                                                                Visibility="{Binding LabelInstalled, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                                            <Button
-                                                                MinHeight="40"
-                                                                Margin="5,0,5,0"
-                                                                Padding="15,5,15,5"
-                                                                HorizontalAlignment="Right"
-                                                                VerticalAlignment="Center"
-                                                                Click="OnExternalPluginUpdateClick"
-                                                                Content="{DynamicResource updatebtn}"
-                                                                Visibility="{Binding LabelUpdate, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                                            <!--  Hide Install Button when installed Item  -->
-                                                        </StackPanel>
-                                                    </Grid>
-                                                </Grid>
-                                            </StackPanel>
                                         </Grid>
-                                    </ToggleButton>
+                                    </Button>
                                 </DataTemplate>
                             </ListView.ItemTemplate>
                         </ListView>

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -1474,6 +1474,7 @@
                             ItemsSource="{Binding ExternalPlugins}"
                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                            SelectionMode="Single"
                             VirtualizingPanel.CacheLength="1,1"
                             VirtualizingPanel.CacheLengthUnit="Page"
                             VirtualizingPanel.IsVirtualizingWhenGrouping="True"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -607,7 +607,8 @@
                     <ScrollViewer
                         Margin="0,0,0,0"
                         Background="{DynamicResource Color01B}"
-                        ScrollViewer.CanContentScroll="False"
+                        CanContentScroll="True"
+                        VirtualizingPanel.ScrollUnit="Pixel"
                         VirtualizingStackPanel.IsVirtualizing="True">
                         <StackPanel Margin="5,18,25,30" Orientation="Vertical">
                             <TextBlock
@@ -1395,6 +1396,7 @@
                                 FontSize="14"
                                 KeyDown="PluginStoreFilterTxb_OnKeyDown"
                                 LostFocus="RefreshPluginStoreEventHandler"
+                         
                                 Text=""
                                 TextAlignment="Left"
                                 ToolTip="{DynamicResource searchpluginToolTip}"
@@ -1436,7 +1438,7 @@
                                 Padding="12,4,12,4"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
-                                Click="OnPluginStoreRefreshClick"
+                                Command="{Binding RefreshExternalPluginsCommand}"
                                 Content="{DynamicResource refresh}"
                                 DockPanel.Dock="Right"
                                 FontSize="13" />
@@ -1515,7 +1517,8 @@
                                         HorizontalContentAlignment="Stretch"
                                         VerticalContentAlignment="Stretch"
                                         BorderThickness="0"
-                                        FocusVisualStyle="{StaticResource StoreItemFocusVisualStyleKey}">
+                                        FocusVisualStyle="{StaticResource StoreItemFocusVisualStyleKey}"
+                                        Click="StoreListItem_Click">
                                         <ui:FlyoutService.Flyout>
                                             <ui:Flyout x:Name="InstallFlyout" Placement="Bottom">
                                                 <Grid MinWidth="200">
@@ -1675,7 +1678,8 @@
                         <ScrollViewer
                             Margin="0,0,0,0"
                             Padding="6,0,24,0"
-                            ScrollViewer.CanContentScroll="False"
+                            ScrollViewer.CanContentScroll="True"
+                            VirtualizingStackPanel.ScrollUnit="Pixel"
                             VirtualizingStackPanel.IsVirtualizing="True">
                             <Grid Margin="0,0,0,0">
                                 <Grid.RowDefinitions>
@@ -2252,7 +2256,8 @@
                     <ScrollViewer
                         Margin="0,0,0,0"
                         Padding="0,0,6,0"
-                        ScrollViewer.CanContentScroll="False"
+                        ScrollViewer.CanContentScroll="True"
+                        VirtualizingStackPanel.ScrollUnit="Pixel"
                         VirtualizingStackPanel.IsVirtualizing="True">
                         <Border>
                             <Grid Margin="5,18,18,10">
@@ -2547,7 +2552,8 @@
                     <ScrollViewer
                         Margin="0,0,0,0"
                         Padding="5,0,24,0"
-                        ScrollViewer.CanContentScroll="False"
+                        ScrollViewer.CanContentScroll="True"
+                        VirtualizingStackPanel.ScrollUnit="Pixel"
                         VirtualizingStackPanel.IsVirtualizing="True">
                         <Border>
 
@@ -2720,7 +2726,8 @@
                         <ScrollViewer
                             Margin="0,0,0,0"
                             Background="{DynamicResource Color01B}"
-                            ScrollViewer.CanContentScroll="False"
+                            ScrollViewer.CanContentScroll="True"
+                            VirtualizingStackPanel.ScrollUnit="Pixel"
                             VirtualizingStackPanel.IsVirtualizing="True">
                             <StackPanel Margin="5,14,25,30" Orientation="Vertical">
                                 <TextBlock

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -1608,6 +1608,7 @@
                                                         Height="32"
                                                         Margin="18,24,0,0"
                                                         HorizontalAlignment="Left"
+                                                        RenderOptions.BitmapScalingMode="Fant"
                                                         Source="{Binding IcoPath, IsAsync=True}" />
                                                     <Border
                                                         x:Name="LabelUpdate"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -1037,12 +1037,12 @@
                                 Background="{DynamicResource Color01B}"
                                 ItemContainerStyle="{StaticResource PluginList}"
                                 ItemsSource="{Binding PluginViewModels}"
-                                ScrollViewer.CanContentScroll="False"
+                                ScrollViewer.CanContentScroll="True"
                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                 SelectedItem="{Binding SelectedPlugin}"
-                                SnapsToDevicePixels="True"
                                 Style="{DynamicResource PluginListStyle}"
                                 VirtualizingStackPanel.IsVirtualizing="True"
+                                VirtualizingPanel.ScrollUnit="Pixel"
                                 VirtualizingStackPanel.VirtualizationMode="Recycling">
                                 <ListBox.ItemsPanel>
                                     <ItemsPanelTemplate>

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -607,7 +607,8 @@
                     <ScrollViewer
                         Margin="0,0,0,0"
                         Background="{DynamicResource Color01B}"
-                        ScrollViewer.CanContentScroll="False">
+                        ScrollViewer.CanContentScroll="False"
+                        VirtualizingStackPanel.IsVirtualizing="True">
                         <StackPanel Margin="5,18,25,30" Orientation="Vertical">
                             <TextBlock
                                 Grid.Row="2"
@@ -1506,7 +1507,7 @@
                                 <DataTemplate>
                                     <!--  Hover Layout Style  -->
                                     <Button
-                                        x:Name="StoreListItem"
+                                        Name="StoreListItem"
                                         Margin="0"
                                         Padding="0"
                                         HorizontalAlignment="Stretch"
@@ -2251,14 +2252,15 @@
                     <ScrollViewer
                         Margin="0,0,0,0"
                         Padding="0,0,6,0"
-                        ScrollViewer.CanContentScroll="False">
+                        ScrollViewer.CanContentScroll="False"
+                        VirtualizingStackPanel.IsVirtualizing="True">
                         <Border>
                             <Grid Margin="5,18,18,10">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="43" />
                                     <RowDefinition Height="80" />
                                     <RowDefinition Height="146" />
-                                    
+
                                     <RowDefinition Height="50" />
                                     <RowDefinition Height="*" />
                                     <RowDefinition Height="50" />
@@ -2422,7 +2424,7 @@
                                         Click="OnAddCustomHotkeyClick"
                                         Content="{DynamicResource add}" />
                                 </StackPanel>
-                                
+
                                 <TextBlock
                                     Grid.Row="6"
                                     Margin="0,0,12,2"
@@ -2432,8 +2434,8 @@
                                     Foreground="{DynamicResource Color05B}"
                                     Text="{DynamicResource customQueryShortcut}" />
                                 <ListView
-                                    Grid.Row="7"
                                     Name="customShortcutView"
+                                    Grid.Row="7"
                                     MinHeight="160"
                                     Margin="0,6,0,0"
                                     Background="{DynamicResource Color02B}"
@@ -2545,7 +2547,8 @@
                     <ScrollViewer
                         Margin="0,0,0,0"
                         Padding="5,0,24,0"
-                        ScrollViewer.CanContentScroll="False">
+                        ScrollViewer.CanContentScroll="False"
+                        VirtualizingStackPanel.IsVirtualizing="True">
                         <Border>
 
                             <StackPanel>
@@ -2717,7 +2720,8 @@
                         <ScrollViewer
                             Margin="0,0,0,0"
                             Background="{DynamicResource Color01B}"
-                            ScrollViewer.CanContentScroll="False">
+                            ScrollViewer.CanContentScroll="False"
+                            VirtualizingStackPanel.IsVirtualizing="True">
                             <StackPanel Margin="5,14,25,30" Orientation="Vertical">
                                 <TextBlock
                                     Grid.Row="2"

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -8,7 +8,9 @@ using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.SharedCommands;
 using Flow.Launcher.ViewModel;
 using ModernWpf;
+using ModernWpf.Controls;
 using System;
+using System.Drawing.Printing;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls.Primitives;
@@ -17,6 +19,7 @@ using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Navigation;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.Window;
 using Button = System.Windows.Controls.Button;
 using Control = System.Windows.Controls.Control;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
@@ -425,6 +428,9 @@ namespace Flow.Launcher
             }
         }
 
+        private void ShowStoreItem_Click(object sender, RoutedEventArgs e)
+        {
+        }
         private void RefreshPluginStoreEventHandler(object sender, RoutedEventArgs e)
         {
             if (pluginStoreFilterTxb.Text != lastPluginStoreSearch)

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -11,6 +11,7 @@ using ModernWpf;
 using System;
 using System.IO;
 using System.Windows;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Forms;
 using System.Windows.Input;

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -428,9 +428,6 @@ namespace Flow.Launcher
             }
         }
 
-        private void ShowStoreItem_Click(object sender, RoutedEventArgs e)
-        {
-        }
         private void RefreshPluginStoreEventHandler(object sender, RoutedEventArgs e)
         {
             if (pluginStoreFilterTxb.Text != lastPluginStoreSearch)

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -340,18 +340,30 @@ namespace Flow.Launcher
                 viewModel.DisplayPluginQuery($"uninstall {name}", PluginManager.GetPluginForId("9f8f9b14-2518-4907-b211-35ab6290dee7"));
             }
 
+
         }
 
         private void OnExternalPluginUninstallClick(object sender, RoutedEventArgs e)
         {
+            if (storeClickedButton != null)
+            {
+                FlyoutService.GetFlyout(storeClickedButton).Hide();
+            }
+
             if (sender is Button { DataContext: PluginStoreItemViewModel plugin })
                 viewModel.DisplayPluginQuery($"uninstall {plugin.Name}", PluginManager.GetPluginForId("9f8f9b14-2518-4907-b211-35ab6290dee7"));
+
         }
 
         private void OnExternalPluginUpdateClick(object sender, RoutedEventArgs e)
         {
+            if (storeClickedButton != null)
+            {
+                FlyoutService.GetFlyout(storeClickedButton).Hide();
+            }
             if (sender is Button { DataContext: PluginStoreItemViewModel plugin })
                 viewModel.DisplayPluginQuery($"update {plugin.Name}", PluginManager.GetPluginForId("9f8f9b14-2518-4907-b211-35ab6290dee7"));
+
         }
 
         private void window_MouseDown(object sender, MouseButtonEventArgs e) /* for close hotkey popup */

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -20,10 +20,11 @@ using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.SharedModels;
 using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace Flow.Launcher.ViewModel
 {
-    public class SettingWindowViewModel : BaseModel
+    public partial class SettingWindowViewModel : BaseModel
     {
         private readonly Updater _updater;
         private readonly IPortable _portable;
@@ -330,7 +331,8 @@ namespace Flow.Launcher.ViewModel
             }
         }
 
-        public async Task RefreshExternalPluginsAsync()
+        [RelayCommand]
+        private async Task RefreshExternalPluginsAsync()
         {
             await PluginsManifest.UpdateManifestAsync();
             OnPropertyChanged(nameof(ExternalPlugins));

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -519,6 +519,8 @@ namespace Flow.Launcher.ViewModel
                     var bitmap = new BitmapImage();
                     bitmap.BeginInit();
                     bitmap.StreamSource = memStream;
+                    bitmap.DecodePixelWidth = 800;
+                    bitmap.DecodePixelHeight = 600;
                     bitmap.EndInit();
                     var brush = new ImageBrush(bitmap) { Stretch = Stretch.UniformToFill };
                     return brush;


### PR DESCRIPTION
## What's the PR

![image](https://user-images.githubusercontent.com/6903107/200494356-cf00f0fd-ba98-415e-859e-5e2f3e3fd651.png)
- Decode Image Size in Theme Preview 
  - Reason : if user use big size wallpaper, it will effect to flow. size decode will solve the problem.
  - I don't think it's a big problem, although the image drops to low definition.
- Use Virtualizing Panels in Plugin Store List / plugin list / ETC for memory leak
- Refactor Plugin Store UI (Changed Wrap panel from Uniform grid.)
  - Reason : in this case, item size doesn't fit with list width. Several implementations were attempted, but this condition was judged to be good because performance problems occurred and design problems were not significant.
- 'Update Label' (Green Ball) changed placement to icon's right.
    - Reason : Due to implementation problems, it could not be displayed in the upper right corner.

## Test Cases
- [ ] No excessive memory leaks should occurrence with all menu.
- [ ] Wallpaper displayed on the theme menu should be displayed in low resolution. (It has to be a level that doesn't bother you.)
- [ ] Items in the plug-in store must be displayed appropriately even if you resize the window
- [ ] The menu displayed when each item is clicked must operate normally.
- [ ]  Group (New, Installed....) and searches must operate normally.