### PR TITLE
[DEV][Plugins Manager] Remove await in updating plugin manifest to speedup startup

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Main.cs
@@ -37,7 +37,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
             contextMenu = new ContextMenu(Context);
             pluginManager = new PluginsManager(Context, Settings);
 
-            await pluginManager.UpdateManifestAsync();
+            _ = pluginManager.UpdateManifestAsync();
         }
 
         public List<Result> LoadContextMenus(Result selectedResult)


### PR DESCRIPTION
In dev branch, the init method of `PluginsManager` awaits the result of updating plugin manifest. With a slow internet connection (like public wifi) it could significantly slow down startup. The manifest can be updated later (since we can use Flow without internet).