### PR TITLE
[Dev] Fix unwanted URL protocols and invalid programs in custom sources

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -388,8 +388,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 ShortcutExtension => LnkProgram(x),
                 UrlExtension => UrlProgram(x),
                 _ => Win32Program(x)
-            });
-
+            }).Where(x => x.Valid);
 
             return programs;
         }
@@ -440,7 +439,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
             var filtered = ExceptDisabledSource(toFilter);
 
-            return filtered.Select(GetProgramFromPath).ToList(); // ToList due to disposing issue
+            return filtered.Select(GetProgramFromPath).Where(x => x.Valid).ToList(); // ToList due to disposing issue
         }
 
         private static IEnumerable<string> GetPathFromRegistry(RegistryKey root)

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -388,7 +388,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 ShortcutExtension => LnkProgram(x),
                 UrlExtension => UrlProgram(x),
                 _ => Win32Program(x)
-            }).Where(x => x.Valid);
+            });
 
             return programs;
         }
@@ -410,7 +410,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                     ShortcutExtension => LnkProgram(x),
                     UrlExtension => UrlProgram(x),
                     _ => Win32Program(x)
-                }).Where(x => x.Valid);
+                });
             return programs;
         }
 
@@ -439,7 +439,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
             var filtered = ExceptDisabledSource(toFilter);
 
-            return filtered.Select(GetProgramFromPath).Where(x => x.Valid).ToList(); // ToList due to disposing issue
+            return filtered.Select(GetProgramFromPath).ToList(); // ToList due to disposing issue
         }
 
         private static IEnumerable<string> GetPathFromRegistry(RegistryKey root)
@@ -568,7 +568,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
                 autoIndexPrograms = ProgramsHasher(autoIndexPrograms);
 
-                return programs.Concat(autoIndexPrograms).Distinct().ToArray();
+                return programs.Concat(autoIndexPrograms).Where(x => x.Valid).Distinct().ToArray();
             }
 #if DEBUG //This is to make developer aware of any unhandled exception and add in handling.
             catch (Exception)


### PR DESCRIPTION
Old source code doesn't check if an indexed program is marked as `Valid`. So .url files with http protocols (disabled by default) can be shown in result. Fixed.