### PR TITLE
Score adjustment for a match that is closer to the start of string

### DIFF
--- a/Flow.Launcher.Infrastructure/StringMatcher.cs
+++ b/Flow.Launcher.Infrastructure/StringMatcher.cs
@@ -202,7 +202,11 @@ namespace Flow.Launcher.Infrastructure
             if (allQuerySubstringsMatched)
             {
                 var nearestSpaceIndex = CalculateClosestSpaceIndex(spaceIndices, firstMatchIndex);
-                var score = CalculateSearchScore(query, stringToCompare, firstMatchIndex - nearestSpaceIndex - 1,
+
+                // firstMatchIndex - nearestSpaceIndex - 1 is to set the firstIndex as the index of the first matched char
+                // preceded by a space e.g. 'world' matching 'hello world' firstIndex would be 0 not 6 
+                // giving more weight than 'we or donald' by allowing the distance calculation to treat the starting position at after the space.
+                var score = CalculateSearchScore(query, stringToCompare, firstMatchIndex - nearestSpaceIndex - 1, spaceIndices,
                     lastMatchIndex - firstMatchIndex, allSubstringsContainedInCompareString);
 
                 var resultList = indexList.Select(x => translationMapping?.MapToOriginalIndex(x) ?? x).Distinct().ToList();
@@ -296,13 +300,21 @@ namespace Flow.Launcher.Infrastructure
             return currentQuerySubstringIndex >= querySubstringsLength;
         }
 
-        private static int CalculateSearchScore(string query, string stringToCompare, int firstIndex, int matchLen,
+        private static int CalculateSearchScore(string query, string stringToCompare, int firstIndex, List<int> spaceIndices, int matchLen,
             bool allSubstringsContainedInCompareString)
         {
             // A match found near the beginning of a string is scored more than a match found near the end
             // A match is scored more if the characters in the patterns are closer to each other, 
             // while the score is lower if they are more spread out
             var score = 100 * (query.Length + 1) / ((1 + firstIndex) + (matchLen + 1));
+
+            // Give more weight to a match that is closer to the start of the string. 
+            // if the first matched char is immediately before space and all strings are contained in the compare string e.g. 'world' matching 'hello world'
+            // and 'world hello', because both have 'world' immediately preceded by space, their firstIndex will be 0 when distance is calculated,
+            // to prevent them scoring the same, we adjust the score by deducting the number of spaces it has from the start of the string, so 'world hello'
+            // will score slightly higher than 'hello world' because 'hello world' has one additional space.
+            if (firstIndex == 0 && allSubstringsContainedInCompareString)
+                score -= spaceIndices.Count;
 
             // A match with less characters assigning more weights
             if (stringToCompare.Length - query.Length < 5)

--- a/Flow.Launcher.Test/FuzzyMatcherTest.cs
+++ b/Flow.Launcher.Test/FuzzyMatcherTest.cs
@@ -129,6 +129,12 @@ namespace Flow.Launcher.Test
             }
         }
 
+
+        /// <summary>
+        /// These are standard match scenarios
+        /// The intention of this test is provide a bench mark for how much the score has increased from a change.
+        /// Usually the increase in scoring should not be drastic, increase of less than 10 is acceptable.
+        /// </summary>
         [TestCase(Chrome, Chrome, 157)]
         [TestCase(Chrome, LastIsChrome, 147)]
         [TestCase("chro", HelpCureHopeRaiseOnMindEntityChrome, 50)]
@@ -275,7 +281,7 @@ namespace Flow.Launcher.Test
                 $"Query: \"{queryString}\"{Environment.NewLine} " +
                 $"CompareString1: \"{compareString1}\", Score: {compareString1Result.Score}{Environment.NewLine}" +
                 $"Should be greater than{Environment.NewLine}" +
-                $"CompareString2: \"{compareString2}\", Score: {compareString1Result.Score}{Environment.NewLine}");
+                $"CompareString2: \"{compareString2}\", Score: {compareString2Result.Score}{Environment.NewLine}");
         }
 
         [TestCase("vim", "Vim", "ignoreDescription", "ignore.exe", "Vim Diff", "ignoreDescription", "ignore.exe")]

--- a/Flow.Launcher.Test/FuzzyMatcherTest.cs
+++ b/Flow.Launcher.Test/FuzzyMatcherTest.cs
@@ -136,13 +136,13 @@ namespace Flow.Launcher.Test
         /// Usually the increase in scoring should not be drastic, increase of less than 10 is acceptable.
         /// </summary>
         [TestCase(Chrome, Chrome, 157)]
-        [TestCase(Chrome, LastIsChrome, 147)]
+        [TestCase(Chrome, LastIsChrome, 145)]
         [TestCase("chro", HelpCureHopeRaiseOnMindEntityChrome, 50)]
         [TestCase("chr", HelpCureHopeRaiseOnMindEntityChrome, 30)]
         [TestCase(Chrome, UninstallOrChangeProgramsOnYourComputer, 21)]
         [TestCase(Chrome, CandyCrushSagaFromKing, 0)]
-        [TestCase("sql", MicrosoftSqlServerManagementStudio, 110)]
-        [TestCase("sql  manag", MicrosoftSqlServerManagementStudio, 121)] //double spacing intended
+        [TestCase("sql", MicrosoftSqlServerManagementStudio, 109)]
+        [TestCase("sql  manag", MicrosoftSqlServerManagementStudio, 120)] //double spacing intended
         public void WhenGivenQueryString_ThenShouldReturn_TheDesiredScoring(
             string queryString, string compareString, int expectedScore)
         {
@@ -261,6 +261,38 @@ namespace Flow.Launcher.Test
         {
             // When
             var matcher = new StringMatcher {UserSettingSearchPrecision = SearchPrecisionScore.Regular};
+
+            // Given
+            var compareString1Result = matcher.FuzzyMatch(queryString, compareString1);
+            var compareString2Result = matcher.FuzzyMatch(queryString, compareString2);
+
+            Debug.WriteLine("");
+            Debug.WriteLine("###############################################");
+            Debug.WriteLine($"QueryString: \"{queryString}\"{Environment.NewLine}");
+            Debug.WriteLine(
+                $"CompareString1: \"{compareString1}\", Score: {compareString1Result.Score}{Environment.NewLine}");
+            Debug.WriteLine(
+                $"CompareString2: \"{compareString2}\", Score: {compareString2Result.Score}{Environment.NewLine}");
+            Debug.WriteLine("###############################################");
+            Debug.WriteLine("");
+
+            // Should
+            Assert.True(compareString1Result.Score > compareString2Result.Score,
+                $"Query: \"{queryString}\"{Environment.NewLine} " +
+                $"CompareString1: \"{compareString1}\", Score: {compareString1Result.Score}{Environment.NewLine}" +
+                $"Should be greater than{Environment.NewLine}" +
+                $"CompareString2: \"{compareString2}\", Score: {compareString2Result.Score}{Environment.NewLine}");
+        }
+
+        [TestCase("red", "red colour", "metro red")]
+        [TestCase("red", "this red colour", "this colour red")]
+        [TestCase("red", "this red colour", "this colour is very red")]
+        [TestCase("red", "this red colour", "this colour is surprisingly super awesome red and cool")]
+        public void WhenGivenTwoStrings_Scoring_ShouldGiveMoreWeightToTheStringCloserToIndexZero(
+            string queryString, string compareString1, string compareString2)
+        {
+            // When
+            var matcher = new StringMatcher { UserSettingSearchPrecision = SearchPrecisionScore.Regular };
 
             // Given
             var compareString1Result = matcher.FuzzyMatch(queryString, compareString1);

--- a/Flow.Launcher.Test/FuzzyMatcherTest.cs
+++ b/Flow.Launcher.Test/FuzzyMatcherTest.cs
@@ -288,6 +288,7 @@ namespace Flow.Launcher.Test
         [TestCase("red", "this red colour", "this colour red")]
         [TestCase("red", "this red colour", "this colour is very red")]
         [TestCase("red", "this red colour", "this colour is surprisingly super awesome red and cool")]
+        [TestCase("red", "this colour is surprisingly super red very and cool", "this colour is surprisingly super very red and cool")]
         public void WhenGivenTwoStrings_Scoring_ShouldGiveMoreWeightToTheStringCloserToIndexZero(
             string queryString, string compareString1, string compareString2)
         {


### PR DESCRIPTION
### Context
Currently scoring is the same regardless of the position of the matched string, e.g. 'hello world' and 'world hello' have the same score. This change adds an adjustment during score calculation to allow 'world hello' to score higher than 'hello world' when query is 'world'.

### How
The conditions for this adjustment to kick in is:
- the matched string has to be immediately preceding a space, and
- query must be a fully contained substring of the compare string.

Score adjustment is done by:
Counting the number of spaces from the start of the string and deduct this from the score. So when matching 'world', 'world hello' has 0 spaces, so nothing is deducted from the score. On the other hand 'crazy on fire world' has three spaces so deduct three from the score.

### Some pretty pictures
Before, notice 'Graphics Settings' should be higher:
![image](https://user-images.githubusercontent.com/26427004/199959717-d08f9c25-176f-4c1a-ba78-5f4a55a8db7c.png)
 
After:
![image](https://user-images.githubusercontent.com/26427004/199959905-3db5667b-b6dd-4031-8bfd-c74ae5faee09.png)

### What's tested
- Added new unit test covering several scenarios
- Manually tested some of the results via running the launcher
- Checked the score adjustment does not impact greatly on other non-relevant results