### PR TITLE
Fix Setting Window Designs 

### DIFF
--- a/Flow.Launcher.Test/Flow.Launcher.Test.csproj
+++ b/Flow.Launcher.Test/Flow.Launcher.Test.csproj
@@ -11,6 +11,7 @@
     <StartupObject />
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
   

--- a/Flow.Launcher.Test/Flow.Launcher.Test.csproj
+++ b/Flow.Launcher.Test/Flow.Launcher.Test.csproj
@@ -10,6 +10,7 @@
     <ApplicationIcon />
     <StartupObject />
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
   

--- a/Flow.Launcher.Test/Flow.Launcher.Test.csproj
+++ b/Flow.Launcher.Test/Flow.Launcher.Test.csproj
@@ -10,8 +10,6 @@
     <ApplicationIcon />
     <StartupObject />
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
   

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -116,4 +116,14 @@
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="taskkill /f /fi &quot;IMAGENAME eq Flow.Launcher.exe&quot;" />
   </Target>
+  
+  <Target Name="RemoveDuplicateAnalyzers" BeforeTargets="CoreCompile">
+    <!-- Work around https://github.com/dotnet/wpf/issues/6792 -->
+
+    <ItemGroup>
+      <FilteredAnalyzer Include="@(Analyzer-&gt;Distinct())" />
+      <Analyzer Remove="@(Analyzer)" />
+      <Analyzer Include="@(FilteredAnalyzer)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -116,14 +116,4 @@
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="taskkill /f /fi &quot;IMAGENAME eq Flow.Launcher.exe&quot;" />
   </Target>
-
-  <Target Name="RemoveDuplicateAnalyzers" BeforeTargets="CoreCompile">
-    <!-- Work around https://github.com/dotnet/wpf/issues/6792 -->
-
-    <ItemGroup>
-      <FilteredAnalyzer Include="@(Analyzer-&gt;Distinct())" />
-      <Analyzer Remove="@(Analyzer)" />
-      <Analyzer Include="@(FilteredAnalyzer)" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/Flow.Launcher/Resources/CustomControlTemplate.xaml
+++ b/Flow.Launcher/Resources/CustomControlTemplate.xaml
@@ -2044,31 +2044,43 @@
                     <Border Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent" SnapsToDevicePixels="False">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="19" />
                                 <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
-                            <Ellipse
-                                x:Name="circle"
-                                Width="19"
-                                Height="19"
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center"
-                                Stroke="Transparent" />
-                            <Path
-                                x:Name="arrow"
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center"
-                                Data="M 1,1.5 L 4.5,5 L 8,1.5"
-                                SnapsToDevicePixels="false"
-                                Stroke="#666"
-                                StrokeThickness="1" />
                             <ContentPresenter
-                                Grid.Column="1"
-                                Margin="4,0,0,0"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
+                                Grid.Column="0"
+                                Margin="0,0,0,0"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Content="{TemplateBinding Content}"
                                 RecognizesAccessKey="True"
                                 SnapsToDevicePixels="True" />
+                            <Grid
+                                x:Name="ChevronGrid"
+                                Grid.Column="1"
+                                Margin="0"
+                                VerticalAlignment="Center"
+                                Background="Transparent"
+                                RenderTransformOrigin="0.5, 0.5">
+                                <Grid.RenderTransform>
+                                    <RotateTransform Angle="0" />
+                                </Grid.RenderTransform>
+                                <Ellipse
+                                    x:Name="circle"
+                                    Width="19"
+                                    Height="19"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Stroke="Transparent" />
+                                <Path
+                                    x:Name="arrow"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Data="M 1,1.5 L 4.5,5 L 8,1.5"
+                                    SnapsToDevicePixels="false"
+                                    Stroke="#666"
+                                    StrokeThickness="1" />
+                            </Grid>
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
@@ -2077,12 +2089,12 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
                             <Setter TargetName="circle" Property="Stroke" Value="Transparent" />
-                            <Setter TargetName="arrow" Property="Stroke" Value="#222" />
+                            <Setter TargetName="arrow" Property="Stroke" Value="{DynamicResource Color05B}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="true">
                             <Setter TargetName="circle" Property="Stroke" Value="Transparent" />
                             <Setter TargetName="circle" Property="StrokeThickness" Value="1.5" />
-                            <Setter TargetName="arrow" Property="Stroke" Value="#FF003366" />
+                            <Setter TargetName="arrow" Property="Stroke" Value="{DynamicResource Color17B}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -2110,7 +2122,7 @@
                                 x:Name="HeaderSite"
                                 MinWidth="0"
                                 MinHeight="0"
-                                Margin="18,0,0,0"
+                                Margin="18,0,18,0"
                                 Padding="{TemplateBinding Padding}"
                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -2127,19 +2139,62 @@
                                 Foreground="{TemplateBinding Foreground}"
                                 IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                 Style="{StaticResource ExpanderDownHeaderStyle}" />
-                            <ContentPresenter
-                                x:Name="ExpandSite"
-                                Margin="{TemplateBinding Padding}"
-                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                DockPanel.Dock="Bottom"
-                                Focusable="false"
-                                Visibility="Collapsed" />
+                            <Border x:Name="ContentPresenterBorder">
+                                <ContentPresenter
+                                    x:Name="ExpandSite"
+                                    Margin="{TemplateBinding Padding}"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    DockPanel.Dock="Bottom"
+                                    Focusable="false" />
+                                <Border.LayoutTransform>
+                                    <ScaleTransform ScaleY="0" />
+                                </Border.LayoutTransform>
+                            </Border>
                         </DockPanel>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsExpanded" Value="true">
                             <Setter TargetName="ExpandSite" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="ContentPresenterBorder" Property="BorderThickness" Value="0,1,0,0" />
+                            <Trigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            Storyboard.TargetName="ContentPresenterBorder"
+                                            Storyboard.TargetProperty="(Border.LayoutTransform).(ScaleTransform.ScaleY)"
+                                            From="0.0"
+                                            To="1.0"
+                                            Duration="00:00:00.00" />
+                                        <DoubleAnimation
+                                            Storyboard.TargetName="ContentPresenterBorder"
+                                            Storyboard.TargetProperty="(Border.Opacity)"
+                                            From="0.0"
+                                            To="1.0"
+                                            Duration="00:00:00.00" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.EnterActions>
+                            <Trigger.ExitActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation
+                                            Storyboard.TargetName="ContentPresenterBorder"
+                                            Storyboard.TargetProperty="(Border.LayoutTransform).(ScaleTransform.ScaleY)"
+                                            From="1.0"
+                                            To="0"
+                                            Duration="00:00:00.00" />
+                                        <!--  Animation 00:00:00.167  -->
+                                        <DoubleAnimation
+                                            Storyboard.TargetName="ContentPresenterBorder"
+                                            Storyboard.TargetProperty="(Border.Opacity)"
+                                            From="1.0"
+                                            To="0.0"
+                                            Duration="00:00:00.00" />
+                                        <!--  Animation 00:00:00.167  -->
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.ExitActions>
                         </Trigger>
                         <Trigger Property="ExpandDirection" Value="Right">
                             <Setter TargetName="ExpandSite" Property="DockPanel.Dock" Value="Right" />

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -48,10 +48,9 @@
                 <scm:SortDescription PropertyName="Source" />
             </CollectionViewSource.SortDescriptions>
         </CollectionViewSource>
-        <CollectionViewSource x:Key="PluginStoreCollectionView"
-            Source="{Binding ExternalPlugins}">
+        <CollectionViewSource x:Key="PluginStoreCollectionView" Source="{Binding ExternalPlugins}">
             <CollectionViewSource.GroupDescriptions>
-                <PropertyGroupDescription PropertyName="Category"></PropertyGroupDescription>
+                <PropertyGroupDescription PropertyName="Category" />
             </CollectionViewSource.GroupDescriptions>
         </CollectionViewSource>
 
@@ -135,6 +134,7 @@
             BasedOn="{StaticResource DefaultToggleSwitch}"
             TargetType="{x:Type ui:ToggleSwitch}">
             <Setter Property="Grid.Column" Value="2" />
+            <Setter Property="FocusVisualMargin" Value="5" />
             <Setter Property="Width" Value="Auto" />
             <Setter Property="HorizontalAlignment" Value="Right" />
             <Setter Property="HorizontalContentAlignment" Value="Right" />
@@ -267,7 +267,9 @@
 
         <Style x:Key="PluginList" TargetType="ListBoxItem">
             <Setter Property="Background" Value="{DynamicResource Color00B}" />
-            <Setter Property="Padding" Value="0,12,0,12" />
+            <Setter Property="Padding" Value="0,0,0,0" />
+            <Setter Property="UseLayoutRounding" Value="True" />
+            <Setter Property="SnapsToDevicePixels" Value="True" />
             <Setter Property="Margin" Value="0,0,18,5" />
             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
             <Setter Property="BorderBrush" Value="{DynamicResource Color03B}" />
@@ -282,7 +284,7 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="5"
-                            SnapsToDevicePixels="True">
+                            UseLayoutRounding="True">
                             <ContentPresenter
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -630,7 +632,11 @@
                                     <StackPanel Style="{StaticResource TextPanel}">
                                         <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource startFlowLauncherOnSystemStartup}" />
                                     </StackPanel>
-                                    <CheckBox IsChecked="{Binding StartFlowLauncherOnSystemStartup}" Style="{DynamicResource SideControlCheckBox}" />
+                                    <ui:ToggleSwitch
+                                        Grid.Column="2"
+                                        FocusVisualMargin="5"
+                                        IsOn="{Binding StartFlowLauncherOnSystemStartup}"
+                                        Style="{DynamicResource SideToggleSwitch}" />
                                     <TextBlock Style="{StaticResource Glyph}">
                                         &#xe8fc;
                                     </TextBlock>
@@ -642,7 +648,11 @@
                                     <StackPanel Style="{StaticResource TextPanel}">
                                         <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource hideOnStartup}" />
                                     </StackPanel>
-                                    <CheckBox IsChecked="{Binding Settings.HideOnStartup}" Style="{DynamicResource SideControlCheckBox}" />
+                                    <ui:ToggleSwitch
+                                        Grid.Column="2"
+                                        FocusVisualMargin="5"
+                                        IsOn="{Binding Settings.HideOnStartup}"
+                                        Style="{DynamicResource SideToggleSwitch}" />
                                     <TextBlock Style="{StaticResource Glyph}">
                                         &#xed1a;
                                     </TextBlock>
@@ -654,7 +664,11 @@
                                     <StackPanel Style="{StaticResource TextPanel}">
                                         <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource hideFlowLauncherWhenLoseFocus}" />
                                     </StackPanel>
-                                    <CheckBox IsChecked="{Binding Settings.HideWhenDeactive}" Style="{DynamicResource SideControlCheckBox}" />
+                                    <ui:ToggleSwitch
+                                        Grid.Column="2"
+                                        FocusVisualMargin="5"
+                                        IsOn="{Binding Settings.HideWhenDeactive}"
+                                        Style="{DynamicResource SideToggleSwitch}" />
                                 </ItemsControl>
                             </Border>
 
@@ -665,7 +679,11 @@
                                         <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource hideNotifyIcon}" />
                                         <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource hideNotifyIconToolTip}" />
                                     </StackPanel>
-                                    <CheckBox IsChecked="{Binding Settings.HideNotifyIcon}" Style="{DynamicResource SideControlCheckBox}" />
+                                    <ui:ToggleSwitch
+                                        Grid.Column="2"
+                                        FocusVisualMargin="5"
+                                        IsOn="{Binding Settings.HideNotifyIcon}"
+                                        Style="{DynamicResource SideToggleSwitch}" />
                                 </ItemsControl>
                             </Border>
 
@@ -697,7 +715,11 @@
                                         <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource ignoreHotkeysOnFullscreen}" />
                                         <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource ignoreHotkeysOnFullscreenToolTip}" />
                                     </StackPanel>
-                                    <CheckBox IsChecked="{Binding Settings.IgnoreHotkeysOnFullscreen}" Style="{DynamicResource SideControlCheckBox}" />
+                                    <ui:ToggleSwitch
+                                        Grid.Column="2"
+                                        FocusVisualMargin="5"
+                                        IsOn="{Binding Settings.IgnoreHotkeysOnFullscreen}"
+                                        Style="{DynamicResource SideToggleSwitch}" />
                                     <TextBlock Style="{StaticResource Glyph}">
                                         &#xe7fc;
                                     </TextBlock>
@@ -710,9 +732,11 @@
                                         <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource ShouldUsePinyin}" />
                                         <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource ShouldUsePinyinToolTip}" />
                                     </StackPanel>
-                                    <CheckBox
-                                        IsChecked="{Binding Settings.ShouldUsePinyin}"
-                                        Style="{DynamicResource SideControlCheckBox}"
+                                    <ui:ToggleSwitch
+                                        Grid.Column="2"
+                                        FocusVisualMargin="5"
+                                        IsOn="{Binding Settings.ShouldUsePinyin}"
+                                        Style="{DynamicResource SideToggleSwitch}"
                                         ToolTip="{DynamicResource ShouldUsePinyinToolTip}" />
                                     <TextBlock Style="{StaticResource Glyph}">
                                         &#xe98a;
@@ -1020,7 +1044,7 @@
                             <ListBox
                                 Name="Plugins"
                                 Width="Auto"
-                                Margin="5,0,0,0"
+                                Margin="0,0,0,0"
                                 Padding="0,0,7,0"
                                 HorizontalAlignment="Stretch"
                                 Background="{DynamicResource Color01B}"
@@ -1036,7 +1060,7 @@
                                 VirtualizingStackPanel.VirtualizationMode="Recycling">
                                 <ListBox.ItemsPanel>
                                     <ItemsPanelTemplate>
-                                        <VirtualizingStackPanel Margin="0,0,0,18" />
+                                        <VirtualizingStackPanel Margin="0,0,0,0" />
                                     </ItemsPanelTemplate>
                                 </ListBox.ItemsPanel>
                                 <ListBox.ItemTemplate>
@@ -1045,57 +1069,54 @@
                                             x:Name="expanderHeader"
                                             Grid.Column="4"
                                             Padding="0"
-                                            Background="Transparent"
-                                            FlowDirection="RightToLeft"
+                                            BorderThickness="0"
+                                            ClipToBounds="True"
                                             IsExpanded="{Binding Mode=TwoWay, Path=IsExpanded}"
+                                            SnapsToDevicePixels="True"
                                             Style="{StaticResource ExpanderStyle1}">
                                             <Expander.Header>
-                                                <Grid
-                                                    Width="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Expander}}, Path=ActualWidth}"
-                                                    HorizontalAlignment="Left"
-                                                    FlowDirection="LeftToRight">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="100" MinWidth="100" />
-                                                        <ColumnDefinition Width="8*" />
-                                                        <ColumnDefinition Width="Auto" />
-                                                        <ColumnDefinition Width="Auto" />
-                                                    </Grid.ColumnDefinitions>
-                                                    <StackPanel
-                                                        Grid.Column="0"
-                                                        Margin="24,0,0,0"
-                                                        VerticalAlignment="Center"
-                                                        FlowDirection="LeftToRight">
-                                                        <Image
-                                                            Width="32"
-                                                            Height="32"
-                                                            Margin="32,0,0,0"
-                                                            FlowDirection="LeftToRight"
-                                                            Source="{Binding Image, IsAsync=True}" />
-                                                    </StackPanel>
-                                                    <StackPanel Grid.Column="1" Margin="12,0,14,0">
-                                                        <TextBlock
-                                                            Foreground="{DynamicResource Color05B}"
-                                                            Text="{Binding PluginPair.Metadata.Name}"
-                                                            TextWrapping="Wrap"
-                                                            ToolTip="{Binding PluginPair.Metadata.Version}" />
-                                                        <TextBlock
-                                                            Margin="0,2,0,0"
-                                                            Foreground="{DynamicResource Color04B}"
-                                                            TextWrapping="WrapWithOverflow">
-                                                            <Run FontSize="12" Text="{Binding PluginPair.Metadata.Description}" />
-                                                        </TextBlock>
-                                                    </StackPanel>
-                                                    <StackPanel
-                                                        Grid.Column="2"
-                                                        HorizontalAlignment="Right"
-                                                        Orientation="Horizontal">
-                                                        <TextBlock
-                                                            Margin="0,0,8,0"
-                                                            VerticalAlignment="Center"
-                                                            FontSize="12"
-                                                            Foreground="{DynamicResource Color08B}"
-                                                            Text="{DynamicResource priority}" />
-                                                        <Border>
+                                                <Border Padding="0,12,0,12">
+                                                    <Grid Width="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Expander}}, Path=ActualWidth}" HorizontalAlignment="Left">
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="36" MinWidth="36" />
+                                                            <ColumnDefinition Width="7*" />
+                                                            <ColumnDefinition Width="Auto" />
+                                                            <ColumnDefinition Width="Auto" />
+                                                        </Grid.ColumnDefinitions>
+                                                        <StackPanel
+                                                            Grid.Column="0"
+                                                            Margin="0,0,0,0"
+                                                            VerticalAlignment="Center">
+                                                            <Image
+                                                                Width="32"
+                                                                Height="32"
+                                                                Margin="0,0,0,0"
+                                                                FlowDirection="LeftToRight"
+                                                                Source="{Binding Image, IsAsync=True}" />
+                                                        </StackPanel>
+                                                        <StackPanel Grid.Column="1" Margin="16,0,14,0">
+                                                            <TextBlock
+                                                                Foreground="{DynamicResource Color05B}"
+                                                                Text="{Binding PluginPair.Metadata.Name}"
+                                                                TextWrapping="Wrap"
+                                                                ToolTip="{Binding PluginPair.Metadata.Version}" />
+                                                            <TextBlock
+                                                                Margin="0,2,0,0"
+                                                                Foreground="{DynamicResource Color04B}"
+                                                                TextWrapping="WrapWithOverflow">
+                                                                <Run FontSize="12" Text="{Binding PluginPair.Metadata.Description}" />
+                                                            </TextBlock>
+                                                        </StackPanel>
+                                                        <StackPanel
+                                                            Grid.Column="2"
+                                                            HorizontalAlignment="Right"
+                                                            Orientation="Horizontal">
+                                                            <TextBlock
+                                                                Margin="0,0,8,0"
+                                                                VerticalAlignment="Center"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource Color08B}"
+                                                                Text="{DynamicResource priority}" />
                                                             <Button
                                                                 x:Name="PriorityButton"
                                                                 Margin="0,0,22,0"
@@ -1126,26 +1147,28 @@
                                                                 </Button.Style>
                                                                 <!--#endregion-->
                                                             </Button>
-                                                        </Border>
-                                                    </StackPanel>
-                                                    <DockPanel Grid.Column="3">
-                                                        <ui:ToggleSwitch
-                                                            Margin="0,0,6,0"
-                                                            HorizontalAlignment="Right"
-                                                            IsOn="{Binding PluginState}"
-                                                            OffContent="{DynamicResource disable}"
-                                                            OnContent="{DynamicResource enable}" />
-                                                    </DockPanel>
-                                                </Grid>
 
+                                                        </StackPanel>
+                                                        <DockPanel Grid.Column="3">
+                                                            <ui:ToggleSwitch
+                                                                Margin="0,0,60,0"
+                                                                HorizontalAlignment="Right"
+                                                                DockPanel.Dock="Right"
+                                                                IsOn="{Binding PluginState}"
+                                                                OffContent="{DynamicResource disable}"
+                                                                OnContent="{DynamicResource enable}" />
+                                                        </DockPanel>
+                                                    </Grid>
+                                                </Border>
                                             </Expander.Header>
 
                                             <Grid FlowDirection="LeftToRight">
-                                                <StackPanel Margin="0,12,0,0" Orientation="Vertical">
+                                                <StackPanel Margin="0,0,0,0" Orientation="Vertical">
                                                     <StackPanel>
                                                         <Border
-                                                            Width="auto"
+                                                            Width="Auto"
                                                             Height="52"
+                                                            Margin="0"
                                                             Padding="0"
                                                             BorderThickness="0,1,0,0"
                                                             CornerRadius="0"
@@ -1170,8 +1193,6 @@
                                                                         DockPanel.Dock="Left"
                                                                         Style="{DynamicResource SettingTitleLabel}"
                                                                         Text="{DynamicResource actionKeywords}" />
-
-
                                                                     <Button
                                                                         Grid.Column="2"
                                                                         Width="100"
@@ -1186,14 +1207,11 @@
                                                                         ToolTip="{DynamicResource actionKeywordsTooltip}"
                                                                         Visibility="{Binding ActionKeywordsVisibility}" />
                                                                 </DockPanel>
-
                                                             </ItemsControl>
                                                         </Border>
                                                     </StackPanel>
 
                                                     <StackPanel>
-
-
                                                         <Border
                                                             Padding="0"
                                                             HorizontalAlignment="Stretch"
@@ -1214,23 +1232,27 @@
                                                                     </Style.Triggers>
                                                                 </Style>
                                                             </Border.Style>
+
+                                                        </Border>
+                                                        <Border Background="{DynamicResource Color00B}">
+                                                            <ContentControl
+                                                                x:Name="PluginSettingControl"
+                                                                Margin="0"
+                                                                Padding="1"
+                                                                VerticalAlignment="Stretch"
+                                                                Content="{Binding SettingControl}" />
                                                         </Border>
                                                         <!--#endregion-->
-                                                        <ContentControl
-                                                            x:Name="PluginSettingControl"
-                                                            Margin="0"
-                                                            Padding="1"
-                                                            VerticalAlignment="Stretch"
-                                                            Content="{Binding SettingControl}" />
+
                                                     </StackPanel>
 
                                                     <StackPanel>
                                                         <Border
                                                             Margin="0"
-                                                            Padding="0,12,0,0"
+                                                            Padding="0,12,0,12"
                                                             VerticalAlignment="Center"
                                                             BorderThickness="0,1,0,0"
-                                                            CornerRadius="0"
+                                                            CornerRadius="0 0 5 5"
                                                             Style="{DynamicResource SettingGroupBox}">
                                                             <ItemsControl Style="{DynamicResource SettingGrid}">
                                                                 <StackPanel
@@ -1317,7 +1339,7 @@
                                                                         FontSize="11"
                                                                         Foreground="{DynamicResource PluginInfoColor}"
                                                                         MouseUp="OnExternalPluginUninstallClick"
-                                                                        Text="{DynamicResource uninstallbtn}"
+                                                                        Text="{DynamicResource plugin_uninstall}"
                                                                         TextDecorations="Underline" />
 
                                                                     <TextBlock
@@ -2365,11 +2387,10 @@
                                                         Text="{DynamicResource showOpenResultHotkey}" />
                                                     <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource showOpenResultHotkeyToolTip}" />
                                                 </StackPanel>
-                                                <CheckBox
+                                                <ui:ToggleSwitch
                                                     Grid.Column="2"
-                                                    FontSize="14"
-                                                    IsChecked="{Binding Settings.ShowOpenResultHotkey}"
-                                                    Style="{DynamicResource SideControlCheckBox}" />
+                                                    IsOn="{Binding Settings.ShowOpenResultHotkey}"
+                                                    Style="{DynamicResource SideToggleSwitch}" />
                                             </ItemsControl>
                                         </Border>
                                     </StackPanel>
@@ -2590,7 +2611,10 @@
                                                     VerticalAlignment="Center"
                                                     Style="{DynamicResource SettingTitleLabel}"
                                                     Text="{DynamicResource enableProxy}" />
-                                                <CheckBox IsChecked="{Binding Settings.Proxy.Enabled}" Style="{DynamicResource SideControlCheckBox}" />
+                                                <ui:ToggleSwitch
+                                                    Grid.Column="2"
+                                                    IsOn="{Binding Settings.Proxy.Enabled}"
+                                                    Style="{DynamicResource SideToggleSwitch}" />
                                             </ItemsControl>
                                         </Border>
                                         <Separator

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -94,7 +94,6 @@
             <Setter Property="Margin" Value="0,5,0,0" />
             <Setter Property="Padding" Value="0,15,0,15" />
             <Setter Property="SnapsToDevicePixels" Value="True" />
-
         </Style>
         <Style x:Key="SettingTitleLabel" TargetType="{x:Type TextBlock}">
             <Setter Property="Foreground" Value="{DynamicResource Color05B}" />
@@ -262,9 +261,6 @@
             </Setter>
         </Style>
 
-        <!--  Plugin Store Item when Selected layout for nothing  -->
-        <Style x:Key="StoreItem" TargetType="{x:Type ToggleButton}" />
-
         <Style x:Key="PluginList" TargetType="ListBoxItem">
             <Setter Property="Background" Value="{DynamicResource Color00B}" />
             <Setter Property="Padding" Value="0,0,0,0" />
@@ -400,6 +396,7 @@
             x:Key="StoreListStyle"
             BasedOn="{StaticResource {x:Type ListBox}}"
             TargetType="ListBox">
+            <Setter Property="Background" Value="{DynamicResource Color01B}" />
             <Style.Triggers>
                 <DataTrigger Binding="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=Items.Count}" Value="0">
                     <Setter Property="Template">
@@ -1044,7 +1041,7 @@
                             <ListBox
                                 Name="Plugins"
                                 Width="Auto"
-                                Margin="0,0,0,0"
+                                Margin="5,0,0,0"
                                 Padding="0,0,7,0"
                                 HorizontalAlignment="Stretch"
                                 Background="{DynamicResource Color01B}"
@@ -1534,7 +1531,45 @@
 
                             <ListView.ItemTemplate>
                                 <DataTemplate>
-                                    <!--  Hover Layout Style  -->
+                                    <DataTemplate.Resources>
+                                        <Style x:Key="StoreListItemBtnStyle" TargetType="Button">
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate TargetType="Button">
+                                                        <Border
+                                                            x:Name="Background"
+                                                            Background="{DynamicResource Color00B}"
+                                                            BorderBrush="{DynamicResource Color03B}"
+                                                            BorderThickness="1"
+                                                            CornerRadius="4"
+                                                            SnapsToDevicePixels="True">
+                                                            <Border
+                                                                x:Name="Border"
+                                                                Padding="{TemplateBinding Padding}"
+                                                                BorderThickness="1"
+                                                                CornerRadius="4">
+                                                                <ContentPresenter
+                                                                    x:Name="ContentPresenter"
+                                                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                                    Focusable="False"
+                                                                    RecognizesAccessKey="True"
+                                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                                            </Border>
+                                                        </Border>
+                                                        <ControlTemplate.Triggers>
+                                                            <Trigger Property="IsMouseOver" Value="True">
+                                                                <Setter TargetName="Background" Property="Background" Value="{DynamicResource Color07B}" />
+                                                            </Trigger>
+                                                            <Trigger Property="IsPressed" Value="True">
+                                                                <Setter TargetName="Background" Property="Background" Value="{DynamicResource Color07B}" />
+                                                            </Trigger>
+                                                        </ControlTemplate.Triggers>
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Style>
+                                    </DataTemplate.Resources>
                                     <Button
                                         Name="StoreListItem"
                                         Margin="0"
@@ -1545,7 +1580,8 @@
                                         VerticalContentAlignment="Stretch"
                                         BorderThickness="0"
                                         Click="StoreListItem_Click"
-                                        FocusVisualStyle="{StaticResource StoreItemFocusVisualStyleKey}">
+                                        FocusVisualStyle="{StaticResource StoreItemFocusVisualStyleKey}"
+                                        Style="{DynamicResource StoreListItemBtnStyle}">
                                         <ui:FlyoutService.Flyout>
                                             <ui:Flyout x:Name="InstallFlyout" Placement="Bottom">
                                                 <Grid MinWidth="200">


### PR DESCRIPTION
**What's the PR**
<strike>- Seperate style to other file from SettingWindow.Xaml (SettingWindow.xaml was too long)</strike>  Let's apply this task when working with valonia.

- Change the Checkboxes to Toggle button in general / Hotkey / Proxy Tab

**Before**

![image](https://user-images.githubusercontent.com/6903107/196340878-8351a33f-bd8d-4c5b-ace6-0c6efa71863e.png)

**After**

![image](https://user-images.githubusercontent.com/6903107/196340785-ca13ce2c-a92a-4e9d-9bc1-caa2f44b8314.png)


**Fix Plugins Designs**
 - Fix Clickable Area
![image](https://user-images.githubusercontent.com/6903107/196903301-7e592d4a-8240-4ae3-856e-2e39d4b4eb1a.png)

 - Fix Hover Color

![image](https://user-images.githubusercontent.com/6903107/196904644-6bb898ed-56e8-4867-aa90-180a1ad23906.png)

 - Adjust Some Colors
 
![image](https://user-images.githubusercontent.com/6903107/196906143-0aaa0f0b-f430-4442-a35e-f3c5b255d0a9.png)

Fix Store with Darkmode
![image](https://user-images.githubusercontent.com/6903107/201377190-745a1c53-f87d-4743-81bb-524c0ef40671.png)
![image](https://user-images.githubusercontent.com/6903107/201401230-6753fb6c-d6e0-4c8b-be77-27b811554dd4.png)


**Why?**
- https://uxdworld.com/2018/08/13/checkbox-vs-toggle-switch-7-use-cases-of-forms-design/
- It is not recommended to mix check boxes and toggles. Organize in a toggle for a sense of unity.
- It was a todo that I tried to do in the beginning redesign, but I didn't know how to bind at the time.

**Test Case**
- Each Toggle Button must operate correctly.
- The color shall be marked accurately when you mouse over the plugin item in plugin list
- Even in dark mode, the color shall be displayed accurately.
- There shall be no other effect on the virtual panel.