### PR TITLE
Appveyor test executable unfound fix and add caching

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,9 @@ before_build:
 build:
   project: Flow.Launcher.sln
   verbosity: minimal
-after_build:
+test_script:
+  - dotnet test --no-build
+after_test:
   - ps: .\Scripts\post_build.ps1
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ build:
   project: Flow.Launcher.sln
   verbosity: minimal
 test_script:
-  - dotnet test --no-build
+  - dotnet test --no-build -c Release
 after_test:
   - ps: .\Scripts\post_build.ps1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ init:
 - sc config WSearch start= auto # Starts Windows Search service- Needed for running ExplorerTest
 - net start WSearch
 
+cache:
+  - '%USERPROFILE%\.nuget\packages -> **.sln, **.csproj'  # preserve nuget folder (packages) unless the solution or projects change
+
+
 assembly_info:
   patch: true
   file: SolutionAssemblyInfo.cs


### PR DESCRIPTION
- Recently CI fails because some weird issue that it detects the Flow.Launcher.Test.dll in path that contains an extra parent of `Any CPU`. This pr try to manually run the test to avoid that.

- Also let the package run after test step is done

- Added caching config to let the builds done faster