### PR TITLE
[Dev] Save Setting Window State (full / normal)

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -52,7 +52,6 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         public double SettingWindowHeight { get; set; } = 700;
         public double SettingWindowTop { get; set; }
         public double SettingWindowLeft { get; set; }
-
         public System.Windows.WindowState SettingWindowState { get; set; } = WindowState.Normal;
 
         public int CustomExplorerIndex { get; set; } = 0;

--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -53,6 +53,8 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         public double SettingWindowTop { get; set; }
         public double SettingWindowLeft { get; set; }
 
+        public System.Windows.WindowState SettingWindowState { get; set; } = WindowState.Normal;
+
         public int CustomExplorerIndex { get; set; } = 0;
 
         [JsonIgnore]

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -253,6 +253,7 @@ namespace Flow.Launcher
 
         private void OnClosed(object sender, EventArgs e)
         {
+            settings.SettingWindowState = WindowState;
             settings.SettingWindowTop = Top;
             settings.SettingWindowLeft = Left;
             viewModel.Save();
@@ -553,6 +554,7 @@ namespace Flow.Launcher
                 Top = WindowTop();
                 Left = WindowLeft();
             }
+            WindowState = settings.SettingWindowState;
         }
         public double WindowLeft()
         {


### PR DESCRIPTION
## what's the PR
- Before : When you close the setting window in full screen state, it does not go into full screen state when you reopen it.
- After : When you close the window in full screen state, it also opens to the full screen when you reopen it.

## Test Cases
- [x] When you close and open the window, it should remain in the window state.
- [x] Window state should be maintained during program shutdown and rerun.
- [x] The window position should not change.