### PR TITLE
[Dev][Program Plugin] Optimize program indexing performance 

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
@@ -61,7 +61,7 @@
         Insert file suffixes you want to index. Suffixes should be separated by ';'. (ex>bat;py)
     </system:String>
     <system:String x:Key="flowlauncher_plugin_program_protocol_tooltip">
-        Insert protocols of .url files you want to index. Protocols should be separated by ';'. (ex>ftp;netflix)
+        Insert protocols of .url files you want to index. Protocols should be separated by ';', and should end with "//". (ex>ftp://;mailto://)
     </system:String>
 
     <system:String x:Key="flowlauncher_plugin_program_run_as_different_user">Run As Different User</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
@@ -61,7 +61,7 @@
         Insert file suffixes you want to index. Suffixes should be separated by ';'. (ex>bat;py)
     </system:String>
     <system:String x:Key="flowlauncher_plugin_program_protocol_tooltip">
-        Insert protocols of .url files you want to index. Protocols should be separated by ';', and should end with "//". (ex>ftp://;mailto://)
+        Insert protocols of .url files you want to index. Protocols should be separated by ';', and should end with "://". (ex>ftp://;mailto://)
     </system:String>
 
     <system:String x:Key="flowlauncher_plugin_program_run_as_different_user">Run As Different User</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Program/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Main.cs
@@ -102,7 +102,7 @@ namespace Flow.Launcher.Plugin.Program
                 await Task.WhenAll(a, b);
 
             Win32.WatchProgramUpdate(_settings);
-            UWP.WatchPackageChange();
+            _ = UWP.WatchPackageChange();
         }
 
         public static void IndexWin32Programs()

--- a/Plugins/Flow.Launcher.Plugin.Program/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Main.cs
@@ -102,7 +102,7 @@ namespace Flow.Launcher.Plugin.Program
                 await Task.WhenAll(a, b);
 
             Win32.WatchProgramUpdate(_settings);
-            _ = UWP.WatchPackageChange();
+            UWP.WatchPackageChange();
         }
 
         public static void IndexWin32Programs()

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -440,9 +440,9 @@ namespace Flow.Launcher.Plugin.Program.Programs
         private static IEnumerable<Win32> PATHPrograms(string[] suffixes, string[] protocols, List<string> commonParents)
         {
             var pathEnv = Environment.GetEnvironmentVariable("Path");
-            if (String.IsNullOrEmpty(pathEnv)) 
-            { 
-                return Array.Empty<Win32>(); 
+            if (String.IsNullOrEmpty(pathEnv))
+            {
+                return Array.Empty<Win32>();
             }
 
             var paths = pathEnv.Split(";", StringSplitOptions.RemoveEmptyEntries).DistinctBy(p => p.ToLowerInvariant());
@@ -722,7 +722,8 @@ namespace Flow.Launcher.Plugin.Program.Programs
             watcher.Deleted += static (_, _) => indexQueue.Writer.TryWrite(default);
             watcher.EnableRaisingEvents = true;
             watcher.IncludeSubdirectories = true;
-            foreach(var extension in extensions) {
+            foreach (var extension in extensions)
+            {
                 watcher.Filters.Add($"*.{extension}");
             }
 
@@ -760,7 +761,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 foreach (var source in group)
                 {
                     if (parents.Any(p => IsSubPathOf(source.Location, p.Location) &&
-                                            source != p)) // TODO startwith not accurate
+                                            source != p))
                     {
                         parents.Remove(source);
                     }

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -224,6 +224,15 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
                 return Default;
             }
+#if !DEBUG
+            catch (Exception e)
+            {
+                ProgramLogger.LogException($"|Win32|Win32Program|{path}" +
+                                                "|An unexpected error occurred in the calling method Win32Program", e);
+
+                return Default;
+        }
+#endif
         }
 
         private static Win32 LnkProgram(string path)
@@ -270,16 +279,14 @@ namespace Flow.Launcher.Plugin.Program.Programs
                                            "|Error caused likely due to trying to get the description of the program",
                     e);
 
-                program.Valid = false;
-                return program;
+                return Default;
             }
             catch (FileNotFoundException e)
             {
                 ProgramLogger.LogException($"|Win32|LnkProgram|{path}" +
                                 "|An unexpected error occurred in the calling method LnkProgram", e);
 
-                program.Valid = false;
-                return program;
+                return Default;
             }
 #if !DEBUG //Only do a catch all in production. This is so make developer aware of any unhandled exception and add the exception handling in.
             catch (Exception e)
@@ -287,8 +294,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 ProgramLogger.LogException($"|Win32|LnkProgram|{path}" +
                                                 "|An unexpected error occurred in the calling method LnkProgram", e);
 
-                program.Valid = false;
-                return program;
+                return Default;
             }
 #endif
         }
@@ -342,6 +348,13 @@ namespace Flow.Launcher.Plugin.Program.Programs
                     program.Description = info.FileDescription;
                 return program;
             }
+            catch (FileNotFoundException e)
+            {
+                ProgramLogger.LogException($"|Win32|ExeProgram|{path}" +
+                           $"|File not found when trying to load the program from {path}", e);
+
+                return Default;
+            }
             catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
             {
                 ProgramLogger.LogException($"|Win32|ExeProgram|{path}" +
@@ -386,8 +399,6 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
             // Remove disabled programs in DisabledProgramSources
             var programs = ExceptDisabledSource(paths).Select(x => GetProgramFromPath(x, protocols));
-                            
-                            .Select(x => GetProgramFromPath(x, protocols));
             return programs;
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -737,6 +737,17 @@ namespace Flow.Launcher.Plugin.Program.Programs
             }
         }
 
+        // https://stackoverflow.com/a/66877016
+        private static bool IsSubPathOf(string subPath, string basePath)
+        {
+            var rel = Path.GetRelativePath(basePath, subPath);
+            return rel != "."
+                && rel != ".."
+                && !rel.StartsWith("../")
+                && !rel.StartsWith(@"..\")
+                && !Path.IsPathRooted(rel);
+        }
+
         private static List<string> GetCommonParents(IEnumerable<ProgramSource> programSources)
         {
             // To avoid unnecessary io
@@ -748,8 +759,8 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 HashSet<ProgramSource> parents = group.ToHashSet();
                 foreach (var source in group)
                 {
-                    if (parents.Any(p => source.Location.StartsWith(p.Location, StringComparison.OrdinalIgnoreCase) &&
-                                            source != p))
+                    if (parents.Any(p => IsSubPathOf(source.Location, p.Location) &&
+                                            source != p)) // TODO startwith not accurate
                     {
                         parents.Remove(source);
                     }

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -379,12 +379,15 @@ namespace Flow.Launcher.Plugin.Program.Programs
         private static IEnumerable<Win32> UnregisteredPrograms(List<ProgramSource> sources, string[] suffixes, string[] protocols)
         {
             // Disabled custom sources are not in DisabledProgramSources
-            var paths = ExceptDisabledSource(sources.Where(s => Directory.Exists(s.Location) && s.Enabled)
+            var paths = sources.Where(s => Directory.Exists(s.Location) && s.Enabled)
+                            .Distinct()
                     .AsParallel()
-                    .SelectMany(s => ProgramPaths(s.Location, suffixes)))
-                    .Distinct();
+                            .SelectMany(s => ProgramPaths(s.Location, suffixes));
 
-            var programs = paths.Select(x => GetProgramFromPath(x, protocols));
+            // Remove disabled programs in DisabledProgramSources
+            var programs = ExceptDisabledSource(paths)
+                            
+                            .Select(x => GetProgramFromPath(x, protocols));
             return programs;
         }
 
@@ -569,7 +572,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
                 programs = programs.Concat(unregistered);
 
-                var autoIndexPrograms = Enumerable.Empty<Win32>();
+                var autoIndexPrograms = Enumerable.Empty<Win32>(); // for single programs, not folders
 
                 if (settings.EnableRegistrySource)
                 {

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -387,7 +387,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
             }
         }
 
-        private static IEnumerable<string> EnmuerateProgramsInDir(string directory, string[] suffixes, bool recursive = true)
+        private static IEnumerable<string> EnumerateProgramsInDir(string directory, string[] suffixes, bool recursive = true)
         {
             if (!Directory.Exists(directory))
                 return Enumerable.Empty<string>();
@@ -416,7 +416,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
         {
             // Disabled custom sources are not in DisabledProgramSources
             var paths = directories.AsParallel()
-                            .SelectMany(s => EnmuerateProgramsInDir(s, suffixes));
+                            .SelectMany(s => EnumerateProgramsInDir(s, suffixes));
 
             // Remove disabled programs in DisabledProgramSources
             var programs = ExceptDisabledSource(paths).Select(x => GetProgramFromPath(x, protocols));
@@ -427,8 +427,8 @@ namespace Flow.Launcher.Plugin.Program.Programs
         {
             var directory1 = Environment.GetFolderPath(Environment.SpecialFolder.Programs);
             var directory2 = Environment.GetFolderPath(Environment.SpecialFolder.CommonPrograms);
-            var paths1 = EnmuerateProgramsInDir(directory1, suffixes);
-            var paths2 = EnmuerateProgramsInDir(directory2, suffixes);
+            var paths1 = EnumerateProgramsInDir(directory1, suffixes);
+            var paths2 = EnumerateProgramsInDir(directory2, suffixes);
 
             var toFilter = paths1.Concat(paths2);
 
@@ -449,7 +449,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
             paths = paths.Where(x => commonParents.All(parent => !x.StartsWith(parent, StringComparison.OrdinalIgnoreCase)));
 
-            var toFilter = paths.AsParallel().SelectMany(p => EnmuerateProgramsInDir(p, suffixes, recursive: false));
+            var toFilter = paths.AsParallel().SelectMany(p => EnumerateProgramsInDir(p, suffixes, recursive: false));
 
             var programs = ExceptDisabledSource(toFilter.Distinct())
                 .Select(x => GetProgramFromPath(x, protocols));

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -414,7 +414,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
             return programs;
         }
 
-        private static IEnumerable<Win32> PATHPrograms(string[] suffixes, string[] protocols)
+        private static IEnumerable<Win32> PATHPrograms(string[] suffixes, string[] protocols, List<string> commonParents)
         {
             var pathEnv = Environment.GetEnvironmentVariable("Path");
             if (String.IsNullOrEmpty(pathEnv)) 
@@ -423,6 +423,8 @@ namespace Flow.Launcher.Plugin.Program.Programs
             }
 
             var paths = pathEnv.Split(";", StringSplitOptions.RemoveEmptyEntries).DistinctBy(p => p.ToLowerInvariant());
+
+            paths = paths.Where(x => commonParents.All(parent => !x.StartsWith(parent, StringComparison.OrdinalIgnoreCase)));
 
             var toFilter = paths.AsParallel().SelectMany(p => EnmuerateProgramsInDir(p, suffixes, recursive: false));
 
@@ -592,8 +594,8 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
                 if (settings.EnablePATHSource)
                 {
-                    var path = PATHPrograms(settings.GetSuffixes(), protocols);
-                    autoIndexPrograms = autoIndexPrograms.Concat(path);
+                    var path = PATHPrograms(settings.GetSuffixes(), protocols, commonParents);
+                    programs = programs.Concat(path);
                 }
 
                 autoIndexPrograms = ProgramsHasher(autoIndexPrograms).ToArray();

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -553,7 +553,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                     if (temp.Any())
                         return DistinctBy(temp, x => x.Description);
                     return g.Take(1);
-                }).ToArray();
+                });
         }
 
 
@@ -589,7 +589,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                     autoIndexPrograms = autoIndexPrograms.Concat(path);
                 }
 
-                autoIndexPrograms = ProgramsHasher(autoIndexPrograms);
+                autoIndexPrograms = ProgramsHasher(autoIndexPrograms).ToArray();
 
                 return programs.Concat(autoIndexPrograms).Where(x => x.Valid).Distinct().ToArray();
             }

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -385,7 +385,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                             .SelectMany(s => ProgramPaths(s.Location, suffixes));
 
             // Remove disabled programs in DisabledProgramSources
-            var programs = ExceptDisabledSource(paths)
+            var programs = ExceptDisabledSource(paths).Select(x => GetProgramFromPath(x, protocols));
                             
                             .Select(x => GetProgramFromPath(x, protocols));
             return programs;
@@ -418,13 +418,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
             var toFilter = paths.AsParallel().SelectMany(p => ProgramPaths(p, suffixes, recursive: false));
 
             var programs = ExceptDisabledSource(toFilter.Distinct())
-                .Select(x => Extension(x) switch
-                {
-                    ShortcutExtension => LnkProgram(x),
-                    UrlExtension => UrlProgram(x, protocols),
-                    ExeExtension => ExeProgram(x),
-                    _ => Win32Program(x)
-                });
+                .Select(x => GetProgramFromPath(x, protocols));
             return programs;
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -396,8 +396,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                             .SelectMany(s => EnmuerateProgramsInDir(s, suffixes));
 
             // Remove disabled programs in DisabledProgramSources
-            var programs = ExceptDisabledSource(paths)
-                .Select(x => GetProgramFromPath(x, protocols));
+            var programs = ExceptDisabledSource(paths).Select(x => GetProgramFromPath(x, protocols));
             return programs;
         }
 
@@ -661,14 +660,11 @@ namespace Flow.Launcher.Plugin.Program.Programs
             if (settings.EnableStartMenuSource)
                 paths.AddRange(GetStartMenuPaths());
 
+            paths.AddRange(from source in settings.ProgramSources where source.Enabled select source.Location);
+
             foreach (var directory in from path in paths where Directory.Exists(path) select path)
             {
                 WatchDirectory(directory);
-            }
-
-            foreach (var directory in from source in settings.ProgramSources where Directory.Exists(source.Location) select source.Location)
-            {
-                WatchDirectory(directory, false);
             }
 
             _ = Task.Run(MonitorDirectoryChangeAsync);
@@ -689,7 +685,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
             }
         }
 
-        public static void WatchDirectory(string directory, bool recursive = true)
+        public static void WatchDirectory(string directory)
         {
             if (!Directory.Exists(directory))
             {
@@ -700,7 +696,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
             watcher.Created += static (_, _) => indexQueue.Writer.TryWrite(default);
             watcher.Deleted += static (_, _) => indexQueue.Writer.TryWrite(default);
             watcher.EnableRaisingEvents = true;
-            watcher.IncludeSubdirectories = recursive;
+            watcher.IncludeSubdirectories = true;
 
             Watchers.Add(watcher);
         }


### PR DESCRIPTION
This is a optimization of #1479. PATH can be a subfolder of custom program sources. It makes unnecessary I/O when enabled PATH indexing because indexing for custom sources is recursive. And a custom source can be a subfolder of another.

And let file change watcher only watch files that can be indexed (`exe`, `lnk', ...).

## Changes

1. Refactored some code for readability.
3. Detect if PATH is a subfolder of a custom source.
4. Detect if a custom source is a subfolder of another.
5. Only watch specific file extensions.
6. Fix an issue where trying to open a .lnk files parent folder, it acutally opens its target's folder.

## Tests

- [x] Programs in PATH can be indexed correctly.
- [x] Programs in custom sources can be indexed correctly.
- [x] Unnecessary IO is avoided.
- [x] Creating/Deleting a file with specifix extension triggers a reindex.