### PR TITLE
Deploy prerelease builds to Flow-Launcher/Prereleases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ init:
 - ps: |
       $version = new-object System.Version $env:APPVEYOR_BUILD_VERSION
       $env:flowVersion = "{0}.{1}.{2}" -f $version.Major, $version.Minor, $version.Build
+      if ($env:APPVEYOR_REPO_BRANCH -eq "dev")
+      {
+        $env:prereleaseTag = "{0}.{1}.{2}.{3}" -f $version.Major, $version.Minor, $version.Build, $version.Revision
+      }
 - sc config WSearch start= auto # Starts Windows Search service- Needed for running ExplorerTest
 - net start WSearch
 
@@ -56,6 +60,16 @@ deploy:
       secure: EwKxUgjI8VGouFq9fdhI68+uj42amAhwE65JixIbqx8VlqLbyEuW97CLjBBOIL0r
     on:
       APPVEYOR_REPO_TAG: true
+
+  - provider: GitHub
+    repository: Flow-Launcher/Prereleases
+    release: v$(prereleaseTag)
+    auth_token:
+      secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
+    artifact: Squirrel Installer, Portable Version, Squirrel nupkg, Squirrel RELEASES
+    force_update: true
+    on:
+      branch: dev
 
   - provider: GitHub
     release: v$(flowVersion)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,6 +64,7 @@ deploy:
   - provider: GitHub
     repository: Flow-Launcher/Prereleases
     release: v$(prereleaseTag)
+    description: 'This is the early access build of our upcoming release. All changes contained here are reviewed, tested and stable to use.\n\nSee our [release](https://github.com/Flow-Launcher/Flow.Launcher/pulls?q=is%3Aopen+is%3Apr+label%3Arelease) Pull Request for details.\n\nFor latest production release visit [here](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest)\n\nPlease report any bugs or issues over at the [main repository](https://github.com/Flow-Launcher/Flow.Launcher/issues)'
     auth_token:
       secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
     artifact: Squirrel Installer, Portable Version, Squirrel nupkg, Squirrel RELEASES


### PR DESCRIPTION
**Context**

Update our deployment pipeline to deploy to the GitHub Releases page in the new [Flow-Launcher/Prereleases](https://github.com/Flow-Launcher/Prereleases) repo when a PR is merged into dev.

**Why:**

We want a place where we can download prerelease builds that is separated from our main repo's releases so it's cleaner and easier to navigate for average users. Having a prerelease repo will bring the following additional benefits:

- Overcome the AppVeyor dev branch artifact download limit
- Easier linking to the prerelease build artifacts via https://github.com/Flow-Launcher/Prereleases/releases/latest
- A dedicated place for all prerelease versions
- Set the foundation for setting up the ability to switch to prerelease version from within Flow's settings by switching the endpoint to the prerelease API endpoint.

**Tested:**

- The prerelease deployment only occurs on specific branch so it will only be triggered by pushes to the dev branch.
- Artifacts uploaded to the Flow-Launcher/Prereleases can be accessed via the .../releases/latest URL.
- Versioning of the prerelease tag should be Flow's production version plus AppVeyor's build number, e.g. v1.9.5.9483
- Tested [packaging](https://github.com/Flow-Launcher/Flow.Launcher/blob/37cc01e5ed74e4fe710963d72b6917076be3dc32/Scripts/post_build.ps1#L88) with version formats 1.9.5.9483 and 1.9.5-prerelease.9483 and no exe was built. 

**Shortcomings and future plans:**

1. Unfortunately, Squirrel.Windows (even with the latest at the moment v2.0.1) does not support the SemVer2 version format, so having versions like 1.9.5-prerelease.5719 or 1.9.5.5719 does not work because Squirrel does not build the exe package. This issue is captured in https://github.com/Squirrel/Squirrel.Windows/issues/1394 and https://github.com/Squirrel/Squirrel.Windows/issues/1829
2. In the long term we will need to switch to [Clowd.Squirrel](https://github.com/clowd/Clowd.Squirrel) to be at a minimum properly version our prerelease builds. This will be a bigger piece of work.
3. In the short term, we can work around it inside our updater code to compare the current version to the tag in the prerelease repo when user switches to prerelease version. Downside will be that in Settings About section it will still show the productioin version instead of the prerelease version like how it is currently when you download it from AppVeyor.