### PR TITLE
[Dev] Allow branch builds and do not skip md files

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,12 +22,6 @@ assembly_info:
   assembly_file_version: $(flowVersion)
   assembly_informational_version: $(flowVersion)
 
-skip_branch_with_pr: true
-
-skip_commits:
-  files:
-    - '*.md'
-
 image: Visual Studio 2022
 platform: Any CPU
 configuration: Release


### PR DESCRIPTION
1. Branch builds are required in order for the dev branch pushes to deploy to the Prerelease repo as configured [here]( https://github.com/Flow-Launcher/Flow.Launcher/pull/1547). When the branch build is disabled, the release pr only does PR builds and consequently does not deploy to prerelease repo. I do not see another way to restrict branch build to only a specific branch so just have to enable it for all.
2. Skipping md files will cause the GitHub build status check to hang and consequently the PR can not be merged, so removing it unless there is a way to get status feedback when the build is skipped.