### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
       - "jjw24"
       - "taooceros"
       - "JohnTheGr8"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,4 +18,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,15 @@
+name: Publish to Winget
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    # Action can only be run on windows
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v1
+        with:
+          identifier: Flow-Launcher.Flow-Launcher
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This action automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

Flow Launcher is already in @vedantmgoyal2009's automation, as stated in https://github.com/Flow-Launcher/Flow.Launcher/pull/1061#issue-1158217797, but the author now urges for GitHub packages to use the action instead. See https://github.com/vedantmgoyal2009/vedantmgoyal2009/issues/931

**Before merging this:**
1. Add a PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN` (or rename the secret name in the workflow).

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @Flow-Launcher. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

The documentation and source code of the action is available [here](https://github.com/vedantmgoyal2009/winget-releaser/).

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been automatically created using 🛫 WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+automatically+created+using+%F0%9F%9B%AB+WinGet+Releaser).
