### PR TITLE
[Dev] Use path of lnk file when launching proram

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -220,8 +220,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
             return Name;
         }
 
-        public static List<FileSystemWatcher> Watchers = new List<FileSystemWatcher>();
-
+        private static List<FileSystemWatcher> Watchers = new List<FileSystemWatcher>();
 
         private static Win32 Win32Program(string path)
         {

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -37,7 +37,6 @@ namespace Flow.Launcher.Plugin.Program.Programs
         /// Path of the actual executable file.
         /// </summary>
         public string ExecutablePath => LnkResolvedPath ?? FullPath;
-        public string WorkingDir => Directory.GetParent(ExecutablePath)?.FullName ?? string.Empty;
         public string ParentDirectory { get; set; }
         public string ExecutableName { get; set; }
         public string Description { get; set; }
@@ -140,8 +139,8 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
                     var info = new ProcessStartInfo
                     {
-                        FileName = ExecutablePath,
-                        WorkingDirectory = WorkingDir,
+                        FileName = FullPath,
+                        WorkingDirectory = ParentDirectory,
                         UseShellExecute = true,
                         Verb = runAsAdmin ? "runas" : null
                     };
@@ -167,8 +166,8 @@ namespace Flow.Launcher.Plugin.Program.Programs
                     {
                         var info = new ProcessStartInfo
                         {
-                            FileName = ExecutablePath,
-                            WorkingDirectory = WorkingDir,
+                            FileName = FullPath,
+                            WorkingDirectory = ParentDirectory,
                             UseShellExecute = true
                         };
 
@@ -187,7 +186,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                         var info = new ProcessStartInfo
                         {
                             FileName = ExecutablePath,
-                            WorkingDirectory = WorkingDir,
+                            WorkingDirectory = ParentDirectory,
                             Verb = "runas",
                             UseShellExecute = true
                         };
@@ -573,6 +572,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
         private static IEnumerable<Win32> ProgramsHasher(IEnumerable<Win32> programs)
         {
+            // TODO: Unable to distinguish multiple lnks to the same excutable but with different params
             return programs.GroupBy(p => p.ExecutablePath.ToLowerInvariant())
                 .AsParallel()
                 .SelectMany(g =>


### PR DESCRIPTION
#1546 changed the behavior of launching .lnk programs. It directly launches the program pointed to. It wasn't intended. Got mislead by the varaible name.) which brings an issue. Start Menu shortcut of Discord can't be launched. This is because it acutally points to `blabla\Discord\Update.exe --processStart Discord.exe` and we don't parse the params. Fixed in this pr.

Known issue of program plugin (not related to this pr or 1546): can't distinguish different .lnk files pointing to the same target but with different params.