### PR TITLE
Add Focus to plugin/plugin store search box when changed tab

### DIFF
--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -994,6 +994,7 @@
                                     TextAlignment="Left" />
                                 <DockPanel DockPanel.Dock="Right">
                                     <TextBox
+                                        Loaded="Plugin_GotFocus"
                                         Name="pluginFilterTxb"
                                         Width="150"
                                         Height="34"
@@ -1428,6 +1429,7 @@
                                 DockPanel.Dock="Right"
                                 FontSize="14"
                                 KeyDown="PluginStoreFilterTxb_OnKeyDown"
+                                Loaded="PluginStore_GotFocus"
                                 LostFocus="RefreshPluginStoreEventHandler"
                                 Text=""
                                 TextAlignment="Left"

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -562,5 +562,15 @@ namespace Flow.Launcher
             };
 
         }
+
+        private void PluginStore_GotFocus(object sender, RoutedEventArgs e)
+        {
+            Keyboard.Focus(pluginStoreFilterTxb);
+        }
+
+        private void Plugin_GotFocus(object sender, RoutedEventArgs e)
+        {
+            Keyboard.Focus(pluginFilterTxb);
+        }
     }
 }


### PR DESCRIPTION
## what's the pr
Add Focus to plugin/plugin store search box when changed tab

## Test Case
- Keyboard focus should be in the search box when switching tabs.
- When entering the hotkey tab, the hotkey tab must not be focused.