### PR TITLE
Fix Second Run not trigger the first run window to show up

### DIFF
--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -183,7 +183,7 @@ namespace Flow.Launcher
 
         public void OnSecondAppStarted()
         {
-            Current.MainWindow.Show();
+            _mainVM.Show();
         }
     }
 }


### PR DESCRIPTION
fix second startup not show the main window. (I believe it's the issue of transparency that will only be changed by the Show() in MainViewModel).

Tested in discord
https://ptb.discord.com/channels/727828229250875472/727828229250875476/1048414123270090822