### PR TITLE
Translatable Bool in List view

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/AddProgramSource.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/AddProgramSource.xaml
@@ -101,7 +101,7 @@
                                 DockPanel.Dock="Right" />
                             <TextBox
                                 Name="Directory"
-                                MinWidth="300"
+                                Width="350"
                                 Margin="10"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Center" />

--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
@@ -12,6 +12,8 @@
     <system:String x:Key="flowlauncher_plugin_program_enable">Enable</system:String>
     <system:String x:Key="flowlauncher_plugin_program_enabled">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_program_disable">Disable</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_true">Enabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_program_location">Location</system:String>
     <system:String x:Key="flowlauncher_plugin_program_all_programs">All Programs</system:String>
     <system:String x:Key="flowlauncher_plugin_program_suffixes">File Type</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
@@ -163,7 +163,7 @@
                     <GridViewColumn Width="90" Header="{DynamicResource flowlauncher_plugin_program_enabled}">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock x:Name="ListViewEnabled" TextAlignment="Left">
+                                <TextBlock TextAlignment="Left">
                                     <TextBlock.Style>
                                         <Style TargetType="TextBlock">
                                             <Setter Property="Text" Value="{DynamicResource flowlauncher_plugin_program_false}" />

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
@@ -149,7 +149,8 @@
             MouseDoubleClick="programSourceView_MouseDoubleClick"
             PreviewMouseRightButtonUp="ProgramSourceView_PreviewMouseRightButtonUp"
             SelectionChanged="programSourceView_SelectionChanged"
-            SelectionMode="Extended">
+            SelectionMode="Extended"
+            SizeChanged="ListView_SizeChanged">
             <ListView.View>
                 <GridView>
                     <GridViewColumn Width="150" Header="{DynamicResource flowlauncher_plugin_program_name}">
@@ -159,20 +160,28 @@
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
-                    <GridViewColumn Header="{DynamicResource flowlauncher_plugin_program_enabled}">
+                    <GridViewColumn Width="90" Header="{DynamicResource flowlauncher_plugin_program_enabled}">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock
-                                    MaxWidth="60"
-                                    Text="{Binding Enabled}"
-                                    TextAlignment="Center" />
+                                <TextBlock x:Name="ListViewEnabled" TextAlignment="Left">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Text" Value="{DynamicResource flowlauncher_plugin_program_false}" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Enabled, UpdateSourceTrigger=PropertyChanged}" Value="True">
+                                                    <Setter Property="Text" Value="{DynamicResource flowlauncher_plugin_program_true}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
-                    <GridViewColumn Width="550" Header="{DynamicResource flowlauncher_plugin_program_location}">
+                    <GridViewColumn Header="{DynamicResource flowlauncher_plugin_program_location}">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding Location, ConverterParameter=(null), Converter={program:LocationConverter}}" />
+                                <TextBlock Text="{Binding Location, ConverterParameter=(null), Converter={program:LocationConverter}}" TextTrimming="CharacterEllipsis" />
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
@@ -9,6 +9,7 @@ using Flow.Launcher.Plugin.Program.Views.Commands;
 using Flow.Launcher.Plugin.Program.Programs;
 using System.ComponentModel;
 using System.Windows.Data;
+using System;
 
 namespace Flow.Launcher.Plugin.Program.Views
 {
@@ -382,6 +383,21 @@ namespace Flow.Launcher.Plugin.Program.Views
         private bool IsAllItemsUserAdded(List<ProgramSource> items)
         {
             return items.All(x => _settings.ProgramSources.Any(y => y.UniqueIdentifier == x.UniqueIdentifier));
+        }
+
+        private void ListView_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            ListView listView = sender as ListView;
+            GridView gView = listView.View as GridView;
+
+            var workingWidth = listView.ActualWidth - SystemParameters.VerticalScrollBarWidth; // take into account vertical scrollbar
+            var col1 = 0.25;
+            var col2 = 0.15;
+            var col3 = 0.60;
+
+            gView.Columns[0].Width = workingWidth * col1;
+            gView.Columns[1].Width = workingWidth * col2;
+            gView.Columns[2].Width = workingWidth * col3;
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/en.xaml
@@ -12,6 +12,8 @@
     <system:String x:Key="flowlauncher_plugin_websearch_delete">Delete</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Edit</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Add</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_true">Enabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirm</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_action_keyword">Action Keyword</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_url">URL</system:String>
@@ -32,7 +34,7 @@
 
     <!--  web search edit  -->
     <system:String x:Key="flowlauncher_plugin_websearch_title">Title</system:String>
-    <system:String x:Key="flowlauncher_plugin_websearch_enable">Enable</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enable">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_select_icon">Select Icon</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_icon">Icon</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_cancel">Cancel</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
@@ -86,13 +86,21 @@
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
-                    <GridViewColumn
-                        Width="80"
-                        DisplayMemberBinding="{Binding Enabled}"
-                        Header="{DynamicResource flowlauncher_plugin_websearch_enable}">
+                    <GridViewColumn Width="140" Header="{DynamicResource flowlauncher_plugin_websearch_enable}">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding Enabled}" />
+                                <TextBlock>
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Text" Value="{DynamicResource flowlauncher_plugin_websearch_false}" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Enabled, UpdateSourceTrigger=PropertyChanged}" Value="True">
+                                                    <Setter Property="Text" Value="{DynamicResource flowlauncher_plugin_websearch_true}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>


### PR DESCRIPTION
## What's the PR
![image](https://user-images.githubusercontent.com/6903107/206604201-e0c6416d-86ae-4772-9013-a8c5c09b4bc6.png)
![image](https://user-images.githubusercontent.com/6903107/206604788-4fe0de7b-e156-49c9-9a34-1140103c10d0.png)


- Change True/False to translatable in list view (program/websearch plugin)
- Add Responsive Width for Removing horizon scrollbar (program plugin)
- Fix Add source window size (program plugin)
- Fix websearch plugin header text. enabled to Status)


## Test Cases
- The size of the Program Plug-in Settings panel list view should change to flexible. Horizontal scrolls should not be visible.
- True / false must be marked as enabled / disabled and must be translatable.
- If the path is long, the window size should not change ("add Program source" window in program plugin)

## About Naming
This PR choose 1. 
<img src="https://user-images.githubusercontent.com/6903107/206604097-d7b34b18-e708-4609-8224-6caeff165eaa.png" width="200">

1. Header : Status / True: Enabled / False: Disabled
2. Header : Status / True : Active / False : Deactive
3. Header : Status / True : On / False : Off