### PR TITLE
Adjust Setting Panel Layout (System & JsonRPC)

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCConfigurationModel.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCConfigurationModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Flow.Launcher.Core.Plugin
 {
@@ -26,6 +27,8 @@ namespace Flow.Launcher.Core.Plugin
         public string Name { get; set; }
         public string Label { get; set; }
         public string Description { get; set; }
+        public string urlLabel { get; set; }
+        public Uri url { get; set; }
         public bool Validation { get; set; }
         public List<string> Options { get; set; }
         public string DefaultValue { get; set; }

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -22,6 +22,9 @@ using Control = System.Windows.Controls.Control;
 using Orientation = System.Windows.Controls.Orientation;
 using TextBox = System.Windows.Controls.TextBox;
 using UserControl = System.Windows.Controls.UserControl;
+using System.Windows.Documents;
+using static System.Windows.Forms.LinkLabel;
+using Droplex;
 
 namespace Flow.Launcher.Core.Plugin
 {
@@ -33,7 +36,6 @@ namespace Flow.Launcher.Core.Plugin
     {
         protected PluginInitContext context;
         public const string JsonRPC = "JsonRPC";
-
         /// <summary>
         /// The language this JsonRPCPlugin support
         /// </summary>
@@ -544,6 +546,28 @@ namespace Flow.Launcher.Core.Plugin
                             Settings[attribute.Name] = ((CheckBox)sender).IsChecked;
                         };
                         contentControl = checkBox;
+                        Grid.SetColumn(contentControl, 1);
+                        Grid.SetRow(contentControl, rowCount);
+                        if (rowCount != 0)
+                            mainPanel.Children.Add(sep);
+                        Grid.SetRow(sep, rowCount);
+                        Grid.SetColumn(sep, 0);
+                        Grid.SetColumnSpan(sep, 2);
+                        break;
+                    case "hyperlink":
+                        var hyperlink = new Hyperlink
+                        {
+                            ToolTip = attribute.Description,
+                            NavigateUri = attribute.url
+                        };
+                        var linkbtn = new Button
+                        {
+                            HorizontalAlignment = HorizontalAlignment.Right,
+                            Margin = settingControlMargin
+                        };
+                        linkbtn.Content = attribute.urlLabel;
+
+                        contentControl = linkbtn;
                         Grid.SetColumn(contentControl, 1);
                         Grid.SetRow(contentControl, rowCount);
                         if (rowCount != 0)

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -25,6 +25,7 @@ using UserControl = System.Windows.Controls.UserControl;
 using System.Windows.Documents;
 using static System.Windows.Forms.LinkLabel;
 using Droplex;
+using System.Windows.Forms;
 
 namespace Flow.Launcher.Core.Plugin
 {
@@ -424,7 +425,7 @@ namespace Flow.Launcher.Core.Plugin
                             Text = attribute.Description.Replace("\\r\\n", "\r\n"),
                             Margin = settingTextBlockMargin,
                             Padding = new Thickness(0,0,0,0),
-                            HorizontalAlignment = HorizontalAlignment.Left,
+                            HorizontalAlignment = System.Windows.HorizontalAlignment.Left,
                             TextAlignment = TextAlignment.Left,
                             TextWrapping = TextWrapping.Wrap
                         };
@@ -444,7 +445,7 @@ namespace Flow.Launcher.Core.Plugin
                         {
                             Text = Settings[attribute.Name] as string ?? string.Empty,
                             Margin = settingControlMargin,
-                            HorizontalAlignment = HorizontalAlignment.Stretch,
+                            HorizontalAlignment = System.Windows.HorizontalAlignment.Stretch,
                             ToolTip = attribute.Description
                         };
                         textBox.TextChanged += (_, _) =>
@@ -461,6 +462,41 @@ namespace Flow.Launcher.Core.Plugin
                             Grid.SetColumnSpan(sep, 2);
                             break;
                     }
+                    case "inputWithFileBtn":
+                        {
+                            var textBox = new TextBox()
+                            {
+                                Margin = new Thickness(10, 0, 0, 0),
+                                Text = Settings[attribute.Name] as string ?? string.Empty,
+                                HorizontalAlignment = System.Windows.HorizontalAlignment.Stretch,
+                                ToolTip = attribute.Description
+                            };
+                            textBox.TextChanged += (_, _) =>
+                            {
+                                Settings[attribute.Name] = textBox.Text;
+                            };
+                            var Btn = new System.Windows.Controls.Button()
+                            {
+                                Margin = new Thickness(10,0,0,0),
+                                Content = "Browse"
+                            };
+                            var dockPanel = new DockPanel()
+                            {
+                                Margin = settingControlMargin
+                            };
+                            DockPanel.SetDock(Btn, Dock.Right);
+                            dockPanel.Children.Add(Btn);
+                            dockPanel.Children.Add(textBox);
+                            contentControl = dockPanel;
+                            Grid.SetColumn(contentControl, 1);
+                            Grid.SetRow(contentControl, rowCount);
+                            if (rowCount != 0)
+                                mainPanel.Children.Add(sep);
+                            Grid.SetRow(sep, rowCount);
+                            Grid.SetColumn(sep, 0);
+                            Grid.SetColumnSpan(sep, 2);
+                            break;
+                        }
                     case "textarea":
                     {
                         var textBox = new TextBox()
@@ -470,7 +506,7 @@ namespace Flow.Launcher.Core.Plugin
                             VerticalAlignment = VerticalAlignment.Center,
                             TextWrapping = TextWrapping.WrapWithOverflow,
                             AcceptsReturn = true,
-                            HorizontalAlignment = HorizontalAlignment.Stretch,
+                            HorizontalAlignment = System.Windows.HorizontalAlignment.Stretch,
                             Text = Settings[attribute.Name] as string ?? string.Empty,
                             ToolTip = attribute.Description
                         };
@@ -495,7 +531,7 @@ namespace Flow.Launcher.Core.Plugin
                             Margin = settingControlMargin,
                             Password = Settings[attribute.Name] as string ?? string.Empty,
                             PasswordChar = attribute.passwordChar == default ? '*' : attribute.passwordChar,
-                            HorizontalAlignment = HorizontalAlignment.Stretch,
+                            HorizontalAlignment = System.Windows.HorizontalAlignment.Stretch,
                             ToolTip = attribute.Description
                         };
                         passwordBox.PasswordChanged += (sender, _) =>
@@ -514,17 +550,17 @@ namespace Flow.Launcher.Core.Plugin
                     }
                     case "dropdown":
                     {
-                        var comboBox = new ComboBox()
+                        var comboBox = new System.Windows.Controls.ComboBox()
                         {
                             ItemsSource = attribute.Options,
                             SelectedItem = Settings[attribute.Name],
                             Margin = settingControlMargin,
-                            HorizontalAlignment = HorizontalAlignment.Right,
+                            HorizontalAlignment = System.Windows.HorizontalAlignment.Right,
                             ToolTip = attribute.Description
                         };
                         comboBox.SelectionChanged += (sender, _) =>
                         {
-                            Settings[attribute.Name] = (string)((ComboBox)sender).SelectedItem;
+                            Settings[attribute.Name] = (string)((System.Windows.Controls.ComboBox)sender).SelectedItem;
                         };
                         contentControl = comboBox;
                             Grid.SetColumn(contentControl, 1);
@@ -541,7 +577,7 @@ namespace Flow.Launcher.Core.Plugin
                         {
                             IsChecked = Settings[attribute.Name] is bool isChecked ? isChecked : bool.Parse(attribute.DefaultValue),
                             Margin = settingCheckboxMargin,
-                            HorizontalAlignment = HorizontalAlignment.Right,
+                            HorizontalAlignment = System.Windows.HorizontalAlignment.Right,
                             ToolTip = attribute.Description
                         };
                         checkBox.Click += (sender, _) =>
@@ -563,9 +599,9 @@ namespace Flow.Launcher.Core.Plugin
                             ToolTip = attribute.Description,
                             NavigateUri = attribute.url
                         };
-                        var linkbtn = new Button
+                        var linkbtn = new System.Windows.Controls.Button
                         {
-                            HorizontalAlignment = HorizontalAlignment.Right,
+                            HorizontalAlignment = System.Windows.HorizontalAlignment.Right,
                             Margin = settingControlMargin
                         };
                         linkbtn.Content = attribute.urlLabel;
@@ -623,7 +659,7 @@ namespace Flow.Launcher.Core.Plugin
                         case PasswordBox passwordBox:
                             passwordBox.Dispatcher.Invoke(() => passwordBox.Password = value as string);
                             break;
-                        case ComboBox comboBox:
+                        case System.Windows.Controls.ComboBox comboBox:
                             comboBox.Dispatcher.Invoke(() => comboBox.SelectedItem = value);
                             break;
                         case CheckBox checkBox:

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -379,7 +379,6 @@ namespace Flow.Launcher.Core.Plugin
                 sep.SetResourceReference(Separator.BackgroundProperty, "Color03B"); /* for theme change */
                 var panel = new StackPanel
                 {
-                    Background = System.Windows.SystemColors.GrayTextBrush,
                     Orientation = Orientation.Vertical, VerticalAlignment = VerticalAlignment.Center,
                     Margin = settingLabelPanelMargin
                 };

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -345,9 +345,10 @@ namespace Flow.Launcher.Core.Plugin
         private static readonly Thickness settingControlMargin = new(0, 9, 18, 9);
         private static readonly Thickness settingCheckboxMargin = new(0, 9, 9, 9);
         private static readonly Thickness settingPanelMargin = new(0, 0, 0, 0);
-        private static readonly Thickness settingTextBlockMargin = new(70, 17, 18, 0);
-        private static readonly Thickness settingLabelMargin = new(70, 0, 18, 0);
-        private static readonly Thickness settingDescMargin = new(70, 0, 18, 0);
+        private static readonly Thickness settingTextBlockMargin = new(70, 9, 18, 9);
+        private static readonly Thickness settingLabelPanelMargin = new(70, 9, 18, 9);
+        private static readonly Thickness settingLabelMargin = new(0, 0, 0, 0);
+        private static readonly Thickness settingDescMargin = new(0, 2, 0, 0);
         private static readonly Thickness settingSepMargin = new(0, 0, 0, 2);
         private JsonRpcConfigurationModel _settingsTemplate;
 
@@ -358,7 +359,7 @@ namespace Flow.Launcher.Core.Plugin
             var settingWindow = new UserControl();
             var mainPanel = new Grid
             {
-                Margin = settingPanelMargin
+                Margin = settingPanelMargin, VerticalAlignment = VerticalAlignment.Center
             };
             ColumnDefinition gridCol1 = new ColumnDefinition();
             ColumnDefinition gridCol2 = new ColumnDefinition();
@@ -377,7 +378,9 @@ namespace Flow.Launcher.Core.Plugin
                 sep.SetResourceReference(Separator.BackgroundProperty, "Color03B"); /* for theme change */
                 var panel = new StackPanel
                 {
-                Orientation = Orientation.Vertical, VerticalAlignment = VerticalAlignment.Center
+                    Background = System.Windows.SystemColors.GrayTextBrush,
+                    Orientation = Orientation.Vertical, VerticalAlignment = VerticalAlignment.Center,
+                    Margin = settingLabelPanelMargin
                 };
                 RowDefinition gridRow = new RowDefinition();
                 mainPanel.RowDefinitions.Add(gridRow);
@@ -420,10 +423,10 @@ namespace Flow.Launcher.Core.Plugin
                         {
                             Text = attribute.Description.Replace("\\r\\n", "\r\n"),
                             Margin = settingTextBlockMargin,
-                            VerticalAlignment = VerticalAlignment.Stretch,
+                            Padding = new Thickness(0,0,0,0),
                             HorizontalAlignment = HorizontalAlignment.Left,
                             TextAlignment = TextAlignment.Left,
-                            TextWrapping = TextWrapping.WrapWithOverflow
+                            TextWrapping = TextWrapping.Wrap
                         };
                             Grid.SetColumn(contentControl, 0);
                             Grid.SetColumnSpan(contentControl, 2);

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -340,9 +340,10 @@ namespace Flow.Launcher.Core.Plugin
             this.context = context;
             await InitSettingAsync();
         }
-        private static readonly Thickness settingControlMargin = new(10, 4, 10, 4);
-        private static readonly Thickness settingPanelMargin = new(15, 20, 15, 20);
-        private static readonly Thickness settingTextBlockMargin = new(10, 4, 10, 4);
+        private static readonly Thickness settingControlMargin = new(0, 6, 0, 6);
+        private static readonly Thickness settingPanelMargin = new(70, 18, 18, 18);
+        private static readonly Thickness settingTextBlockMargin = new(0, 6, 0, 6);
+        private static readonly Thickness settingLabelMargin = new(0, 0, 18, 0);
         private JsonRpcConfigurationModel _settingsTemplate;
 
         public Control CreateSettingPanel()
@@ -350,26 +351,35 @@ namespace Flow.Launcher.Core.Plugin
             if (Settings == null)
                 return new();
             var settingWindow = new UserControl();
-            var mainPanel = new StackPanel
+            var mainPanel = new Grid
             {
-                Margin = settingPanelMargin, Orientation = Orientation.Vertical
+                Margin = settingPanelMargin
             };
+            ColumnDefinition gridCol1 = new ColumnDefinition() { Width = GridLength.Auto };
+            ColumnDefinition gridCol2 = new ColumnDefinition();
+            gridCol2.Width = new GridLength(75, GridUnitType.Star);
+            mainPanel.ColumnDefinitions.Add(gridCol1);
+            mainPanel.ColumnDefinitions.Add(gridCol2);
+            
             settingWindow.Content = mainPanel;
-
+            int rowCount = 0;
             foreach (var (type, attribute) in _settingsTemplate.Body)
             {
-                var panel = new StackPanel
-                {
-                    Orientation = Orientation.Horizontal, Margin = settingControlMargin
-                };
+                //var panel = new StackPanel
+                //{
+                //Orientation = Orientation.Horizontal, Margin = settingControlMargin
+                //};
+                RowDefinition gridRow = new RowDefinition();
+                mainPanel.RowDefinitions.Add(gridRow);
                 var name = new TextBlock()
                 {
                     Text = attribute.Label,
-                    Width = 120,
                     VerticalAlignment = VerticalAlignment.Center,
-                    Margin = settingControlMargin,
+                    Margin = settingLabelMargin,
                     TextWrapping = TextWrapping.WrapWithOverflow
                 };
+                Grid.SetColumn(name, 0);
+                Grid.SetRow(name, rowCount);
 
                 FrameworkElement contentControl;
 
@@ -381,10 +391,15 @@ namespace Flow.Launcher.Core.Plugin
                         {
                             Text = attribute.Description.Replace("\\r\\n", "\r\n"),
                             Margin = settingTextBlockMargin,
-                            MaxWidth = 500,
+                            VerticalAlignment = VerticalAlignment.Center,
+                            HorizontalAlignment = HorizontalAlignment.Left,
+                            TextAlignment = TextAlignment.Left,
                             TextWrapping = TextWrapping.WrapWithOverflow
                         };
-                        break;
+                            Grid.SetColumn(contentControl, 0);
+                            Grid.SetColumnSpan(contentControl, 2);
+                            Grid.SetRow(contentControl, rowCount);
+                            break;
                     }
                     case "input":
                     {
@@ -393,6 +408,7 @@ namespace Flow.Launcher.Core.Plugin
                             Width = 300,
                             Text = Settings[attribute.Name] as string ?? string.Empty,
                             Margin = settingControlMargin,
+                            HorizontalAlignment = HorizontalAlignment.Left,
                             ToolTip = attribute.Description
                         };
                         textBox.TextChanged += (_, _) =>
@@ -400,7 +416,9 @@ namespace Flow.Launcher.Core.Plugin
                             Settings[attribute.Name] = textBox.Text;
                         };
                         contentControl = textBox;
-                        break;
+                            Grid.SetColumn(contentControl, 1);
+                            Grid.SetRow(contentControl, rowCount);
+                            break;
                     }
                     case "textarea":
                     {
@@ -411,6 +429,7 @@ namespace Flow.Launcher.Core.Plugin
                             Margin = settingControlMargin,
                             TextWrapping = TextWrapping.WrapWithOverflow,
                             AcceptsReturn = true,
+                            HorizontalAlignment = HorizontalAlignment.Left,
                             Text = Settings[attribute.Name] as string ?? string.Empty,
                             ToolTip = attribute.Description
                         };
@@ -419,7 +438,9 @@ namespace Flow.Launcher.Core.Plugin
                             Settings[attribute.Name] = ((TextBox)sender).Text;
                         };
                         contentControl = textBox;
-                        break;
+                            Grid.SetColumn(contentControl, 1);
+                            Grid.SetRow(contentControl, rowCount);
+                            break;
                     }
                     case "passwordBox":
                     {
@@ -429,6 +450,7 @@ namespace Flow.Launcher.Core.Plugin
                             Margin = settingControlMargin,
                             Password = Settings[attribute.Name] as string ?? string.Empty,
                             PasswordChar = attribute.passwordChar == default ? '*' : attribute.passwordChar,
+                            HorizontalAlignment = HorizontalAlignment.Left,
                             ToolTip = attribute.Description
                         };
                         passwordBox.PasswordChanged += (sender, _) =>
@@ -436,7 +458,9 @@ namespace Flow.Launcher.Core.Plugin
                             Settings[attribute.Name] = ((PasswordBox)sender).Password;
                         };
                         contentControl = passwordBox;
-                        break;
+                            Grid.SetColumn(contentControl, 1);
+                            Grid.SetRow(contentControl, rowCount);
+                            break;
                     }
                     case "dropdown":
                     {
@@ -445,6 +469,7 @@ namespace Flow.Launcher.Core.Plugin
                             ItemsSource = attribute.Options,
                             SelectedItem = Settings[attribute.Name],
                             Margin = settingControlMargin,
+                            HorizontalAlignment = HorizontalAlignment.Left,
                             ToolTip = attribute.Description
                         };
                         comboBox.SelectionChanged += (sender, _) =>
@@ -452,13 +477,16 @@ namespace Flow.Launcher.Core.Plugin
                             Settings[attribute.Name] = (string)((ComboBox)sender).SelectedItem;
                         };
                         contentControl = comboBox;
-                        break;
+                            Grid.SetColumn(contentControl, 1);
+                            Grid.SetRow(contentControl, rowCount);
+                            break;
                     }
                     case "checkbox":
                         var checkBox = new CheckBox
                         {
                             IsChecked = Settings[attribute.Name] is bool isChecked ? isChecked : bool.Parse(attribute.DefaultValue),
                             Margin = settingControlMargin,
+                            HorizontalAlignment = HorizontalAlignment.Left,
                             ToolTip = attribute.Description
                         };
                         checkBox.Click += (sender, _) =>
@@ -466,15 +494,17 @@ namespace Flow.Launcher.Core.Plugin
                             Settings[attribute.Name] = ((CheckBox)sender).IsChecked;
                         };
                         contentControl = checkBox;
+                        Grid.SetColumn(contentControl, 1);
+                        Grid.SetRow(contentControl, rowCount);
                         break;
                     default:
                         continue;
                 }
                 if (type != "textBlock")
                     _settingControls[attribute.Name] = contentControl;
-                panel.Children.Add(name);
-                panel.Children.Add(contentControl);
-                mainPanel.Children.Add(panel);
+                mainPanel.Children.Add(name);
+                mainPanel.Children.Add(contentControl);
+                rowCount++;
             }
             return settingWindow;
         }

--- a/Plugins/Flow.Launcher.Plugin.Sys/SysSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Sys/SysSettings.xaml
@@ -1,33 +1,39 @@
-<UserControl x:Class="Flow.Launcher.Plugin.Sys.SysSettings"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300">
-    <Grid Margin="10">
-        <ListView x:Name="lbxCommands" Grid.Row="0" Style="{StaticResource {x:Static GridView.GridViewStyleKey}}" 
-                  BorderBrush="DarkGray" 
-                  BorderThickness="1"
-                  Margin="7 15 0 25">
-			<ListView.View>
-				<GridView>
-					<GridViewColumn Header="{DynamicResource flowlauncher_plugin_sys_command}"  Width="150">
-						<GridViewColumn.CellTemplate>
-							<DataTemplate>
-								<TextBlock Text="{Binding Title}"/>
-							</DataTemplate>
-						</GridViewColumn.CellTemplate>
-					</GridViewColumn>
-                    <GridViewColumn Header="{DynamicResource flowlauncher_plugin_sys_desc}"  Width="379">
-						<GridViewColumn.CellTemplate>
-							<DataTemplate>
-								<TextBlock Text="{Binding SubTitle}"/>
-							</DataTemplate>
-						</GridViewColumn.CellTemplate>
-					</GridViewColumn>
-				</GridView>
-			</ListView.View>
-		</ListView>
-	</Grid>
+<UserControl
+    x:Class="Flow.Launcher.Plugin.Sys.SysSettings"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="300"
+    d:DesignWidth="300"
+    mc:Ignorable="d">
+    <Grid Margin="70,18,18,18">
+        <ListView
+            x:Name="lbxCommands"
+            Grid.Row="0"
+            Margin="0"
+            BorderBrush="DarkGray"
+            BorderThickness="1"
+            SizeChanged="ListView_SizeChanged"
+            Style="{StaticResource {x:Static GridView.GridViewStyleKey}}">
+            <ListView.View>
+                <GridView>
+                    <GridViewColumn Width="150" Header="{DynamicResource flowlauncher_plugin_sys_command}">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Title}" TextTrimming="CharacterEllipsis" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                    <GridViewColumn Width="379" Header="{DynamicResource flowlauncher_plugin_sys_desc}">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding SubTitle}" TextTrimming="CharacterEllipsis" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                </GridView>
+            </ListView.View>
+        </ListView>
+    </Grid>
 </UserControl>

--- a/Plugins/Flow.Launcher.Plugin.Sys/SysSettings.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/SysSettings.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace Flow.Launcher.Plugin.Sys
@@ -13,6 +14,18 @@ namespace Flow.Launcher.Plugin.Sys
             {
                 lbxCommands.Items.Add(Result);
             }
+        }
+        private void ListView_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            ListView listView = sender as ListView;
+            GridView gView = listView.View as GridView;
+
+            var workingWidth = listView.ActualWidth - SystemParameters.VerticalScrollBarWidth; // take into account vertical scrollbar
+            var col1 = 0.3;
+            var col2 = 0.7;            
+
+            gView.Columns[0].Width = workingWidth * col1;
+            gView.Columns[1].Width = workingWidth * col2;
         }
     }
 }


### PR DESCRIPTION
## What's the PR
- Adjust Setting Panel Margin & Column Width to responsive (System plugin)
- Adjust JsonRPC Panel Layout
- Added layout for input box with browse button / hyperlink (function not implement,  This part will be implemented later.)

## TestCases
- [x] The left margin must be positioned to align with the top item.
- [x] The settings panel for plugins using jsorpc should be displayed appropriately.
- [x] Panel item's color should change when changed setting window theme

![image](https://user-images.githubusercontent.com/6903107/206811249-80989577-7a50-4195-a2c2-db797a87841e.png)
