### PR TITLE
Adjust Plugin info area

### DIFF
--- a/Flow.Launcher/Languages/da.xaml
+++ b/Flow.Launcher/Languages/da.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Kunne ikke registrere genvejstast: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Kunne ikke starte {0}</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">af</system:String>
     <system:String x:Key="plugin_init_time">Initaliseringstid:</system:String>
     <system:String x:Key="plugin_query_time">Søgetid:</system:String>
-    <system:String x:Key="plugin_query_version">| Version</system:String>
+    <system:String x:Key="plugin_query_version">Version</system:String>
     <system:String x:Key="plugin_query_web">Website</system:String>
     <system:String x:Key="plugin_uninstall">Uninstall</system:String>
 

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -91,7 +91,7 @@
     <system:String x:Key="author">by</system:String>
     <system:String x:Key="plugin_init_time">Init time:</system:String>
     <system:String x:Key="plugin_query_time">Query time:</system:String>
-    <system:String x:Key="plugin_query_version">| Version</system:String>
+    <system:String x:Key="plugin_query_version">Version</system:String>
     <system:String x:Key="plugin_query_web">Website</system:String>
     <system:String x:Key="plugin_uninstall">Uninstall</system:String>
 

--- a/Flow.Launcher/Languages/es-419.xaml
+++ b/Flow.Launcher/Languages/es-419.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Error al registrar la tecla de acceso directo: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">No se pudo iniciar {0}</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">por</system:String>
     <system:String x:Key="plugin_init_time">Tiempo de inicio:</system:String>
     <system:String x:Key="plugin_query_time">Tiempo de consulta:</system:String>
-    <system:String x:Key="plugin_query_version">| Versión</system:String>
+    <system:String x:Key="plugin_query_version">Versión</system:String>
     <system:String x:Key="plugin_query_web">Sitio web</system:String>
     <system:String x:Key="plugin_uninstall">Uninstall</system:String>
 

--- a/Flow.Launcher/Languages/es.xaml
+++ b/Flow.Launcher/Languages/es.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">No se ha podido registrar el atajo de teclado: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">No se ha podido iniciar {0}</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">por</system:String>
     <system:String x:Key="plugin_init_time">Tiempo de inicio:</system:String>
     <system:String x:Key="plugin_query_time">Tiempo de consulta:</system:String>
-    <system:String x:Key="plugin_query_version">| Versión</system:String>
+    <system:String x:Key="plugin_query_version">Versión</system:String>
     <system:String x:Key="plugin_query_web">Sitio web</system:String>
     <system:String x:Key="plugin_uninstall">Desinstalar</system:String>
 

--- a/Flow.Launcher/Languages/fr.xaml
+++ b/Flow.Launcher/Languages/fr.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Impossible d'enregistrer le raccourci clavier : {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Impossible de lancer {0}</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">by</system:String>
     <system:String x:Key="plugin_init_time">Chargement :</system:String>
     <system:String x:Key="plugin_query_time">Utilisation :</system:String>
-    <system:String x:Key="plugin_query_version">| Version</system:String>
+    <system:String x:Key="plugin_query_version">Version</system:String>
     <system:String x:Key="plugin_query_web">Website</system:String>
     <system:String x:Key="plugin_uninstall">Désinstaller</system:String>
 

--- a/Flow.Launcher/Languages/it.xaml
+++ b/Flow.Launcher/Languages/it.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Impossibile salvare il tasto di scelta rapida: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Avvio fallito {0}</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">da</system:String>
     <system:String x:Key="plugin_init_time">Tempo di avvio:</system:String>
     <system:String x:Key="plugin_query_time">Tempo ricerca:</system:String>
-    <system:String x:Key="plugin_query_version">| Versione</system:String>
+    <system:String x:Key="plugin_query_version">Versione</system:String>
     <system:String x:Key="plugin_query_web">Sito Web</system:String>
     <system:String x:Key="plugin_uninstall">Disinstalla</system:String>
 
@@ -200,8 +203,8 @@
     <system:String x:Key="newVersionTips">Una nuova versione {0} è disponibile, riavvia Flow Launcher per favore.</system:String>
     <system:String x:Key="checkUpdatesFailed">Ricerca aggiornamenti fallita, per favore controlla la tua connessione e le eventuali impostazioni proxy per api.github.com.</system:String>
     <system:String x:Key="downloadUpdatesFailed">
-        Download degli aggiornamenti fallito, per favore controlla la tua connessione ed eventuali impostazioni proxy per github-cloud.s3.amazonaws.com, 
-		oppure vai su https://github.com/Flow-Launcher/Flow.Launcher/releases per scaricare gli aggiornamenti manualmente.
+        Download degli aggiornamenti fallito, per favore controlla la tua connessione ed eventuali impostazioni proxy per github-cloud.s3.amazonaws.com,
+        oppure vai su https://github.com/Flow-Launcher/Flow.Launcher/releases per scaricare gli aggiornamenti manualmente.
     </system:String>
     <system:String x:Key="releaseNotes">Note di rilascio</system:String>
     <system:String x:Key="documentation">Usage Tips</system:String>

--- a/Flow.Launcher/Languages/ja.xaml
+++ b/Flow.Launcher/Languages/ja.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">ホットキー「{0}」の登録に失敗しました</system:String>
     <system:String x:Key="couldnotStartCmd">{0}の起動に失敗しました</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">by</system:String>
     <system:String x:Key="plugin_init_time">初期化時間:</system:String>
     <system:String x:Key="plugin_query_time">クエリ時間:</system:String>
-    <system:String x:Key="plugin_query_version">| バージョン</system:String>
+    <system:String x:Key="plugin_query_version">バージョン</system:String>
     <system:String x:Key="plugin_query_web">ウェブサイト</system:String>
     <system:String x:Key="plugin_uninstall">アンインストール</system:String>
 
@@ -250,7 +253,7 @@
     <system:String x:Key="actionkeyword_tips">アクションキーボードを指定しない場合、* を使用してください</system:String>
 
     <!--  Custom Query Hotkey Dialog  -->
-    <system:String x:Key="customeQueryHotkeyTitle"></system:String>
+    <system:String x:Key="customeQueryHotkeyTitle" />
     <system:String x:Key="customeQueryHotkeyTips">Press a custom hotkey to open Flow Laucher and input the specified query automatically.</system:String>
     <system:String x:Key="preview">プレビュー</system:String>
     <system:String x:Key="hotkeyIsNotUnavailable">ホットキーは使用できません。新しいホットキーを選択してください</system:String>

--- a/Flow.Launcher/Languages/ko.xaml
+++ b/Flow.Launcher/Languages/ko.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">단축키 등록 실패: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">{0}을 실행할 수 없습니다.</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">제작자</system:String>
     <system:String x:Key="plugin_init_time">초기화 시간:</system:String>
     <system:String x:Key="plugin_query_time">쿼리 시간:</system:String>
-    <system:String x:Key="plugin_query_version">| 버전</system:String>
+    <system:String x:Key="plugin_query_version">버전</system:String>
     <system:String x:Key="plugin_query_web">웹사이트</system:String>
     <system:String x:Key="plugin_uninstall">제거</system:String>
 

--- a/Flow.Launcher/Languages/nb.xaml
+++ b/Flow.Launcher/Languages/nb.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Failed to register hotkey: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Could not start {0}</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">by</system:String>
     <system:String x:Key="plugin_init_time">Init time:</system:String>
     <system:String x:Key="plugin_query_time">Query time:</system:String>
-    <system:String x:Key="plugin_query_version">| Version</system:String>
+    <system:String x:Key="plugin_query_version">Version</system:String>
     <system:String x:Key="plugin_query_web">Website</system:String>
     <system:String x:Key="plugin_uninstall">Uninstall</system:String>
 

--- a/Flow.Launcher/Languages/pl.xaml
+++ b/Flow.Launcher/Languages/pl.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Nie udało się ustawić skrótu klawiszowego: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Nie udało się uruchomić: {0}</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">by</system:String>
     <system:String x:Key="plugin_init_time">Czas ładowania:</system:String>
     <system:String x:Key="plugin_query_time">Czas zapytania:</system:String>
-    <system:String x:Key="plugin_query_version">| Version</system:String>
+    <system:String x:Key="plugin_query_version">Version</system:String>
     <system:String x:Key="plugin_query_web">Website</system:String>
     <system:String x:Key="plugin_uninstall">Odinstalowywanie</system:String>
 

--- a/Flow.Launcher/Languages/pt-br.xaml
+++ b/Flow.Launcher/Languages/pt-br.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Falha ao registrar atalho: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Não foi possível iniciar {0}</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">by</system:String>
     <system:String x:Key="plugin_init_time">Tempo de inicialização:</system:String>
     <system:String x:Key="plugin_query_time">Tempo de consulta:</system:String>
-    <system:String x:Key="plugin_query_version">| Version</system:String>
+    <system:String x:Key="plugin_query_version">Version</system:String>
     <system:String x:Key="plugin_query_web">Website</system:String>
     <system:String x:Key="plugin_uninstall">Desinstalar</system:String>
 

--- a/Flow.Launcher/Languages/ru.xaml
+++ b/Flow.Launcher/Languages/ru.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Регистрация хоткея {0} не удалась</system:String>
     <system:String x:Key="couldnotStartCmd">Не удалось запустить {0}</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">by</system:String>
     <system:String x:Key="plugin_init_time">Инициализация:</system:String>
     <system:String x:Key="plugin_query_time">Запрос:</system:String>
-    <system:String x:Key="plugin_query_version">| Version</system:String>
+    <system:String x:Key="plugin_query_version">Version</system:String>
     <system:String x:Key="plugin_query_web">Website</system:String>
     <system:String x:Key="plugin_uninstall">Удалить</system:String>
 

--- a/Flow.Launcher/Languages/sk.xaml
+++ b/Flow.Launcher/Languages/sk.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Nepodarilo sa registrovať klávesovú skratku {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Nepodarilo sa spustiť {0}</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">od</system:String>
     <system:String x:Key="plugin_init_time">Inicializácia:</system:String>
     <system:String x:Key="plugin_query_time">Trvanie dopytu:</system:String>
-    <system:String x:Key="plugin_query_version">| Verzia</system:String>
+    <system:String x:Key="plugin_query_version">Verzia</system:String>
     <system:String x:Key="plugin_query_web">Webstránka</system:String>
     <system:String x:Key="plugin_uninstall">Odinštalovať</system:String>
 
@@ -292,7 +295,7 @@
     <system:String x:Key="update_flowlauncher_updating">Aktualizuje sa...</system:String>
     <system:String x:Key="update_flowlauncher_fail_moving_portable_user_profile_data">
         Flow Launcher nedokázal presunúť používateľské údaje do aktualizovanej verzie.
-            Prosím, presuňte profilový priečinok data z {0} do {1}
+        Prosím, presuňte profilový priečinok data z {0} do {1}
     </system:String>
     <system:String x:Key="update_flowlauncher_new_update">Nová aktualizácia</system:String>
     <system:String x:Key="update_flowlauncher_update_new_version_available">Je dostupná nová verzia Flow Launchera {0}</system:String>

--- a/Flow.Launcher/Languages/sr.xaml
+++ b/Flow.Launcher/Languages/sr.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Neuspešno registrovana prečica: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Neuspešno pokretanje {0}</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">by</system:String>
     <system:String x:Key="plugin_init_time">Vreme inicijalizacije:</system:String>
     <system:String x:Key="plugin_query_time">Vreme upita:</system:String>
-    <system:String x:Key="plugin_query_version">| Version</system:String>
+    <system:String x:Key="plugin_query_version">Version</system:String>
     <system:String x:Key="plugin_query_web">Website</system:String>
     <system:String x:Key="plugin_uninstall">Uninstall</system:String>
 
@@ -200,7 +203,7 @@
     <system:String x:Key="newVersionTips">Nove verzija {0} je dostupna, molim Vas ponovo pokrenite Flow Launcher.</system:String>
     <system:String x:Key="checkUpdatesFailed">Neuspešna provera ažuriranja, molim Vas proverite vašu vezu i podešavanja za proksi prema api.github.com.</system:String>
     <system:String x:Key="downloadUpdatesFailed">
-        Neuspešno preuzimanje ažuriranja, molim Vas proverite vašu vezu i podešavanja za proksi prema github-cloud.s3.amazonaws.com, 
+        Neuspešno preuzimanje ažuriranja, molim Vas proverite vašu vezu i podešavanja za proksi prema github-cloud.s3.amazonaws.com,
         ili posetite https://github.com/Flow-Launcher/Flow.Launcher/releases da preuzmete ažuriranja ručno.
     </system:String>
     <system:String x:Key="releaseNotes">U novoj verziji</system:String>

--- a/Flow.Launcher/Languages/uk-UA.xaml
+++ b/Flow.Launcher/Languages/uk-UA.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Реєстрація хоткея {0} не вдалася</system:String>
     <system:String x:Key="couldnotStartCmd">Не вдалося запустити {0}</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">за</system:String>
     <system:String x:Key="plugin_init_time">Ініціалізація:</system:String>
     <system:String x:Key="plugin_query_time">Запит:</system:String>
-    <system:String x:Key="plugin_query_version">| Версія</system:String>
+    <system:String x:Key="plugin_query_version">Версія</system:String>
     <system:String x:Key="plugin_query_web">Сайт</system:String>
     <system:String x:Key="plugin_uninstall">Uninstall</system:String>
 

--- a/Flow.Launcher/Languages/zh-cn.xaml
+++ b/Flow.Launcher/Languages/zh-cn.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">注册热键：{0} 失败</system:String>
     <system:String x:Key="couldnotStartCmd">启动命令 {0} 失败</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">出自</system:String>
     <system:String x:Key="plugin_init_time">加载耗时：</system:String>
     <system:String x:Key="plugin_query_time">查询耗时：</system:String>
-    <system:String x:Key="plugin_query_version">| 版本</system:String>
+    <system:String x:Key="plugin_query_version">版本</system:String>
     <system:String x:Key="plugin_query_web">官方网站</system:String>
     <system:String x:Key="plugin_uninstall">卸载</system:String>
 
@@ -200,7 +203,7 @@
     <system:String x:Key="newVersionTips">发现新版本 {0}, 请重启 Flow Launcher</system:String>
     <system:String x:Key="checkUpdatesFailed">下载更新失败，请检查您与 api.github.com 的连接状态或检查代理设置</system:String>
     <system:String x:Key="downloadUpdatesFailed">
-        下载更新失败，请检查您与 github-cloud.s3.amazonaws.com 的连接状态或检查代理设置， 
+        下载更新失败，请检查您与 github-cloud.s3.amazonaws.com 的连接状态或检查代理设置，
         或访问 https://github.com/Flow-Launcher/Flow.Launcher/releases 手动下载更新
     </system:String>
     <system:String x:Key="releaseNotes">更新说明</system:String>

--- a/Flow.Launcher/Languages/zh-tw.xaml
+++ b/Flow.Launcher/Languages/zh-tw.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">登錄快捷鍵：{0} 失敗</system:String>
     <system:String x:Key="couldnotStartCmd">啟動命令 {0} 失敗</system:String>
@@ -87,7 +90,7 @@
     <system:String x:Key="author">作者</system:String>
     <system:String x:Key="plugin_init_time">載入耗時：</system:String>
     <system:String x:Key="plugin_query_time">查詢耗時：</system:String>
-    <system:String x:Key="plugin_query_version">| 版本</system:String>
+    <system:String x:Key="plugin_query_version">版本</system:String>
     <system:String x:Key="plugin_query_web">官方網站</system:String>
     <system:String x:Key="plugin_uninstall">解除安裝</system:String>
 

--- a/Flow.Launcher/Resources/CustomControlTemplate.xaml
+++ b/Flow.Launcher/Resources/CustomControlTemplate.xaml
@@ -3230,4 +3230,26 @@
 
     <ui:TextContextMenu x:Key="TextControlContextMenu" x:Shared="False" />
 
+    <!--  Text Button style for Plugin Area  -->
+    <Style x:Key="LinkBtnStyle" TargetType="TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource PluginInfoColor}" />
+        <Setter Property="HorizontalAlignment" Value="Right" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="FontFamily" Value="/Resources/#Segoe Fluent Icons" />
+        <Setter Property="FontSize" Value="11" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource Color05B}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style x:Key="HyperLinkBtnStyle" TargetType="Hyperlink">
+        <Setter Property="Foreground" Value="{DynamicResource PluginInfoColor}" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource Color05B}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
 </ResourceDictionary>

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -1283,7 +1283,6 @@
                                                                     VerticalAlignment="Center"
                                                                     Orientation="Horizontal"
                                                                     Style="{StaticResource TextPanel}">
-
                                                                     <TextBlock
                                                                         Margin="10,0,0,0"
                                                                         VerticalAlignment="center"
@@ -1316,138 +1315,44 @@
                                                                         FontSize="11"
                                                                         Foreground="{DynamicResource PluginInfoColor}"
                                                                         Text="|" />
-
                                                                     <TextBlock
                                                                         Margin="5,0,0,0"
-                                                                        HorizontalAlignment="Right"
-                                                                        VerticalAlignment="Center"
-                                                                        Cursor="Hand"
-                                                                        FontFamily="/Resources/#Segoe Fluent Icons"
-                                                                        FontSize="11"
-                                                                        TextDecorations="None"
+                                                                        Style="{DynamicResource LinkBtnStyle}"
                                                                         ToolTip="{DynamicResource plugin_query_web}">
                                                                         <Hyperlink
-                                                                            Foreground="{DynamicResource PluginInfoColor}"
                                                                             NavigateUri="{Binding PluginPair.Metadata.Website}"
                                                                             RequestNavigate="OnRequestNavigate"
+                                                                            Style="{DynamicResource HyperLinkBtnStyle}"
                                                                             TextDecorations="None">
-                                                                            <!--<Run Text="{DynamicResource plugin_query_web}" />-->
                                                                             <Run Text="&#xe80f;" />
                                                                         </Hyperlink>
                                                                     </TextBlock>
-
                                                                     <TextBlock
                                                                         Margin="10,0,0,0"
-                                                                        HorizontalAlignment="Right"
-                                                                        VerticalAlignment="Center"
-                                                                        Cursor="Hand"
-                                                                        FontFamily="/Resources/#Segoe Fluent Icons"
-                                                                        FontSize="11"
-                                                                        Foreground="{DynamicResource PluginInfoColor}"
                                                                         MouseUp="OnExternalPluginUninstallClick"
+                                                                        Style="{DynamicResource LinkBtnStyle}"
                                                                         Text="&#xe74d;"
-                                                                        TextDecorations="None"
                                                                         ToolTip="{DynamicResource plugin_uninstall}" />
-
                                                                     <TextBlock
                                                                         Margin="10,0,5,0"
-                                                                        HorizontalAlignment="Right"
-                                                                        VerticalAlignment="Center"
-                                                                        Cursor="Hand"
-                                                                        FontFamily="/Resources/#Segoe Fluent Icons"
-                                                                        FontSize="11"
-                                                                        Foreground="{DynamicResource PluginInfoColor}"
+                                                                        Style="{DynamicResource LinkBtnStyle}"
                                                                         Text="&#xe8b7;"
                                                                         ToolTip="{DynamicResource pluginDirectory}">
                                                                         <TextBlock.InputBindings>
                                                                             <MouseBinding Command="{Binding OpenPluginDirectoryCommand}" MouseAction="LeftClick" />
                                                                         </TextBlock.InputBindings>
                                                                     </TextBlock>
-                                                                    <!--
-                                                                      <TextBlock
-                                                                        Margin="5,0,0,0"
-                                                                        FontSize="11"
-                                                                        Foreground="{DynamicResource PluginInfoColor}"
-                                                                        Text="{DynamicResource plugin_init_time}" />
-                                                                    <TextBlock
-                                                                        MaxWidth="100"
-                                                                        Margin="5,0,0,0"
-                                                                        FontSize="11"
-                                                                        Foreground="{DynamicResource PluginInfoColor}"
-                                                                        Text="{Binding InitilizaTime}" />
-                                                                    <TextBlock
-                                                                        Margin="5,0,0,0"
-                                                                        VerticalAlignment="Center"
-                                                                        FontSize="11"
-                                                                        Foreground="{DynamicResource PluginInfoColor}"
-                                                                        Text="|" />
-                                                                    <TextBlock
-                                                                        Margin="5,0,0,0"
-                                                                        FontSize="11"
-                                                                        Foreground="{DynamicResource PluginInfoColor}"
-                                                                        Text="{DynamicResource plugin_query_time}" />
-                                                                    <TextBlock
-                                                                        Margin="5,0,0,0"
-                                                                        FontSize="11"
-                                                                        Foreground="{DynamicResource PluginInfoColor}"
-                                                                        Text="{Binding QueryTime}" />
-                                                                    -->
-                                                                    <!--
-                                                                    <Button
-                                                                        Margin="0,0,0,0"
-                                                                        Background="Transparent"
-                                                                        BorderThickness="0"
-                                                                        Content="&#xe712;"
-                                                                        FontFamily="/Resources/#Segoe Fluent Icons"
-                                                                        FontSize="11"
-                                                                        Foreground="{DynamicResource PluginInfoColor}"
-                                                                        Style="{DynamicResource DefaultNonBDButtonStyle}">
-                                                                        <ui:FlyoutService.Flyout>
-                                                                            <ui:MenuFlyout>
-                                                                                <MenuItem Click="OpenWelcomeWindow" Header="{DynamicResource plugin_query_web}">
-                                                                                    <MenuItem.Icon>
-                                                                                        <ui:FontIcon Glyph="&#xe939;" />
-                                                                                    </MenuItem.Icon>
-                                                                                </MenuItem>
-                                                                                <MenuItem Click="OpenSettingFolder" Header="{DynamicResource plugin_uninstall}">
-                                                                                    <MenuItem.Icon>
-                                                                                        <ui:FontIcon Glyph="&#xe8b7;" />
-                                                                                    </MenuItem.Icon>
-                                                                                </MenuItem>
-                                                                                <MenuItem Click="OpenLogFolder" Header="{DynamicResource pluginDirectory}">
-                                                                                    <MenuItem.Icon>
-                                                                                        <ui:FontIcon Glyph="&#xe8b7;" />
-                                                                                    </MenuItem.Icon>
-                                                                                </MenuItem>
-                                                                                <MenuItem Click="OpenLogFolder" Header="{DynamicResource pluginDirectory}">
-                                                                                    <MenuItem.Icon>
-                                                                                        <ui:FontIcon Glyph="&#xe8b7;" />
-                                                                                    </MenuItem.Icon>
-                                                                                </MenuItem>
-                                                                                <MenuItem Click="OpenLogFolder" Header="{DynamicResource pluginDirectory}">
-                                                                                    <MenuItem.Icon>
-                                                                                        <ui:FontIcon Glyph="&#xe8b7;" />
-                                                                                    </MenuItem.Icon>
-                                                                                </MenuItem>
-                                                                            </ui:MenuFlyout>
-                                                                        </ui:FlyoutService.Flyout>
-                                                                    </Button>
-                                                                    -->
                                                                 </StackPanel>
-
                                                             </ItemsControl>
                                                         </Border>
-
                                                     </StackPanel>
                                                 </StackPanel>
                                             </Grid>
                                         </Expander>
-
                                     </DataTemplate>
                                 </ListBox.ItemTemplate>
                             </ListBox>
                         </Border>
-
                     </Grid>
                 </TabItem>
 

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -1309,7 +1309,7 @@
                                                                         Foreground="{DynamicResource PluginInfoColor}"
                                                                         Text="{Binding Version}"
                                                                         ToolTip="{Binding InitAndQueryTime}"
-                                                                        ToolTipService.InitialShowDelay="0" />
+                                                                        ToolTipService.InitialShowDelay="500" />
                                                                     <TextBlock
                                                                         Margin="5,0,5,0"
                                                                         VerticalAlignment="Center"
@@ -1325,8 +1325,7 @@
                                                                         FontFamily="/Resources/#Segoe Fluent Icons"
                                                                         FontSize="11"
                                                                         TextDecorations="None"
-                                                                        ToolTip="{DynamicResource plugin_query_web}"
-                                                                        ToolTipService.InitialShowDelay="0">
+                                                                        ToolTip="{DynamicResource plugin_query_web}">
                                                                         <Hyperlink
                                                                             Foreground="{DynamicResource PluginInfoColor}"
                                                                             NavigateUri="{Binding PluginPair.Metadata.Website}"
@@ -1348,8 +1347,7 @@
                                                                         MouseUp="OnExternalPluginUninstallClick"
                                                                         Text="&#xe74d;"
                                                                         TextDecorations="None"
-                                                                        ToolTip="{DynamicResource plugin_uninstall}"
-                                                                        ToolTipService.InitialShowDelay="0" />
+                                                                        ToolTip="{DynamicResource plugin_uninstall}" />
 
                                                                     <TextBlock
                                                                         Margin="10,0,5,0"
@@ -1360,8 +1358,7 @@
                                                                         FontSize="11"
                                                                         Foreground="{DynamicResource PluginInfoColor}"
                                                                         Text="&#xe8b7;"
-                                                                        ToolTip="{DynamicResource pluginDirectory}"
-                                                                        ToolTipService.InitialShowDelay="0">
+                                                                        ToolTip="{DynamicResource pluginDirectory}">
                                                                         <TextBlock.InputBindings>
                                                                             <MouseBinding Command="{Binding OpenPluginDirectoryCommand}" MouseAction="LeftClick" />
                                                                         </TextBlock.InputBindings>

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -1010,7 +1010,6 @@
                                     TextAlignment="Left" />
                                 <DockPanel DockPanel.Dock="Right">
                                     <TextBox
-                                        Loaded="Plugin_GotFocus"
                                         Name="pluginFilterTxb"
                                         Width="150"
                                         Height="34"
@@ -1019,6 +1018,7 @@
                                         DockPanel.Dock="Right"
                                         FontSize="14"
                                         KeyDown="PluginFilterTxb_OnKeyDown"
+                                        Loaded="Plugin_GotFocus"
                                         LostFocus="RefreshPluginListEventHandler"
                                         Text=""
                                         TextAlignment="Left"
@@ -1221,8 +1221,8 @@
                                                                         Height="34"
                                                                         Margin="5,0,0,0"
                                                                         HorizontalAlignment="Right"
-                                                                        Content="{Binding ActionKeywordsText}"
                                                                         Command="{Binding SetActionKeywordsCommand}"
+                                                                        Content="{Binding ActionKeywordsText}"
                                                                         Cursor="Hand"
                                                                         DockPanel.Dock="Right"
                                                                         FontWeight="Bold"
@@ -1271,7 +1271,7 @@
                                                     <StackPanel>
                                                         <Border
                                                             Margin="0"
-                                                            Padding="0,12,0,12"
+                                                            Padding="0,10,0,10"
                                                             VerticalAlignment="Center"
                                                             BorderThickness="0,1,0,0"
                                                             CornerRadius="0 0 5 5"
@@ -1283,23 +1283,91 @@
                                                                     VerticalAlignment="Center"
                                                                     Orientation="Horizontal"
                                                                     Style="{StaticResource TextPanel}">
+
                                                                     <TextBlock
                                                                         Margin="10,0,0,0"
+                                                                        VerticalAlignment="center"
                                                                         FontSize="11"
                                                                         Foreground="{DynamicResource PluginInfoColor}"
                                                                         Text="{DynamicResource author}" />
                                                                     <TextBlock
                                                                         Margin="5,0,0,0"
+                                                                        VerticalAlignment="center"
                                                                         FontSize="11"
                                                                         Foreground="{DynamicResource PluginInfoColor}"
                                                                         Text="{Binding PluginPair.Metadata.Author}" />
                                                                     <TextBlock
-                                                                        Margin="5,0,0,0"
+                                                                        Margin="10,0,0,0"
                                                                         VerticalAlignment="Center"
                                                                         FontSize="11"
                                                                         Foreground="{DynamicResource PluginInfoColor}"
                                                                         Text="|" />
                                                                     <TextBlock
+                                                                        Margin="10,0,5,0"
+                                                                        VerticalAlignment="Center"
+                                                                        FontSize="11"
+                                                                        Foreground="{DynamicResource PluginInfoColor}"
+                                                                        Text="{Binding Version}"
+                                                                        ToolTip="{Binding InitAndQueryTime}"
+                                                                        ToolTipService.InitialShowDelay="0" />
+                                                                    <TextBlock
+                                                                        Margin="5,0,5,0"
+                                                                        VerticalAlignment="Center"
+                                                                        FontSize="11"
+                                                                        Foreground="{DynamicResource PluginInfoColor}"
+                                                                        Text="|" />
+
+                                                                    <TextBlock
+                                                                        Margin="5,0,0,0"
+                                                                        HorizontalAlignment="Right"
+                                                                        VerticalAlignment="Center"
+                                                                        Cursor="Hand"
+                                                                        FontFamily="/Resources/#Segoe Fluent Icons"
+                                                                        FontSize="11"
+                                                                        TextDecorations="None"
+                                                                        ToolTip="{DynamicResource plugin_query_web}"
+                                                                        ToolTipService.InitialShowDelay="0">
+                                                                        <Hyperlink
+                                                                            Foreground="{DynamicResource PluginInfoColor}"
+                                                                            NavigateUri="{Binding PluginPair.Metadata.Website}"
+                                                                            RequestNavigate="OnRequestNavigate"
+                                                                            TextDecorations="None">
+                                                                            <!--<Run Text="{DynamicResource plugin_query_web}" />-->
+                                                                            <Run Text="&#xe80f;" />
+                                                                        </Hyperlink>
+                                                                    </TextBlock>
+
+                                                                    <TextBlock
+                                                                        Margin="10,0,0,0"
+                                                                        HorizontalAlignment="Right"
+                                                                        VerticalAlignment="Center"
+                                                                        Cursor="Hand"
+                                                                        FontFamily="/Resources/#Segoe Fluent Icons"
+                                                                        FontSize="11"
+                                                                        Foreground="{DynamicResource PluginInfoColor}"
+                                                                        MouseUp="OnExternalPluginUninstallClick"
+                                                                        Text="&#xe74d;"
+                                                                        TextDecorations="None"
+                                                                        ToolTip="{DynamicResource plugin_uninstall}"
+                                                                        ToolTipService.InitialShowDelay="0" />
+
+                                                                    <TextBlock
+                                                                        Margin="10,0,5,0"
+                                                                        HorizontalAlignment="Right"
+                                                                        VerticalAlignment="Center"
+                                                                        Cursor="Hand"
+                                                                        FontFamily="/Resources/#Segoe Fluent Icons"
+                                                                        FontSize="11"
+                                                                        Foreground="{DynamicResource PluginInfoColor}"
+                                                                        Text="&#xe8b7;"
+                                                                        ToolTip="{DynamicResource pluginDirectory}"
+                                                                        ToolTipService.InitialShowDelay="0">
+                                                                        <TextBlock.InputBindings>
+                                                                            <MouseBinding Command="{Binding OpenPluginDirectoryCommand}" MouseAction="LeftClick" />
+                                                                        </TextBlock.InputBindings>
+                                                                    </TextBlock>
+                                                                    <!--
+                                                                      <TextBlock
                                                                         Margin="5,0,0,0"
                                                                         FontSize="11"
                                                                         Foreground="{DynamicResource PluginInfoColor}"
@@ -1326,59 +1394,48 @@
                                                                         FontSize="11"
                                                                         Foreground="{DynamicResource PluginInfoColor}"
                                                                         Text="{Binding QueryTime}" />
-                                                                    <TextBlock
-                                                                        Margin="5,0,0,0"
-                                                                        VerticalAlignment="Center"
+                                                                    -->
+                                                                    <!--
+                                                                    <Button
+                                                                        Margin="0,0,0,0"
+                                                                        Background="Transparent"
+                                                                        BorderThickness="0"
+                                                                        Content="&#xe712;"
+                                                                        FontFamily="/Resources/#Segoe Fluent Icons"
                                                                         FontSize="11"
                                                                         Foreground="{DynamicResource PluginInfoColor}"
-                                                                        Text="{DynamicResource plugin_query_version}" />
-                                                                    <TextBlock
-                                                                        Margin="5,0,0,0"
-                                                                        VerticalAlignment="Center"
-                                                                        FontSize="11"
-                                                                        Foreground="{DynamicResource PluginInfoColor}"
-                                                                        Text="{Binding PluginPair.Metadata.Version}" />
-
-                                                                    <TextBlock
-                                                                        Margin="10,0,0,0"
-                                                                        HorizontalAlignment="Right"
-                                                                        VerticalAlignment="Center"
-                                                                        Cursor="Hand"
-                                                                        FontSize="11">
-                                                                        <Hyperlink
-                                                                            Foreground="{DynamicResource PluginInfoColor}"
-                                                                            NavigateUri="{Binding PluginPair.Metadata.Website}"
-                                                                            RequestNavigate="OnRequestNavigate">
-                                                                            <Run Text="{DynamicResource plugin_query_web}" />
-                                                                        </Hyperlink>
-                                                                    </TextBlock>
-
-                                                                    <TextBlock
-                                                                        Margin="10,0,0,0"
-                                                                        HorizontalAlignment="Right"
-                                                                        VerticalAlignment="Center"
-                                                                        Cursor="Hand"
-                                                                        FontSize="11"
-                                                                        Foreground="{DynamicResource PluginInfoColor}"
-                                                                        MouseUp="OnExternalPluginUninstallClick"
-                                                                        Text="{DynamicResource plugin_uninstall}"
-                                                                        TextDecorations="Underline" />
-
-                                                                    <TextBlock
-                                                                        Margin="10,0,0,0"
-                                                                        HorizontalAlignment="Right"
-                                                                        VerticalAlignment="Center"
-                                                                        Cursor="Hand"
-                                                                        FontSize="11"
-                                                                        Foreground="{DynamicResource PluginInfoColor}"
-                                                                        Text="{DynamicResource pluginDirectory}"
-                                                                        TextDecorations="Underline" >
-                                                                        <TextBlock.InputBindings>
-                                                                            <MouseBinding
-                                                                                Command="{Binding OpenPluginDirectoryCommand}"
-                                                                                MouseAction="LeftClick"/>
-                                                                        </TextBlock.InputBindings>
-                                                                    </TextBlock>
+                                                                        Style="{DynamicResource DefaultNonBDButtonStyle}">
+                                                                        <ui:FlyoutService.Flyout>
+                                                                            <ui:MenuFlyout>
+                                                                                <MenuItem Click="OpenWelcomeWindow" Header="{DynamicResource plugin_query_web}">
+                                                                                    <MenuItem.Icon>
+                                                                                        <ui:FontIcon Glyph="&#xe939;" />
+                                                                                    </MenuItem.Icon>
+                                                                                </MenuItem>
+                                                                                <MenuItem Click="OpenSettingFolder" Header="{DynamicResource plugin_uninstall}">
+                                                                                    <MenuItem.Icon>
+                                                                                        <ui:FontIcon Glyph="&#xe8b7;" />
+                                                                                    </MenuItem.Icon>
+                                                                                </MenuItem>
+                                                                                <MenuItem Click="OpenLogFolder" Header="{DynamicResource pluginDirectory}">
+                                                                                    <MenuItem.Icon>
+                                                                                        <ui:FontIcon Glyph="&#xe8b7;" />
+                                                                                    </MenuItem.Icon>
+                                                                                </MenuItem>
+                                                                                <MenuItem Click="OpenLogFolder" Header="{DynamicResource pluginDirectory}">
+                                                                                    <MenuItem.Icon>
+                                                                                        <ui:FontIcon Glyph="&#xe8b7;" />
+                                                                                    </MenuItem.Icon>
+                                                                                </MenuItem>
+                                                                                <MenuItem Click="OpenLogFolder" Header="{DynamicResource pluginDirectory}">
+                                                                                    <MenuItem.Icon>
+                                                                                        <ui:FontIcon Glyph="&#xe8b7;" />
+                                                                                    </MenuItem.Icon>
+                                                                                </MenuItem>
+                                                                            </ui:MenuFlyout>
+                                                                        </ui:FlyoutService.Flyout>
+                                                                    </Button>
+                                                                    -->
                                                                 </StackPanel>
 
                                                             </ItemsControl>

--- a/Flow.Launcher/ViewModel/PluginViewModel.cs
+++ b/Flow.Launcher/ViewModel/PluginViewModel.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
 using Flow.Launcher.Plugin;
@@ -6,6 +6,7 @@ using Flow.Launcher.Infrastructure.Image;
 using Flow.Launcher.Core.Plugin;
 using System.Windows.Controls;
 using CommunityToolkit.Mvvm.Input;
+using Flow.Launcher.Core.Resource;
 
 namespace Flow.Launcher.ViewModel
 {
@@ -74,6 +75,8 @@ namespace Flow.Launcher.ViewModel
         public Visibility ActionKeywordsVisibility => PluginPair.Metadata.ActionKeywords.Count == 1 ? Visibility.Visible : Visibility.Collapsed;
         public string InitilizaTime => PluginPair.Metadata.InitTime + "ms";
         public string QueryTime => PluginPair.Metadata.AvgQueryTime + "ms";
+        public string Version => InternationalizationManager.Instance.GetTranslation("plugin_query_version") + " " + PluginPair.Metadata.Version;
+        public string InitAndQueryTime => InternationalizationManager.Instance.GetTranslation("plugin_init_time") + " " + PluginPair.Metadata.InitTime + "ms, " + InternationalizationManager.Instance.GetTranslation("plugin_query_time") + " " + PluginPair.Metadata.AvgQueryTime + "ms";
         public string ActionKeywordsText => string.Join(Query.ActionKeywordSeparator, PluginPair.Metadata.ActionKeywords);
         public int Priority => PluginPair.Metadata.Priority;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6903107/206880446-7be469ba-4b8d-4736-97e4-c32846e7d97c.png)
<img src="https://user-images.githubusercontent.com/6903107/206880483-4518f69e-8830-4267-9bf1-0bf7250b8d0b.png" width="200">

## What's the PR
- It simplified the plugin info area
- init/query time changed it to be seen as a tooltip in version.
- The relevant String has been cleaned up.

## Test Case
- [x] Each button must operate normally.
- [x] It should work properly when changing the language.