### PR TITLE
[Dev] Fix duplicate Quick Access results from CreateOpenCurrentFolderResult

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
@@ -57,7 +57,7 @@ namespace Flow.Launcher.Plugin.Explorer
                 var icoPath = (record.Type == ResultType.File) ? Constants.FileImagePath : Constants.FolderImagePath;
                 var fileOrFolder = (record.Type == ResultType.File) ? "file" : "folder";
 
-                if (Settings.QuickAccessLinks.All(x => x.Path != record.FullPath))
+                if (Settings.QuickAccessLinks.All(x => !x.Path.Equals(record.FullPath, StringComparison.OrdinalIgnoreCase)))
                 {
                     contextMenus.Add(new Result
                     {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -168,7 +168,11 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
         internal static Result CreateOpenCurrentFolderResult(string path, bool windowsIndexed = false)
         {
-            var folderName = path.TrimEnd(Constants.DirectorySeperator).Split(new[]
+            // Path passed from PathSearchAsync ends with Constants.DirectorySeperator ('\'), need to remove the seperator
+            // so it's consistent with folder results returned by index search which does not end with one
+            var folderPath = path.TrimEnd(Constants.DirectorySeperator);
+            
+            var folderName = folderPath.TrimEnd(Constants.DirectorySeperator).Split(new[]
             {
                 Path.DirectorySeparatorChar
             }, StringSplitOptions.None).Last();
@@ -186,19 +190,19 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 Title = title,
                 SubTitle = $"Use > to search within {subtitleFolderName}, " +
                            $"* to search for file extensions or >* to combine both searches.",
-                AutoCompleteText = GetPathWithActionKeyword(path, ResultType.Folder),
-                IcoPath = path,
+                AutoCompleteText = GetPathWithActionKeyword(folderPath, ResultType.Folder),
+                IcoPath = folderPath,
                 Score = 500,
-                CopyText = path,
+                CopyText = folderPath,
                 Action = _ =>
                 {
-                    Context.API.OpenDirectory(path);
+                    Context.API.OpenDirectory(folderPath);
                     return true;
                 },
                 ContextData = new SearchResult
                 {
                     Type = ResultType.Folder,
-                    FullPath = path,
+                    FullPath = folderPath,
                     WindowsIndexed = windowsIndexed
                 }
             };


### PR DESCRIPTION
1. Fix duplication when Quick Access is added from the open current folder result
2. Fix duplication of results due to case sensitivity

Repro:

1. Go to c:\users\ and on the top result open current folder go to context menu
3.  select 'Add to Quick Access'
4. while still in c:\users\ see the duplicated entries.

Before:
![image](https://user-images.githubusercontent.com/26427004/206947129-70f16233-ad0c-4033-9abc-9c0f48913dd7.png)

After fix:
![image](https://user-images.githubusercontent.com/26427004/206947283-d277fe6b-0263-4784-89d1-c1b2d7d0d81a.png)
