### PR TITLE
[Dev] Fix action keyword missing when traversing paths or using autocomplete

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -21,16 +21,15 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             Settings = settings;
         }
 
-        private static string GetPathWithActionKeyword(string path, ResultType type)
+        private static string GetPathWithActionKeyword(string path, ResultType type, string actionKeyword)
         {
-            // one of it is enabled
-            var keyword = Settings.SearchActionKeywordEnabled ? Settings.SearchActionKeyword : Settings.PathSearchActionKeyword;
-
-            keyword = keyword == Query.GlobalPluginWildcardSign ? string.Empty : keyword + " ";
+            // Query.ActionKeyword is string.Empty when Global Action Keyword ('*') is used
+            var keyword = actionKeyword != string.Empty ? actionKeyword + " " : string.Empty;
 
             var formatted_path = path;
 
             if (type == ResultType.Folder)
+                // the seperator is needed so when navigating the folder structure contents of the folder are listed
                 formatted_path = path.EndsWith(Constants.DirectorySeperator) ? path : path + Constants.DirectorySeperator;
 
             return $"{keyword}{formatted_path}";
@@ -55,7 +54,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 Title = title,
                 IcoPath = path,
                 SubTitle = Path.GetDirectoryName(path),
-                AutoCompleteText = GetPathWithActionKeyword(path, ResultType.Folder),
+                AutoCompleteText = GetPathWithActionKeyword(path, ResultType.Folder, query.ActionKeyword),
                 TitleHighlightData = StringMatcher.FuzzySearch(query.Search, title).MatchData,
                 CopyText = path,
                 Action = c =>
@@ -74,7 +73,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                         }
                     }
 
-                    Context.API.ChangeQuery(GetPathWithActionKeyword(path, ResultType.Folder));
+                    Context.API.ChangeQuery(GetPathWithActionKeyword(path, ResultType.Folder, query.ActionKeyword));
 
                     return false;
                 },
@@ -90,7 +89,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             };
         }
 
-        internal static Result CreateDriveSpaceDisplayResult(string path, bool windowsIndexed = false)
+        internal static Result CreateDriveSpaceDisplayResult(string path, string actionKeyword, bool windowsIndexed = false)
         {
             var progressBarColor = "#26a0da";
             var title = string.Empty; // hide title when use progress bar,
@@ -109,7 +108,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             {
                 Title = title,
                 SubTitle = subtitle,
-                AutoCompleteText = GetPathWithActionKeyword(path, ResultType.Folder),
+                AutoCompleteText = GetPathWithActionKeyword(path, ResultType.Folder, actionKeyword),
                 IcoPath = path,
                 Score = 500,
                 ProgressBar = progressValue,
@@ -166,7 +165,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             return returnStr;
         }
 
-        internal static Result CreateOpenCurrentFolderResult(string path, bool windowsIndexed = false)
+        internal static Result CreateOpenCurrentFolderResult(string path, string actionKeyword, bool windowsIndexed = false)
         {
             var folderName = path.TrimEnd(Constants.DirectorySeperator).Split(new[]
             {
@@ -186,7 +185,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 Title = title,
                 SubTitle = $"Use > to search within {subtitleFolderName}, " +
                            $"* to search for file extensions or >* to combine both searches.",
-                AutoCompleteText = GetPathWithActionKeyword(path, ResultType.Folder),
+                AutoCompleteText = GetPathWithActionKeyword(path, ResultType.Folder, actionKeyword),
                 IcoPath = path,
                 Score = 500,
                 CopyText = path,
@@ -217,7 +216,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 SubTitle = Path.GetDirectoryName(filePath),
                 IcoPath = filePath,
                 Preview = preview,
-                AutoCompleteText = GetPathWithActionKeyword(filePath, ResultType.File),
+                AutoCompleteText = GetPathWithActionKeyword(filePath, ResultType.File, query.ActionKeyword),
                 TitleHighlightData = StringMatcher.FuzzySearch(query.Search, Path.GetFileName(filePath)).MatchData,
                 Score = score,
                 CopyText = filePath,

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -176,8 +176,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             var retrievedDirectoryPath = FilesFolders.ReturnPreviousDirectoryIfIncompleteString(locationPath);
 
             results.Add(retrievedDirectoryPath.EndsWith(":\\") 
-                ? ResultManager.CreateDriveSpaceDisplayResult(retrievedDirectoryPath, useIndexSearch)
-                : ResultManager.CreateOpenCurrentFolderResult(retrievedDirectoryPath, useIndexSearch));
+                ? ResultManager.CreateDriveSpaceDisplayResult(retrievedDirectoryPath, query.ActionKeyword, useIndexSearch)
+                : ResultManager.CreateOpenCurrentFolderResult(retrievedDirectoryPath, query.ActionKeyword, useIndexSearch));
 
             if (token.IsCancellationRequested)
                 return new List<Result>();


### PR DESCRIPTION
Fix action keyword missing when traversing paths or using autocomplete

Repro:
1. Use path action keyword to go to c:\users\
2. see action keyword for path is removed after entering into the directory.

Tested:
1. Path traversing with action keyword
2. Path traversing without action keyword
3. Autocomplete with action keyword on Open Current Folder result
4. Autocomplete with action keyword on Drive Disk Space result
5. Autocomplete without action keyword on Open Current Folder result
6. Autocomplete without action keyword on Drive Disk Space result