### PR TITLE
Fix the bottom margin issue when loading progress

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -180,7 +180,10 @@
             Modifiers="{Binding OpenResultCommandModifiers}" />
     </Window.InputBindings>
     <Grid>
-        <Border MouseDown="OnMouseDown" Style="{DynamicResource WindowBorderStyle}">
+        <Border
+            ClipToBounds="True"
+            MouseDown="OnMouseDown"
+            Style="{DynamicResource WindowBorderStyle}">
             <StackPanel Orientation="Vertical">
                 <Grid>
                     <Border Style="{DynamicResource QueryBoxBgStyle}">

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -180,10 +180,7 @@
             Modifiers="{Binding OpenResultCommandModifiers}" />
     </Window.InputBindings>
     <Grid>
-        <Border
-            ClipToBounds="True"
-            MouseDown="OnMouseDown"
-            Style="{DynamicResource WindowBorderStyle}">
+        <Border MouseDown="OnMouseDown" Style="{DynamicResource WindowBorderStyle}">
             <StackPanel Orientation="Vertical">
                 <Grid>
                     <Border Style="{DynamicResource QueryBoxBgStyle}">

--- a/Flow.Launcher/ResultListBox.xaml
+++ b/Flow.Launcher/ResultListBox.xaml
@@ -7,7 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="clr-namespace:Flow.Launcher.ViewModel"
     MaxHeight="{Binding MaxHeight}"
-    Margin="{DynamicResource ResultMargin}"
     HorizontalContentAlignment="Stretch"
     d:DataContext="{d:DesignInstance vm:ResultsViewModel}"
     d:DesignHeight="100"

--- a/Flow.Launcher/Themes/Base.xaml
+++ b/Flow.Launcher/Themes/Base.xaml
@@ -248,8 +248,9 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-        <Setter Property="Margin" Value="0,0,0,0" />
+        <Setter Property="Margin" Value="{DynamicResource ResultMargin}" />
         <Setter Property="Padding" Value="0,0,0,0" />
+
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ListBox">
@@ -273,6 +274,11 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Items.Count}" Value="0">
+                <Setter Property="Margin" Value="0" />
+            </DataTrigger>
+        </Style.Triggers>
     </Style>
 
     <!--  ScrollViewer Style  -->
@@ -360,7 +366,6 @@
         <Style.Triggers>
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding ElementName=QueryTextBox, UpdateSourceTrigger=PropertyChanged, Path=Text.Length}" Value="0" />
                     <Condition Binding="{Binding ElementName=ResultListBox, Path=Visibility}" Value="Collapsed" />
                     <Condition Binding="{Binding ElementName=ContextMenu, Path=Visibility}" Value="Collapsed" />
                     <Condition Binding="{Binding ElementName=History, Path=Visibility}" Value="Collapsed" />

--- a/Flow.Launcher/Themes/Win10Light.xaml
+++ b/Flow.Launcher/Themes/Win10Light.xaml
@@ -13,6 +13,12 @@
         <Setter Property="Foreground" Value="#000000" />
     </Style>
     <Style
+        x:Key="ItemGlyphSelectedStyle"
+        BasedOn="{StaticResource BaseGlyphStyle}"
+        TargetType="{x:Type TextBlock}">
+        <Setter Property="Foreground" Value="#000000" />
+    </Style>
+    <Style
         x:Key="QueryBoxStyle"
         BasedOn="{StaticResource BaseQueryBoxStyle}"
         TargetType="{x:Type TextBox}">


### PR DESCRIPTION
- Fix the problem that the bottom margin was larger than before when loading without the result item.

## Before
![image](https://user-images.githubusercontent.com/6903107/207752045-69f2e3f3-6541-453a-ab48-d135bd2f286f.png)

## After
![image](https://user-images.githubusercontent.com/6903107/207752058-66b77c6c-751a-43a0-b691-5be6d5d8bac9.png)
