### PR TITLE
Fix Progressbar & Margin issue with preview panel

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -261,16 +261,6 @@
                     </StackPanel>
                     <Border>
                         <Grid>
-                            <ui:ProgressRing
-                                x:Name="ProgressBar"
-                                Width="24"
-                                Height="24"
-                                Margin="0,0,68,0"
-                                HorizontalAlignment="Right"
-                                VerticalAlignment="Center"
-                                Panel.ZIndex="2"
-                                IsActive="true"
-                                Visibility="{Binding ProgressBarVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <Image
                                 x:Name="PluginActivationIcon"
                                 Width="32"
@@ -294,6 +284,20 @@
                             </Canvas>
                         </Grid>
                     </Border>
+                    <Line
+                        x:Name="ProgressBar"
+                        Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Grid}}, Path=ActualWidth}"
+                        Height="2"
+                        Margin="12,0,12,0"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Bottom"
+                        StrokeThickness="2"
+                        Style="{DynamicResource PendingLineStyle}"
+                        Visibility="{Binding ProgressBarVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        X1="-100"
+                        X2="0"
+                        Y1="0"
+                        Y2="0" />
                 </Grid>
 
                 <Grid ClipToBounds="True">
@@ -320,6 +324,7 @@
                             HorizontalAlignment="Stretch"
                             Style="{DynamicResource SeparatorStyle}" />
                     </ContentControl>
+
                 </Grid>
                 <Grid>
                     <Grid.ColumnDefinitions>

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -261,6 +261,16 @@
                     </StackPanel>
                     <Border>
                         <Grid>
+                            <ui:ProgressRing
+                                x:Name="ProgressBar"
+                                Width="24"
+                                Height="24"
+                                Margin="0,0,68,0"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                Panel.ZIndex="2"
+                                IsActive="true"
+                                Visibility="{Binding ProgressBarVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <Image
                                 x:Name="PluginActivationIcon"
                                 Width="32"
@@ -310,18 +320,6 @@
                             HorizontalAlignment="Stretch"
                             Style="{DynamicResource SeparatorStyle}" />
                     </ContentControl>
-                    <Line
-                        x:Name="ProgressBar"
-                        Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Grid}}, Path=ActualWidth}"
-                        Height="2"
-                        HorizontalAlignment="Right"
-                        StrokeThickness="1"
-                        Style="{DynamicResource PendingLineStyle}"
-                        Visibility="{Binding ProgressBarVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                        X1="-150"
-                        X2="-50"
-                        Y1="0"
-                        Y2="0" />
                 </Grid>
                 <Grid>
                     <Grid.ColumnDefinitions>

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -362,15 +362,14 @@ namespace Flow.Launcher
         private void InitProgressbarAnimation()
         {
 
-            //var da = new DoubleAnimation(ProgressBar.X2, ActualWidth + 150,
-            //    new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
-            //var da1 = new DoubleAnimation(ProgressBar.X1, ActualWidth + 50, new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
-            //Storyboard.SetTargetProperty(da, new PropertyPath("(Line.X2)"));
-            //Storyboard.SetTargetProperty(da1, new PropertyPath("(Line.X1)"));
-            //_progressBarStoryboard.Children.Add(da);
-            //_progressBarStoryboard.Children.Add(da1);
-            _progressBarStoryboard.RepeatBehavior = RepeatBehavior.Forever;
+            var da = new DoubleAnimation(ProgressBar.X2, ActualWidth + 100, new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
+            var da1 = new DoubleAnimation(ProgressBar.X1, ActualWidth + 0, new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
 
+            Storyboard.SetTargetProperty(da, new PropertyPath("(Line.X2)"));
+            Storyboard.SetTargetProperty(da1, new PropertyPath("(Line.X1)"));
+            _progressBarStoryboard.Children.Add(da);
+            _progressBarStoryboard.Children.Add(da1);
+            _progressBarStoryboard.RepeatBehavior = RepeatBehavior.Forever;
             _viewModel.ProgressBarVisibility = Visibility.Hidden;
             isProgressBarStoryboardPaused = true;
         }

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -361,9 +361,8 @@ namespace Flow.Launcher
         }
         private void InitProgressbarAnimation()
         {
-
-            var da = new DoubleAnimation(ProgressBar.X2, ActualWidth + 100, new Duration(new TimeSpan(0, 0, 0, 0, 1200)));
-            var da1 = new DoubleAnimation(ProgressBar.X1, ActualWidth + 0, new Duration(new TimeSpan(0, 0, 0, 0, 1200)));
+            var da = new DoubleAnimation(ProgressBar.X2, ActualWidth + 100, new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
+            var da1 = new DoubleAnimation(ProgressBar.X1, ActualWidth + 0, new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
             Storyboard.SetTargetProperty(da, new PropertyPath("(Line.X2)"));
             Storyboard.SetTargetProperty(da1, new PropertyPath("(Line.X1)"));
             _progressBarStoryboard.Children.Add(da);

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -361,13 +361,14 @@ namespace Flow.Launcher
         }
         private void InitProgressbarAnimation()
         {
-            var da = new DoubleAnimation(ProgressBar.X2, ActualWidth + 150,
-                new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
-            var da1 = new DoubleAnimation(ProgressBar.X1, ActualWidth + 50, new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
-            Storyboard.SetTargetProperty(da, new PropertyPath("(Line.X2)"));
-            Storyboard.SetTargetProperty(da1, new PropertyPath("(Line.X1)"));
-            _progressBarStoryboard.Children.Add(da);
-            _progressBarStoryboard.Children.Add(da1);
+
+            //var da = new DoubleAnimation(ProgressBar.X2, ActualWidth + 150,
+            //    new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
+            //var da1 = new DoubleAnimation(ProgressBar.X1, ActualWidth + 50, new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
+            //Storyboard.SetTargetProperty(da, new PropertyPath("(Line.X2)"));
+            //Storyboard.SetTargetProperty(da1, new PropertyPath("(Line.X1)"));
+            //_progressBarStoryboard.Children.Add(da);
+            //_progressBarStoryboard.Children.Add(da1);
             _progressBarStoryboard.RepeatBehavior = RepeatBehavior.Forever;
 
             _viewModel.ProgressBarVisibility = Visibility.Hidden;

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -362,9 +362,8 @@ namespace Flow.Launcher
         private void InitProgressbarAnimation()
         {
 
-            var da = new DoubleAnimation(ProgressBar.X2, ActualWidth + 100, new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
-            var da1 = new DoubleAnimation(ProgressBar.X1, ActualWidth + 0, new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
-
+            var da = new DoubleAnimation(ProgressBar.X2, ActualWidth + 100, new Duration(new TimeSpan(0, 0, 0, 0, 1200)));
+            var da1 = new DoubleAnimation(ProgressBar.X1, ActualWidth + 0, new Duration(new TimeSpan(0, 0, 0, 0, 1200)));
             Storyboard.SetTargetProperty(da, new PropertyPath("(Line.X2)"));
             Storyboard.SetTargetProperty(da1, new PropertyPath("(Line.X1)"));
             _progressBarStoryboard.Children.Add(da);

--- a/Flow.Launcher/Themes/Base.xaml
+++ b/Flow.Launcher/Themes/Base.xaml
@@ -451,15 +451,16 @@
         <Style.Triggers>
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
+                    <!--
                     <Condition Binding="{Binding ElementName=ResultListBox, Path=Visibility}" Value="Collapsed" />
                     <Condition Binding="{Binding ElementName=ContextMenu, Path=Visibility}" Value="Collapsed" />
-                    <Condition Binding="{Binding ElementName=History, Path=Visibility}" Value="Collapsed" />
+                    <Condition Binding="{Binding ElementName=History, Path=Visibility}" Value="Collapsed" />-->
+                    <Condition Binding="{Binding ElementName=ResultListBox, Path=Items.Count}" Value="0" />
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>
                     <Setter Property="Height" Value="0" />
                 </MultiDataTrigger.Setters>
             </MultiDataTrigger>
-
         </Style.Triggers>
     </Style>
     <!--  for classic themes  -->

--- a/Flow.Launcher/Themes/Base.xaml
+++ b/Flow.Launcher/Themes/Base.xaml
@@ -366,7 +366,7 @@
         <Style.Triggers>
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding ElementName=ResultListBox, Path=Visibility}" Value="Collapsed" />
+                    <Condition Binding="{Binding ElementName=ResultListBox, Path=Items.Count}" Value="0" />
                     <Condition Binding="{Binding ElementName=ContextMenu, Path=Visibility}" Value="Collapsed" />
                     <Condition Binding="{Binding ElementName=History, Path=Visibility}" Value="Collapsed" />
                 </MultiDataTrigger.Conditions>


### PR DESCRIPTION
## What's the PR
- Fix #1655
- Fix wrong margin with non-result with preview state.
- Changed Progress bar height (to large)
- The Progress bar screen has been adjusted so that it does not come out of the screen.

## Test Case
- With no items present, there should be no margin below when loading.
- If there are no result items, the separator (middle line) should not be displayed.