### PR TITLE
Disable PATH programs by default

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -620,7 +620,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                     autoIndexPrograms = autoIndexPrograms.Concat(startMenu);
                 }
 
-                if (settings.EnablePATHSource)
+                if (settings.EnablePathSource)
                 {
                     var path = PATHPrograms(settings.GetSuffixes(), protocols, commonParents);
                     programs = programs.Concat(path);

--- a/Plugins/Flow.Launcher.Plugin.Program/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Settings.cs
@@ -118,7 +118,7 @@ namespace Flow.Launcher.Plugin.Program
         public bool EnableDescription { get; set; } = false;
         public bool HideAppsPath { get; set; } = true;
         public bool EnableRegistrySource { get; set; } = true;
-        public bool EnablePATHSource { get; set; } = true;
+        public bool EnablePathSource { get; set; } = false;
 
         public string CustomizedExplorer { get; set; } = Explorer;
         public string CustomizedArgs { get; set; } = ExplorerArgs;

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
@@ -69,10 +69,10 @@ namespace Flow.Launcher.Plugin.Program.Views
 
         public bool EnablePATHSource
         {
-            get => _settings.EnablePATHSource;
+            get => _settings.EnablePathSource;
             set
             {
-                _settings.EnablePATHSource = value;
+                _settings.EnablePathSource = value;
                 ReIndexing();
             }
         }

--- a/Plugins/Flow.Launcher.Plugin.Program/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Program/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Program",
   "Description": "Search programs in Flow.Launcher",
   "Author": "qianlifeng",
-  "Version": "2.0.0",
+  "Version": "2.0.1",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Program.dll",


### PR DESCRIPTION
Rename the variable in settings to disable indexing PATH programs by default.

Tested:
- [x] The option is false when upgrading to this build.