### PR TITLE
Always Start in English Layout

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -147,6 +147,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         /// </summary>
         public bool ShouldUsePinyin { get; set; } = false;
         public bool AlwaysPreview { get; set; } = false;
+        public bool AlwaysStartEn { get; set; } = false;
 
         [JsonInclude, JsonConverter(typeof(JsonStringEnumConverter))]
         public SearchPrecisionScore QuerySearchPrecision { get; private set; } = SearchPrecisionScore.Regular;

--- a/Flow.Launcher/Converters/BoolToIMEConversionModeConverter.cs
+++ b/Flow.Launcher/Converters/BoolToIMEConversionModeConverter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Input;
+
+namespace Flow.Launcher.Converters
+{
+    internal class BoolToIMEConversionModeConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool v)
+            {
+                if (v)
+                {
+                    return ImeConversionModeValues.Alphanumeric;
+                }
+                else
+                {
+                    return ImeConversionModeValues.DoNotCare;
+                }
+            }
+            return ImeConversionModeValues.DoNotCare;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Flow.Launcher/Converters/BoolToIMEConversionModeConverter.cs
+++ b/Flow.Launcher/Converters/BoolToIMEConversionModeConverter.cs
@@ -28,4 +28,28 @@ namespace Flow.Launcher.Converters
             throw new NotImplementedException();
         }
     }
+
+    internal class BoolToIMEStateConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool v)
+            {
+                if (v)
+                {
+                    return InputMethodState.Off;
+                }
+                else
+                {
+                    return InputMethodState.DoNotCare;
+                }
+            }
+            return InputMethodState.DoNotCare;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -56,7 +56,7 @@
     <system:String x:Key="defaultBrowser">Default Web Browser</system:String>
     <system:String x:Key="defaultBrowserToolTip">Setting for New Tab, New Window, Private Mode.</system:String>
     <system:String x:Key="typingStartEn">Always Start Typing in English Mode</system:String>
-    <system:String x:Key="typingStartEnTooltip">Automatically change your input method to English mode when activating Flow.</system:String>
+    <system:String x:Key="typingStartEnTooltip">Temporarily change your input method to English mode when activating Flow.</system:String>
     <system:String x:Key="pythonDirectory">Python Directory</system:String>
     <system:String x:Key="autoUpdates">Auto Update</system:String>
     <system:String x:Key="selectPythonDirectory">Select</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -55,8 +55,8 @@
     <system:String x:Key="defaultFileManagerToolTip">Select the file manager to use when opening the folder.</system:String>
     <system:String x:Key="defaultBrowser">Default Web Browser</system:String>
     <system:String x:Key="defaultBrowserToolTip">Setting for New Tab, New Window, Private Mode.</system:String>
-    <system:String x:Key="typingStartEn">Always Start in English Layout</system:String>
-    <system:String x:Key="typingStartEnTooltip">If you are using both native language and English keyboard layouts, start the flow in English layout state.</system:String>
+    <system:String x:Key="typingStartEn">Always Start Typing in English Mode</system:String>
+    <system:String x:Key="typingStartEnTooltip">Automatically change your input method to English mode when activating Flow.</system:String>
     <system:String x:Key="pythonDirectory">Python Directory</system:String>
     <system:String x:Key="autoUpdates">Auto Update</system:String>
     <system:String x:Key="selectPythonDirectory">Select</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -55,6 +55,8 @@
     <system:String x:Key="defaultFileManagerToolTip">Select the file manager to use when opening the folder.</system:String>
     <system:String x:Key="defaultBrowser">Default Web Browser</system:String>
     <system:String x:Key="defaultBrowserToolTip">Setting for New Tab, New Window, Private Mode.</system:String>
+    <system:String x:Key="typingStartEn">Always Start in English Layout</system:String>
+    <system:String x:Key="typingStartEnTooltip">If you are using both native language and English keyboard layouts, start the flow in English layout state.</system:String>
     <system:String x:Key="pythonDirectory">Python Directory</system:String>
     <system:String x:Key="autoUpdates">Auto Update</system:String>
     <system:String x:Key="selectPythonDirectory">Select</system:String>

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -9,6 +9,7 @@
     xmlns:svgc="http://sharpvectors.codeplex.com/svgc/"
     xmlns:ui="http://schemas.modernwpf.com/2019"
     xmlns:vm="clr-namespace:Flow.Launcher.ViewModel"
+    d:DataContext="{d:DesignInstance Type=vm:MainViewModel}"
     Name="FlowMainWindow"
     Title="Flow Launcher"
     MinWidth="{Binding MainWindowWidth, Mode=OneWay}"
@@ -37,6 +38,7 @@
         <converters:QuerySuggestionBoxConverter x:Key="QuerySuggestionBoxConverter" />
         <converters:BorderClipConverter x:Key="BorderClipConverter" />
         <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <converters:BoolToIMEConversionModeConverter x:Key="BoolToIMEConversionModeConverter"/>
     </Window.Resources>
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />
@@ -204,6 +206,7 @@
                                 PreviewKeyUp="QueryTextBox_KeyUp"
                                 Style="{DynamicResource QueryBoxStyle}"
                                 Text="{Binding QueryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                InputMethod.PreferredImeConversionMode="{Binding StartWithEnglishMode, Converter={StaticResource BoolToIMEConversionModeConverter}}"
                                 Visibility="Visible">
                                 <TextBox.CommandBindings>
                                     <CommandBinding Command="ApplicationCommands.Copy" Executed="OnCopy" />

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -244,6 +244,7 @@
                             </TextBox>
                         </Grid>
                     </Border>
+
                     <StackPanel
                         x:Name="ClockPanel"
                         IsHitTestVisible="False"

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -39,6 +39,7 @@
         <converters:BorderClipConverter x:Key="BorderClipConverter" />
         <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <converters:BoolToIMEConversionModeConverter x:Key="BoolToIMEConversionModeConverter"/>
+        <converters:BoolToIMEStateConverter x:Key="BoolToIMEStateConverter"/>
     </Window.Resources>
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />
@@ -207,6 +208,7 @@
                                 Style="{DynamicResource QueryBoxStyle}"
                                 Text="{Binding QueryText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                 InputMethod.PreferredImeConversionMode="{Binding StartWithEnglishMode, Converter={StaticResource BoolToIMEConversionModeConverter}}"
+                                InputMethod.PreferredImeState="{Binding StartWithEnglishMode, Converter={StaticResource BoolToIMEStateConverter}}"
                                 Visibility="Visible">
                                 <TextBox.CommandBindings>
                                     <CommandBinding Command="ApplicationCommands.Copy" Executed="OnCopy" />

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -34,6 +34,9 @@ using System.Security.Cryptography;
 using System.Runtime.CompilerServices;
 using Microsoft.VisualBasic.Devices;
 using Microsoft.FSharp.Data.UnitSystems.SI.UnitNames;
+using NLog.Targets;
+using YamlDotNet.Core.Tokens;
+using Key = System.Windows.Input.Key;
 
 namespace Flow.Launcher
 {
@@ -128,6 +131,7 @@ namespace Flow.Launcher
                                 UpdatePosition();
                                 PreviewReset();
                                 Activate();
+                                QueryTextBox_StartEn();
                                 QueryTextBox.Focus();
                                 _settings.ActivateTimes++;
                                 if (!_viewModel.LastQuerySelected)
@@ -190,6 +194,9 @@ namespace Flow.Launcher
                         break;
                     case nameof(Settings.Language):
                         UpdateNotifyIconText();
+                        break;
+                    case nameof(Settings.AlwaysStartEn):
+                        QueryTextBox_StartEn();
                         break;
                     case nameof(Settings.Hotkey):
                         UpdateNotifyIconText();
@@ -694,6 +701,20 @@ namespace Flow.Launcher
             {
                 BindingExpression be = QueryTextBox.GetBindingExpression(System.Windows.Controls.TextBox.TextProperty);
                 be.UpdateSource();
+            }
+        }
+
+        private void QueryTextBox_StartEn()
+        {
+            if (_settings.AlwaysStartEn)
+            {
+                QueryTextBox.SetValue(InputMethod.PreferredImeConversionModeProperty, ImeConversionModeValues.Alphanumeric); 
+                QueryTextBox.SetValue(InputMethod.PreferredImeStateProperty, InputMethodState.Off);
+            }
+            else
+            {
+                QueryTextBox.ClearValue(InputMethod.PreferredImeConversionModeProperty);
+                QueryTextBox.ClearValue(InputMethod.PreferredImeStateProperty);
             }
         }
     }

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -20,22 +20,9 @@ using Flow.Launcher.Infrastructure;
 using System.Windows.Media;
 using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Plugin.SharedCommands;
-using System.Text;
-using DataObject = System.Windows.DataObject;
-using System.Diagnostics;
-using Microsoft.AspNetCore.Http;
-using System.IO;
 using System.Windows.Threading;
 using System.Windows.Data;
 using ModernWpf.Controls;
-using System.Drawing;
-using System.Windows.Forms.Design.Behavior;
-using System.Security.Cryptography;
-using System.Runtime.CompilerServices;
-using Microsoft.VisualBasic.Devices;
-using Microsoft.FSharp.Data.UnitSystems.SI.UnitNames;
-using NLog.Targets;
-using YamlDotNet.Core.Tokens;
 using Key = System.Windows.Input.Key;
 
 namespace Flow.Launcher
@@ -131,7 +118,6 @@ namespace Flow.Launcher
                                 UpdatePosition();
                                 PreviewReset();
                                 Activate();
-                                QueryTextBox_StartEn();
                                 QueryTextBox.Focus();
                                 _settings.ActivateTimes++;
                                 if (!_viewModel.LastQuerySelected)
@@ -194,9 +180,6 @@ namespace Flow.Launcher
                         break;
                     case nameof(Settings.Language):
                         UpdateNotifyIconText();
-                        break;
-                    case nameof(Settings.AlwaysStartEn):
-                        QueryTextBox_StartEn();
                         break;
                     case nameof(Settings.Hotkey):
                         UpdateNotifyIconText();
@@ -701,20 +684,6 @@ namespace Flow.Launcher
             {
                 BindingExpression be = QueryTextBox.GetBindingExpression(System.Windows.Controls.TextBox.TextProperty);
                 be.UpdateSource();
-            }
-        }
-
-        private void QueryTextBox_StartEn()
-        {
-            if (_settings.AlwaysStartEn)
-            {
-                QueryTextBox.SetValue(InputMethod.PreferredImeConversionModeProperty, ImeConversionModeValues.Alphanumeric); 
-                QueryTextBox.SetValue(InputMethod.PreferredImeStateProperty, InputMethodState.Off);
-            }
-            else
-            {
-                QueryTextBox.ClearValue(InputMethod.PreferredImeConversionModeProperty);
-                QueryTextBox.ClearValue(InputMethod.PreferredImeStateProperty);
             }
         }
     }

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -737,9 +737,11 @@
                                         <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource AlwaysPreview}" />
                                         <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource AlwaysPreviewToolTip}" />
                                     </StackPanel>
-                                    <CheckBox
-                                        IsChecked="{Binding Settings.AlwaysPreview}"
-                                        Style="{DynamicResource SideControlCheckBox}"
+                                    <ui:ToggleSwitch
+                                        Grid.Column="2"
+                                        FocusVisualMargin="5"
+                                        IsOn="{Binding Settings.AlwaysPreview}"
+                                        Style="{DynamicResource SideToggleSwitch}"
                                         ToolTip="{DynamicResource AlwaysPreviewToolTip}" />
                                     <TextBlock Style="{StaticResource Glyph}">
                                         &#xe8a1;
@@ -943,10 +945,31 @@
                                             Text="{Binding Settings.PluginSettings.PythonDirectory, TargetNullValue='No Setting'}" />
                                         <Button
                                             Height="34"
-                                            Margin="10,10,18,10"
+                                            Margin="10,0,18,0"
                                             Click="OnSelectPythonDirectoryClick"
                                             Content="{DynamicResource selectPythonDirectory}" />
                                     </StackPanel>
+                                </ItemsControl>
+                            </Border>
+
+                            <Border Margin="0,30,0,0" Style="{DynamicResource SettingGroupBox}">
+                                <ItemsControl Style="{StaticResource SettingGrid}">
+                                    <StackPanel Style="{StaticResource TextPanel}">
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            VerticalAlignment="Center"
+                                            Style="{DynamicResource SettingTitleLabel}"
+                                            Text="{DynamicResource typingStartEn}" />
+                                        <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource typingStartEnTooltip}" />
+                                    </StackPanel>
+                                    <ui:ToggleSwitch
+                                        Grid.Column="2"
+                                        FocusVisualMargin="5"
+                                        IsOn="{Binding Settings.AlwaysStartEn}"
+                                        Style="{DynamicResource SideToggleSwitch}" />
+                                    <TextBlock Style="{StaticResource Glyph}">
+                                        &#xe8d3;
+                                    </TextBlock>
                                 </ItemsControl>
                             </Border>
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -71,6 +71,9 @@ namespace Flow.Launcher.ViewModel
                     case nameof(Settings.WindowSize):
                         OnPropertyChanged(nameof(MainWindowWidth));
                         break;
+                    case nameof(Settings.AlwaysStartEn):
+                        OnPropertyChanged(nameof(StartWithEnglishMode));
+                        break;
                 }
             };
 
@@ -513,6 +516,8 @@ namespace Flow.Launcher.ViewModel
         public string OpenResultCommandModifiers { get; private set; }
 
         public string Image => Constant.QueryTextBoxIconImagePath;
+
+        public bool StartWithEnglishMode => Settings.AlwaysStartEn;
 
         #endregion
 


### PR DESCRIPTION
## What's the PR
- Add settings that always start in English when you start flow.
  -  If the user is using a Native/English layout, Sometimes the input will start in an unwanted language.
- It always starts in English, regardless of your language status, so you can avoid typing incorrectly.
- This setting can be turned on and off; the default is off.

## Test Cases
- [x] Korean / Japanese / Chinese (pinyin)
- [x] When you turn the flow back on in the native keyboard layout state, typing must begin in English.