### PR TITLE
Change Status Label to Enabled

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/ko.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/ko.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <!--  Program setting  -->
     <system:String x:Key="flowlauncher_plugin_program_reset">기본값으로 되돌리기</system:String>
@@ -8,11 +11,11 @@
     <system:String x:Key="flowlauncher_plugin_program_add">추가</system:String>
     <system:String x:Key="flowlauncher_plugin_program_name">이름</system:String>
     <system:String x:Key="flowlauncher_plugin_program_enable">활성화</system:String>
-    <system:String x:Key="flowlauncher_plugin_program_enabled">켬</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enabled">사용</system:String>
     <system:String x:Key="flowlauncher_plugin_program_disable">비활성화</system:String>
-    <system:String x:Key="flowlauncher_plugin_program_status">Status</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_status">상태</system:String>
     <system:String x:Key="flowlauncher_plugin_program_true">켬</system:String>
-    <system:String x:Key="flowlauncher_plugin_program_false">Disabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_false">끔</system:String>
     <system:String x:Key="flowlauncher_plugin_program_location">위치</system:String>
     <system:String x:Key="flowlauncher_plugin_program_all_programs">모든 프로그램</system:String>
     <system:String x:Key="flowlauncher_plugin_program_suffixes">파일 형식</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/ko.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/ko.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <system:String x:Key="flowlauncher_plugin_websearch_window_title">검색 출처 설정</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_open_search_in">Open search in:</system:String>
@@ -9,7 +12,8 @@
     <system:String x:Key="flowlauncher_plugin_websearch_choose">Choose</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_delete">삭제</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_edit">편집</system:String>
-    <system:String x:Key="flowlauncher_plugin_websearch_add">추</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_add">추가</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enabled">사용</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">켬</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">확인</system:String>
@@ -32,7 +36,7 @@
 
     <!--  web search edit  -->
     <system:String x:Key="flowlauncher_plugin_websearch_title">이름</system:String>
-    <system:String x:Key="flowlauncher_plugin_websearch_enable">Status</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enable">상태</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_select_icon">아이콘 선택</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_icon">아이콘</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_cancel">취소</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/ko.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/ko.xaml
@@ -36,7 +36,8 @@
 
     <!--  web search edit  -->
     <system:String x:Key="flowlauncher_plugin_websearch_title">이름</system:String>
-    <system:String x:Key="flowlauncher_plugin_websearch_enable">상태</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enabled">상태</system:String>
+
     <system:String x:Key="flowlauncher_plugin_websearch_select_icon">아이콘 선택</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_icon">아이콘</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_cancel">취소</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
@@ -179,7 +179,7 @@
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
                                     FontSize="14"
-                                    Text="{DynamicResource flowlauncher_plugin_websearch_enable}" />
+                                    Text="{DynamicResource flowlauncher_plugin_websearch_enabled}" />
                                 <CheckBox
                                     Grid.Row="4"
                                     Grid.Column="1"


### PR DESCRIPTION
## Background
In the past, True False was changed to Enabled/Disabled and Header was changed to Status. 
At this time, some enabled labels were changed to status. 

## So...
This PR changed it because the Enabled item is displayed as Status in some windows. I adjusted this part because I judged that there were cases where it was necessary to separate depending on the language.