### PR TITLE
Remove Hiding the Disabled menu Item

### DIFF
--- a/Flow.Launcher/Resources/CustomControlTemplate.xaml
+++ b/Flow.Launcher/Resources/CustomControlTemplate.xaml
@@ -2999,8 +2999,6 @@
                 <Setter TargetName="KeyboardAcceleratorTextBlock" Property="Foreground" Value="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForegroundPressed}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="False">
-                <!--  Hide Disabled Item  -->
-                <Setter TargetName="LayoutRoot" Property="Visibility" Value="Collapsed" />
                 <Setter TargetName="LayoutRoot" Property="Background" Value="{DynamicResource MenuFlyoutItemBackgroundDisabled}" />
                 <Setter TargetName="LayoutRoot" Property="TextElement.Foreground" Value="{DynamicResource MenuFlyoutItemForegroundDisabled}" />
                 <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource MenuFlyoutItemForegroundDisabled}" />


### PR DESCRIPTION
- If there is nothing on the clipboard, a problem occurs when an empty context menu is displayed.
- Resolve the issue by disabled context menu by not hiding it