### PR TITLE
Remove await Task.Run for IconDelegate

### DIFF
--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -179,7 +179,7 @@ namespace Flow.Launcher.ViewModel
             {
                 try
                 {
-                    var image = await Task.Run(() => icon()).ConfigureAwait(false);
+                    var image = icon();
                     return image;
                 }
                 catch (Exception e)


### PR DESCRIPTION
Let's trust plugin developer when they use that for icon
This will solve the icon blink for uwp and some other plugin that use IconDelegate.

Tested:
- [x] VScode Plugin doesn't have icon flickering