### PR TITLE
Fix quick access path search and autocomplete text

### DIFF
--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -269,5 +269,65 @@ namespace Flow.Launcher.Test.Plugins
             // Then
             Assert.AreEqual(expectedString, resultString);
         }
+
+        [TestCase("c:\\somefolder\\someotherfolder", ResultType.Folder, "irrelevant", false, true, "c:\\somefolder\\someotherfolder\\")]
+        [TestCase("c:\\somefolder\\someotherfolder\\", ResultType.Folder, "irrelevant", true, true, "c:\\somefolder\\someotherfolder\\")]
+        [TestCase("c:\\somefolder\\someotherfolder", ResultType.Folder, "irrelevant", true, false, "p c:\\somefolder\\someotherfolder\\")]
+        [TestCase("c:\\somefolder\\someotherfolder\\", ResultType.Folder, "irrelevant", false, false, "c:\\somefolder\\someotherfolder\\")]
+        [TestCase("c:\\somefolder\\someotherfolder", ResultType.Folder, "p", true, false, "p c:\\somefolder\\someotherfolder\\")]
+        [TestCase("c:\\somefolder\\someotherfolder", ResultType.Folder, "", true, true, "c:\\somefolder\\someotherfolder\\")]
+        public void GivenFolderResult_WhenGetPath_ThenPathShouldBeExpectedString(
+            string path, 
+            ResultType type, 
+            string actionKeyword,
+            bool pathSearchKeywordEnabled, 
+            bool searchActionKeywordEnabled,
+            string expectedResult)
+        {
+            // Given
+            var settings = new Settings() 
+            {
+                PathSearchKeywordEnabled = pathSearchKeywordEnabled,
+                PathSearchActionKeyword = "p",
+                SearchActionKeywordEnabled = searchActionKeywordEnabled,
+                SearchActionKeyword = Query.GlobalPluginWildcardSign
+            };
+            ResultManager.Init(new PluginInitContext(), settings);
+            
+            // When
+            var result = ResultManager.GetPathWithActionKeyword(path, type, actionKeyword);
+
+            // Then
+            Assert.AreEqual(result, expectedResult);
+        }
+
+        [TestCase("c:\\somefolder\\somefile", ResultType.File, "irrelevant", false, true, "e c:\\somefolder\\somefile")]
+        [TestCase("c:\\somefolder\\somefile", ResultType.File, "p", true, false, "p c:\\somefolder\\somefile")]
+        [TestCase("c:\\somefolder\\somefile", ResultType.File, "e", true, true, "e c:\\somefolder\\somefile")]
+        [TestCase("c:\\somefolder\\somefile", ResultType.File, "irrelevant", false, false, "e c:\\somefolder\\somefile")]
+        public void GivenFileResult_WhenGetPath_ThenPathShouldBeExpectedString(
+            string path,
+            ResultType type,
+            string actionKeyword,
+            bool pathSearchKeywordEnabled,
+            bool searchActionKeywordEnabled,
+            string expectedResult)
+        {
+            // Given
+            var settings = new Settings()
+            {
+                PathSearchKeywordEnabled = pathSearchKeywordEnabled,
+                PathSearchActionKeyword = "p",
+                SearchActionKeywordEnabled = searchActionKeywordEnabled,
+                SearchActionKeyword = "e"
+            };
+            ResultManager.Init(new PluginInitContext(), settings);
+
+            // When
+            var result = ResultManager.GetPathWithActionKeyword(path, type, actionKeyword);
+
+            // Then
+            Assert.AreEqual(result, expectedResult);
+        }
     }
 }

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -329,5 +329,69 @@ namespace Flow.Launcher.Test.Plugins
             // Then
             Assert.AreEqual(result, expectedResult);
         }
+
+        [TestCase("somefolder", "c:\\somefolder\\", ResultType.Folder, "q", false, false, "q somefolder")]
+        [TestCase("somefolder", "c:\\somefolder\\", ResultType.Folder, "i", true, false, "p c:\\somefolder\\")]
+        [TestCase("somefolder", "c:\\somefolder\\", ResultType.Folder, "irrelevant", true, true, "c:\\somefolder\\")]
+        public void GivenQueryWithFolderTypeResult_WhenGetAutoComplete_ThenResultShouldBeExpectedString(
+            string title,
+            string path,
+            ResultType resultType,
+            string actionKeyword,
+            bool pathSearchKeywordEnabled,
+            bool searchActionKeywordEnabled,
+            string expectedResult)
+        {
+            // Given
+            var query = new Query() { ActionKeyword = actionKeyword };
+            var settings = new Settings()
+            {
+                PathSearchKeywordEnabled = pathSearchKeywordEnabled,
+                PathSearchActionKeyword = "p",
+                SearchActionKeywordEnabled = searchActionKeywordEnabled,
+                SearchActionKeyword = Query.GlobalPluginWildcardSign,
+                QuickAccessActionKeyword = "q",
+                IndexSearchActionKeyword = "i"
+            };
+            ResultManager.Init(new PluginInitContext(), settings);
+
+            // When
+            var result = ResultManager.GetAutoCompleteText(title, query, path, resultType);
+
+            // Then
+            Assert.AreEqual(result, expectedResult);
+        }
+
+        [TestCase("somefile", "c:\\somefolder\\somefile", ResultType.File, "q", false, false, "q somefile")]
+        [TestCase("somefile", "c:\\somefolder\\somefile", ResultType.File, "i", true, false, "p c:\\somefolder\\somefile")]
+        [TestCase("somefile", "c:\\somefolder\\somefile", ResultType.File, "irrelevant", true, true, "c:\\somefolder\\somefile")]
+        public void GivenQueryWithFileTypeResult_WhenGetAutoComplete_ThenResultShouldBeExpectedString(
+            string title,
+            string path,
+            ResultType resultType,
+            string actionKeyword,
+            bool pathSearchKeywordEnabled,
+            bool searchActionKeywordEnabled,
+            string expectedResult)
+        {
+            // Given
+            var query = new Query() { ActionKeyword = actionKeyword };
+            var settings = new Settings()
+            {
+                QuickAccessActionKeyword = "q",
+                IndexSearchActionKeyword = "i",
+                PathSearchActionKeyword = "p",
+                PathSearchKeywordEnabled = pathSearchKeywordEnabled,
+                SearchActionKeywordEnabled = searchActionKeywordEnabled,
+                SearchActionKeyword = Query.GlobalPluginWildcardSign
+            };
+            ResultManager.Init(new PluginInitContext(), settings);
+
+            // When
+            var result = ResultManager.GetAutoCompleteText(title, query, path, resultType);
+
+            // Then
+            Assert.AreEqual(result, expectedResult);
+        }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -1,4 +1,4 @@
-﻿using Flow.Launcher.Core.Resource;
+using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Plugin.SharedCommands;
 using System;
@@ -38,6 +38,13 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             return $"{keyword}{formatted_path}";
         }
 
+        private static string GetAutoCompleteText(string title, Query query, string path, ResultType resultType)
+        {
+            return !Settings.PathSearchKeywordEnabled && !Settings.SearchActionKeywordEnabled
+                        ? $"{query.ActionKeyword} {title}" // Only Quick Access action keyword is used in this scenario
+                        : GetPathWithActionKeyword(path, resultType);
+        }
+
         public static Result CreateResult(Query query, SearchResult result)
         {
             return result.Type switch
@@ -57,9 +64,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 Title = title,
                 IcoPath = path,
                 SubTitle = Path.GetDirectoryName(path),
-                AutoCompleteText = !Settings.PathSearchKeywordEnabled && !Settings.SearchActionKeywordEnabled 
-                                        ? $"{query.ActionKeyword} {title}" // Only Quick Access action keyword is used in this scenario
-                                        : GetPathWithActionKeyword(path, ResultType.Folder),
+                AutoCompleteText = GetAutoCompleteText(title, query, path, ResultType.Folder),
                 TitleHighlightData = StringMatcher.FuzzySearch(query.Search, title).MatchData,
                 CopyText = path,
                 Action = c =>
@@ -219,14 +224,16 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 PreviewImagePath = filePath,
             } : Result.PreviewInfo.Default;
 
+            var title = Path.GetFileName(filePath);
+
             var result = new Result
             {
-                Title = Path.GetFileName(filePath),
+                Title = title,
                 SubTitle = Path.GetDirectoryName(filePath),
                 IcoPath = filePath,
                 Preview = preview,
-                AutoCompleteText = GetPathWithActionKeyword(filePath, ResultType.File),
-                TitleHighlightData = StringMatcher.FuzzySearch(query.Search, Path.GetFileName(filePath)).MatchData,
+                AutoCompleteText = GetAutoCompleteText(title, query, filePath, ResultType.File),
+                TitleHighlightData = StringMatcher.FuzzySearch(query.Search, title).MatchData,
                 Score = score,
                 CopyText = filePath,
                 Action = c =>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -1,4 +1,4 @@
-using Flow.Launcher.Core.Resource;
+﻿using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Plugin.SharedCommands;
 using System;
@@ -21,23 +21,22 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             Settings = settings;
         }
 
-        private static string GetPathWithActionKeyword(string path, ResultType type, string actionKeyword)
+        public static string GetPathWithActionKeyword(string path, ResultType type, string actionKeyword)
         {
-            string keyword;
-            // Using Quick Access or Index Search action keywords to then navigate to directory
-            if (actionKeyword == Settings.PathSearchActionKeyword || actionKeyword == Settings.SearchActionKeyword)
-            {
-                keyword = actionKeyword == Settings.PathSearchActionKeyword ? $"{actionKeyword} " : string.Empty;
-            }
-            else
-            {
-                keyword = Settings.PathSearchKeywordEnabled && !Settings.SearchActionKeywordEnabled
-                            ? $"{Settings.PathSearchActionKeyword} "
-                            : Settings.SearchActionKeyword == Query.GlobalPluginWildcardSign
-                                ? string.Empty // Query.ActionKeyword is string.Empty when Global Action Keyword ('*') is used
-                                : $"{Settings.SearchActionKeyword} ";
-            }
+            // actionKeyword will be empty string if using global, query.ActionKeyword is ""
 
+            var usePathSearchActionKeyword = Settings.PathSearchKeywordEnabled && !Settings.SearchActionKeywordEnabled;
+
+            var pathSearchActionKeyword = Settings.PathSearchActionKeyword == Query.GlobalPluginWildcardSign 
+                ? string.Empty 
+                : $"{Settings.PathSearchActionKeyword} ";
+
+            var searchActionKeyword = Settings.SearchActionKeyword == Query.GlobalPluginWildcardSign
+                ? string.Empty
+                : $"{Settings.SearchActionKeyword} ";
+
+            var keyword = usePathSearchActionKeyword ? pathSearchActionKeyword : searchActionKeyword;
+            
             var formatted_path = path;
 
             if (type == ResultType.Folder)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -21,13 +21,22 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             Settings = settings;
         }
 
-        private static string GetPathWithActionKeyword(string path, ResultType type)
+        private static string GetPathWithActionKeyword(string path, ResultType type, string actionKeyword)
         {
-            var keyword = Settings.PathSearchKeywordEnabled && !Settings.SearchActionKeywordEnabled
+            string keyword;
+            // Using Quick Access or Index Search action keywords to then navigate to directory
+            if (actionKeyword == Settings.PathSearchActionKeyword || actionKeyword == Settings.SearchActionKeyword)
+            {
+                keyword = actionKeyword == Settings.PathSearchActionKeyword ? $"{actionKeyword} " : string.Empty;
+            }
+            else
+            {
+                keyword = Settings.PathSearchKeywordEnabled && !Settings.SearchActionKeywordEnabled
                             ? $"{Settings.PathSearchActionKeyword} "
                             : Settings.SearchActionKeyword == Query.GlobalPluginWildcardSign
                                 ? string.Empty // Query.ActionKeyword is string.Empty when Global Action Keyword ('*') is used
                                 : $"{Settings.SearchActionKeyword} ";
+            }
 
             var formatted_path = path;
 
@@ -42,7 +51,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         {
             return !Settings.PathSearchKeywordEnabled && !Settings.SearchActionKeywordEnabled
                         ? $"{query.ActionKeyword} {title}" // Only Quick Access action keyword is used in this scenario
-                        : GetPathWithActionKeyword(path, resultType);
+                        : GetPathWithActionKeyword(path, resultType, query.ActionKeyword);
         }
 
         public static Result CreateResult(Query query, SearchResult result)
@@ -83,7 +92,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                         }
                     }
 
-                    Context.API.ChangeQuery(GetPathWithActionKeyword(path, ResultType.Folder));
+                    Context.API.ChangeQuery(GetPathWithActionKeyword(path, ResultType.Folder, query.ActionKeyword));
 
                     return false;
                 },
@@ -118,7 +127,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             {
                 Title = title,
                 SubTitle = subtitle,
-                AutoCompleteText = GetPathWithActionKeyword(path, ResultType.Folder),
+                AutoCompleteText = GetPathWithActionKeyword(path, ResultType.Folder, actionKeyword),
                 IcoPath = path,
                 Score = 500,
                 ProgressBar = progressValue,
@@ -199,7 +208,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 Title = title,
                 SubTitle = $"Use > to search within {subtitleFolderName}, " +
                            $"* to search for file extensions or >* to combine both searches.",
-                AutoCompleteText = GetPathWithActionKeyword(folderPath, ResultType.Folder),
+                AutoCompleteText = GetPathWithActionKeyword(folderPath, ResultType.Folder, actionKeyword),
                 IcoPath = folderPath,
                 Score = 500,
                 CopyText = folderPath,

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -46,7 +46,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             return $"{keyword}{formatted_path}";
         }
 
-        private static string GetAutoCompleteText(string title, Query query, string path, ResultType resultType)
+        public static string GetAutoCompleteText(string title, Query query, string path, ResultType resultType)
         {
             return !Settings.PathSearchKeywordEnabled && !Settings.SearchActionKeywordEnabled
                         ? $"{query.ActionKeyword} {title}" // Only Quick Access action keyword is used in this scenario

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -49,12 +49,20 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
         internal static Result CreateFolderResult(string title, string subtitle, string path, Query query, int score = 0, bool windowsIndexed = false)
         {
+            var pathSearchActionKeyword = Settings.PathSearchKeywordEnabled && !Settings.SearchActionKeywordEnabled 
+                                            ? Settings.PathSearchActionKeyword 
+                                            : Settings.SearchActionKeyword == Query.GlobalPluginWildcardSign
+                                                ? string.Empty 
+                                                : Settings.SearchActionKeyword;
+
             return new Result
             {
                 Title = title,
                 IcoPath = path,
                 SubTitle = Path.GetDirectoryName(path),
-                AutoCompleteText = GetPathWithActionKeyword(path, ResultType.Folder, query.ActionKeyword),
+                AutoCompleteText = !Settings.PathSearchKeywordEnabled && !Settings.SearchActionKeywordEnabled 
+                                        ? $"{query.ActionKeyword} {title}" // Only Quick Access action keyword is used in this scenario
+                                        : GetPathWithActionKeyword(path, ResultType.Folder, pathSearchActionKeyword),
                 TitleHighlightData = StringMatcher.FuzzySearch(query.Search, title).MatchData,
                 CopyText = path,
                 Action = c =>
@@ -73,7 +81,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                         }
                     }
 
-                    Context.API.ChangeQuery(GetPathWithActionKeyword(path, ResultType.Folder, query.ActionKeyword));
+                    Context.API.ChangeQuery(GetPathWithActionKeyword(path, ResultType.Folder, pathSearchActionKeyword));
 
                     return false;
                 },


### PR DESCRIPTION
- Fix directory path search when triggered from quick access
- Fix autocomplete text when both path and search action keywords are disabled
- Added unit tests

Note: if both path and search action keywords are disabled, selecting the result will open the folder instead of navigating to the path. 

**Tested:**
- Select folder result listed via Quick Access will navigate to the path with search action keyword when both search and path search action keywords are enabled or only search action keyword is enabled
- When search action keyword is disabled and path search is enabled, selecting result will navigate to the path with path search action keyword
- When both path and search action keywords are disabled, selecting result will open the folder instead
- When both path and search action keywords are disabled, autocomplete will autocomplete with the title of the folder
- Using content search will navigate to folder/file paths correctly via autocomplete or selecting folder result