### PR TITLE
Catch exceptions during shortcut expansion

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -769,8 +769,16 @@ namespace Flow.Launcher.ViewModel
             {
                 foreach (var shortcut in builtInShortcuts)
                 {
-                    queryBuilder.Replace(shortcut.Key, shortcut.Expand());
-                    queryBuilderTmp.Replace(shortcut.Key, shortcut.Expand());
+                    try
+                    {
+                        var expansion = shortcut.Expand();
+                        queryBuilder.Replace(shortcut.Key, expansion);
+                        queryBuilderTmp.Replace(shortcut.Key, expansion);
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Exception($"{nameof(MainViewModel)}.{nameof(ConstructQuery)}|Error when expanding shortcut {shortcut.Key}", e);
+                    }
                 }
             });
 


### PR DESCRIPTION
Fix #1697 #1629.

Can't reproduce those issues so no actual test was done. A catch all should fix them.