### PR TITLE
Configurable preview panel toggle hotkey and use lazy load preview image

### DIFF
--- a/Flow.Launcher.Infrastructure/Image/ImageCache.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageCache.cs
@@ -87,6 +87,21 @@ namespace Flow.Launcher.Infrastructure.Image
             return key is not null && Data.ContainsKey((key, isFullImage)) && Data[(key, isFullImage)].imageSource != null;
         }
 
+        public bool TryGetValue(string key, bool isFullImage, out ImageSource image)
+        {
+            if (key is not null)
+            {
+                bool hasKey = Data.TryGetValue((key, isFullImage), out var imageUsage);
+                image = hasKey ? imageUsage.imageSource : null;
+                return hasKey;
+            }
+            else
+            {
+                image = null;
+                return false;
+            }
+        }
+
         public int CacheSize()
         {
             return Data.Count;

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -251,6 +251,11 @@ namespace Flow.Launcher.Infrastructure.Image
             return ImageCache.ContainsKey(path, false) && ImageCache[path, loadFullImage] != null;
         }
 
+        public static bool TryGetValue(string path, bool loadFullImage, out ImageSource image)
+        {
+            return ImageCache.TryGetValue(path, loadFullImage, out image);
+        }
+
         public static async ValueTask<ImageSource> LoadAsync(string path, bool loadFullImage = false)
         {
             var imageResult = await LoadInternalAsync(path, loadFullImage);

--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -18,7 +18,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         public string ColorScheme { get; set; } = "System";
         public bool ShowOpenResultHotkey { get; set; } = true;
         public double WindowSize { get; set; } = 580;
-        public string PreviewHotkey { get; set; } = $"F1"; // TODO: change to another value
+        public string PreviewHotkey { get; set; } = $"F1";
 
         public string Language
         {

--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -18,6 +18,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         public string ColorScheme { get; set; } = "System";
         public bool ShowOpenResultHotkey { get; set; } = true;
         public double WindowSize { get; set; } = 580;
+        public string PreviewHotkey { get; set; } = $"F1"; // TODO: change to another value
 
         public string Language
         {

--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -246,12 +246,14 @@ namespace Flow.Launcher.Plugin
             /// </summary>
             public bool IsMedia { get; set; }
             public string Description { get; set; }
+            public IconDelegate PreviewDelegate { get; set; }
 
             public static PreviewInfo Default { get; } = new()
             {
                 PreviewImagePath = null,
                 Description = null,
                 IsMedia = false,
+                PreviewDelegate = null,
             };
         }
     }

--- a/Flow.Launcher/Converters/StringToKeyBindingConverter.cs
+++ b/Flow.Launcher/Converters/StringToKeyBindingConverter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Input;
+
+namespace Flow.Launcher.Converters
+{
+    class StringToKeyBindingConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var mode = parameter as string;
+            var hotkeyStr = value as string;
+            var converter = new KeyGestureConverter();
+            var key = (KeyGesture)converter.ConvertFromString(hotkeyStr);
+            if (mode == "key")
+            {
+                return key.Key;
+            }
+            else if (mode == "modifiers")
+            {
+                return key.Modifiers;
+            }
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Flow.Launcher/Languages/da.xaml
+++ b/Flow.Launcher/Languages/da.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Search with Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Allows using Pinyin to search. Pinyin is the standard system of romanized spelling for translating Chinese.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/de.xaml
+++ b/Flow.Launcher/Languages/de.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Pinyin aktivieren</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Ermöglicht die Verwendung von Pinyin für die Suche. Pinyin ist das Standardsystem der romanisierten Schreibweise für die Übersetzung von chinesischen Texten.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Der Schatteneffekt ist nicht zulässig, wenn das aktuelle Thema den Weichzeichneffekt aktiviert hat</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -70,7 +70,7 @@
     <system:String x:Key="ShouldUsePinyin">Search with Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Allows using Pinyin to search. Pinyin is the standard system of romanized spelling for translating Chinese.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview.</system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->
@@ -153,6 +153,8 @@
     <system:String x:Key="hotkey">Hotkey</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher Hotkey</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Enter shortcut to show/hide Flow Launcher.</system:String>
+    <system:String x:Key="previewHotkey">Preview Hotkey</system:String>
+    <system:String x:Key="previewHotkeyToolTip">Enter shortcut to show/hide preview in search window.</system:String>
     <system:String x:Key="openResultModifiers">Open Result Modifier Key</system:String>
     <system:String x:Key="openResultModifiersToolTip">Select a modifier key to open selected result via keyboard.</system:String>
     <system:String x:Key="showOpenResultHotkey">Show Hotkey</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -70,7 +70,7 @@
     <system:String x:Key="ShouldUsePinyin">Search with Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Allows using Pinyin to search. Pinyin is the standard system of romanized spelling for translating Chinese.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press {0} to toggle preview.</system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/es-419.xaml
+++ b/Flow.Launcher/Languages/es-419.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Search with Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Allows using Pinyin to search. Pinyin is the standard system of romanized spelling for translating Chinese.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">El efecto de sombra no está permitido mientras el tema actual tenga el efecto de desenfoque habilitado</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/es.xaml
+++ b/Flow.Launcher/Languages/es.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Buscar con Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Permite utilizar Pinyin para la búsqueda. Pinyin es el sistema estándar de ortografía romanizado para traducir chino.</system:String>
     <system:String x:Key="AlwaysPreview">Mostrar siempre vista previa</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Muestra siempre el panel de vista previa al iniciar Flow. Pulse F1 para mostrar/ocultar la vista previa. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Muestra siempre el panel de vista previa al iniciar Flow. Pulse {0} para mostrar/ocultar la vista previa. </system:String>
     <system:String x:Key="shadowEffectNotAllowed">El efecto de sombra no está permitido mientras el tema actual tenga el efecto de desenfoque activado</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/fr.xaml
+++ b/Flow.Launcher/Languages/fr.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Devrait utiliser le pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Allows using Pinyin to search. Pinyin is the standard system of romanized spelling for translating Chinese.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/it.xaml
+++ b/Flow.Launcher/Languages/it.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Dovrebbe usare il Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Consente di utilizzare il Pinyin per la ricerca. Il Pinyin è il sistema standard di ortografia romanizzata per la traduzione del cinese.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">L'effetto ombra non è consentito mentre il tema corrente ha un effetto di sfocatura abilitato</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/ja.xaml
+++ b/Flow.Launcher/Languages/ja.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Search with Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Allows using Pinyin to search. Pinyin is the standard system of romanized spelling for translating Chinese.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/ko.xaml
+++ b/Flow.Launcher/Languages/ko.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">항상 Pinyin 사용</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Pinyin을 사용하여 검색할 수 있습니다. Pinyin (병음) 은 로마자 중국어 입력 방식입니다.</system:String>
     <system:String x:Key="AlwaysPreview">항상 미리보기</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">항상 미리보기 패널이 열린 상태로 Flow를 시작합니다. F1키로 미리보기를 on/off 합니다. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">항상 미리보기 패널이 열린 상태로 Flow를 시작합니다. {0} 키로 미리보기를 on/off 합니다. </system:String>
     <system:String x:Key="shadowEffectNotAllowed">반투명 흐림 효과를 사용하는 경우, 그림자 효과를 쓸 수 없습니다.</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/nb.xaml
+++ b/Flow.Launcher/Languages/nb.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Search with Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Allows using Pinyin to search. Pinyin is the standard system of romanized spelling for translating Chinese.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/nl.xaml
+++ b/Flow.Launcher/Languages/nl.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Zou Pinyin moeten gebruiken</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Zorgt ervoor dat Pinyin gebruikt kan worden om te zoeken. Pinyin is het standaard systeem van geromaniseerde spelling voor het vertalen van Chinees.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Schaduw effect is niet toegestaan omdat het huidige thema een vervagingseffect heeft</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/pl.xaml
+++ b/Flow.Launcher/Languages/pl.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Search with Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Allows using Pinyin to search. Pinyin is the standard system of romanized spelling for translating Chinese.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/pt-br.xaml
+++ b/Flow.Launcher/Languages/pt-br.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Search with Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Allows using Pinyin to search. Pinyin is the standard system of romanized spelling for translating Chinese.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/pt-pt.xaml
+++ b/Flow.Launcher/Languages/pt-pt.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Pesquisar com Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Permite a utilização de Pinyin para pesquisar. Pinyin é um sistema normalizado de ortografia romanizada para tradução de mandarim.</system:String>
     <system:String x:Key="AlwaysPreview">Pré-visualizar sempre</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Abrir painel de pré-visualização ao iniciar a aplicação. Prima F1 para comutar esta opção. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Abrir painel de pré-visualização ao iniciar a aplicação. Prima {0} para comutar esta opção. </system:String>
     <system:String x:Key="shadowEffectNotAllowed">O efeito sombra não é permitido com este tema porque o efeito desfocar está ativo</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/ru.xaml
+++ b/Flow.Launcher/Languages/ru.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Search with Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Allows using Pinyin to search. Pinyin is the standard system of romanized spelling for translating Chinese.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/sk.xaml
+++ b/Flow.Launcher/Languages/sk.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Vyhľadávanie pomocou pchin-jin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Umožňuje vyhľadávanie pomocou pchin-jin. Pchin-jin je systém zápisu čínskeho jazyka pomocou písmen latinky.</system:String>
     <system:String x:Key="AlwaysPreview">Vždy zobraziť náhľad</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Pri spustení Flowu vždy otvoriť panel s náhľadom. Stlačením klávesu F1 prepnete náhľad. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Pri spustení Flowu vždy otvoriť panel s náhľadom. Stlačením klávesu {0} prepnete náhľad. </system:String>
     <system:String x:Key="shadowEffectNotAllowed">Efekt tieňa nie je povolený, kým má aktuálny motív povolený efekt rozostrenia</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/sr.xaml
+++ b/Flow.Launcher/Languages/sr.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Search with Pinyin</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Allows using Pinyin to search. Pinyin is the standard system of romanized spelling for translating Chinese.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/tr.xaml
+++ b/Flow.Launcher/Languages/tr.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Pinyin kullanılmalı</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Arama yapmak için Pinyin'in kullanılmasına izin verir. Pinyin, Çince'yi çevirmek için standart romanlaştırılmış yazım sistemidir.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Mevcut temada bulanıklık efekti etkinken gölge efektine izin verilmez</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/uk-UA.xaml
+++ b/Flow.Launcher/Languages/uk-UA.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">Використовувати піньїнь</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">Дозволяє використовувати пінїнь для пошуку. Піньїнь - це стандартна система написання для перекладу китайської.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Ефект тіні не дозволено, коли поточна тема має ефект розмиття</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/zh-cn.xaml
+++ b/Flow.Launcher/Languages/zh-cn.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">使用 Pinyin 搜索</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">允许使用拼音进行搜索.</system:String>
     <system:String x:Key="AlwaysPreview">始终打开预览</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Flow 启动时总是打开预览面板。按 F1 以切换预览。 </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Flow 启动时总是打开预览面板。按 {0} 以切换预览。 </system:String>
     <system:String x:Key="shadowEffectNotAllowed">当前主题已启用模糊效果，不允许启用阴影效果</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/Languages/zh-tw.xaml
+++ b/Flow.Launcher/Languages/zh-tw.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="ShouldUsePinyin">拼音搜索</system:String>
     <system:String x:Key="ShouldUsePinyinToolTip">允許使用拼音來搜索.</system:String>
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
-    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow starts. Press F1 to toggle preview. </system:String>
+    <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
 
     <!--  Setting Plugin  -->

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -343,7 +343,7 @@
                     <StackPanel
                         x:Name="ResultArea"
                         Grid.Column="0"
-                        Grid.ColumnSpan="2">
+                        Grid.ColumnSpan="{Binding ResultAreaColumn}">
                         <Border Style="{DynamicResource WindowRadius}">
                             <Border.Clip>
                                 <MultiBinding Converter="{StaticResource BorderClipConverter}">
@@ -397,11 +397,13 @@
                         x:Name="Preview"
                         Grid.Column="1"
                         VerticalAlignment="Stretch"
-                        d:DataContext="{d:DesignInstance vm:ResultViewModel}"
-                        DataContext="{Binding SelectedItem, ElementName=ResultListBox}"
                         Style="{DynamicResource PreviewArea}"
-                        Visibility="Collapsed">
-                        <Border Style="{DynamicResource PreviewBorderStyle}" Visibility="{Binding ShowDefaultPreview}">
+                        Visibility="{Binding PreviewVisible, Converter={StaticResource BoolToVisibilityConverter}}">
+                        <Border 
+                            Style="{DynamicResource PreviewBorderStyle}" 
+                            d:DataContext="{d:DesignInstance vm:ResultViewModel}"
+                            DataContext="{Binding SelectedItem, ElementName=ResultListBox}"
+                            Visibility="{Binding ShowDefaultPreview}">
                             <Grid
                                 Margin="20,0,10,0"
                                 VerticalAlignment="Stretch"
@@ -472,7 +474,11 @@
                                 </StackPanel>
                             </Grid>
                         </Border>
-                        <Border Style="{DynamicResource PreviewBorderStyle}" Visibility="{Binding ShowCustomizedPreview}">
+                        <Border 
+                            d:DataContext="{d:DesignInstance vm:ResultViewModel}"
+                            DataContext="{Binding SelectedItem, ElementName=ResultListBox}"
+                            Style="{DynamicResource PreviewBorderStyle}" 
+                            Visibility="{Binding ShowCustomizedPreview}">
                             <ContentControl Content="{Binding Result.PreviewPanel.Value}" />
                         </Border>
                     </Grid>

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -40,6 +40,7 @@
         <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <converters:BoolToIMEConversionModeConverter x:Key="BoolToIMEConversionModeConverter"/>
         <converters:BoolToIMEStateConverter x:Key="BoolToIMEStateConverter"/>
+        <converters:StringToKeyBindingConverter x:Key="StringToKeyBindingConverter"/>
     </Window.Resources>
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />
@@ -181,9 +182,9 @@
             Command="{Binding ToggleGameModeCommand}"
             Modifiers="Ctrl"/>
         <KeyBinding
-            Key="{Binding TogglePreviewHotkey}"
+            Key="{Binding PreviewHotkey, Converter={StaticResource StringToKeyBindingConverter}, ConverterParameter='key'}"
             Command="{Binding TogglePreviewCommand}"
-            Modifiers="{Binding TogglePreviewModifiers}"/>
+            Modifiers="{Binding PreviewHotkey, Converter={StaticResource StringToKeyBindingConverter}, ConverterParameter='modifiers'}"/>
     </Window.InputBindings>
     <Grid>
         <Border MouseDown="OnMouseDown" Style="{DynamicResource WindowBorderStyle}">

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -43,7 +43,6 @@
     </Window.Resources>
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />
-        <!--KeyBinding Key="F1" Command="{Binding StartHelpCommand}" /-->
         <KeyBinding Key="F5" Command="{Binding ReloadPluginDataCommand}" />
         <KeyBinding Key="Tab" Command="{Binding AutocompleteQueryCommand}" />
         <KeyBinding

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -438,7 +438,7 @@
                                         HorizontalAlignment="Center"
                                         Source="{Binding PreviewImage}"
                                         StretchDirection="DownOnly"
-                                        Visibility="{Binding ShowPreviewImage, Converter={StaticResource BoolToVisibilityConverter}}">
+                                        Visibility="{Binding ShowPreviewImage}">
                                         <Image.Style>
                                             <Style TargetType="{x:Type Image}">
                                                 <Setter Property="MaxWidth" Value="96" />

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -181,6 +181,9 @@
             Command="{Binding OpenResultCommand}"
             CommandParameter="9"
             Modifiers="{Binding OpenResultCommandModifiers}" />
+        <KeyBinding
+            Key="{Binding TogglePreviewHotkey}"
+            Command="{Binding TogglePreviewCommand}"/>
     </Window.InputBindings>
     <Grid>
         <Border MouseDown="OnMouseDown" Style="{DynamicResource WindowBorderStyle}">

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -43,7 +43,7 @@
     </Window.Resources>
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />
-        <KeyBinding Key="F1" Command="{Binding StartHelpCommand}" />
+        <!--KeyBinding Key="F1" Command="{Binding StartHelpCommand}" /-->
         <KeyBinding Key="F5" Command="{Binding ReloadPluginDataCommand}" />
         <KeyBinding Key="Tab" Command="{Binding AutocompleteQueryCommand}" />
         <KeyBinding

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -182,7 +182,8 @@
             Modifiers="Ctrl"/>
         <KeyBinding
             Key="{Binding TogglePreviewHotkey}"
-            Command="{Binding TogglePreviewCommand}"/>
+            Command="{Binding TogglePreviewCommand}"
+            Modifiers="{Binding TogglePreviewModifiers}"/>
     </Window.InputBindings>
     <Grid>
         <Border MouseDown="OnMouseDown" Style="{DynamicResource WindowBorderStyle}">

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -438,7 +438,7 @@
                                         HorizontalAlignment="Center"
                                         Source="{Binding PreviewImage}"
                                         StretchDirection="DownOnly"
-                                        Visibility="{Binding ShowIcon}">
+                                        Visibility="{Binding ShowPreviewImage, Converter={StaticResource BoolToVisibilityConverter}}">
                                         <Image.Style>
                                             <Style TargetType="{x:Type Image}">
                                                 <Setter Property="MaxWidth" Value="96" />

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -630,10 +630,6 @@ namespace Flow.Launcher
         {
             _viewModel.ResetPreview();
         }
-        public void PreviewToggle()
-        {
-            _viewModel.TogglePreview();
-        }
 
         private void MoveQueryTextToEnd()
         {

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -620,11 +620,6 @@ namespace Flow.Launcher
                         }
                     }
                     break;
-                case Key.F1:
-                    PreviewToggle();
-                    e.Handled = true;
-                    break;
-
                 default:
                     break;
 

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -633,30 +633,11 @@ namespace Flow.Launcher
 
         public void PreviewReset()
         {
-            if (_settings.AlwaysPreview == true)
-            {
-                ResultArea.SetValue(Grid.ColumnSpanProperty, 1);
-                Preview.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                ResultArea.SetValue(Grid.ColumnSpanProperty, 2);
-                Preview.Visibility = Visibility.Collapsed;
-            }
+            _viewModel.ResetPreview();
         }
         public void PreviewToggle()
         {
-
-            if (Preview.Visibility == Visibility.Collapsed)
-            {
-                ResultArea.SetValue(Grid.ColumnSpanProperty, 1);
-                Preview.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                ResultArea.SetValue(Grid.ColumnSpanProperty, 2);
-                Preview.Visibility = Visibility.Collapsed;
-            }
+            _viewModel.TogglePreview();
         }
 
         private void MoveQueryTextToEnd()

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -2415,8 +2415,33 @@
                                     </Border>
                                 </StackPanel>
 
+                                <StackPanel Grid.Row="2">
+                                    <Border Margin="0,8,0,0" Style="{DynamicResource SettingGroupBox}">
+                                        <ItemsControl Style="{StaticResource SettingGrid}">
+                                            <StackPanel Style="{StaticResource TextPanel}">
+                                                <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource previewHotkey}"/>
+                                                <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource previewHotkeyToolTip}" />
+                                            </StackPanel>
+                                            <flowlauncher:HotkeyControl
+                                                x:Name="PreviewHotkeyControl"
+                                                Grid.Row="0"
+                                                Grid.Column="2"
+                                                Width="300"
+                                                Height="35"
+                                                Margin="0,0,0,0"
+                                                HorizontalAlignment="Right"
+                                                HorizontalContentAlignment="Right"
+                                                Loaded="OnPreviewHotkeyControlLoaded"
+                                                LostFocus="OnPreviewHotkeyControlFocusLost" />
+                                            <TextBlock Style="{StaticResource Glyph}">
+                                                &#xeda7;
+                                            </TextBlock>
+                                        </ItemsControl>
+                                    </Border>
+                                </StackPanel>
+
                                 <Border
-                                    Grid.Row="2"
+                                    Grid.Row="3"
                                     Margin="0,12,0,0"
                                     Padding="0"
                                     CornerRadius="5"
@@ -2473,7 +2498,7 @@
                                 </Border>
 
                                 <TextBlock
-                                    Grid.Row="3"
+                                    Grid.Row="4"
                                     Margin="0,10,12,10"
                                     Padding="0,12,0,0"
                                     VerticalAlignment="Center"
@@ -2481,7 +2506,7 @@
                                     Foreground="{DynamicResource Color05B}"
                                     Text="{DynamicResource customQueryHotkey}" />
                                 <ListView
-                                    Grid.Row="4"
+                                    Grid.Row="5"
                                     MinHeight="160"
                                     Margin="0,0,0,0"
                                     Background="{DynamicResource Color02B}"
@@ -2510,7 +2535,7 @@
                                     </ListView.View>
                                 </ListView>
                                 <StackPanel
-                                    Grid.Row="5"
+                                    Grid.Row="6"
                                     Margin="0"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Top"
@@ -2533,7 +2558,7 @@
                                 </StackPanel>
 
                                 <TextBlock
-                                    Grid.Row="6"
+                                    Grid.Row="7"
                                     Margin="0,0,12,2"
                                     Padding="0,12,0,0"
                                     VerticalAlignment="Center"
@@ -2542,7 +2567,7 @@
                                     Text="{DynamicResource customQueryShortcut}" />
                                 <ListView
                                     Name="customShortcutView"
-                                    Grid.Row="7"
+                                    Grid.Row="8"
                                     MinHeight="160"
                                     Margin="0,6,0,0"
                                     Background="{DynamicResource Color02B}"
@@ -2571,7 +2596,7 @@
                                     </ListView.View>
                                 </ListView>
                                 <StackPanel
-                                    Grid.Row="8"
+                                    Grid.Row="9"
                                     Margin="0"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Top"
@@ -2594,7 +2619,7 @@
                                 </StackPanel>
 
                                 <TextBlock
-                                    Grid.Row="9"
+                                    Grid.Row="10"
                                     Margin="0,0,12,2"
                                     Padding="0,12,0,0"
                                     VerticalAlignment="Center"
@@ -2602,7 +2627,7 @@
                                     Foreground="{DynamicResource Color05B}"
                                     Text="{DynamicResource builtinShortcuts}" />
                                 <ListView
-                                    Grid.Row="10"
+                                    Grid.Row="11"
                                     MinHeight="160"
                                     Margin="0,6,0,20"
                                     Background="{DynamicResource Color02B}"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -743,7 +743,7 @@
                                         FocusVisualMargin="5"
                                         IsOn="{Binding Settings.AlwaysPreview}"
                                         Style="{DynamicResource SideToggleSwitch}"
-                                        ToolTip="{DynamicResource AlwaysPreviewToolTip}" />
+                                        ToolTip="{Binding AlwaysPreviewToolTip}" />
                                     <TextBlock Style="{StaticResource Glyph}">
                                         &#xe8a1;
                                     </TextBlock>

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -736,7 +736,7 @@
                                 <ItemsControl Style="{StaticResource SettingGrid}">
                                     <StackPanel Style="{StaticResource TextPanel}">
                                         <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource AlwaysPreview}" />
-                                        <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource AlwaysPreviewToolTip}" />
+                                        <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{Binding AlwaysPreviewToolTip}" />
                                     </StackPanel>
                                     <ui:ToggleSwitch
                                         Grid.Column="2"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -2434,7 +2434,7 @@
                                                 Loaded="OnPreviewHotkeyControlLoaded"
                                                 LostFocus="OnPreviewHotkeyControlFocusLost" />
                                             <TextBlock Style="{StaticResource Glyph}">
-                                                &#xeda7;
+                                                &#xe8a1;
                                             </TextBlock>
                                         </ItemsControl>
                                     </Border>

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -131,6 +131,19 @@ namespace Flow.Launcher
             }
         }
 
+        private void OnPreviewHotkeyControlLoaded(object sender, RoutedEventArgs e)
+        {
+            _ = PreviewHotkeyControl.SetHotkeyAsync(settings.PreviewHotkey, false);
+        }
+
+        private void OnPreviewHotkeyControlFocusLost(object sender, RoutedEventArgs e)
+        {
+            if (PreviewHotkeyControl.CurrentHotkeyAvailable)
+            {
+                settings.PreviewHotkey = PreviewHotkeyControl.CurrentHotkey.ToString();
+            }
+        }
+
         private void OnDeleteCustomHotkeyClick(object sender, RoutedEventArgs e)
         {
             var item = viewModel.SelectedCustomPluginHotkey;

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -75,7 +75,7 @@ namespace Flow.Launcher.ViewModel
                         OnPropertyChanged(nameof(OpenResultCommandModifiers));
                         break;
                     case nameof(Settings.PreviewHotkey):
-                        UpdatePreviewHotkey();
+                        OnPropertyChanged(nameof(PreviewHotkey));
                         break;
                 }
             };
@@ -115,7 +115,6 @@ namespace Flow.Launcher.ViewModel
             RegisterViewUpdate();
             RegisterResultsUpdatedEvent();
             _ = RegisterClockAndDateUpdateAsync();
-            UpdatePreviewHotkey();
         }
 
         private void RegisterViewUpdate()
@@ -584,9 +583,7 @@ namespace Flow.Launcher.ViewModel
 
         public string OpenResultCommandModifiers => Settings.OpenResultModifiers;
 
-        public Key TogglePreviewHotkey { get; set; }
-
-        public ModifierKeys TogglePreviewModifiers { get; set; }
+        public string PreviewHotkey => Settings.PreviewHotkey;
 
         public string Image => Constant.QueryTextBoxIconImagePath;
 
@@ -1016,14 +1013,6 @@ namespace Flow.Launcher.ViewModel
         public bool ShouldIgnoreHotkeys()
         {
             return Settings.IgnoreHotkeysOnFullscreen && WindowsInteropHelper.IsWindowFullscreen() || GameModeStatus;
-        }
-
-        private void UpdatePreviewHotkey()
-        {
-            var converter = new KeyGestureConverter();
-            var key = (KeyGesture)converter.ConvertFromString(Settings.PreviewHotkey);
-            TogglePreviewHotkey = key.Key;
-            TogglePreviewModifiers = key.Modifiers;
         }
 
         #endregion

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -74,6 +74,9 @@ namespace Flow.Launcher.ViewModel
                     case nameof(Settings.AlwaysStartEn):
                         OnPropertyChanged(nameof(StartWithEnglishMode));
                         break;
+                    case nameof(Settings.PreviewHotkey):
+                        OnPropertyChanged(nameof(TogglePreviewHotkey));
+                        break;
                 }
             };
 
@@ -569,6 +572,8 @@ namespace Flow.Launcher.ViewModel
         public string PluginIconPath { get; set; } = null;
 
         public string OpenResultCommandModifiers { get; private set; }
+
+        public string TogglePreviewHotkey => Settings.PreviewHotkey; // TODO: is hotkey combo possible?
 
         public string Image => Constant.QueryTextBoxIconImagePath;
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -23,6 +23,7 @@ using System.IO;
 using System.Collections.Specialized;
 using CommunityToolkit.Mvvm.Input;
 using System.Globalization;
+using System.Windows.Input;
 
 namespace Flow.Launcher.ViewModel
 {
@@ -74,7 +75,7 @@ namespace Flow.Launcher.ViewModel
                         OnPropertyChanged(nameof(OpenResultCommandModifiers));
                         break;
                     case nameof(Settings.PreviewHotkey):
-                        OnPropertyChanged(nameof(TogglePreviewHotkey));
+                        UpdatePreviewHotkey();
                         break;
                 }
             };
@@ -114,6 +115,7 @@ namespace Flow.Launcher.ViewModel
             RegisterViewUpdate();
             RegisterResultsUpdatedEvent();
             _ = RegisterClockAndDateUpdateAsync();
+            UpdatePreviewHotkey();
         }
 
         private void RegisterViewUpdate()
@@ -582,7 +584,9 @@ namespace Flow.Launcher.ViewModel
 
         public string OpenResultCommandModifiers => Settings.OpenResultModifiers;
 
-        public string TogglePreviewHotkey => Settings.PreviewHotkey; // TODO: is hotkey combo possible?
+        public Key TogglePreviewHotkey { get; set; }
+
+        public ModifierKeys TogglePreviewModifiers { get; set; }
 
         public string Image => Constant.QueryTextBoxIconImagePath;
 
@@ -1012,6 +1016,14 @@ namespace Flow.Launcher.ViewModel
         public bool ShouldIgnoreHotkeys()
         {
             return Settings.IgnoreHotkeysOnFullscreen && WindowsInteropHelper.IsWindowFullscreen() || GameModeStatus;
+        }
+
+        private void UpdatePreviewHotkey()
+        {
+            var converter = new KeyGestureConverter();
+            var key = (KeyGesture)converter.ConvertFromString(Settings.PreviewHotkey);
+            TogglePreviewHotkey = key.Key;
+            TogglePreviewModifiers = key.Modifiers;
         }
 
         #endregion

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -104,7 +104,7 @@ namespace Flow.Launcher.ViewModel
             RegisterResultsUpdatedEvent();
             RegisterClockAndDateUpdateAsync();
 
-            SetOpenResultModifiers();
+            SetOpenResultModifiers(); // TODO?
         }
 
         private void RegisterViewUpdate()
@@ -424,6 +424,43 @@ namespace Flow.Launcher.ViewModel
             Settings.MaxResultsToShow -= 1;
         }
 
+        [RelayCommand]
+        public void TogglePreview()
+        {
+            if (!PreviewVisible)
+            {
+                ShowPreview();
+            }
+            else
+            {
+                HidePreview();
+            }
+        }
+
+        private void ShowPreview()
+        {
+            ResultAreaColumn = 1;
+            PreviewVisible = true;
+        }
+
+        private void HidePreview()
+        {
+            ResultAreaColumn = 2;
+            PreviewVisible = false;
+        }
+
+        public void ResetPreview()
+        {
+            if (Settings.AlwaysPreview == true)
+            {
+                ShowPreview();
+            }
+            else
+            {
+                HidePreview();
+            }
+        }
+
         /// <summary>
         /// we need move cursor to end when we manually changed query
         /// but we don't want to move cursor to end when query is updated from TextBox
@@ -518,6 +555,10 @@ namespace Flow.Launcher.ViewModel
         public string Image => Constant.QueryTextBoxIconImagePath;
 
         public bool StartWithEnglishMode => Settings.AlwaysStartEn;
+
+        public bool PreviewVisible { get; set; } = false;
+
+        public int ResultAreaColumn { get; set; } = 1;
 
         #endregion
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -99,6 +99,15 @@ namespace Flow.Launcher.ViewModel
             };
             _selectedResults = Results;
 
+            Results.PropertyChanged += (_, args) =>
+            {
+                switch (args.PropertyName)
+                {
+                    case nameof(Results.SelectedItem):
+                        UpdatePreview();
+                        break;
+                }
+            };
 
             RegisterViewUpdate();
             RegisterResultsUpdatedEvent();
@@ -441,6 +450,7 @@ namespace Flow.Launcher.ViewModel
         {
             ResultAreaColumn = 1;
             PreviewVisible = true;
+            Results.SelectedItem?.LoadPreviewImage();
         }
 
         private void HidePreview()
@@ -458,6 +468,14 @@ namespace Flow.Launcher.ViewModel
             else
             {
                 HidePreview();
+            }
+        }
+
+        private void UpdatePreview()
+        {
+            if (PreviewVisible)
+            {
+                Results.SelectedItem?.LoadPreviewImage();
             }
         }
 

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -90,6 +90,30 @@ namespace Flow.Launcher.ViewModel
             }
         }
 
+        public bool ShowPreviewImage
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(Result.Preview.PreviewImagePath) || Result.Preview.PreviewDelegate != null)
+                {
+                    return true;
+                }
+                else
+                {
+                    // Fall back to Icon
+                    if (!ImgIconAvailable && !GlyphAvailable)
+                        return true;
+
+                    // Although user can choose to use glyph icons, plugins may choose to supply only image icons.
+                    // In this case we ignore the setting because otherwise icons will not display as intended
+                    if (Settings.UseGlyphIcons && !GlyphAvailable && ImgIconAvailable)
+                        return true;
+
+                    return !Settings.UseGlyphIcons && ImgIconAvailable;
+                }
+            }
+        }
+
         public double IconRadius
         {
             get
@@ -119,6 +143,8 @@ namespace Flow.Launcher.ViewModel
         private bool GlyphAvailable => Glyph is not null;
 
         private bool ImgIconAvailable => !string.IsNullOrEmpty(Result.IcoPath) || Result.Icon is not null;
+
+        private bool PreviewImageAvailable => !string.IsNullOrEmpty(Result.Preview.PreviewImagePath) || Result.Preview.PreviewDelegate != null;
 
         public string OpenResultModifiers => Settings.OpenResultModifiers;
 
@@ -218,7 +244,7 @@ namespace Flow.Launcher.ViewModel
         {
             if (ShowDefaultPreview == Visibility.Visible)
             {
-                if (!PreviewImageLoaded && ShowIcon == Visibility.Visible)
+                if (!PreviewImageLoaded && ShowPreviewImage)
                 {
                     PreviewImageLoaded = true;
                     _ = LoadPreviewImageAsync();

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -202,7 +202,7 @@ namespace Flow.Launcher.ViewModel
         private async Task LoadPreviewImageAsync()
         {
             var imagePath = string.IsNullOrEmpty(Result.Preview.PreviewImagePath) ? Result.IcoPath : Result.Preview.PreviewImagePath;
-            var iconDelegate = Result.Icon;
+            var iconDelegate = Result.Icon ?? Result.Preview.PreviewDelegate;
             if (ImageLoader.CacheContainImage(imagePath, true))
             {
                 previewImage = await LoadImageInternalAsync(imagePath, iconDelegate, true).ConfigureAwait(false);

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -214,9 +214,9 @@ namespace Flow.Launcher.ViewModel
         {
             var imagePath = Result.IcoPath;
             var iconDelegate = Result.Icon;
-            if (ImageLoader.CacheContainImage(imagePath, false))
+            if (ImageLoader.TryGetValue(imagePath, false, out ImageSource img))
             {
-                image = await LoadImageInternalAsync(imagePath, iconDelegate, false).ConfigureAwait(false);
+                image = img;
             }
             else
             {
@@ -229,9 +229,9 @@ namespace Flow.Launcher.ViewModel
         {
             var imagePath = Result.Preview.PreviewImagePath ?? Result.IcoPath;
             var iconDelegate = Result.Preview.PreviewDelegate ?? Result.Icon;
-            if (ImageLoader.CacheContainImage(imagePath, true))
+            if (ImageLoader.TryGetValue(imagePath, true, out ImageSource img))
             {
-                previewImage = await LoadImageInternalAsync(imagePath, iconDelegate, true).ConfigureAwait(false);
+                previewImage = img;
             }
             else
             {

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -90,26 +90,18 @@ namespace Flow.Launcher.ViewModel
             }
         }
 
-        public bool ShowPreviewImage
+        public Visibility ShowPreviewImage
         {
             get
             {
-                if (!string.IsNullOrEmpty(Result.Preview.PreviewImagePath) || Result.Preview.PreviewDelegate != null)
+                if (PreviewImageAvailable)
                 {
-                    return true;
+                    return Visibility.Visible;
                 }
                 else
                 {
-                    // Fall back to Icon
-                    if (!ImgIconAvailable && !GlyphAvailable)
-                        return true;
-
-                    // Although user can choose to use glyph icons, plugins may choose to supply only image icons.
-                    // In this case we ignore the setting because otherwise icons will not display as intended
-                    if (Settings.UseGlyphIcons && !GlyphAvailable && ImgIconAvailable)
-                        return true;
-
-                    return !Settings.UseGlyphIcons && ImgIconAvailable;
+                    // Fall back to icon
+                    return ShowIcon;
                 }
             }
         }
@@ -244,7 +236,7 @@ namespace Flow.Launcher.ViewModel
         {
             if (ShowDefaultPreview == Visibility.Visible)
             {
-                if (!PreviewImageLoaded && ShowPreviewImage)
+                if (!PreviewImageLoaded && ShowPreviewImage == Visibility.Visible)
                 {
                     PreviewImageLoaded = true;
                     _ = LoadPreviewImageAsync();

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -90,14 +90,6 @@ namespace Flow.Launcher.ViewModel
             }
         }
 
-        public bool UsePreviewImage
-        {
-            //todo binding
-            get => !ImgIconAvailable && !GlyphAvailable ||
-                Settings.UseGlyphIcons && !GlyphAvailable && ImgIconAvailable ||
-                !Settings.UseGlyphIcons && ImgIconAvailable;
-        }
-
         public double IconRadius
         {
             get
@@ -224,7 +216,7 @@ namespace Flow.Launcher.ViewModel
 
         public void LoadPreviewImage()
         {
-            if (!PreviewImageLoaded && UsePreviewImage)
+            if (!PreviewImageLoaded && ShowIcon == Visibility.Visible)
             {
                 PreviewImageLoaded = true;
                 _ = LoadPreviewImageAsync();

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -90,6 +90,14 @@ namespace Flow.Launcher.ViewModel
             }
         }
 
+        public bool UsePreviewImage
+        {
+            //todo binding
+            get => !ImgIconAvailable && !GlyphAvailable ||
+                Settings.UseGlyphIcons && !GlyphAvailable && ImgIconAvailable ||
+                !Settings.UseGlyphIcons && ImgIconAvailable;
+        }
+
         public double IconRadius
         {
             get
@@ -153,16 +161,7 @@ namespace Flow.Launcher.ViewModel
 
         public ImageSource PreviewImage
         {
-            get
-            {
-                if (!PreviewImageLoaded)
-                {
-                    PreviewImageLoaded = true;
-                    _ = LoadPreviewImageAsync();
-                }
-
-                return previewImage;
-            }
+            get => previewImage;
             private set => previewImage = value;
         }
 
@@ -220,6 +219,15 @@ namespace Flow.Launcher.ViewModel
             {
                 // We need to modify the property not field here to trigger the OnPropertyChanged event
                 PreviewImage = await LoadImageInternalAsync(imagePath, iconDelegate, true).ConfigureAwait(false);
+            }
+        }
+
+        public void LoadPreviewImage()
+        {
+            if (!PreviewImageLoaded && UsePreviewImage)
+            {
+                PreviewImageLoaded = true;
+                _ = LoadPreviewImageAsync();
             }
         }
 

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -216,10 +216,13 @@ namespace Flow.Launcher.ViewModel
 
         public void LoadPreviewImage()
         {
-            if (!PreviewImageLoaded && ShowIcon == Visibility.Visible)
+            if (ShowDefaultPreview == Visibility.Visible)
             {
-                PreviewImageLoaded = true;
-                _ = LoadPreviewImageAsync();
+                if (!PreviewImageLoaded && ShowIcon == Visibility.Visible)
+                {
+                    PreviewImageLoaded = true;
+                    _ = LoadPreviewImageAsync();
+                }
             }
         }
 

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -227,8 +227,8 @@ namespace Flow.Launcher.ViewModel
 
         private async Task LoadPreviewImageAsync()
         {
-            var imagePath = string.IsNullOrEmpty(Result.Preview.PreviewImagePath) ? Result.IcoPath : Result.Preview.PreviewImagePath;
-            var iconDelegate = Result.Icon ?? Result.Preview.PreviewDelegate;
+            var imagePath = Result.Preview.PreviewImagePath ?? Result.IcoPath;
+            var iconDelegate = Result.Preview.PreviewDelegate ?? Result.Icon;
             if (ImageLoader.CacheContainImage(imagePath, true))
             {
                 previewImage = await LoadImageInternalAsync(imagePath, iconDelegate, true).ConfigureAwait(false);

--- a/Flow.Launcher/ViewModel/ResultsViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultsViewModel.cs
@@ -9,7 +9,6 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
-using JetBrains.Annotations;
 
 namespace Flow.Launcher.ViewModel
 {

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -58,6 +58,10 @@ namespace Flow.Launcher.ViewModel
                     case nameof(Settings.Language):
                         OnPropertyChanged(nameof(ClockText));
                         OnPropertyChanged(nameof(DateText));
+                        OnPropertyChanged(nameof(AlwaysPreviewToolTip));
+                        break;
+                    case nameof(Settings.PreviewHotkey):
+                        OnPropertyChanged(nameof(AlwaysPreviewToolTip));
                         break;
                 }
             };
@@ -243,7 +247,7 @@ namespace Flow.Launcher.ViewModel
         public List<Language> Languages => _translater.LoadAvailableLanguages();
         public IEnumerable<int> MaxResultsRange => Enumerable.Range(2, 16);
 
-        public string AlwaysPreviewTooltip => string.Format(_translater.GetTranslation("AlwaysPreviewToolTip"), Settings.PreviewHotkey);
+        public string AlwaysPreviewToolTip => string.Format(_translater.GetTranslation("AlwaysPreviewToolTip"), Settings.PreviewHotkey);
 
         public string TestProxy()
         {

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -243,9 +243,6 @@ namespace Flow.Launcher.ViewModel
         public List<Language> Languages => _translater.LoadAvailableLanguages();
         public IEnumerable<int> MaxResultsRange => Enumerable.Range(2, 16);
 
-        public ObservableCollection<CustomShortcutModel> CustomShortcuts => Settings.CustomShortcuts;
-        public ObservableCollection<BuiltinShortcutModel> BuiltinShortcuts => Settings.BuiltinShortcuts;
-
         public string TestProxy()
         {
             var proxyServer = Settings.Proxy.Server;
@@ -741,6 +738,10 @@ namespace Flow.Launcher.ViewModel
         #endregion
 
         #region shortcut
+
+        public ObservableCollection<CustomShortcutModel> CustomShortcuts => Settings.CustomShortcuts;
+
+        public ObservableCollection<BuiltinShortcutModel> BuiltinShortcuts => Settings.BuiltinShortcuts;
 
         public CustomShortcutModel? SelectedCustomShortcut { get; set; }
 

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -243,6 +243,8 @@ namespace Flow.Launcher.ViewModel
         public List<Language> Languages => _translater.LoadAvailableLanguages();
         public IEnumerable<int> MaxResultsRange => Enumerable.Range(2, 16);
 
+        public string AlwaysPreviewTooltip => string.Format(_translater.GetTranslation("AlwaysPreviewToolTip"), Settings.PreviewHotkey);
+
         public string TestProxy()
         {
             var proxyServer = Settings.Proxy.Server;

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ And you can download <a href="https://github.com/Flow-Launcher/Flow.Launcher/dis
 | <kbd>←</kbd><kbd>→</kbd>                                     | Back to result / Open Context Menu           |
 | <kbd>Ctrl</kbd> +<kbd>O</kbd> , <kbd>Shift</kbd> +<kbd>Enter</kbd> | Open Context Menu                      |
 | <kbd>Tab</kbd>                                               | Autocomplete                                 |
-| <kbd>F1</kbd>                                                | Toggle Preveiw Panel (default and configurable)|
+| <kbd>F1</kbd>                                                | Toggle Preveiw Panel                         |
 | <kbd>Esc</kbd>                                               | Back to results / hide search window         |
 | <kbd>Ctrl</kbd> +<kbd>C</kbd>                                | Copy the actual folder / file                |
 | <kbd>Ctrl</kbd> +<kbd>I</kbd>                                | Open flow's settings                         |

--- a/README.md
+++ b/README.md
@@ -274,12 +274,12 @@ And you can download <a href="https://github.com/Flow-Launcher/Flow.Launcher/dis
 | <kbd>←</kbd><kbd>→</kbd>                                     | Back to result / Open Context Menu           |
 | <kbd>Ctrl</kbd> +<kbd>O</kbd> , <kbd>Shift</kbd> +<kbd>Enter</kbd> | Open Context Menu                      |
 | <kbd>Tab</kbd>                                               | Autocomplete                                 |
-| <kbd>F1</kbd>                                                | Toggle Preveiw Panel                         |
+| <kbd>F1</kbd>                                                | Toggle Preveiw Panel (default and configurable)|
 | <kbd>Esc</kbd>                                               | Back to results / hide search window         |
 | <kbd>Ctrl</kbd> +<kbd>C</kbd>                                | Copy the actual folder / file                |
 | <kbd>Ctrl</kbd> +<kbd>I</kbd>                                | Open flow's settings                         |
 | <kbd>F5</kbd>                                                | Reload all plugin data                       |
-| <kbd>Ctrl</kbd> + <kbd>F12</kbd>                             | Toggle Game Mode when in search window.      |
+| <kbd>Ctrl</kbd> + <kbd>F12</kbd>                             | Toggle Game Mode when in search window       |
 | <kbd>Ctrl</kbd> + <kbd>+</kbd>,<kbd>-</kbd>                  | Quickly change maximum results shown         |
 | <kbd>Ctrl</kbd> + <kbd>[</kbd>,<kbd>]</kbd>                  | Quickly change search window width           |
 | <kbd>Ctrl</kbd> + <kbd>H</kbd>                               | Open search history                          |


### PR DESCRIPTION
Changes:
- Load preview image when opening preview panel.
- Add preview hotkey property in settings. ~~(no UI to modify it, can't figure out a good way to edit it yet)~~
- Add an option to modifty the hotkey
![图片](https://user-images.githubusercontent.com/10308169/209765751-8176d31f-f1a7-4eda-b5c6-dcca9df7d5fc.png)
- Add hotkey text in tooltip
![图片](https://user-images.githubusercontent.com/10308169/209766955-6582eab7-8429-4c75-bad3-1f1f8d52dffb.png)
- Add separate preview delegate in Result class.
- Add `TryGetValue` for ImageLoader.


Tests:
- [x] Preview can be toggled.
- [x] Preview image changes when changing selected item.
- [x] Preview hotkey can be modified and works properly.
- [x] Tootip reflects changes in hotkey.