### PR TITLE
Refactor Toggle Game Mode logic in main window

### DIFF
--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -1,4 +1,4 @@
-using Flow.Launcher.Infrastructure.Hotkey;
+﻿using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Infrastructure.UserSettings;
 using System;
 using NHotkey;
@@ -25,7 +25,7 @@ namespace Flow.Launcher.Helper
 
         internal static void OnToggleHotkey(object sender, HotkeyEventArgs args)
         {
-            if (!mainViewModel.ShouldIgnoreHotkeys() && !mainViewModel.GameModeStatus)
+            if (!mainViewModel.ShouldIgnoreHotkeys())
                 mainViewModel.ToggleFlowLauncher();
         }
 
@@ -74,7 +74,7 @@ namespace Flow.Launcher.Helper
         {
             SetHotkey(hotkey.Hotkey, (s, e) =>
             {
-                if (mainViewModel.ShouldIgnoreHotkeys() || mainViewModel.GameModeStatus)
+                if (mainViewModel.ShouldIgnoreHotkeys())
                     return;
 
                 mainViewModel.Show();

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -86,14 +86,10 @@
             Key="O"
             Command="{Binding LoadContextMenuCommand}"
             Modifiers="Ctrl" />
-        <KeyBinding Key="Right" Command="{Binding LoadContextMenuCommand}" />
-        <KeyBinding Key="Left" Command="{Binding EscCommand}" />
         <KeyBinding
             Key="H"
             Command="{Binding LoadHistoryCommand}"
             Modifiers="Ctrl" />
-        <KeyBinding Key="Right" Command="{Binding LoadContextMenuCommand}" />
-        <KeyBinding Key="Left" Command="{Binding EscCommand}" />
         <KeyBinding
             Key="OemCloseBrackets"
             Command="{Binding IncreaseWidthCommand}"

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -177,6 +177,10 @@
             Command="{Binding OpenResultCommand}"
             CommandParameter="9"
             Modifiers="{Binding OpenResultCommandModifiers}" />
+        <KeyBinding
+            Key="F12"
+            Command="{Binding ToggleGameModeCommand}"
+            Modifiers="Ctrl"/>
     </Window.InputBindings>
     <Grid>
         <Border MouseDown="OnMouseDown" Style="{DynamicResource WindowBorderStyle}">

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -101,6 +101,7 @@ namespace Flow.Launcher
             // since the default main window visibility is visible
             // so we need set focus during startup
             QueryTextBox.Focus();
+
             _viewModel.PropertyChanged += (o, e) =>
             {
                 switch (e.PropertyName)
@@ -169,9 +170,12 @@ namespace Flow.Launcher
                             _viewModel.QueryTextCursorMovedToEnd = false;
                         }
                         break;
-
+                    case nameof(MainViewModel.GameModeStatus):
+                        _notifyIcon.Icon = _viewModel.GameModeStatus ? Properties.Resources.gamemode : Properties.Resources.app;
+                        break;
                 }
             };
+
             _settings.PropertyChanged += (o, e) =>
             {
                 switch (e.PropertyName)
@@ -286,7 +290,7 @@ namespace Flow.Launcher
             };
 
             open.Click += (o, e) => _viewModel.ToggleFlowLauncher();
-            gamemode.Click += (o, e) => ToggleGameMode();
+            gamemode.Click += (o, e) => _viewModel.ToggleGameMode();
             positionreset.Click += (o, e) => PositionReset();
             settings.Click += (o, e) => App.API.OpenSettingDialog();
             exit.Click += (o, e) => Close();
@@ -330,20 +334,6 @@ namespace Flow.Launcher
         {
             var WelcomeWindow = new WelcomeWindow(_settings);
             WelcomeWindow.Show();
-        }
-
-        private void ToggleGameMode()
-        {
-            if (_viewModel.GameModeStatus)
-            {
-                _notifyIcon.Icon = Properties.Resources.app;
-                _viewModel.GameModeStatus = false;
-            }
-            else
-            {
-                _notifyIcon.Icon = Properties.Resources.gamemode;
-                _viewModel.GameModeStatus = true;
-            }
         }
 
         private async void PositionReset()
@@ -599,12 +589,6 @@ namespace Flow.Launcher
                     {
                         _viewModel.EscCommand.Execute(null);
                         e.Handled = true;
-                    }
-                    break;
-                case Key.F12:
-                    if (specialKeyState.CtrlPressed)
-                    {
-                        ToggleGameMode();
                     }
                     break;
                 case Key.Back:

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -70,6 +70,7 @@ namespace Flow.Launcher
                 _viewModel.ResultCopy(QueryTextBox.SelectedText);
             }
         }
+
         private async void OnClosing(object sender, CancelEventArgs e)
         {
             _settings.WindowTop = Top;
@@ -324,11 +325,13 @@ namespace Flow.Launcher
                 OpenWelcomeWindow();
             }
         }
+
         private void OpenWelcomeWindow()
         {
             var WelcomeWindow = new WelcomeWindow(_settings);
             WelcomeWindow.Show();
         }
+
         private void ToggleGameMode()
         {
             if (_viewModel.GameModeStatus)
@@ -342,6 +345,7 @@ namespace Flow.Launcher
                 _viewModel.GameModeStatus = true;
             }
         }
+
         private async void PositionReset()
         {
             _viewModel.Show();
@@ -349,6 +353,7 @@ namespace Flow.Launcher
             Left = HorizonCenter();
             Top = VerticalCenter();
         }
+
         private void InitProgressbarAnimation()
         {
             var da = new DoubleAnimation(ProgressBar.X2, ActualWidth + 100, new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
@@ -361,6 +366,7 @@ namespace Flow.Launcher
             _viewModel.ProgressBarVisibility = Visibility.Hidden;
             isProgressBarStoryboardPaused = true;
         }
+
         public void WindowAnimator()
         {
             if (_animating)
@@ -474,7 +480,6 @@ namespace Flow.Launcher
 
             App.API.OpenSettingDialog();
         }
-
 
         private async void OnDeactivated(object sender, EventArgs e)
         {
@@ -644,6 +649,7 @@ namespace Flow.Launcher
                 Preview.Visibility = Visibility.Collapsed;
             }
         }
+
         public void PreviewToggle()
         {
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Input;
 using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Helper;
@@ -24,7 +23,6 @@ using System.IO;
 using System.Collections.Specialized;
 using CommunityToolkit.Mvvm.Input;
 using System.Globalization;
-using System.Windows.Threading;
 
 namespace Flow.Launcher.ViewModel
 {

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -135,8 +135,6 @@ namespace Flow.Launcher.ViewModel
                 Log.Error("MainViewModel", "Unexpected ResultViewUpdate ends");
             }
 
-            ;
-
             void continueAction(Task t)
             {
 #if DEBUG
@@ -180,6 +178,7 @@ namespace Flow.Launcher.ViewModel
             await PluginManager.ReloadDataAsync().ConfigureAwait(false);
             Notification.Show(InternationalizationManager.Instance.GetTranslation("success"), InternationalizationManager.Instance.GetTranslation("completedSuccessfully"));
         }
+
         [RelayCommand]
         private void LoadHistory()
         {
@@ -193,6 +192,7 @@ namespace Flow.Launcher.ViewModel
                 SelectedResults = Results;
             }
         }
+
         [RelayCommand]
         private void LoadContextMenu()
         {
@@ -208,6 +208,7 @@ namespace Flow.Launcher.ViewModel
                 SelectedResults = Results;
             }
         }
+
         [RelayCommand]
         private void Backspace(object index)
         {
@@ -220,6 +221,7 @@ namespace Flow.Launcher.ViewModel
 
             ChangeQueryText($"{actionKeyword}{path}");
         }
+
         [RelayCommand]
         private void AutocompleteQuery()
         {
@@ -246,6 +248,7 @@ namespace Flow.Launcher.ViewModel
                 ChangeQueryText(autoCompleteText);
             }
         }
+
         [RelayCommand]
         private async Task OpenResultAsync(string index)
         {
@@ -280,6 +283,7 @@ namespace Flow.Launcher.ViewModel
                 SelectedResults = Results;
             }
         }
+
         [RelayCommand]
         private void OpenSetting()
         {
@@ -297,6 +301,7 @@ namespace Flow.Launcher.ViewModel
         {
             SelectedResults.SelectFirstResult();
         }
+
         [RelayCommand]
         private void SelectPrevPage()
         {
@@ -308,11 +313,13 @@ namespace Flow.Launcher.ViewModel
         {
             SelectedResults.SelectNextPage();
         }
+
         [RelayCommand]
         private void SelectPrevItem()
         {
             SelectedResults.SelectPrevResult();
         }
+
         [RelayCommand]
         private void SelectNextItem()
         {
@@ -519,6 +526,8 @@ namespace Flow.Launcher.ViewModel
         public bool StartWithEnglishMode => Settings.AlwaysStartEn;
 
         #endregion
+
+        #region Query
 
         public void Query()
         {
@@ -873,6 +882,8 @@ namespace Flow.Launcher.ViewModel
             return selected;
         }
 
+        #endregion
+
         #region Hotkey
 
         public void ToggleFlowLauncher()
@@ -928,9 +939,6 @@ namespace Flow.Launcher.ViewModel
             MainWindowVisibility = Visibility.Collapsed;
         }
 
-        #endregion
-
-
         /// <summary>
         /// Checks if Flow Launcher should ignore any hotkeys
         /// </summary>
@@ -939,7 +947,7 @@ namespace Flow.Launcher.ViewModel
             return Settings.IgnoreHotkeysOnFullscreen && WindowsInteropHelper.IsWindowFullscreen();
         }
 
-
+        #endregion
 
         #region Public Methods
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -72,6 +72,9 @@ namespace Flow.Launcher.ViewModel
                     case nameof(Settings.AlwaysStartEn):
                         OnPropertyChanged(nameof(StartWithEnglishMode));
                         break;
+                    case nameof(Settings.OpenResultModifiers):
+                        OnPropertyChanged(nameof(OpenResultCommandModifiers));
+                        break;
                 }
             };
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -337,6 +337,12 @@ namespace Flow.Launcher.ViewModel
             }
         }
 
+        [RelayCommand]
+        public void ToggleGameMode()
+        {
+            GameModeStatus = !GameModeStatus;
+        }
+
         #endregion
 
         #region ViewModel Properties
@@ -365,7 +371,7 @@ namespace Flow.Launcher.ViewModel
 
         public ResultsViewModel History { get; private set; }
 
-        public bool GameModeStatus { get; set; }
+        public bool GameModeStatus { get; set; } = false;
 
         private string _queryText;
         public string QueryText
@@ -378,7 +384,6 @@ namespace Flow.Launcher.ViewModel
                 Query();
             }
         }
-
 
         [RelayCommand]
         private void IncreaseWidth()
@@ -942,7 +947,7 @@ namespace Flow.Launcher.ViewModel
         /// </summary>
         public bool ShouldIgnoreHotkeys()
         {
-            return Settings.IgnoreHotkeysOnFullscreen && WindowsInteropHelper.IsWindowFullscreen();
+            return Settings.IgnoreHotkeysOnFullscreen && WindowsInteropHelper.IsWindowFullscreen() || GameModeStatus;
         }
 
         #endregion

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -32,8 +32,6 @@ namespace Flow.Launcher.ViewModel
     {
         #region Private Fields
 
-        private const string DefaultOpenResultModifiers = "Alt";
-
         private bool _isQueryRunning;
         private Query _lastQuery;
         private string _queryTextBeforeLeaveResults;
@@ -103,8 +101,6 @@ namespace Flow.Launcher.ViewModel
             RegisterViewUpdate();
             RegisterResultsUpdatedEvent();
             RegisterClockAndDateUpdateAsync();
-
-            SetOpenResultModifiers();
         }
 
         private void RegisterViewUpdate()
@@ -513,7 +509,7 @@ namespace Flow.Launcher.ViewModel
 
         public string PluginIconPath { get; set; } = null;
 
-        public string OpenResultCommandModifiers { get; private set; }
+        public string OpenResultCommandModifiers => Settings.OpenResultModifiers;
 
         public string Image => Constant.QueryTextBoxIconImagePath;
 
@@ -875,11 +871,6 @@ namespace Flow.Launcher.ViewModel
         }
 
         #region Hotkey
-
-        private void SetOpenResultModifiers()
-        {
-            OpenResultCommandModifiers = Settings.OpenResultModifiers ?? DefaultOpenResultModifiers;
-        }
 
         public void ToggleFlowLauncher()
         {

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -101,7 +101,7 @@ namespace Flow.Launcher.ViewModel
 
             RegisterViewUpdate();
             RegisterResultsUpdatedEvent();
-            RegisterClockAndDateUpdateAsync();
+            _ = RegisterClockAndDateUpdateAsync();
         }
 
         private void RegisterViewUpdate()


### PR DESCRIPTION
Changes:
- Refactored Toggle Game Mode logic.
- Fixed an issue that changing Open Result modifier in settings window won't reflect to main window.
- Formatting and removed redundant codes.

Tests:
- [x] Can toggle game mode by hotkey and context menu.
- [x] Changing Open Result modifier in settings window affects main window