### PR TITLE
Fix ImageCache when loading full image

### DIFF
--- a/Flow.Launcher.Infrastructure/Image/ImageCache.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageCache.cs
@@ -1,9 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Media;
 
 namespace Flow.Launcher.Infrastructure.Image

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -248,7 +248,7 @@ namespace Flow.Launcher.Infrastructure.Image
 
         public static bool CacheContainImage(string path, bool loadFullImage = false)
         {
-            return ImageCache.ContainsKey(path, false) && ImageCache[path, loadFullImage] != null;
+            return ImageCache.ContainsKey(path, loadFullImage) && ImageCache[path, loadFullImage] != null;
         }
 
         public static async ValueTask<ImageSource> LoadAsync(string path, bool loadFullImage = false)
@@ -259,10 +259,6 @@ namespace Flow.Launcher.Infrastructure.Image
             if (imageResult.ImageType != ImageType.Error && imageResult.ImageType != ImageType.Cache)
             { // we need to get image hash
                 string hash = EnableImageHash ? _hashGenerator.GetHashFromImage(img) : null;
-                if (imageResult.ImageType == ImageType.FullImageFile)
-                {
-                    path = $"{path}_{ImageType.FullImageFile}";
-                }
                 if (hash != null)
                 {
 
@@ -278,7 +274,7 @@ namespace Flow.Launcher.Infrastructure.Image
                 }
 
                 // update cache
-                ImageCache[path, false] = img;
+                ImageCache[path, loadFullImage] = img;
             }
 
             return img;

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -248,7 +248,7 @@ namespace Flow.Launcher.Infrastructure.Image
 
         public static bool CacheContainImage(string path, bool loadFullImage = false)
         {
-            return ImageCache.ContainsKey(path, loadFullImage) && ImageCache[path, loadFullImage] != null;
+            return ImageCache.ContainsKey(path, loadFullImage);
         }
 
         public static async ValueTask<ImageSource> LoadAsync(string path, bool loadFullImage = false)


### PR DESCRIPTION
No need to append ImageType to path. `loadfullimage==true` already indicates that it's a full image.