### PR TITLE
Refactor clear log folder logic

### DIFF
--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -3041,7 +3041,7 @@
                                                 Name="ClearLogFolderBtn"
                                                 Margin="0,0,12,0"
                                                 Click="ClearLogFolder"
-                                                Content="{Binding CheckLogFolder, UpdateSourceTrigger=PropertyChanged}" />
+                                                Content="{Binding CheckLogFolder, Mode=OneWay}" />
                                             <Button
                                                 Margin="0,0,8,0"
                                                 Content="&#xec7a;"

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -250,7 +250,7 @@ namespace Flow.Launcher
         }
         private void OpenLogFolder(object sender, RoutedEventArgs e)
         {
-            PluginManager.API.OpenDirectory(Path.Combine(DataLocation.DataDirectory(), Constant.Logs, Constant.Version));
+            viewModel.OpenLogFolder();
         }
         private void ClearLogFolder(object sender, RoutedEventArgs e)
         {
@@ -262,8 +262,6 @@ namespace Flow.Launcher
             if (confirmResult == MessageBoxResult.Yes)
             {
                 viewModel.ClearLogFolder();
-                
-                ClearLogFolderBtn.Content = viewModel.CheckLogFolder;
             }
         }
 

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -863,31 +863,48 @@ namespace Flow.Launcher.ViewModel
         {
             get
             {
-                var dirInfo = new DirectoryInfo(Path.Combine(DataLocation.DataDirectory(), Constant.Logs, Constant.Version));
-                long size = dirInfo.EnumerateFiles("*", SearchOption.AllDirectories).Sum(file => file.Length);
-
-                return _translater.GetTranslation("clearlogfolder") + " (" + FormatBytes(size) + ")";
+                var logFiles = GetLogFiles();
+                long size = logFiles.Sum(file => file.Length);
+                return string.Format("{0} ({1})", _translater.GetTranslation("clearlogfolder"), BytesToReadableString(size));
             }
+        }
+
+        private static DirectoryInfo GetLogDir(string version = "")
+        {
+            return new DirectoryInfo(Path.Combine(DataLocation.DataDirectory(), Constant.Logs, version));
+        }
+
+        private static List<FileInfo> GetLogFiles(string version = "")
+        {
+            return GetLogDir(version).EnumerateFiles("*", SearchOption.AllDirectories).ToList();
         }
 
         internal void ClearLogFolder()
         {
-            var directory = new DirectoryInfo(
-                Path.Combine(
-                    DataLocation.DataDirectory(),
-                    Constant.Logs,
-                    Constant.Version));
+            var logDirectory = GetLogDir();
+            var logFiles = GetLogFiles();
 
-            directory.EnumerateFiles()
+            logFiles.ForEach(f => f.Delete());
+
+            logDirectory.EnumerateDirectories("*", SearchOption.TopDirectoryOnly)
+                .Where(dir => !Constant.Version.Equals(dir.Name))
                 .ToList()
-                .ForEach(x => x.Delete());
+                .ForEach(dir => dir.Delete());
+
+            OnPropertyChanged(nameof(CheckLogFolder));
         }
-        internal string FormatBytes(long bytes)
+
+        internal void OpenLogFolder()
+        {
+            App.API.OpenDirectory(GetLogDir(Constant.Version).FullName);
+        }
+
+        internal static string BytesToReadableString(long bytes)
         {
             const int scale = 1024;
             string[] orders = new string[]
             {
-                "GB", "MB", "KB", "Bytes"
+                "GB", "MB", "KB", "B"
             };
             long max = (long)Math.Pow(scale, orders.Length - 1);
 
@@ -898,7 +915,7 @@ namespace Flow.Launcher.ViewModel
 
                 max /= scale;
             }
-            return "0 Bytes";
+            return "0 B";
         }
 
         #endregion


### PR DESCRIPTION
Changes:

- Clear logs of all versions
- Use binding for button text
- Move open log dir to vm
- Text: "Bytes" to "B"

Tests:
- Logs of all versions are cleared
- Log size text updated after clearing