### PR TITLE
Stop spell check on push

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -65,7 +65,7 @@ jobs:
     outputs:
       followup: ${{ steps.spelling.outputs.followup }}
     runs-on: ubuntu-latest
-    if: (contains(github.event_name, 'pull_request') && github.head_ref != 'l10n_dev') || github.event_name == 'push'
+    if: (contains(github.event_name, 'pull_request') && github.head_ref != 'l10n_dev')
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
       # note: If you use only_check_changed_files, you do not want cancel-in-progress
@@ -103,21 +103,21 @@ jobs:
 
 
 
-  comment-push:
-    name: Report (Push)
-    # If your workflow isn't running on push, you can remove this job
-    runs-on: ubuntu-latest
-    needs: spelling
-    permissions:
-      contents: write
-    if: (success() || failure()) && needs.spelling.outputs.followup && github.event_name == 'push'
-    steps:
-    - name: comment
-      uses: check-spelling/check-spelling@main
-      with:
-        checkout: true
-        spell_check_this: check-spelling/spell-check-this@main
-        task: ${{ needs.spelling.outputs.followup }}
+#   comment-push:
+#     name: Report (Push)
+#     # If your workflow isn't running on push, you can remove this job
+#     runs-on: ubuntu-latest
+#     needs: spelling
+#     permissions:
+#       contents: write
+#     if: (success() || failure()) && needs.spelling.outputs.followup && github.event_name == 'push'
+#     steps:
+#     - name: comment
+#       uses: check-spelling/check-spelling@main
+#       with:
+#         checkout: true
+#         spell_check_this: check-spelling/spell-check-this@main
+#         task: ${{ needs.spelling.outputs.followup }}
 
   comment-pr:
     name: Report (PR)

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -34,12 +34,12 @@ name: Check Spelling
 #   For background, see: https://github.com/check-spelling/check-spelling/wiki/Feature:-Update-with-deploy-key
 
 on:
-  push:
-    branches:
-    - '**'
-    - '!l10n_dev'
-    tags-ignore:
-    - "**"
+#   push:
+#     branches:
+#     - '**'
+#     - '!l10n_dev'
+#     tags-ignore:
+#     - "**"
   pull_request_target:
     branches:
     - '**'


### PR DESCRIPTION
Stop checking on push to avoid checking merge commits on dev branch. Commits of PRs can be checked on synchronized.