### PR TITLE
Safer Updater

### DIFF
--- a/Flow.Launcher.Core/Updater.cs
+++ b/Flow.Launcher.Core/Updater.cs
@@ -33,7 +33,7 @@ namespace Flow.Launcher.Core
 
         public async Task UpdateAppAsync(IPublicAPI api, bool silentUpdate = true)
         {
-            await UpdateLock.WaitAsync();
+            await UpdateLock.WaitAsync().ConfigureAwait(false);
             try
             {
                 if (!silentUpdate)
@@ -88,9 +88,13 @@ namespace Flow.Launcher.Core
                     UpdateManager.RestartApp(Constant.ApplicationFileName);
                 }
             }
-            catch (Exception e) when (e is HttpRequestException or WebException or SocketException || e.InnerException is TimeoutException)
+            catch (Exception e)
             {
-                Log.Exception($"|Updater.UpdateApp|Check your connection and proxy settings to github-cloud.s3.amazonaws.com.", e);
+                if ((e is HttpRequestException or WebException or SocketException || e.InnerException is TimeoutException))
+                    Log.Exception($"|Updater.UpdateApp|Check your connection and proxy settings to github-cloud.s3.amazonaws.com.", e);
+                else
+                    Log.Exception($"|Updater.UpdateApp|Error Occurred", e);
+                
                 if (!silentUpdate)
                     api.ShowMsg(api.GetTranslation("update_flowlauncher_fail"),
                         api.GetTranslation("update_flowlauncher_check_connection"));

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -92,7 +92,7 @@ namespace Flow.Launcher
                 // load plugin before change language, because plugin language also needs be changed
                 InternationalizationManager.Instance.Settings = _settings;
                 InternationalizationManager.Instance.ChangeLanguage(_settings.Language);
-                // main windows needs initialized before theme change because of blur settigns
+                // main windows needs initialized before theme change because of blur settings
                 ThemeManager.Instance.Settings = _settings;
                 ThemeManager.Instance.ChangeTheme(_settings.Theme);
 

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -88,7 +88,7 @@ namespace Flow.Launcher
 
                 HotKeyMapper.Initialize(_mainVM);
 
-                // happlebao todo temp fix for instance code logic
+                // todo temp fix for instance code logic
                 // load plugin before change language, because plugin language also needs be changed
                 InternationalizationManager.Instance.Settings = _settings;
                 InternationalizationManager.Instance.ChangeLanguage(_settings.Language);

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 using System.Windows;
@@ -84,7 +85,7 @@ namespace Flow.Launcher
 
                 Current.MainWindow = window;
                 Current.MainWindow.Title = Constant.FlowLauncher;
-                
+
                 HotKeyMapper.Initialize(_mainVM);
 
                 // happlebao todo temp fix for instance code logic
@@ -130,20 +131,17 @@ namespace Flow.Launcher
         //[Conditional("RELEASE")]
         private void AutoUpdates()
         {
-            Task.Run(async () =>
+            _ = Task.Run(async () =>
             {
                 if (_settings.AutoUpdates)
                 {
-                    // check udpate every 5 hours
-                    var timer = new Timer(1000 * 60 * 60 * 5);
-                    timer.Elapsed += async (s, e) =>
-                    {
-                        await _updater.UpdateAppAsync(API);
-                    };
-                    timer.Start();
-
-                    // check updates on startup
+                    // check update every 5 hours
+                    var timer = new PeriodicTimer(TimeSpan.FromHours(5));
                     await _updater.UpdateAppAsync(API);
+
+                    while (await timer.WaitForNextTickAsync())
+                        // check updates on startup
+                        await _updater.UpdateAppAsync(API);
                 }
             });
         }


### PR DESCRIPTION
might close https://github.com/Flow-Launcher/Flow.Launcher/issues/1504

Note:
I am not so sure why the autoupdater may crash flow itself...I guess it is because the Elapsed callback is triggered from the main thread, but I cannot find evidence to support it, because based on document, this happens only when SynchronizingObject is set which is not we have done.

Though, I have suppressed the error of general exception from updater, so now at least it will be safer to use the autoupdater.