### PR TITLE
Validate hotkey when setting it

### DIFF
--- a/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
@@ -28,19 +28,19 @@ namespace Flow.Launcher.Infrastructure.Hotkey
                 ModifierKeys modifierKeys = ModifierKeys.None;
                 if (Alt)
                 {
-                    modifierKeys = ModifierKeys.Alt;
+                    modifierKeys |= ModifierKeys.Alt;
                 }
                 if (Shift)
                 {
-                    modifierKeys = modifierKeys | ModifierKeys.Shift;
+                    modifierKeys |= ModifierKeys.Shift;
                 }
                 if (Win)
                 {
-                    modifierKeys = modifierKeys | ModifierKeys.Windows;
+                    modifierKeys |= ModifierKeys.Windows;
                 }
                 if (Ctrl)
                 {
-                    modifierKeys = modifierKeys | ModifierKeys.Control;
+                    modifierKeys |= ModifierKeys.Control;
                 }
                 return modifierKeys;
             }

--- a/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
@@ -11,10 +11,21 @@ namespace Flow.Launcher.Infrastructure.Hotkey
         public bool Shift { get; set; }
         public bool Win { get; set; }
         public bool Ctrl { get; set; }
-        public Key CharKey { get; set; }
 
+        private Key charKey = Key.None;
+        public Key CharKey
+        {
+            get => charKey;
+            set
+            {
+                if (ValidateHotkey(value))
+                {
+                    charKey = value;
+                }
+            }
+        }
 
-        Dictionary<Key, string> specialSymbolDictionary = new Dictionary<Key, string>
+        private static readonly Dictionary<Key, string> specialSymbolDictionary = new Dictionary<Key, string>
         {
             {Key.Space, "Space"},
             {Key.Oem3, "~"}
@@ -86,7 +97,7 @@ namespace Flow.Launcher.Infrastructure.Hotkey
                 Ctrl = true;
                 keys.Remove("Ctrl");
             }
-            if (keys.Count > 0)
+            if (keys.Count == 1)
             {
                 string charKey = keys[0];
                 KeyValuePair<Key, string>? specialSymbolPair = specialSymbolDictionary.FirstOrDefault(pair => pair.Value == charKey);
@@ -110,36 +121,61 @@ namespace Flow.Launcher.Infrastructure.Hotkey
 
         public override string ToString()
         {
-            string text = string.Empty;
+            List<string> keys = new List<string>();
             if (Ctrl)
             {
-                text += "Ctrl + ";
+                keys.Add("Ctrl");
             }
             if (Alt)
             {
-                text += "Alt + ";
+                keys.Add("Alt");
             }
             if (Shift)
             {
-                text += "Shift + ";
+                keys.Add("Shift");
             }
             if (Win)
             {
-                text += "Win + ";
+                keys.Add("Win");
             }
 
             if (CharKey != Key.None)
             {
-                text += specialSymbolDictionary.ContainsKey(CharKey)
+                keys.Add(specialSymbolDictionary.ContainsKey(CharKey)
                     ? specialSymbolDictionary[CharKey]
-                    : CharKey.ToString();
+                    : CharKey.ToString());
             }
-            else if (!string.IsNullOrEmpty(text))
-            {
-                text = text.Remove(text.Length - 3);
-            }
+            return string.Join(" + ", keys);
+        }
 
-            return text;
+        private static bool ValidateHotkey(Key key)
+        {
+            HashSet<Key> invalidKeys = new()
+            {
+                Key.LeftAlt, Key.RightAlt,
+                Key.LeftCtrl, Key.RightCtrl,
+                Key.LeftShift, Key.RightShift,
+                Key.LWin, Key.RWin,
+            };
+
+            return !invalidKeys.Contains(key);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is HotkeyModel other)
+            {
+                return ModifierKeys == other.ModifierKeys && CharKey == other.charKey;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            return this.ToString().GetHashCode();
         }
     }
 }

--- a/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
+using System.Windows.Navigation;
 
 namespace Flow.Launcher.Infrastructure.Hotkey
 {
@@ -148,7 +149,7 @@ namespace Flow.Launcher.Infrastructure.Hotkey
             return string.Join(" + ", keys);
         }
 
-        private static bool ValidateHotkey(Key key)
+        private bool ValidateHotkey(Key key)
         {
             HashSet<Key> invalidKeys = new()
             {
@@ -158,7 +159,15 @@ namespace Flow.Launcher.Infrastructure.Hotkey
                 Key.LWin, Key.RWin,
             };
 
-            return !invalidKeys.Contains(key);
+            if (invalidKeys.Contains(key)) 
+            {
+                return false;
+            }
+            if (ModifierKeys == ModifierKeys.None)
+            {
+                return key >= Key.F1 && key <= Key.F24;
+            }
+            return true;
         }
 
         public override bool Equals(object obj)

--- a/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
@@ -177,7 +177,7 @@ namespace Flow.Launcher.Infrastructure.Hotkey
 
         public override int GetHashCode()
         {
-            return this.ToString().GetHashCode();
+            return HashCode.Combine(ModifierKeys, CharKey);
         }
     }
 }

--- a/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
@@ -154,7 +154,9 @@ namespace Flow.Launcher.Infrastructure.Hotkey
                 default:
                     if (ModifierKeys == ModifierKeys.None)
                     {
-                        return CharKey >= Key.F1 && CharKey <= Key.F24;
+                        return !((CharKey >= Key.A && CharKey <= Key.Z) ||
+                            (CharKey >= Key.D0 && CharKey <= Key.D9) ||
+                            (CharKey >= Key.NumPad0 && CharKey <= Key.NumPad9));
                     }
                     else
                     {

--- a/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
@@ -13,18 +13,7 @@ namespace Flow.Launcher.Infrastructure.Hotkey
         public bool Win { get; set; }
         public bool Ctrl { get; set; }
 
-        private Key charKey = Key.None;
-        public Key CharKey
-        {
-            get => charKey;
-            set
-            {
-                if (ValidateHotkey(value))
-                {
-                    charKey = value;
-                }
-            }
-        }
+        public Key CharKey { get; set; } = Key.None;
 
         private static readonly Dictionary<Key, string> specialSymbolDictionary = new Dictionary<Key, string>
         {
@@ -149,32 +138,36 @@ namespace Flow.Launcher.Infrastructure.Hotkey
             return string.Join(" + ", keys);
         }
 
-        private bool ValidateHotkey(Key key)
+        public bool Validate()
         {
-            HashSet<Key> invalidKeys = new()
+            switch (CharKey)
             {
-                Key.LeftAlt, Key.RightAlt,
-                Key.LeftCtrl, Key.RightCtrl,
-                Key.LeftShift, Key.RightShift,
-                Key.LWin, Key.RWin,
-            };
-
-            if (invalidKeys.Contains(key)) 
-            {
-                return false;
+                case Key.LeftAlt:
+                case Key.RightAlt:
+                case Key.LeftCtrl:
+                case Key.RightCtrl:
+                case Key.LeftShift:
+                case Key.RightShift:
+                case Key.LWin:
+                case Key.RWin:
+                    return false;
+                default:
+                    if (ModifierKeys == ModifierKeys.None)
+                    {
+                        return CharKey >= Key.F1 && CharKey <= Key.F24;
+                    }
+                    else
+                    {
+                        return CharKey != Key.None;
+                    }
             }
-            if (ModifierKeys == ModifierKeys.None)
-            {
-                return key >= Key.F1 && key <= Key.F24;
-            }
-            return true;
         }
 
         public override bool Equals(object obj)
         {
             if (obj is HotkeyModel other)
             {
-                return ModifierKeys == other.ModifierKeys && CharKey == other.charKey;
+                return ModifierKeys == other.ModifierKeys && CharKey == other.CharKey;
             }
             else
             {

--- a/Flow.Launcher/HotkeyControl.xaml
+++ b/Flow.Launcher/HotkeyControl.xaml
@@ -48,6 +48,7 @@
             Margin="0,0,18,0"
             VerticalContentAlignment="Center"
             input:InputMethod.IsInputMethodEnabled="False"
+            GotFocus="tbHotkey_GotFocus"
             LostFocus="tbHotkey_LostFocus"
             PreviewKeyDown="TbHotkey_OnPreviewKeyDown"
             TabIndex="100" />

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -70,18 +70,8 @@ namespace Flow.Launcher
 
             if (triggerValidate)
             {
-                CurrentHotkeyAvailable = CurrentHotkey.CharKey != Key.None && CheckHotkeyAvailability();
-                if (!CurrentHotkeyAvailable)
-                {
-                    tbMsg.Foreground = new SolidColorBrush(Colors.Red);
-                    tbMsg.Text = InternationalizationManager.Instance.GetTranslation("hotkeyUnavailable");
-                }
-                else
-                {
-                    tbMsg.Foreground = new SolidColorBrush(Colors.Green);
-                    tbMsg.Text = InternationalizationManager.Instance.GetTranslation("success");
-                }
-                tbMsg.Visibility = Visibility.Visible;
+                bool hotkeyAvailable = keyModel.CharKey != Key.None && CheckHotkeyAvailability(keyModel);
+                SetMessage(hotkeyAvailable);
                 OnHotkeyChanged();
 
                 var token = hotkeyUpdateSource.Token;
@@ -116,6 +106,21 @@ namespace Flow.Launcher
         {
             tbMsg.Text = InternationalizationManager.Instance.GetTranslation("flowlauncherPressHotkey");
             tbMsg.SetResourceReference(TextBox.ForegroundProperty, "Color05B");
+        }
+
+        private void SetMessage(bool hotkeyAvailable)
+        {
+            if (!hotkeyAvailable)
+            {
+                tbMsg.Foreground = new SolidColorBrush(Colors.Red);
+                tbMsg.Text = InternationalizationManager.Instance.GetTranslation("hotkeyUnavailable");
+            }
+            else
+            {
+                tbMsg.Foreground = new SolidColorBrush(Colors.Green);
+                tbMsg.Text = InternationalizationManager.Instance.GetTranslation("success");
+            }
+            tbMsg.Visibility = Visibility.Visible;
         }
     }
 }

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -14,10 +14,6 @@ namespace Flow.Launcher
 {
     public partial class HotkeyControl : UserControl
     {
-        private Brush tbMsgForegroundColorOriginal;
-
-        private string tbMsgTextOriginal;
-
         public HotkeyModel CurrentHotkey { get; private set; }
         public bool CurrentHotkeyAvailable { get; private set; }
 
@@ -28,8 +24,6 @@ namespace Flow.Launcher
         public HotkeyControl()
         {
             InitializeComponent();
-            tbMsgTextOriginal = tbMsg.Text;
-            tbMsgForegroundColorOriginal = tbMsg.Foreground;
         }
 
         private CancellationTokenSource hotkeyUpdateSource;
@@ -110,7 +104,17 @@ namespace Flow.Launcher
 
         private void tbHotkey_LostFocus(object sender, RoutedEventArgs e)
         {
-            tbMsg.Text = tbMsgTextOriginal;
+            
+        }
+
+        private void tbHotkey_GotFocus(object sender, RoutedEventArgs e)
+        {
+            ResetMessage();
+        }
+
+        private void ResetMessage()
+        {
+            tbMsg.Text = InternationalizationManager.Instance.GetTranslation("flowlauncherPressHotkey");
             tbMsg.SetResourceReference(TextBox.ForegroundProperty, "Color05B");
         }
     }

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -70,7 +70,7 @@ namespace Flow.Launcher
 
             if (triggerValidate)
             {
-                bool hotkeyAvailable = keyModel.CharKey != Key.None && CheckHotkeyAvailability(keyModel);
+                bool hotkeyAvailable = CheckHotkeyAvailability(keyModel);
                 SetMessage(hotkeyAvailable);
                 OnHotkeyChanged();
 
@@ -88,7 +88,7 @@ namespace Flow.Launcher
             return SetHotkeyAsync(new HotkeyModel(keyStr), triggerValidate);
         }
 
-        private bool CheckHotkeyAvailability() => HotKeyMapper.CheckAvailability(CurrentHotkey);
+        private static bool CheckHotkeyAvailability(HotkeyModel hotkey) => hotkey.Validate() && HotKeyMapper.CheckAvailability(hotkey);
 
         public new bool IsFocused => tbHotkey.IsFocused;
 

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -54,9 +54,7 @@ namespace Flow.Launcher
                 specialKeyState.CtrlPressed,
                 key);
 
-            var hotkeyString = hotkeyModel.ToString();
-
-            if (hotkeyString == tbHotkey.Text)
+            if (hotkeyModel.Equals(CurrentHotkey))
             {
                 return;
             }

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -9,7 +9,6 @@ using Flow.Launcher.Helper;
 using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Plugin;
 using System.Threading;
-using System.Windows.Interop;
 
 namespace Flow.Launcher
 {
@@ -79,7 +78,7 @@ namespace Flow.Launcher
 
             if (triggerValidate)
             {
-                CurrentHotkeyAvailable = CheckHotkeyAvailability();
+                CurrentHotkeyAvailable = CurrentHotkey.CharKey != Key.None && CheckHotkeyAvailability();
                 if (!CurrentHotkeyAvailable)
                 {
                     tbMsg.Foreground = new SolidColorBrush(Colors.Red);

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -103,7 +103,8 @@ namespace Flow.Launcher
 
         private void tbHotkey_LostFocus(object sender, RoutedEventArgs e)
         {
-
+            tbHotkey.Text = CurrentHotkey.ToString();
+            tbHotkey.Select(tbHotkey.Text.Length, 0);
         }
 
         private void tbHotkey_GotFocus(object sender, RoutedEventArgs e)

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -63,14 +63,13 @@ namespace Flow.Launcher
 
         public async Task SetHotkeyAsync(HotkeyModel keyModel, bool triggerValidate = true)
         {
-            CurrentHotkey = keyModel;
-
-            tbHotkey.Text = CurrentHotkey.ToString();
+            tbHotkey.Text = keyModel.ToString();
             tbHotkey.Select(tbHotkey.Text.Length, 0);
 
             if (triggerValidate)
             {
                 bool hotkeyAvailable = CheckHotkeyAvailability(keyModel);
+                CurrentHotkeyAvailable = hotkeyAvailable;
                 SetMessage(hotkeyAvailable);
                 OnHotkeyChanged();
 
@@ -78,8 +77,18 @@ namespace Flow.Launcher
                 await Task.Delay(500, token);
                 if (token.IsCancellationRequested)
                     return;
-                FocusManager.SetFocusedElement(FocusManager.GetFocusScope(this), null);
-                Keyboard.ClearFocus();
+
+                if (CurrentHotkeyAvailable)
+                {
+                    CurrentHotkey = keyModel;
+                    // To trigger LostFocus
+                    FocusManager.SetFocusedElement(FocusManager.GetFocusScope(this), null);
+                    Keyboard.ClearFocus();
+                }
+            }
+            else
+            {
+                CurrentHotkey = keyModel;
             }
         }
 
@@ -94,7 +103,7 @@ namespace Flow.Launcher
 
         private void tbHotkey_LostFocus(object sender, RoutedEventArgs e)
         {
-            
+
         }
 
         private void tbHotkey_GotFocus(object sender, RoutedEventArgs e)

--- a/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
@@ -27,7 +27,7 @@ namespace Flow.Launcher.Resources.Pages
             tbMsgTextOriginal = HotkeyControl.tbMsg.Text;
             tbMsgForegroundColorOriginal = HotkeyControl.tbMsg.Foreground;
 
-            HotkeyControl.SetHotkeyAsync(new Infrastructure.Hotkey.HotkeyModel(Settings.Hotkey), false);
+            HotkeyControl.SetHotkeyAsync(Settings.Hotkey, false);
         }
         private void HotkeyControl_OnGotFocus(object sender, RoutedEventArgs args)
         {


### PR DESCRIPTION
- Prevent user from setting single "Alt" "Ctrl" "Shift" "Win" as hotkey. Fix #1755.
- Prevent setting single alphanumeric key as hotkey.
- - When a pressed hotkey is unavailable, stay focused inside the text box so user can continue to try a new hotkey.
- When clicked away and the hotkey is unavailable, return to the previous set hotkey.

Tests:
- Toggle hotkey can be modified.
- Preview hotkey can be modified.
- Single special key can't be set as hotkey.
- Single function key can be set as hotkey.
- Single alphanumeric key can't be set as hotkey.
- When a pressed hotkey is unavailable, stay focused inside the text box so user can continue to try a new hotkey.
- When clicked away and the hotkey is unavailable, return to the previous set hotkey.