### PR TITLE
Add slash to active explorer path return string

### DIFF
--- a/Flow.Launcher.Infrastructure/FileExplorerHelper.cs
+++ b/Flow.Launcher.Infrastructure/FileExplorerHelper.cs
@@ -15,7 +15,7 @@ namespace Flow.Launcher.Infrastructure
         {
             var explorerWindow = GetActiveExplorer();
             string locationUrl = explorerWindow?.LocationURL;
-            return !string.IsNullOrEmpty(locationUrl) ? new Uri(locationUrl).LocalPath : null;
+            return !string.IsNullOrEmpty(locationUrl) ? new Uri(locationUrl).LocalPath + "\\" : null;
         }
 
         /// <summary>


### PR DESCRIPTION
When used via Explorer plugin this will help results come up already inside the directory.