### PR TITLE
Always show/search description in program results if enabled

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/UWP.cs
@@ -378,15 +378,10 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 MatchResult matchResult;
 
                 // We suppose Name won't be null
-                if (!Main._settings.EnableDescription || Description == null || Name.StartsWith(Description))
+                if (!Main._settings.EnableDescription || string.IsNullOrWhiteSpace(Description) || Name.Equals(Description))
                 {
                     title = Name;
-                    matchResult = StringMatcher.FuzzySearch(query, title);
-                }
-                else if (Description.StartsWith(Name))
-                {
-                    title = Description;
-                    matchResult = StringMatcher.FuzzySearch(query, Description);
+                    matchResult = StringMatcher.FuzzySearch(query, Name);
                 }
                 else
                 {
@@ -401,10 +396,13 @@ namespace Flow.Launcher.Plugin.Program.Programs
                         }
                         matchResult = descriptionMatch;
                     }
-                    else matchResult = nameMatch;
+                    else
+                    {
+                        matchResult = nameMatch;
+                    }
                 }
 
-                if (!matchResult.Success)
+                if (!matchResult.IsSearchPrecisionScoreMet())
                     return null;
 
                 var result = new Result

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -90,44 +90,28 @@ namespace Flow.Launcher.Plugin.Program.Programs
             bool useLocalizedName = !string.IsNullOrEmpty(LocalizedName) && !Name.Equals(LocalizedName);
             string resultName = useLocalizedName ? LocalizedName : Name;
 
-            if (!Main._settings.EnableDescription)
+            if (!Main._settings.EnableDescription || string.IsNullOrWhiteSpace(Description) || resultName.Equals(Description))
             {
                 title = resultName;
                 matchResult = StringMatcher.FuzzySearch(query, resultName);
             }
             else
             {
-                if (string.IsNullOrEmpty(Description) || resultName.StartsWith(Description))
+                // Search in both
+                title = $"{resultName}: {Description}";
+                var nameMatch = StringMatcher.FuzzySearch(query, resultName);
+                var descriptionMatch = StringMatcher.FuzzySearch(query, Description);
+                if (descriptionMatch.Score > nameMatch.Score)
                 {
-                    // Description is invalid or included in resultName
-                    // Description is always localized, so Name.StartsWith(Description) is generally useless
-                    title = resultName;
-                    matchResult = StringMatcher.FuzzySearch(query, resultName);
-                }
-                else if (Description.StartsWith(resultName))
-                {
-                    // resultName included in Description
-                    title = Description;
-                    matchResult = StringMatcher.FuzzySearch(query, Description);
+                    for (int i = 0; i < descriptionMatch.MatchData.Count; i++)
+                    {
+                        descriptionMatch.MatchData[i] += resultName.Length + 2; // 2 is ": "
+                    }
+                    matchResult = descriptionMatch;
                 }
                 else
                 {
-                    // Search in both
-                    title = $"{resultName}: {Description}";
-                    var nameMatch = StringMatcher.FuzzySearch(query, resultName);
-                    var descriptionMatch = StringMatcher.FuzzySearch(query, Description);
-                    if (descriptionMatch.Score > nameMatch.Score)
-                    {
-                        for (int i = 0; i < descriptionMatch.MatchData.Count; i++)
-                        {
-                            descriptionMatch.MatchData[i] += resultName.Length + 2; // 2 is ": "
-                        }
-                        matchResult = descriptionMatch;
-                    }
-                    else
-                    {
-                        matchResult = nameMatch;
-                    }
+                    matchResult = nameMatch;
                 }
             }
 


### PR DESCRIPTION
Always show/search description in program results if description is enabled in settings. If name and desc are equal the desc is omitted.


This pr is done because an uwp app named "Xbox" but with a description "XboxPcApp". Currently in this case the result title is "XboxPcApp" when description is enabled. In this pr the title will be "Xbox: XboxPcApp".

P.S: The diff view is messy somehow. git blame is fine. Most of the changes are deletion.

Change:
- Always show description if enabled, unless name and description are equal.


Test:
- programs can be searched via name and description