### PR TITLE
Fix bugs in explorer plugin

### DIFF
--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-#if !DEBUG
+#pragma warning disable IDE0005
 using System.Windows;
-#endif
+#pragma warning restore IDE0005
 
 namespace Flow.Launcher.Plugin.SharedCommands
 {

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -254,7 +254,7 @@ namespace Flow.Launcher.Plugin.SharedCommands
         /// <returns></returns>
         public static bool PathContains(string parentPath, string subPath, bool allowEqual = false)
         {
-            var rel = Path.GetRelativePath(parentPath, subPath);
+            var rel = Path.GetRelativePath(parentPath.EnsureTrailingSlash(), subPath);
             return (rel != "." || allowEqual)
                    && rel != ".."
                    && !rel.StartsWith("../")

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Windows;
 
 namespace Flow.Launcher.Plugin.SharedCommands
 {
@@ -243,16 +242,17 @@ namespace Flow.Launcher.Plugin.SharedCommands
         }
 
         /// <summary>
-        /// Returns if <paramref name="subPath"/> is a sub path of <paramref name="basePath"/>.
+        /// Returns if <paramref name="parentPath"/> contains <paramref name="subPath"/>.
         /// From https://stackoverflow.com/a/66877016
         /// </summary>
-        /// <param name="subPath"></param>
-        /// <param name="basePath"></param>
+        /// <param name="parentPath">Parent path</param>
+        /// <param name="subPath">Sub path</param>
+        /// <param name="allowEqual">If <see langword="true"/>, when <paramref name="parentPath"/> and <paramref name="subPath"/> are equal, returns <see langword="true"/></param>
         /// <returns></returns>
-        public static bool IsSubPathOf(string subPath, string basePath)
+        public static bool PathContains(string parentPath, string subPath, bool allowEqual = false)
         {
-            var rel = Path.GetRelativePath(basePath, subPath);
-            return rel != "."
+            var rel = Path.GetRelativePath(parentPath, subPath);
+            return (rel != "." || allowEqual)
                    && rel != ".."
                    && !rel.StartsWith("../")
                    && !rel.StartsWith(@"..\")

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -261,5 +261,15 @@ namespace Flow.Launcher.Plugin.SharedCommands
                    && !rel.StartsWith(@"..\")
                    && !Path.IsPathRooted(rel);
         }
+        
+        /// <summary>
+        /// Returns path ended with "\"
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public static string EnsureTrailingSlash(this string path)
+        {
+            return path.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        }
     }
 }

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+#if !DEBUG
+using System.Windows;
+#endif
 
 namespace Flow.Launcher.Plugin.SharedCommands
 {

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -241,5 +241,22 @@ namespace Flow.Launcher.Plugin.SharedCommands
 
             return path;
         }
+
+        /// <summary>
+        /// Returns if <paramref name="subPath"/> is a sub path of <paramref name="basePath"/>.
+        /// From https://stackoverflow.com/a/66877016
+        /// </summary>
+        /// <param name="subPath"></param>
+        /// <param name="basePath"></param>
+        /// <returns></returns>
+        public static bool IsSubPathOf(string subPath, string basePath)
+        {
+            var rel = Path.GetRelativePath(basePath, subPath);
+            return rel != "."
+                   && rel != ".."
+                   && !rel.StartsWith("../")
+                   && !rel.StartsWith(@"..\")
+                   && !Path.IsPathRooted(rel);
+        }
     }
 }

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -208,22 +208,16 @@ namespace Flow.Launcher.Plugin.SharedCommands
         ///</summary>
         public static string GetPreviousExistingDirectory(Func<string, bool> locationExists, string path)
         {
-            var previousDirectoryPath = "";
             var index = path.LastIndexOf('\\');
             if (index > 0 && index < (path.Length - 1))
             {
-                previousDirectoryPath = path.Substring(0, index + 1);
-                if (!locationExists(previousDirectoryPath))
-                {
-                    return "";
-                }
+                string previousDirectoryPath = path.Substring(0, index + 1);
+                return locationExists(previousDirectoryPath) ? previousDirectoryPath : "";
             }
             else
             {
                 return "";
             }
-
-            return previousDirectoryPath;
         }
 
         ///<summary>

--- a/Flow.Launcher.Test/FilesFoldersTest.cs
+++ b/Flow.Launcher.Test/FilesFoldersTest.cs
@@ -44,7 +44,7 @@ namespace Flow.Launcher.Test
 
         [TestCase(@"c:\foo", @"c:\foo", true)]
         [TestCase(@"c:\foo\", @"c:\foo", true)]
-        [TestCase(@"c:\foo\", @"c:\foo", true)]
+        [TestCase(@"c:\foo", @"c:\foo\", true)]
         public void TestPathContainsWhenEqual(string parentPath, string path, bool expectedResult)
         {
             Assert.AreEqual(expectedResult, FilesFolders.PathContains(parentPath, path, true));

--- a/Flow.Launcher.Test/FilesFoldersTest.cs
+++ b/Flow.Launcher.Test/FilesFoldersTest.cs
@@ -1,0 +1,53 @@
+﻿using Flow.Launcher.Plugin.SharedCommands;
+using NUnit.Framework;
+
+namespace Flow.Launcher.Test
+{
+    [TestFixture]
+    
+    public class FilesFoldersTest
+    {
+        // Testcases from https://stackoverflow.com/a/31941905/20703207
+        // Disk
+        [TestCase(@"c:", @"c:\foo", true)]
+        [TestCase(@"c:\", @"c:\foo", true)]
+        // Slash
+        [TestCase(@"c:\foo\bar\", @"c:\foo\", false)]
+        [TestCase(@"c:\foo\bar", @"c:\foo\", false)]
+        [TestCase(@"c:\foo", @"c:\foo\bar", true)]
+        [TestCase(@"c:\foo\", @"c:\foo\bar", true)]
+        // File
+        [TestCase(@"c:\foo", @"c:\foo\a.txt", true)]
+        [TestCase(@"c:\foo", @"c:/foo/a.txt", true)]
+        [TestCase(@"c:\FOO\a.txt", @"c:\foo", false)]
+        [TestCase(@"c:\foo\a.txt", @"c:\foo\", false)]
+        [TestCase(@"c:\foobar\a.txt", @"c:\foo", false)]
+        [TestCase(@"c:\foobar\a.txt", @"c:\foo\", false)]
+        [TestCase(@"c:\foo\", @"c:\foo.txt", false)]
+        // Prefix
+        [TestCase(@"c:\foo", @"c:\foobar", false)]
+        [TestCase(@"C:\Program", @"C:\Program Files\", false)]
+        [TestCase(@"c:\foobar", @"c:\foo\a.txt", false)]
+        [TestCase(@"c:\foobar\", @"c:\foo\a.txt", false)]
+        // Edge case
+        [TestCase(@"c:\foo", @"c:\foo\..\bar\baz", false)]
+        [TestCase(@"c:\bar", @"c:\foo\..\bar\baz", true)]
+        [TestCase(@"c:\barr", @"c:\foo\..\bar\baz", false)]
+        // Equality
+        [TestCase(@"c:\foo", @"c:\foo", false)]
+        [TestCase(@"c:\foo\", @"c:\foo", false)]
+        [TestCase(@"c:\foo", @"c:\foo\", false)]
+        public void TestPathContains(string parentPath, string path, bool expectedResult)
+        {
+            Assert.AreEqual(expectedResult, FilesFolders.PathContains(parentPath, path));
+        }
+
+        [TestCase(@"c:\foo", @"c:\foo", true)]
+        [TestCase(@"c:\foo\", @"c:\foo", true)]
+        [TestCase(@"c:\foo\", @"c:\foo", true)]
+        public void TestPathContainsWhenEqual(string parentPath, string path, bool expectedResult)
+        {
+            Assert.AreEqual(expectedResult, FilesFolders.PathContains(parentPath, path, true));
+        }
+    }
+}

--- a/Flow.Launcher.Test/FilesFoldersTest.cs
+++ b/Flow.Launcher.Test/FilesFoldersTest.cs
@@ -1,4 +1,4 @@
-﻿using Flow.Launcher.Plugin.SharedCommands;
+using Flow.Launcher.Plugin.SharedCommands;
 using NUnit.Framework;
 
 namespace Flow.Launcher.Test
@@ -37,7 +37,7 @@ namespace Flow.Launcher.Test
         [TestCase(@"c:\foo", @"c:\foo", false)]
         [TestCase(@"c:\foo\", @"c:\foo", false)]
         [TestCase(@"c:\foo", @"c:\foo\", false)]
-        public void TestPathContains(string parentPath, string path, bool expectedResult)
+        public void GivenTwoPaths_WhenCheckPathContains_ThenShouldBeExpectedResult(string parentPath, string path, bool expectedResult)
         {
             Assert.AreEqual(expectedResult, FilesFolders.PathContains(parentPath, path));
         }
@@ -45,7 +45,7 @@ namespace Flow.Launcher.Test
         [TestCase(@"c:\foo", @"c:\foo", true)]
         [TestCase(@"c:\foo\", @"c:\foo", true)]
         [TestCase(@"c:\foo", @"c:\foo\", true)]
-        public void TestPathContainsWhenEqual(string parentPath, string path, bool expectedResult)
+        public void GivenTwoPathsAreTheSame_WhenCheckPathContains_ThenShouldBeTrue(string parentPath, string path, bool expectedResult)
         {
             Assert.AreEqual(expectedResult, FilesFolders.PathContains(parentPath, path, true));
         }

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -7,9 +7,11 @@ using Flow.Launcher.Plugin.SharedCommands;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
+using static Flow.Launcher.Plugin.Explorer.Search.SearchManager;
 
 namespace Flow.Launcher.Test.Plugins
 {
@@ -393,6 +395,45 @@ namespace Flow.Launcher.Test.Plugins
 
             // Then
             Assert.AreEqual(result, expectedResult);
+        }
+
+        [TestCase(@"c:\foo", @"c:\foo", true)]
+        [TestCase(@"C:\Foo\", @"c:\foo\", true)]
+        [TestCase(@"c:\foo", @"c:\foo\", false)]
+        public void PathEqualityComparatorEquality(string path1, string path2, bool expectedResult)
+        {
+            var comparator = PathEqualityComparator.Instance;
+            var result1 = new Result
+            {
+                Title = Path.GetFileName(path1),
+                SubTitle = path1
+            };
+            var result2 = new Result
+            {
+                Title = Path.GetFileName(path2),
+                SubTitle = path2
+            };
+            Assert.AreEqual(expectedResult, comparator.Equals(result1, result2));
+        }
+
+        [TestCase(@"c:\foo\", @"c:\foo\")]
+        [TestCase(@"C:\Foo\", @"c:\foo\")]
+        public void PathEqualityComparatorHashCode(string path1, string path2)
+        {
+            var comparator = PathEqualityComparator.Instance;
+            var result1 = new Result
+            {
+                Title = Path.GetFileName(path1),
+                SubTitle = path1
+            };
+            var result2 = new Result
+            {
+                Title = Path.GetFileName(path2),
+                SubTitle = path2
+            };
+            var hash1 = comparator.GetHashCode(result1);
+            var hash2 = comparator.GetHashCode(result2);
+            Assert.IsTrue(hash1 == hash2);
         }
     }
 }

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -400,8 +400,9 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase(@"c:\foo", @"c:\foo", true)]
         [TestCase(@"C:\Foo\", @"c:\foo\", true)]
         [TestCase(@"c:\foo", @"c:\foo\", false)]
-        public void PathEqualityComparatorEquality(string path1, string path2, bool expectedResult)
+        public void GivenTwoPaths_WhenCompared_ThenShouldBeExpectedSameOrDifferent(string path1, string path2, bool expectedResult)
         {
+            // Given
             var comparator = PathEqualityComparator.Instance;
             var result1 = new Result
             {
@@ -413,13 +414,16 @@ namespace Flow.Launcher.Test.Plugins
                 Title = Path.GetFileName(path2),
                 SubTitle = path2
             };
+
+            // When, Then
             Assert.AreEqual(expectedResult, comparator.Equals(result1, result2));
         }
 
         [TestCase(@"c:\foo\", @"c:\foo\")]
         [TestCase(@"C:\Foo\", @"c:\foo\")]
-        public void PathEqualityComparatorHashCode(string path1, string path2)
+        public void GivenTwoPaths_WhenComparedHasCode_ThenShouldBeSame(string path1, string path2)
         {
+            // Given
             var comparator = PathEqualityComparator.Instance;
             var result1 = new Result
             {
@@ -431,8 +435,11 @@ namespace Flow.Launcher.Test.Plugins
                 Title = Path.GetFileName(path2),
                 SubTitle = path2
             };
+
             var hash1 = comparator.GetHashCode(result1);
             var hash2 = comparator.GetHashCode(result2);
+
+            // When, Then
             Assert.IsTrue(hash1 == hash2);
         }
     }

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -442,5 +442,22 @@ namespace Flow.Launcher.Test.Plugins
             // When, Then
             Assert.IsTrue(hash1 == hash2);
         }
+
+        [TestCase(@"%appdata%", true)]
+        [TestCase(@"%appdata%\123", true)]
+        [TestCase(@"c:\foo %appdata%\", false)]
+        [TestCase(@"c:\users\%USERNAME%\downloads", true)]
+        [TestCase(@"c:\downloads", false)]
+        [TestCase(@"%", false)]
+        [TestCase(@"%%", false)]
+        [TestCase(@"%bla%blabla%", false)]
+        public void GivenPath_WhenHavingEnvironmentVariableOrNot_ThenShouldBeExpected(string path, bool expectedResult)
+        {
+            // When
+            var result = EnvironmentVariables.HasEnvironmentVar(path);
+
+            // Then
+            Assert.AreEqual(result, expectedResult);
+        }
     }
 }

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -176,7 +176,7 @@ namespace Flow.Launcher.Test.Plugins
             var searchManager = new SearchManager(new Settings(), new PluginInitContext());
 
             // When
-            var result = SearchManager.IsFileContentSearch(query.ActionKeyword);
+            var result = searchManager.IsFileContentSearch(query.ActionKeyword);
 
             // Then
             Assert.IsTrue(result,
@@ -193,6 +193,7 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase(@"c:\>*", true)]
         [TestCase(@"c:\>", true)]
         [TestCase(@"c:\SomeLocation\SomeOtherLocation\>", true)]
+        [TestCase(@"c:\SomeLocation\SomeOtherLocation", true)]
         public void WhenGivenQuerySearchString_ThenShouldIndicateIfIsLocationPathString(string querySearchString, bool expectedResult)
         {
             // When, Given

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Exceptions/EngineNotAvailableException.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Exceptions/EngineNotAvailableException.cs
@@ -3,8 +3,6 @@
 using System;
 using System.Threading.Tasks;
 using System.Windows;
-using Flow.Launcher.Plugin.Explorer.Search.IProvider;
-using JetBrains.Annotations;
 
 namespace Flow.Launcher.Plugin.Explorer.Exceptions;
 
@@ -20,7 +18,7 @@ public class EngineNotAvailableException : Exception
         string engineName,
         string resolution,
         string message,
-        Func<ActionContext, ValueTask<bool>> action = null) : base(message)
+        Func<ActionContext, ValueTask<bool>>? action = null) : base(message)
     {
         EngineName = engineName;
         Resolution = resolution;
@@ -39,6 +37,23 @@ public class EngineNotAvailableException : Exception
     {
         EngineName = engineName;
         Resolution = resolution;
+    }
+    
+    public EngineNotAvailableException(
+    string engineName,
+    string resolution,
+    string message,
+    string errorIconPath,
+    Func<ActionContext, ValueTask<bool>>? action = null) : base(message)
+    {
+        EngineName = engineName;
+        Resolution = resolution;
+        ErrorIcon = errorIconPath;
+        Action = action ?? (_ =>
+        {
+            Clipboard.SetDataObject(this.ToString());
+            return ValueTask.FromResult(true);
+        });
     }
 
     public override string ToString()

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
@@ -52,8 +52,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                     path = Path.IsPathFullyQualified(path) ? path : Path.GetFullPath(path);
 
                     // Variables are returned with a mixture of all upper/lower case. 
-                    // Call ToLower() to make the results look consistent
-                    envStringPaths.Add(special.Key.ToString().ToLower(), path);
+                    // Call ToUpper() to make the results look consistent
+                    envStringPaths.Add(special.Key.ToString().ToUpper(), path);
                 }
             }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
@@ -16,7 +16,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             {
                 if (_envStringPaths == null)
                 {
-                    _envStringPaths = LoadEnvironmentStringPaths();
+                    LoadEnvironmentStringPaths();
                 }
                 return _envStringPaths;
             }
@@ -40,9 +40,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                                         dir.Split('%').Length == 3);
         }
 
-        internal static Dictionary<string, string> LoadEnvironmentStringPaths()
+        private static void LoadEnvironmentStringPaths()
         {
-            var envStringPaths = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+            _envStringPaths = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
             var homedrive = Environment.GetEnvironmentVariable("HOMEDRIVE")?.EnsureTrailingSlash() ?? "C:\\";
 
             foreach (DictionaryEntry special in Environment.GetEnvironmentVariables())
@@ -61,11 +61,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 {
                     // Variables are returned with a mixture of all upper/lower case. 
                     // Call ToUpper() to make the results look consistent
-                    envStringPaths.Add(special.Key.ToString().ToUpper(), path);
+                    _envStringPaths.Add(special.Key.ToString().ToUpper(), path);
                 }
             }
-
-            return envStringPaths;
         }
 
         internal static List<Result> GetEnvironmentStringPathSuggestions(string querySearch, Query query, PluginInitContext context)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Plugin.Explorer.Search
@@ -29,9 +30,14 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                     && EnvStringPaths.Count > 0;
         }
 
-        internal static bool BeginsWithEnvironmentVar(string search)
+        public static bool HasEnvironmentVar(string search)
         {
-            return search[0] == '%' && search[1..].Contains("%\\");
+            // "c:\foo %appdata%\" returns false
+            var splited = search.Split(Path.DirectorySeparatorChar);
+            return splited.Any(dir => dir.StartsWith('%') && 
+                                        dir.EndsWith('%') &&
+                                        dir.Length > 2 &&
+                                        dir.Split('%').Length == 3);
         }
 
         internal static Dictionary<string, string> LoadEnvironmentStringPaths()

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/EnvironmentVariables.cs
@@ -60,11 +60,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             return envStringPaths;
         }
 
-        internal static string TranslateEnvironmentVariablePath(string environmentVariablePath)
-        {
-            return Environment.ExpandEnvironmentVariables(environmentVariablePath);
-        }
-
         internal static List<Result> GetEnvironmentStringPathSuggestions(string querySearch, Query query, PluginInitContext context)
         {
             var results = new List<Result>();

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingSearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingSearchManager.cs
@@ -27,20 +27,16 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                         Enum.GetName(Settings.IndexSearchEngineOption.Everything)!,
                         Main.Context.API.GetTranslation("flowlauncher_plugin_everything_click_to_launch_or_install"),
                         Main.Context.API.GetTranslation("flowlauncher_plugin_everything_is_not_running"),
-                        ClickToInstallEverythingAsync)
-                    {
-                        ErrorIcon = Constants.EverythingErrorImagePath
-                    };
+                        Constants.EverythingErrorImagePath,
+                        ClickToInstallEverythingAsync);
             }
             catch (DllNotFoundException)
             {
                 throw new EngineNotAvailableException(
                     Enum.GetName(Settings.IndexSearchEngineOption.Everything)!,
                     "Please check whether your system is x86 or x64",
-                    Main.Context.API.GetTranslation("flowlauncher_plugin_everything_sdk_issue"))
-                {
-                    ErrorIcon = Constants.GeneralSearchErrorImagePath
-                };
+                    Constants.GeneralSearchErrorImagePath,
+                    Main.Context.API.GetTranslation("flowlauncher_plugin_everything_sdk_issue"));
             }
         }
         private async ValueTask<bool> ClickToInstallEverythingAsync(ActionContext _)
@@ -72,16 +68,14 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             if (!Settings.EnableEverythingContentSearch)
             {
                 throw new EngineNotAvailableException(Enum.GetName(Settings.IndexSearchEngineOption.Everything)!,
-                    "Click to Enable Everything Content Search (only applicable to Everything 1.5+ with indexed content)",
-                    "Everything Content Search is not enabled.",
+                    Main.Context.API.GetTranslation("flowlauncher_plugin_everything_enable_content_search"),
+                    Main.Context.API.GetTranslation("flowlauncher_plugin_everything_enable_content_search_tips"),
+                    Constants.EverythingErrorImagePath,
                     _ =>
                     {
                         Settings.EnableEverythingContentSearch = true;
                         return ValueTask.FromResult(true);
-                    })
-                {
-                    ErrorIcon = Constants.EverythingErrorImagePath
-                };
+                    });
             }
             if (token.IsCancellationRequested)
                 yield break;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -71,7 +71,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             {
                 Title = title,
                 IcoPath = path,
-                SubTitle = Path.GetDirectoryName(path),
+                SubTitle = subtitle,
                 AutoCompleteText = GetAutoCompleteText(title, query, path, ResultType.Folder),
                 TitleHighlightData = StringMatcher.FuzzySearch(query.Search, title).MatchData,
                 CopyText = path,

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -121,7 +121,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             }
 
             results.RemoveWhere(r => Settings.IndexSearchExcludedSubdirectoryPaths.Any(
-                excludedPath => IsSubPathOf(r.SubTitle, excludedPath.Path)));
+                excludedPath => FilesFolders.IsSubPathOf(r.SubTitle, excludedPath.Path)));
 
             return results.ToList();
         }
@@ -255,17 +255,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             return search.StartsWith("%") 
                    && search != "%%"
                    && !search.Contains('\\');
-        }
-
-        // https://stackoverflow.com/a/66877016
-        internal static bool IsSubPathOf(string subPath, string basePath)
-        {
-            var rel = Path.GetRelativePath(basePath, subPath);
-            return rel != "."
-                   && rel != ".."
-                   && !rel.StartsWith("../")
-                   && !rel.StartsWith(@"..\")
-                   && !Path.IsPathRooted(rel);
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Flow.Launcher.Plugin.Explorer.Exceptions;
+using System.IO;
 
 namespace Flow.Launcher.Plugin.Explorer.Search
 {
@@ -119,7 +120,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             }
             
             results.RemoveWhere(r => Settings.IndexSearchExcludedSubdirectoryPaths.Any(
-                excludedPath => r.SubTitle.StartsWith(excludedPath.Path, StringComparison.OrdinalIgnoreCase)));
+                excludedPath => IsSubPathOf(r.SubTitle, excludedPath.Path)));
 
             return results.ToList();
         }
@@ -253,6 +254,17 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             return search.StartsWith("%") 
                    && search != "%%"
                    && !search.Contains('\\');
+        }
+
+        // https://stackoverflow.com/a/66877016
+        internal static bool IsSubPathOf(string subPath, string basePath)
+        {
+            var rel = Path.GetRelativePath(basePath, subPath);
+            return rel != "."
+                   && rel != ".."
+                   && !rel.StartsWith("../")
+                   && !rel.StartsWith(@"..\")
+                   && !Path.IsPathRooted(rel);
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -31,12 +31,13 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             public bool Equals(Result x, Result y)
             {
-                return x.Title == y.Title && x.SubTitle == y.SubTitle;
+                return x.Title.Equals(y.Title, StringComparison.OrdinalIgnoreCase) 
+                    && string.Equals(x.SubTitle, y.SubTitle, StringComparison.OrdinalIgnoreCase);
             }
 
             public int GetHashCode(Result obj)
             {
-                return HashCode.Combine(obj.Title.GetHashCode(), obj.SubTitle?.GetHashCode() ?? 0);
+                return HashCode.Combine(obj.Title.ToLowerInvariant(), obj.SubTitle?.ToLowerInvariant() ?? "");
             }
         }
 
@@ -118,7 +119,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             {
                 throw new SearchException(engineName, e.Message, e);
             }
-            
+
             results.RemoveWhere(r => Settings.IndexSearchExcludedSubdirectoryPaths.Any(
                 excludedPath => IsSubPathOf(r.SubTitle, excludedPath.Path)));
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -121,7 +121,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             }
 
             results.RemoveWhere(r => Settings.IndexSearchExcludedSubdirectoryPaths.Any(
-                excludedPath => FilesFolders.IsSubPathOf(r.SubTitle, excludedPath.Path)));
+                excludedPath => FilesFolders.PathContains(excludedPath.Path, r.SubTitle)));
 
             return results.ToList();
         }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Flow.Launcher.Plugin.Explorer.Exceptions;
-using System.IO;
 
 namespace Flow.Launcher.Plugin.Explorer.Search
 {
@@ -24,14 +23,17 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             Settings = settings;
         }
 
-        private class PathEqualityComparator : IEqualityComparer<Result>
+        /// <summary>
+        /// Note: Assuming all diretories end with "\".
+        /// </summary>
+        public class PathEqualityComparator : IEqualityComparer<Result>
         {
             private static PathEqualityComparator instance;
             public static PathEqualityComparator Instance => instance ??= new PathEqualityComparator();
 
             public bool Equals(Result x, Result y)
             {
-                return x.Title.Equals(y.Title, StringComparison.OrdinalIgnoreCase) 
+                return x.Title.Equals(y.Title, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(x.SubTitle, y.SubTitle, StringComparison.OrdinalIgnoreCase);
             }
 
@@ -178,7 +180,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             // Query is a location path with a full environment variable, eg. %appdata%\somefolder\
             var isEnvironmentVariablePath = EnvironmentVariables.BeginsWithEnvironmentVar(querySearch);
-            
+
             var locationPath = querySearch;
 
             if (isEnvironmentVariablePath)
@@ -249,10 +251,10 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                        x => FilesFolders.ReturnPreviousDirectoryIfIncompleteString(pathToDirectory).StartsWith(x.Path, StringComparison.OrdinalIgnoreCase))
                    && WindowsIndex.WindowsIndex.PathIsIndexed(pathToDirectory);
         }
-        
+
         internal static bool IsEnvironmentVariableSearch(string search)
         {
-            return search.StartsWith("%") 
+            return search.StartsWith("%")
                    && search != "%%"
                    && !search.Contains('\\');
         }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -175,7 +175,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 return EnvironmentVariables.GetEnvironmentStringPathSuggestions(querySearch, query, Context);
 
             // Query is a location path with a full environment variable, eg. %appdata%\somefolder\
-            var isEnvironmentVariablePath = querySearch[0] == '%' && querySearch[1..].Contains("%\\");
+            var isEnvironmentVariablePath = EnvironmentVariables.BeginsWithEnvironmentVar(querySearch);
 
             var locationPath = querySearch;
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -178,11 +178,11 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             // Query is a location path with a full environment variable, eg. %appdata%\somefolder\
             var isEnvironmentVariablePath = EnvironmentVariables.BeginsWithEnvironmentVar(querySearch);
-
+            
             var locationPath = querySearch;
 
             if (isEnvironmentVariablePath)
-                locationPath = EnvironmentVariables.TranslateEnvironmentVariablePath(locationPath);
+                locationPath = Environment.ExpandEnvironmentVariables(locationPath);
 
             // Check that actual location exists, otherwise directory search will throw directory not found exception
             if (!FilesFolders.ReturnPreviousDirectoryIfIncompleteString(locationPath).LocationExists())

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -173,18 +173,12 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
             var results = new HashSet<Result>(PathEqualityComparator.Instance);
 
-            var isEnvironmentVariable = EnvironmentVariables.IsEnvironmentVariableSearch(querySearch);
-
-            if (isEnvironmentVariable)
+            if (EnvironmentVariables.IsEnvironmentVariableSearch(querySearch))
                 return EnvironmentVariables.GetEnvironmentStringPathSuggestions(querySearch, query, Context);
 
-            // Query is a location path with a full environment variable, eg. %appdata%\somefolder\
-            var isEnvironmentVariablePath = EnvironmentVariables.BeginsWithEnvironmentVar(querySearch);
-
-            var locationPath = querySearch;
-
-            if (isEnvironmentVariablePath)
-                locationPath = Environment.ExpandEnvironmentVariables(locationPath);
+            // Query is a location path with a full environment variable, eg. %appdata%\somefolder\, c:\users\%USERNAME%\downloads
+            var needToExpand = EnvironmentVariables.HasEnvironmentVar(querySearch);
+            var locationPath = needToExpand ? Environment.ExpandEnvironmentVariables(querySearch) : querySearch;
 
             // Check that actual location exists, otherwise directory search will throw directory not found exception
             if (!FilesFolders.ReturnPreviousDirectoryIfIncompleteString(locationPath).LocationExists())

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -13,9 +13,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 {
     public class SearchManager
     {
-        internal static PluginInitContext Context;
+        internal PluginInitContext Context;
 
-        internal static Settings Settings;
+        internal Settings Settings;
 
         public SearchManager(Settings settings, PluginInitContext context)
         {
@@ -144,7 +144,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             };
         }
 
-        private static List<Result> EverythingContentSearchResult(Query query)
+        private List<Result> EverythingContentSearchResult(Query query)
         {
             return new List<Result>()
             {
@@ -236,7 +236,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             return results.ToList();
         }
 
-        public static bool IsFileContentSearch(string actionKeyword) => actionKeyword == Settings.FileContentSearchActionKeyword;
+        public bool IsFileContentSearch(string actionKeyword) => actionKeyword == Settings.FileContentSearchActionKeyword;
 
 
         private bool UseWindowsIndexForDirectorySearch(string locationPath)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -111,7 +111,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             }
             catch (OperationCanceledException)
             {
-                return results.ToList();
+                return new List<Result>();
             }
             catch (EngineNotAvailableException)
             {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -105,14 +105,16 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 await foreach (var search in searchResults.WithCancellation(token).ConfigureAwait(false))
                     results.Add(ResultManager.CreateResult(query, search));
             }
+            catch (OperationCanceledException)
+            {
+                return results.ToList();
+            }
+            catch (EngineNotAvailableException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
-                if (e is OperationCanceledException)
-                    return results.ToList();
-
-                if (e is EngineNotAvailableException)
-                    throw;
-
                 throw new SearchException(engineName, e.Message, e);
             }
             

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -175,7 +175,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 return EnvironmentVariables.GetEnvironmentStringPathSuggestions(querySearch, query, Context);
 
             // Query is a location path with a full environment variable, eg. %appdata%\somefolder\
-            var isEnvironmentVariablePath = querySearch[1..].Contains("%\\");
+            var isEnvironmentVariablePath = querySearch[0] == '%' && querySearch[1..].Contains("%\\");
 
             var locationPath = querySearch;
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -24,7 +24,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         }
 
         /// <summary>
-        /// Note: Assuming all diretories end with "\".
+        /// Note: A path that ends with "\" and one that doesn't will not be regarded as equal.
         /// </summary>
         public class PathEqualityComparator : IEqualityComparer<Result>
         {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/WindowsIndexSearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/WindowsIndexSearchManager.cs
@@ -97,10 +97,10 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
 
         private IAsyncEnumerable<SearchResult> HandledEngineNotAvailableExceptionAsync()
         {
-            if (!SearchManager.Settings.WarnWindowsSearchServiceOff)
+            if (!Settings.WarnWindowsSearchServiceOff)
                 return AsyncEnumerable.Empty<SearchResult>();
 
-            var api = SearchManager.Context.API;
+            var api = Main.Context.API;
 
             throw new EngineNotAvailableException(
                 "Windows Index",
@@ -108,7 +108,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                 api.GetTranslation("plugin_explorer_windowsSearchServiceNotRunning"),
                 c =>
                 {
-                    SearchManager.Settings.WarnWindowsSearchServiceOff = false;
+                    Settings.WarnWindowsSearchServiceOff = false;
 
                     // Clears the warning message so user is not mistaken that it has not worked
                     api.ChangeQuery(string.Empty);

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/WindowsIndexSearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/WindowsIndexSearchManager.cs
@@ -106,6 +106,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                 "Windows Index",
                 api.GetTranslation("plugin_explorer_windowsSearchServiceFix"),
                 api.GetTranslation("plugin_explorer_windowsSearchServiceNotRunning"),
+                Constants.WindowsIndexErrorImagePath,
                 c =>
                 {
                     Settings.WarnWindowsSearchServiceOff = false;
@@ -114,10 +115,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
                     api.ChangeQuery(string.Empty);
 
                     return ValueTask.FromResult(false);
-                })
-            {
-                ErrorIcon = Constants.WindowsIndexErrorImagePath
-            };
+                });
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -471,7 +471,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
             var paths = pathEnv.Split(";", StringSplitOptions.RemoveEmptyEntries).DistinctBy(p => p.ToLowerInvariant());
 
-            var toFilter = paths.Where(x => commonParents.All(parent => !IsSubPathOf(x, parent)))
+            var toFilter = paths.Where(x => commonParents.All(parent => !FilesFolders.IsSubPathOf(x, parent)))
                 .AsParallel()
                 .SelectMany(p => EnumerateProgramsInDir(p, suffixes, recursive: false));
 
@@ -763,17 +763,6 @@ namespace Flow.Launcher.Plugin.Program.Programs
             }
         }
 
-        // https://stackoverflow.com/a/66877016
-        private static bool IsSubPathOf(string subPath, string basePath)
-        {
-            var rel = Path.GetRelativePath(basePath, subPath);
-            return rel != "."
-                   && rel != ".."
-                   && !rel.StartsWith("../")
-                   && !rel.StartsWith(@"..\")
-                   && !Path.IsPathRooted(rel);
-        }
-
         private static List<string> GetCommonParents(IEnumerable<ProgramSource> programSources)
         {
             // To avoid unnecessary io
@@ -785,7 +774,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 HashSet<ProgramSource> parents = group.ToHashSet();
                 foreach (var source in group)
                 {
-                    if (parents.Any(p => IsSubPathOf(source.Location, p.Location) &&
+                    if (parents.Any(p => FilesFolders.IsSubPathOf(source.Location, p.Location) &&
                                          source != p))
                     {
                         parents.Remove(source);

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -470,8 +470,8 @@ namespace Flow.Launcher.Plugin.Program.Programs
             }
 
             var paths = pathEnv.Split(";", StringSplitOptions.RemoveEmptyEntries).DistinctBy(p => p.ToLowerInvariant());
-
-            var toFilter = paths.Where(x => commonParents.All(parent => !FilesFolders.IsSubPathOf(x, parent)))
+            
+            var toFilter = paths.Where(x => commonParents.All(parent => !FilesFolders.PathContains(parent, x)))
                 .AsParallel()
                 .SelectMany(p => EnumerateProgramsInDir(p, suffixes, recursive: false));
 
@@ -774,8 +774,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 HashSet<ProgramSource> parents = group.ToHashSet();
                 foreach (var source in group)
                 {
-                    if (parents.Any(p => FilesFolders.IsSubPathOf(source.Location, p.Location) &&
-                                         source != p))
+                    if (parents.Any(p => FilesFolders.PathContains(p.Location, source.Location)))
                     {
                         parents.Remove(source);
                     }


### PR DESCRIPTION
Changes:
- Fix #1802 (Fix null subtitle when creating disk result)
- Fix #1796 (Only expand environment var when path starts with %)
- Use case-insensitive comparator for path results
- Use api for subpath check

Tests:
- A single ":" when excluded path is not empty won't cause exception. (1802)
- Unit test for environment path expansion
- Unit test for subpath check
- Unit test for result comparator