### PR TITLE
Change the default shortcut for Plugin Indicator to `?` #1825

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json
@@ -1,10 +1,10 @@
 {
   "ID": "6A122269676E40EB86EB543B945932B9",
-  "ActionKeyword": "*",
+  "ActionKeyword": "?",
   "Name": "Plugin Indicator",
   "Description": "Provides plugin action keyword suggestions",
   "Author": "qianlifeng",
-  "Version": "2.0.1",
+  "Version": "2.0.2",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.PluginIndicator.dll",


### PR DESCRIPTION
Change the shortcut for the `Plugin Indicator` plugin  to `?`, to make the Out Of The Box experience better for new users of Flow.Launcher

Closes #1825 