### PR TITLE
Everything Search: Match Path 

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingAPI.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingAPI.cs
@@ -13,13 +13,12 @@ using Flow.Launcher.Plugin.Explorer.Exceptions;
 
 namespace Flow.Launcher.Plugin.Explorer.Search.Everything
 {
-
     public static class EverythingApi
     {
-
         private const int BufferSize = 4096;
 
         private static SemaphoreSlim _semaphore = new(1, 1);
+
         // cached buffer to remove redundant allocations.
         private static readonly StringBuilder buffer = new(BufferSize);
 
@@ -33,46 +32,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             CreateThreadError,
             InvalidIndexError,
             InvalidCallError
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether [match path].
-        /// </summary>
-        /// <value><c>true</c> if [match path]; otherwise, <c>false</c>.</value>
-        public static bool MatchPath // TODO these seem to be unused, and they're related exactly to the feature i want: make everything search through the whole path. How should these be used? Should they be removed instead? IMHO, it seems better to use full path search by default, so i'd remove this completely
-        {
-            get => EverythingApiDllImport.Everything_GetMatchPath();
-            set => EverythingApiDllImport.Everything_SetMatchPath(value);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether [match case].
-        /// </summary>
-        /// <value><c>true</c> if [match case]; otherwise, <c>false</c>.</value>
-        public static bool MatchCase
-        {
-            get => EverythingApiDllImport.Everything_GetMatchCase();
-            set => EverythingApiDllImport.Everything_SetMatchCase(value);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether [match whole word].
-        /// </summary>
-        /// <value><c>true</c> if [match whole word]; otherwise, <c>false</c>.</value>
-        public static bool MatchWholeWord
-        {
-            get => EverythingApiDllImport.Everything_GetMatchWholeWord();
-            set => EverythingApiDllImport.Everything_SetMatchWholeWord(value);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether [enable regex].
-        /// </summary>
-        /// <value><c>true</c> if [enable regex]; otherwise, <c>false</c>.</value>
-        public static bool EnableRegex
-        {
-            get => EverythingApiDllImport.Everything_GetRegex();
-            set => EverythingApiDllImport.Everything_SetRegex(value);
         }
 
         /// <summary>
@@ -95,7 +54,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
 
             try
             {
-                EverythingApiDllImport.Everything_GetMajorVersion(); 
+                EverythingApiDllImport.Everything_GetMajorVersion();
                 var result = EverythingApiDllImport.Everything_GetLastError() != StateCode.IPCError;
                 return result;
             }
@@ -122,7 +81,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             
             await _semaphore.WaitAsync(token);
 
-            
+
             try
             {
                 if (token.IsCancellationRequested)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingAPI.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingAPI.cs
@@ -152,6 +152,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                 EverythingApiDllImport.Everything_SetMax(option.MaxCount);
 
                 EverythingApiDllImport.Everything_SetSort(option.SortOption);
+                EverythingApiDllImport.Everything_SetMatchPath(true);
 
                 if (token.IsCancellationRequested) yield break;
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingAPI.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingAPI.cs
@@ -39,7 +39,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
         /// Gets or sets a value indicating whether [match path].
         /// </summary>
         /// <value><c>true</c> if [match path]; otherwise, <c>false</c>.</value>
-        public static bool MatchPath
+        public static bool MatchPath // TODO these seem to be unused, and they're related exactly to the feature i want: make everything search through the whole path. How should these be used? Should they be removed instead? IMHO, it seems better to use full path search by default, so i'd remove this completely
         {
             get => EverythingApiDllImport.Everything_GetMatchPath();
             set => EverythingApiDllImport.Everything_SetMatchPath(value);

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingAPI.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingAPI.cs
@@ -152,7 +152,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                 EverythingApiDllImport.Everything_SetMax(option.MaxCount);
 
                 EverythingApiDllImport.Everything_SetSort(option.SortOption);
-                EverythingApiDllImport.Everything_SetMatchPath(true);
+                EverythingApiDllImport.Everything_SetMatchPath(option.IsFullPathSearch);
 
                 if (token.IsCancellationRequested) yield break;
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingSearchOption.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingSearchOption.cs
@@ -3,12 +3,15 @@ using Flow.Launcher.Plugin.Everything.Everything;
 
 namespace Flow.Launcher.Plugin.Explorer.Search.Everything
 {
-    public record struct EverythingSearchOption(string Keyword, 
+    public record struct EverythingSearchOption(
+        string Keyword,
         SortOption SortOption,
-        bool IsContentSearch = false, 
+        bool IsContentSearch = false,
         string ContentSearchKeyword = default,
         string ParentPath = default,
         bool IsRecursive = true,
-        int Offset = 0, 
-        int MaxCount = 100);
+        int Offset = 0,
+        int MaxCount = 100,
+        bool IsFullPathSearch = true
+    );
 }


### PR DESCRIPTION
This option makes searching take into account the full path of a file at once, instead of "chunks of the path delimited by "/" (folder separator)".

For example:

I have a folder `D:/all/wallpapers/artstation/pics and nested folders here`

In `Everything`, if i enable `Search` -> `Match Path` (<kbd>Ctrl</kbd>+<kbd>U</kbd>) i can simply type `wall arts` and it shows me all the correct files. It matches the folder `D:/all/wallpapers/artstation/` and everything underneath it.

With FL, before this feature, i have to type `wall*/arts` to have the same. Typing `wall*arts` does not work either.

Basically i have to:
1. add `*` to instruct "match all characters after `wall` until folder separator
2. add `/` (folder separator) because  `*` character does not match it

With this feature, it is enough to type `wall arts`, just like you would type in `Everything`.  Space character works as a `.*` regexp over the full path of a file.

Moreover, this gives you even more flexibility, because now you can type characters from the middle of the path as well, and they will match, for example `all tati` brings you the same result.

Screenshot of the feature in action: 
![image](https://user-images.githubusercontent.com/4482210/214579809-4c522106-c385-4fd6-b990-a0b227d70858.png)




Closes: https://github.com/Flow-Launcher/Flow.Launcher/issues/1805
Closes: https://github.com/Flow-Launcher/Flow.Launcher/discussions/1800