### PR TITLE
Fix autocomplete on Program plugin

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/UWP.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/UWP.cs
@@ -375,17 +375,20 @@ namespace Flow.Launcher.Plugin.Program.Programs
             public Result Result(string query, IPublicAPI api)
             {
                 string title;
+                string titleOnly;
                 MatchResult matchResult;
 
                 // We suppose Name won't be null
                 if (!Main._settings.EnableDescription || string.IsNullOrWhiteSpace(Description) || Name.Equals(Description))
                 {
                     title = Name;
+                    titleOnly = Name;
                     matchResult = StringMatcher.FuzzySearch(query, Name);
                 }
                 else
                 {
                     title = $"{Name}: {Description}";
+                    titleOnly = Name;
                     var nameMatch = StringMatcher.FuzzySearch(query, Name);
                     var descriptionMatch = StringMatcher.FuzzySearch(query, Description);
                     if (descriptionMatch.Score > nameMatch.Score)
@@ -408,6 +411,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 var result = new Result
                 {
                     Title = title,
+                    AutoCompleteText = titleOnly,
                     SubTitle = Main._settings.HideAppsPath ? string.Empty : Location,
                     IcoPath = LogoPath,
                     Preview = new Result.PreviewInfo

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -83,6 +83,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
         public Result Result(string query, IPublicAPI api)
         {
             string title;
+            string titleOnly;
             MatchResult matchResult;
 
             // Name of the result
@@ -93,12 +94,14 @@ namespace Flow.Launcher.Plugin.Program.Programs
             if (!Main._settings.EnableDescription || string.IsNullOrWhiteSpace(Description) || resultName.Equals(Description))
             {
                 title = resultName;
+                titleOnly = resultName;
                 matchResult = StringMatcher.FuzzySearch(query, resultName);
             }
             else
             {
                 // Search in both
                 title = $"{resultName}: {Description}";
+                titleOnly = resultName;
                 var nameMatch = StringMatcher.FuzzySearch(query, resultName);
                 var descriptionMatch = StringMatcher.FuzzySearch(query, Description);
                 if (descriptionMatch.Score > nameMatch.Score)
@@ -155,6 +158,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
             var result = new Result
             {
                 Title = title,
+                AutoCompleteText = titleOnly,
                 SubTitle = subtitle,
                 IcoPath = IcoPath,
                 Score = matchResult.Score,


### PR DESCRIPTION
Fixed the issue mentioned in #1803 which autocompletes the _name + program description_ when the **Show Description** is enabled in the Program plugin.