### PR TITLE
[Bookmarks Plugin] Add custom firefox browser support

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Commands/BookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Commands/BookmarkLoader.cs
@@ -44,15 +44,12 @@ namespace Flow.Launcher.Plugin.BrowserBookmark.Commands
 
             foreach (var browser in setting.CustomChromiumBrowsers)
             {
-                IBookmarkLoader loader;
-                if (browser.BrowserType == BrowserType.Chromium)
+                IBookmarkLoader loader = browser.BrowserType switch
                 {
-                    loader = new CustomChromiumBookmarkLoader(browser);
-                }
-                else
-                {
-                    loader = new CustomFirefoxBookmarkLoader(browser);
-                }
+                    BrowserType.Chromium => new CustomChromiumBookmarkLoader(browser),
+                    BrowserType.Firefox => new CustomFirefoxBookmarkLoader(browser),
+                    _ => new CustomChromiumBookmarkLoader(browser),
+                };
                 allBookmarks.AddRange(loader.GetBookmarks());
             }
 

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Commands/BookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Commands/BookmarkLoader.cs
@@ -44,7 +44,15 @@ namespace Flow.Launcher.Plugin.BrowserBookmark.Commands
 
             foreach (var browser in setting.CustomChromiumBrowsers)
             {
-                var loader = new CustomChromiumBookmarkLoader(browser);
+                IBookmarkLoader loader;
+                if (browser.BrowserType == BrowserType.Chromium)
+                {
+                    loader = new CustomChromiumBookmarkLoader(browser);
+                }
+                else
+                {
+                    loader = new CustomFirefoxBookmarkLoader(browser);
+                }
                 allBookmarks.AddRange(loader.GetBookmarks());
             }
 

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/CustomFirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/CustomFirefoxBookmarkLoader.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Flow.Launcher.Plugin.BrowserBookmark.Models;
+
+namespace Flow.Launcher.Plugin.BrowserBookmark
+{
+    public class CustomFirefoxBookmarkLoader : FirefoxBookmarkLoaderBase
+    {
+        public CustomFirefoxBookmarkLoader(CustomBrowser browser)
+        {
+            BrowserName = browser.Name;
+            BrowserDataPath = browser.DataDirectoryPath;
+        }
+        
+        /// <summary>
+        /// Path to places.sqlite
+        /// </summary>
+        public string BrowserDataPath { get; init; }
+        
+        public string BrowserName { get; init; }
+
+        public override List<Bookmark> GetBookmarks()
+        {
+            return GetBookmarksFromPath(BrowserDataPath);
+        }
+    }
+}

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/CustomFirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/CustomFirefoxBookmarkLoader.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Flow.Launcher.Plugin.BrowserBookmark.Models;
 
 namespace Flow.Launcher.Plugin.BrowserBookmark

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/CustomFirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/CustomFirefoxBookmarkLoader.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using Flow.Launcher.Plugin.BrowserBookmark.Models;
 
 namespace Flow.Launcher.Plugin.BrowserBookmark
@@ -20,7 +21,7 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
 
         public override List<Bookmark> GetBookmarks()
         {
-            return GetBookmarksFromPath(BrowserDataPath);
+            return GetBookmarksFromPath(Path.Combine(BrowserDataPath, "places.sqlite"));
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
@@ -7,8 +7,10 @@ using System.Linq;
 
 namespace Flow.Launcher.Plugin.BrowserBookmark
 {
-    public class FirefoxBookmarkLoader : IBookmarkLoader
+    public abstract class FirefoxBookmarkLoaderBase : IBookmarkLoader
     {
+        public abstract List<Bookmark> GetBookmarks();
+
         private const string queryAllBookmarks = @"SELECT moz_places.url, moz_bookmarks.title
               FROM moz_places
               INNER JOIN moz_bookmarks ON (
@@ -19,21 +21,18 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
 
         private const string dbPathFormat = "Data Source ={0};Version=3;New=False;Compress=True;";
 
-        /// <summary>
-        /// Searches the places.sqlite db and returns all bookmarks
-        /// </summary>
-        public List<Bookmark> GetBookmarks()
+        protected static List<Bookmark> GetBookmarksFromPath(string placesPath)
         {
             // Return empty list if the places.sqlite file cannot be found
-            if (string.IsNullOrEmpty(PlacesPath) || !File.Exists(PlacesPath))
+            if (string.IsNullOrEmpty(placesPath) || !File.Exists(placesPath))
                 return new List<Bookmark>();
 
             var bookmarkList = new List<Bookmark>();
-            
-            Main.RegisterBookmarkFile(PlacesPath);
+
+            Main.RegisterBookmarkFile(placesPath);
 
             // create the connection string and init the connection
-            string dbPath = string.Format(dbPathFormat, PlacesPath);
+            string dbPath = string.Format(dbPathFormat, placesPath);
             using var dbConnection = new SQLiteConnection(dbPath);
             // Open connection to the database file and execute the query
             dbConnection.Open();
@@ -41,13 +40,25 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
 
             // return results in List<Bookmark> format
             bookmarkList = reader.Select(
-                x => new Bookmark(x["title"] is DBNull ? string.Empty : x["title"].ToString(), 
+                x => new Bookmark(x["title"] is DBNull ? string.Empty : x["title"].ToString(),
                     x["url"].ToString())
             ).ToList();
 
             return bookmarkList;
         }
+    }
 
+
+    public class FirefoxBookmarkLoader : FirefoxBookmarkLoaderBase
+    {
+        /// <summary>
+        /// Searches the places.sqlite db and returns all bookmarks
+        /// </summary>
+        public override List<Bookmark> GetBookmarks()
+        {
+            return GetBookmarksFromPath(PlacesPath);
+        }
+        
         /// <summary>
         /// Path to places.sqlite
         /// </summary>

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Languages/en.xaml
@@ -22,4 +22,5 @@
     <system:String x:Key="flowlauncher_plugin_browserbookmark_addBrowserBookmark">Add</system:String>
     <system:String x:Key="flowlauncher_plugin_browserbookmark_removeBrowserBookmark">Delete</system:String>
     <system:String x:Key="flowlauncher_plugin_browserbookmark_others">Others</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_browserEngine">Browser Engine</system:String>
 </ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Models/CustomBrowser.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Models/CustomBrowser.cs
@@ -4,6 +4,8 @@
     {
         private string _name;
         private string _dataDirectoryPath;
+        private BrowserType browserType = BrowserType.Chromium;
+
         public string Name
         {
             get => _name;
@@ -13,6 +15,7 @@
                 OnPropertyChanged(nameof(Name));
             } 
         }
+        
         public string DataDirectoryPath
         {
             get => _dataDirectoryPath;
@@ -22,5 +25,21 @@
                 OnPropertyChanged(nameof(DataDirectoryPath));
             }
         }
+        
+        public BrowserType BrowserType
+        {
+            get => browserType;
+            set
+            {
+                browserType = value;
+                OnPropertyChanged(nameof(BrowserType));
+            }
+        }
+    }
+
+    public enum BrowserType
+    {
+        Chromium,
+        Firefox,
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/CustomBrowserSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/CustomBrowserSetting.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Flow.Launcher.Plugin.BrowserBookmark.Models"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="clr-namespace:Flow.Launcher.Infrastructure.UI;assembly=Flow.Launcher.Infrastructure"
     Title="{DynamicResource flowlauncher_plugin_browserbookmark_bookmarkDataSetting}"
     Width="520"
     Background="{DynamicResource PopuBGColor}"
@@ -79,6 +80,7 @@
                         <Grid.RowDefinitions>
                             <RowDefinition />
                             <RowDefinition />
+                            <RowDefinition />
                         </Grid.RowDefinitions>
                         <TextBlock
                             Grid.Row="0"
@@ -104,9 +106,28 @@
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             FontSize="14"
+                            Text="{DynamicResource flowlauncher_plugin_browserbookmark_browserEngine}" />
+                        <ComboBox
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Width="120"
+                            Height="34"
+                            Margin="5,10,10,0"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            ItemsSource="{Binding Source={ui:EnumBindingSource {x:Type local:BrowserType}}}"
+                            SelectedItem="{Binding BrowserType}">
+                        </ComboBox>
+                        <TextBlock
+                            Grid.Row="2"
+                            Grid.Column="0"
+                            Margin="5,10,20,0"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            FontSize="14"
                             Text="{DynamicResource flowlauncher_plugin_browserbookmark_browserBookmarkDataDirectory}" />
                         <TextBox
-                            Grid.Row="1"
+                            Grid.Row="2"
                             Grid.Column="1"
                             Height="34"
                             Margin="5,10,0,0"

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/CustomBrowserSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/CustomBrowserSetting.xaml.cs
@@ -1,17 +1,7 @@
 ﻿using Flow.Launcher.Plugin.BrowserBookmark.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 
 namespace Flow.Launcher.Plugin.BrowserBookmark.Views
 {
@@ -27,7 +17,9 @@ namespace Flow.Launcher.Plugin.BrowserBookmark.Views
             currentCustomBrowser = browser;
             DataContext = new CustomBrowser
             {
-                Name = browser.Name, DataDirectoryPath = browser.DataDirectoryPath
+                Name = browser.Name,
+                DataDirectoryPath = browser.DataDirectoryPath,
+                BrowserType = browser.BrowserType,
             };
         }
 
@@ -39,6 +31,7 @@ namespace Flow.Launcher.Plugin.BrowserBookmark.Views
                 {
                     currentCustomBrowser.Name = editBrowser.Name;
                     currentCustomBrowser.DataDirectoryPath = editBrowser.DataDirectoryPath;
+                    currentCustomBrowser.BrowserType = editBrowser.BrowserType;
                     Close();
                 }
             }

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/SettingsControl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/SettingsControl.xaml
@@ -46,6 +46,8 @@
                                             Header="{DynamicResource flowlauncher_plugin_browserbookmark_browserName}"/>
                             <GridViewColumn DisplayMemberBinding="{Binding DataDirectoryPath, Mode=OneWay}"
                                             Header="{DynamicResource flowlauncher_plugin_browserbookmark_browserBookmarkDataDirectory}"/>
+                            <GridViewColumn DisplayMemberBinding="{Binding BrowserType, Mode=OneWay}"
+                                            Header="{DynamicResource flowlauncher_plugin_browserbookmark_browserEngine}"/>
                         </GridView>
                     </ListView.View>
                 </ListView>


### PR DESCRIPTION
Close #1856 

Add a combobox in add custom browser dialog to choose browser engine (chromium or Firefox)
![图片](https://user-images.githubusercontent.com/10308169/216886968-9362a7ac-55dc-47d5-8814-310d6d534987.png)

![图片](https://user-images.githubusercontent.com/10308169/216887138-faed9d44-00a7-4056-bcf1-aa0d5f09341d.png)


Test:
- Firefox bookmarks can be searched by adding data folder path to custom browser