### PR TITLE
Change Singular Hotkey/Plugin title area to Plural (Hotkeys/Plugins)

### DIFF
--- a/Flow.Launcher/Languages/da.xaml
+++ b/Flow.Launcher/Languages/da.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Kunne ikke registrere genvejstast: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Kunne ikke starte {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Find flere plugins</system:String>
     <system:String x:Key="enable">On</system:String>
     <system:String x:Key="disable">Deaktiver</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Genvejstast</system:String>
+    <system:String x:Key="hotkeys">Genvejstast</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher genvejstast</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Enter shortcut to show/hide Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/Languages/de.xaml
+++ b/Flow.Launcher/Languages/de.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Tastenkombinationregistrierung: {0} fehlgeschlagen</system:String>
     <system:String x:Key="couldnotStartCmd">Kann {0} nicht starten</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Erweiterung</system:String>
+    <system:String x:Key="plugins">Erweiterung</system:String>
     <system:String x:Key="browserMorePlugins">Suche nach weiteren Plugins</system:String>
     <system:String x:Key="enable">Aktivieren</system:String>
     <system:String x:Key="disable">Deaktivieren</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Tastenkombination</system:String>
+    <system:String x:Key="hotkeys">Tastenkombination</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher Tastenkombination</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Verknüpfung eingeben, um Flow Launcher anzuzeigen/auszublenden.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -82,6 +82,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Find more plugins</system:String>
     <system:String x:Key="enable">On</system:String>
     <system:String x:Key="disable">Off</system:String>
@@ -154,6 +155,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Hotkey</system:String>
+    <system:String x:Key="hotkeys">Hotkeys</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher Hotkey</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Enter shortcut to show/hide Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>
@@ -162,9 +164,9 @@
     <system:String x:Key="openResultModifiersToolTip">Select a modifier key to open selected result via keyboard.</system:String>
     <system:String x:Key="showOpenResultHotkey">Show Hotkey</system:String>
     <system:String x:Key="showOpenResultHotkeyToolTip">Show result selection hotkey with results.</system:String>
-    <system:String x:Key="customQueryHotkey">Custom Query Hotkey</system:String>
-    <system:String x:Key="customQueryShortcut">Custom Query Shortcut</system:String>
-    <system:String x:Key="builtinShortcuts">Built-in Shortcut</system:String>
+    <system:String x:Key="customQueryHotkey">Custom Query Hotkeys</system:String>
+    <system:String x:Key="customQueryShortcut">Custom Query Shortcuts</system:String>
+    <system:String x:Key="builtinShortcuts">Built-in Shortcuts</system:String>
     <system:String x:Key="customQuery">Query</system:String>
     <system:String x:Key="customShortcut">Shortcut</system:String>
     <system:String x:Key="customShortcutExpansion">Expansion</system:String>

--- a/Flow.Launcher/Languages/es-419.xaml
+++ b/Flow.Launcher/Languages/es-419.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Error al registrar la tecla de acceso directo: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">No se pudo iniciar {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Encontrar más plugins</system:String>
     <system:String x:Key="enable">Activado</system:String>
     <system:String x:Key="disable">Desactivado</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Tecla Rápida</system:String>
+    <system:String x:Key="hotkeys">Tecla Rápida</system:String>
     <system:String x:Key="flowlauncherHotkey">Tecla de acceso a Flow Launcher</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Introduzca el acceso directo para mostrar/ocultar Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/Languages/es.xaml
+++ b/Flow.Launcher/Languages/es.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">No se ha podido registrar el atajo de teclado: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">No se ha podido iniciar {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No se han encontrado resultados</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Por favor, intente una búsqueda diferente.</system:String>
     <system:String x:Key="plugin">Complementos</system:String>
+    <system:String x:Key="plugins">Complementos</system:String>
     <system:String x:Key="browserMorePlugins">Buscar más complementos</system:String>
     <system:String x:Key="enable">Activado</system:String>
     <system:String x:Key="disable">Desactivado</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Atajos de teclado</system:String>
+    <system:String x:Key="hotkeys">Atajos de teclado</system:String>
     <system:String x:Key="flowlauncherHotkey">Atajo de teclado de Flow Launcher</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Introduzca el atajo de teclado para mostrar/ocultar Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Atajo de teclado para vista previa</system:String>

--- a/Flow.Launcher/Languages/fr.xaml
+++ b/Flow.Launcher/Languages/fr.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Impossible d'enregistrer le raccourci clavier : {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Impossible de lancer {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Trouver plus de modules</system:String>
     <system:String x:Key="enable">On</system:String>
     <system:String x:Key="disable">Désactivé</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Raccourcis</system:String>
+    <system:String x:Key="hotkeys">Raccourcis</system:String>
     <system:String x:Key="flowlauncherHotkey">Ouvrir Flow Launcher</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Enter shortcut to show/hide Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/Languages/it.xaml
+++ b/Flow.Launcher/Languages/it.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Impossibile salvare il tasto di scelta rapida: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Avvio fallito {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Cerca altri plugins</system:String>
     <system:String x:Key="enable">Attivo</system:String>
     <system:String x:Key="disable">Disabilita</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Tasti scelta rapida</system:String>
+    <system:String x:Key="hotkeys">Tasti scelta rapida</system:String>
     <system:String x:Key="flowlauncherHotkey">Tasto scelta rapida Flow Launcher</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Immettere la scorciatoia per mostrare/nascondere Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>
@@ -211,8 +216,8 @@
     <system:String x:Key="newVersionTips">Una nuova versione {0} è disponibile, riavvia Flow Launcher per favore.</system:String>
     <system:String x:Key="checkUpdatesFailed">Ricerca aggiornamenti fallita, per favore controlla la tua connessione e le eventuali impostazioni proxy per api.github.com.</system:String>
     <system:String x:Key="downloadUpdatesFailed">
-        Download degli aggiornamenti fallito, per favore controlla la tua connessione ed eventuali impostazioni proxy per github-cloud.s3.amazonaws.com, 
-		oppure vai su https://github.com/Flow-Launcher/Flow.Launcher/releases per scaricare gli aggiornamenti manualmente.
+        Download degli aggiornamenti fallito, per favore controlla la tua connessione ed eventuali impostazioni proxy per github-cloud.s3.amazonaws.com,
+        oppure vai su https://github.com/Flow-Launcher/Flow.Launcher/releases per scaricare gli aggiornamenti manualmente.
     </system:String>
     <system:String x:Key="releaseNotes">Note di rilascio</system:String>
     <system:String x:Key="documentation">Usage Tips</system:String>

--- a/Flow.Launcher/Languages/ja.xaml
+++ b/Flow.Launcher/Languages/ja.xaml
@@ -80,6 +80,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">プラグインを探す</system:String>
     <system:String x:Key="enable">有効</system:String>
     <system:String x:Key="disable">無効</system:String>
@@ -152,6 +153,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">ホットキー</system:String>
+    <system:String x:Key="hotkeys">ホットキー</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher ホットキー</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Enter shortcut to show/hide Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/Languages/ko.xaml
+++ b/Flow.Launcher/Languages/ko.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">단축키 등록 실패: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">{0}을 실행할 수 없습니다.</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">검색 결과를 찾을 수 없습니다.</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">다른 검색어를 시도해주세요.</system:String>
     <system:String x:Key="plugin">플러그인</system:String>
+    <system:String x:Key="plugins">플러그인</system:String>
     <system:String x:Key="browserMorePlugins">플러그인 더 찾아보기</system:String>
     <system:String x:Key="enable">켬</system:String>
     <system:String x:Key="disable">끔</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">단축키</system:String>
+    <system:String x:Key="hotkeys">단축키</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher 단축키</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Flow Launcher를 열 때 사용할 단축키를 입력하세요.</system:String>
     <system:String x:Key="previewHotkey">미리보기 단축키</system:String>

--- a/Flow.Launcher/Languages/nb-NO.xaml
+++ b/Flow.Launcher/Languages/nb-NO.xaml
@@ -1,7 +1,8 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib">
-    <!--MainWindow-->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
+    <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Kunne ikke registrere hurtigtast: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Kunne ikke starte {0}</system:String>
     <system:String x:Key="invalidFlowLauncherPluginFileFormat">Ugyldig filformat for Flow Launcher-utvidelse</system:String>
@@ -14,7 +15,7 @@
     <system:String x:Key="iconTrayAbout">Om</system:String>
     <system:String x:Key="iconTrayExit">Avslutt</system:String>
 
-    <!--Setting General-->
+    <!--  Setting General  -->
     <system:String x:Key="flowlauncher_settings">Flow Launcher-innstillinger</system:String>
     <system:String x:Key="general">Generelt</system:String>
     <system:String x:Key="startFlowLauncherOnSystemStartup">Start Flow Launcher ved systemstart</system:String>
@@ -32,8 +33,9 @@
     <system:String x:Key="select">Velg</system:String>
     <system:String x:Key="hideOnStartup">Skjul Flow Launcher ved oppstart</system:String>
 
-    <!--Setting Plugin-->
+    <!--  Setting Plugin  -->
     <system:String x:Key="plugin">Utvidelse</system:String>
+    <system:String x:Key="plugins">Utvidelse</system:String>
     <system:String x:Key="browserMorePlugins">Finn flere utvidelser</system:String>
     <system:String x:Key="disable">Deaktiver</system:String>
     <system:String x:Key="actionKeywords">Handlingsnøkkelord</system:String>
@@ -42,7 +44,7 @@
     <system:String x:Key="plugin_init_time">Oppstartstid:</system:String>
     <system:String x:Key="plugin_query_time">Spørringstid:</system:String>
 
-    <!--Setting Theme-->
+    <!--  Setting Theme  -->
     <system:String x:Key="theme">Tema</system:String>
     <system:String x:Key="browserMoreThemes">Finn flere temaer</system:String>
     <system:String x:Key="queryBoxFont">Font for spørringsboks</system:String>
@@ -50,8 +52,9 @@
     <system:String x:Key="windowMode">Vindusmodus</system:String>
     <system:String x:Key="opacity">Gjennomsiktighet</system:String>
 
-    <!--Setting Hotkey-->
+    <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Hurtigtast</system:String>
+    <system:String x:Key="hotkeys">Hurtigtast</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher-hurtigtast</system:String>
     <system:String x:Key="openResultModifiers">Åpne resultatmodifiserere</system:String>
     <system:String x:Key="customQueryHotkey">Egendefinerd spørringshurtigtast</system:String>
@@ -62,7 +65,7 @@
     <system:String x:Key="pleaseSelectAnItem">Vennligst velg et element</system:String>
     <system:String x:Key="deleteCustomHotkeyWarning">Er du sikker på at du vil slette utvidelserhurtigtasten for {0}?</system:String>
 
-    <!--Setting Proxy-->
+    <!--  Setting Proxy  -->
     <system:String x:Key="proxy">HTTP-proxy</system:String>
     <system:String x:Key="enableProxy">Aktiver HTTP-proxy</system:String>
     <system:String x:Key="server">HTTP-server</system:String>
@@ -78,7 +81,7 @@
     <system:String x:Key="proxyIsCorrect">Proxy konfigurert riktig</system:String>
     <system:String x:Key="proxyConnectFailed">Proxy-tilkobling feilet</system:String>
 
-    <!--Setting About-->
+    <!--  Setting About  -->
     <system:String x:Key="about">Om</system:String>
     <system:String x:Key="website">Netside</system:String>
     <system:String x:Key="version">Versjon</system:String>
@@ -87,12 +90,12 @@
     <system:String x:Key="newVersionTips">Ny versjon {0} er tilgjengelig, vennligst start Flow Launcher på nytt.</system:String>
     <system:String x:Key="checkUpdatesFailed">Oppdateringssjekk feilet, vennligst sjekk tilkoblingen og proxy-innstillene for api.github.com.</system:String>
     <system:String x:Key="downloadUpdatesFailed">
-        Nedlastning av oppdateringer feilet, vennligst sjekk tilkoblingen og proxy-innstillene for github-cloud.s3.amazonaws.com, 
+        Nedlastning av oppdateringer feilet, vennligst sjekk tilkoblingen og proxy-innstillene for github-cloud.s3.amazonaws.com,
         eller gå til https://github.com/Flow-Launcher/Flow.Launcher/releases for å laste ned oppdateringer manuelt.
     </system:String>
     <system:String x:Key="releaseNotes">Versjonsmerknader:</system:String>
 
-    <!--Action Keyword Setting Dialog-->
+    <!--  Action Keyword Setting Dialog  -->
     <system:String x:Key="oldActionKeywords">Gammelt handlingsnøkkelord</system:String>
     <system:String x:Key="newActionKeywords">Nytt handlingsnøkkelord</system:String>
     <system:String x:Key="cancel">Avbryt</system:String>
@@ -103,16 +106,16 @@
     <system:String x:Key="success">Vellykket</system:String>
     <system:String x:Key="actionkeyword_tips">Bruk * hvis du ikke ønsker å angi et handlingsnøkkelord</system:String>
 
-    <!--Custom Query Hotkey Dialog-->
+    <!--  Custom Query Hotkey Dialog  -->
     <system:String x:Key="preview">Forhåndsvis</system:String>
     <system:String x:Key="hotkeyIsNotUnavailable">Hurtigtasten er ikke tilgjengelig, vennligst velg en ny hurtigtast</system:String>
     <system:String x:Key="invalidPluginHotkey">Ugyldig hurtigtast for utvidelse</system:String>
     <system:String x:Key="update">Oppdater</system:String>
 
-    <!--Hotkey Control-->
+    <!--  Hotkey Control  -->
     <system:String x:Key="hotkeyUnavailable">Hurtigtast utilgjengelig</system:String>
 
-    <!--Crash Reporter-->
+    <!--  Crash Reporter  -->
     <system:String x:Key="reportWindow_version">Versjon</system:String>
     <system:String x:Key="reportWindow_time">Tid</system:String>
     <system:String x:Key="reportWindow_reproduce">Fortell oss hvordan programmet krasjet, så vi kan fikse det</system:String>
@@ -128,7 +131,7 @@
     <system:String x:Key="reportWindow_report_failed">Kunne ikke sende rapport</system:String>
     <system:String x:Key="reportWindow_flowlauncher_got_an_error">Flow Launcher møtte på en feil</system:String>
 
-    <!--update-->
+    <!--  update  -->
     <system:String x:Key="update_flowlauncher_update_new_version_available">Versjon {0} av Flow Launcher er nå tilgjengelig</system:String>
     <system:String x:Key="update_flowlauncher_update_error">En feil oppstod under installasjon av programvareoppdateringer</system:String>
     <system:String x:Key="update_flowlauncher_update">Oppdater</system:String>

--- a/Flow.Launcher/Languages/nb.xaml
+++ b/Flow.Launcher/Languages/nb.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Failed to register hotkey: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Could not start {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Find more plugins</system:String>
     <system:String x:Key="enable">On</system:String>
     <system:String x:Key="disable">Off</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Hotkey</system:String>
+    <system:String x:Key="hotkeys">Hotkeys</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher Hotkey</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Enter shortcut to show/hide Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/Languages/nl.xaml
+++ b/Flow.Launcher/Languages/nl.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Sneltoets registratie: {0} mislukt</system:String>
     <system:String x:Key="couldnotStartCmd">Kan {0} niet starten</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Zoek meer plugins</system:String>
     <system:String x:Key="enable">Aan</system:String>
     <system:String x:Key="disable">Disable</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Sneltoets</system:String>
+    <system:String x:Key="hotkeys">Sneltoets</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher Sneltoets</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Voer snelkoppeling in om Flow Launcher te tonen/verbergen.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/Languages/pl.xaml
+++ b/Flow.Launcher/Languages/pl.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Nie udało się ustawić skrótu klawiszowego: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Nie udało się uruchomić: {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Znajdź więcej wtyczek</system:String>
     <system:String x:Key="enable">On</system:String>
     <system:String x:Key="disable">Wyłącz</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Skrót klawiszowy</system:String>
+    <system:String x:Key="hotkeys">Skrót klawiszowy</system:String>
     <system:String x:Key="flowlauncherHotkey">Skrót klawiszowy Flow Launcher</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Enter shortcut to show/hide Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/Languages/pt-br.xaml
+++ b/Flow.Launcher/Languages/pt-br.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Falha ao registrar atalho: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Não foi possível iniciar {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Encontrar mais plugins</system:String>
     <system:String x:Key="enable">On</system:String>
     <system:String x:Key="disable">Desabilitar</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Atalho</system:String>
+    <system:String x:Key="hotkeys">Atalho</system:String>
     <system:String x:Key="flowlauncherHotkey">Atalho do Flow Launcher</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Enter shortcut to show/hide Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/Languages/pt-pt.xaml
+++ b/Flow.Launcher/Languages/pt-pt.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Falha ao registar tecla de atalho: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Não foi possível iniciar {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">Não existem resultados</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Experimente outro termo de pesquisa.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Mais plugins</system:String>
     <system:String x:Key="enable">Ativo</system:String>
     <system:String x:Key="disable">Inativo</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Tecla de atalho</system:String>
+    <system:String x:Key="hotkeys">Tecla de atalho</system:String>
     <system:String x:Key="flowlauncherHotkey">Tecla de atalho Flow Launcher</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Introduza o atalho para mostrar/ocultar Flow Launcher</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>
@@ -302,7 +307,7 @@
     <system:String x:Key="update_flowlauncher_updating">A atualizar...</system:String>
     <system:String x:Key="update_flowlauncher_fail_moving_portable_user_profile_data">
         Flow Launcher não conseguiu mover o seu perfil de dados para a nova versão.
-Queira por favor mover a pasta do seu perfil de {0} para {1}
+        Queira por favor mover a pasta do seu perfil de {0} para {1}
     </system:String>
     <system:String x:Key="update_flowlauncher_new_update">Nova atualização</system:String>
     <system:String x:Key="update_flowlauncher_update_new_version_available">Está disponível a versão {0} do Flow Launcher</system:String>

--- a/Flow.Launcher/Languages/ru.xaml
+++ b/Flow.Launcher/Languages/ru.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Регистрация хоткея {0} не удалась</system:String>
     <system:String x:Key="couldnotStartCmd">Не удалось запустить {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Найти больше плагинов</system:String>
     <system:String x:Key="enable">On</system:String>
     <system:String x:Key="disable">Отключить</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Горячая клавиша</system:String>
+    <system:String x:Key="hotkeys">Горячая клавиша</system:String>
     <system:String x:Key="flowlauncherHotkey">Горячая клавиша Flow Launcher</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Enter shortcut to show/hide Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/Languages/sk.xaml
+++ b/Flow.Launcher/Languages/sk.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Nepodarilo sa registrovať klávesovú skratku {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Nepodarilo sa spustiť {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">Nenašli sa žiadne výsledky</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Skúste použiť iné vyhľadávanie.</system:String>
     <system:String x:Key="plugin">Pluginy</system:String>
+    <system:String x:Key="plugins">Pluginy</system:String>
     <system:String x:Key="browserMorePlugins">Nájsť ďalšie pluginy</system:String>
     <system:String x:Key="enable">Zapnuté</system:String>
     <system:String x:Key="disable">Vypnuté</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Klávesové skratky</system:String>
+    <system:String x:Key="hotkeys">Klávesové skratky</system:String>
     <system:String x:Key="flowlauncherHotkey">Klávesová skratka pre Flow Launcher</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Zadajte skratku na zobrazenie/skrytie Flow Launchera.</system:String>
     <system:String x:Key="previewHotkey">Klávesová skratka pre náhľad</system:String>
@@ -303,7 +308,7 @@
     <system:String x:Key="update_flowlauncher_updating">Aktualizuje sa...</system:String>
     <system:String x:Key="update_flowlauncher_fail_moving_portable_user_profile_data">
         Flow Launcher nedokázal presunúť používateľské údaje do aktualizovanej verzie.
-            Prosím, presuňte profilový priečinok data z {0} do {1}
+        Prosím, presuňte profilový priečinok data z {0} do {1}
     </system:String>
     <system:String x:Key="update_flowlauncher_new_update">Nová aktualizácia</system:String>
     <system:String x:Key="update_flowlauncher_update_new_version_available">Je dostupná nová verzia Flow Launchera {0}</system:String>

--- a/Flow.Launcher/Languages/sr.xaml
+++ b/Flow.Launcher/Languages/sr.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Neuspešno registrovana prečica: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Neuspešno pokretanje {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Nađi još plugin-a</system:String>
     <system:String x:Key="enable">On</system:String>
     <system:String x:Key="disable">Onemogući</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Prečica</system:String>
+    <system:String x:Key="hotkeys">Prečica</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher prečica</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Enter shortcut to show/hide Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>
@@ -211,7 +216,7 @@
     <system:String x:Key="newVersionTips">Nove verzija {0} je dostupna, molim Vas ponovo pokrenite Flow Launcher.</system:String>
     <system:String x:Key="checkUpdatesFailed">Neuspešna provera ažuriranja, molim Vas proverite vašu vezu i podešavanja za proksi prema api.github.com.</system:String>
     <system:String x:Key="downloadUpdatesFailed">
-        Neuspešno preuzimanje ažuriranja, molim Vas proverite vašu vezu i podešavanja za proksi prema github-cloud.s3.amazonaws.com, 
+        Neuspešno preuzimanje ažuriranja, molim Vas proverite vašu vezu i podešavanja za proksi prema github-cloud.s3.amazonaws.com,
         ili posetite https://github.com/Flow-Launcher/Flow.Launcher/releases da preuzmete ažuriranja ručno.
     </system:String>
     <system:String x:Key="releaseNotes">U novoj verziji</system:String>

--- a/Flow.Launcher/Languages/tr.xaml
+++ b/Flow.Launcher/Languages/tr.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Kısayol tuşu ataması başarısız oldu: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">{0} başlatılamıyor</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Eklenti</system:String>
+    <system:String x:Key="plugins">Eklenti</system:String>
     <system:String x:Key="browserMorePlugins">Daha fazla eklenti bul</system:String>
     <system:String x:Key="enable">Açık</system:String>
     <system:String x:Key="disable">Devre Dışı</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Kısayol Tuşu</system:String>
+    <system:String x:Key="hotkeys">Kısayol Tuşu</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher Kısayolu</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Enter shortcut to show/hide Flow Launcher.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/Languages/uk-UA.xaml
+++ b/Flow.Launcher/Languages/uk-UA.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">Реєстрація хоткея {0} не вдалася</system:String>
     <system:String x:Key="couldnotStartCmd">Не вдалося запустити {0}</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">Plugin</system:String>
+    <system:String x:Key="plugins">Plugins</system:String>
     <system:String x:Key="browserMorePlugins">Знайти більше плагінів</system:String>
     <system:String x:Key="enable">Увімкнено</system:String>
     <system:String x:Key="disable">Відключити</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Гаряча клавіша</system:String>
+    <system:String x:Key="hotkeys">Гаряча клавіша</system:String>
     <system:String x:Key="flowlauncherHotkey">Гаряча клавіша Flow Launcher</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">Введіть ярлик для відображення/приховання потокового запуску.</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/Languages/zh-cn.xaml
+++ b/Flow.Launcher/Languages/zh-cn.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">注册热键：{0} 失败</system:String>
     <system:String x:Key="couldnotStartCmd">启动命令 {0} 失败</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">未找到结果</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">请尝试搜索不同的内容。</system:String>
     <system:String x:Key="plugin">插件</system:String>
+    <system:String x:Key="plugins">插件</system:String>
     <system:String x:Key="browserMorePlugins">浏览更多插件</system:String>
     <system:String x:Key="enable">启用</system:String>
     <system:String x:Key="disable">禁用</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">热键</system:String>
+    <system:String x:Key="hotkeys">热键</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher 激活热键</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">输入显示/隐藏 Flow Launcher 的快捷键。</system:String>
     <system:String x:Key="previewHotkey">预览快捷键</system:String>
@@ -211,7 +216,7 @@
     <system:String x:Key="newVersionTips">发现新版本 {0}, 请重启 Flow Launcher</system:String>
     <system:String x:Key="checkUpdatesFailed">下载更新失败，请检查您与 api.github.com 的连接状态或检查代理设置</system:String>
     <system:String x:Key="downloadUpdatesFailed">
-        下载更新失败，请检查您与 github-cloud.s3.amazonaws.com 的连接状态或检查代理设置， 
+        下载更新失败，请检查您与 github-cloud.s3.amazonaws.com 的连接状态或检查代理设置，
         或访问 https://github.com/Flow-Launcher/Flow.Launcher/releases 手动下载更新
     </system:String>
     <system:String x:Key="releaseNotes">更新说明</system:String>

--- a/Flow.Launcher/Languages/zh-tw.xaml
+++ b/Flow.Launcher/Languages/zh-tw.xaml
@@ -1,5 +1,8 @@
-﻿<?xml version="1.0"?>
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
+﻿<?xml version="1.0" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--  MainWindow  -->
     <system:String x:Key="registerHotkeyFailed">登錄快捷鍵：{0} 失敗</system:String>
     <system:String x:Key="couldnotStartCmd">啟動命令 {0} 失敗</system:String>
@@ -80,6 +83,7 @@
     <system:String x:Key="searchplugin_Noresult_Title">No results found</system:String>
     <system:String x:Key="searchplugin_Noresult_Subtitle">Please try a different search.</system:String>
     <system:String x:Key="plugin">插件</system:String>
+    <system:String x:Key="plugins">插件</system:String>
     <system:String x:Key="browserMorePlugins">瀏覽更多外掛</system:String>
     <system:String x:Key="enable">啟用</system:String>
     <system:String x:Key="disable">停用</system:String>
@@ -152,6 +156,7 @@
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">快捷鍵</system:String>
+    <system:String x:Key="hotkeys">快捷鍵</system:String>
     <system:String x:Key="flowlauncherHotkey">Flow Launcher 快捷鍵</system:String>
     <system:String x:Key="flowlauncherHotkeyToolTip">執行快捷鍵以顯示 / 隱藏 Flow Launcher。</system:String>
     <system:String x:Key="previewHotkey">Preview Hotkey</system:String>

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -1027,7 +1027,7 @@
                             <TextBlock
                                 Grid.Column="1"
                                 Style="{StaticResource TabMenu}"
-                                Text="{DynamicResource plugin}" />
+                                Text="{DynamicResource plugins}" />
                         </Grid>
                     </TabItem.Header>
 
@@ -1049,7 +1049,7 @@
                                     DockPanel.Dock="Left"
                                     FontSize="30"
                                     Style="{StaticResource PageTitle}"
-                                    Text="{DynamicResource plugin}"
+                                    Text="{DynamicResource plugins}"
                                     TextAlignment="Left" />
                                 <DockPanel DockPanel.Dock="Right">
                                     <TextBox
@@ -2388,7 +2388,7 @@
                             <TextBlock
                                 Grid.Column="1"
                                 Style="{StaticResource TabMenu}"
-                                Text="{DynamicResource hotkey}" />
+                                Text="{DynamicResource hotkeys}" />
                         </Grid>
                     </TabItem.Header>
                     <ScrollViewer
@@ -2404,7 +2404,7 @@
                                     Margin="0,5,0,2"
                                     FontSize="30"
                                     Style="{StaticResource PageTitle}"
-                                    Text="{DynamicResource hotkey}"
+                                    Text="{DynamicResource hotkeys}"
                                     TextAlignment="left" />
 
                                 <StackPanel Grid.Row="1">


### PR DESCRIPTION
## What's the PR
- Fix https://github.com/Flow-Launcher/Flow.Launcher/issues/1888
- Change Hotkey/Plugin title area to plural (Hotkeys / plugins)
- Fix Hotkey tab's singular texts : hotkeys / shortcuts
- Other languages have added key values and pasted existing text.
 
![image](https://user-images.githubusercontent.com/6903107/217998589-87108cb0-5d2a-41d0-a279-e4f10699fb2c.png)

![image](https://user-images.githubusercontent.com/6903107/217998537-e418bd2d-36fa-4189-a64b-a4143b29a363.png)

![image](https://user-images.githubusercontent.com/6903107/217998544-32a7d0a4-f9e9-4042-aa7c-8a1c143f2051.png)


## Test Case
- There should be no typos in the key value.