### PR TITLE
Remove Obsolete Property and use Status Property for Sorting

### DIFF
--- a/Flow.Launcher/Resources/Dark.xaml
+++ b/Flow.Launcher/Resources/Dark.xaml
@@ -59,6 +59,7 @@
 
     <SolidColorBrush x:Key="ThemeHoverButton" Color="#3c3c3c" />
     <SolidColorBrush x:Key="PopuBGColor" Color="#202020" />
+    <SolidColorBrush x:Key="PopupBGColor" Color="#202020" />
     <SolidColorBrush x:Key="PopupTextColor" Color="#cfcfcf" />
     <SolidColorBrush x:Key="PopupButtonAreaBGColor" Color="#2b2b2b" />
     <SolidColorBrush x:Key="PopupButtonAreaBorderColor" Color="#3f3f3f" />

--- a/Flow.Launcher/Resources/Light.xaml
+++ b/Flow.Launcher/Resources/Light.xaml
@@ -51,7 +51,9 @@
     <SolidColorBrush x:Key="BasicLabelColor" Color="#1b1b1b" />
 
     <SolidColorBrush x:Key="ThemeHoverButton" Color="#f6f6f6" />
+    <!--  Typo  -->
     <SolidColorBrush x:Key="PopuBGColor" Color="#ffffff" />
+    <SolidColorBrush x:Key="PopupBGColor" Color="#ffffff" />
     <SolidColorBrush x:Key="PopupTextColor" Color="#1b1b1b" />
     <SolidColorBrush x:Key="PopupButtonAreaBGColor" Color="#f3f3f3" />
     <SolidColorBrush x:Key="PopupButtonAreaBorderColor" Color="#e5e5e5" />

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/en.xaml
@@ -12,6 +12,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_delete">Delete</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Edit</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Add</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirm</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSource.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSource.cs
@@ -35,6 +35,9 @@ namespace Flow.Launcher.Plugin.WebSearch
         }
 
         public string Url { get; set; }
+
+        [JsonIgnore]
+        public bool Status => Enabled;
         public bool Enabled { get; set; }
 
         public SearchSource DeepCopy()

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
@@ -8,7 +8,7 @@
     Title="{DynamicResource flowlauncher_plugin_websearch_window_title}"
     Width="550"
     d:DataContext="{d:DesignInstance vm:SearchSourceViewModel}"
-    Background="{DynamicResource PopuBGColor}"
+    Background="{DynamicResource PopupBGColor}"
     Foreground="{DynamicResource PopupTextColor}"
     ResizeMode="NoResize"
     SizeToContent="Height"

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
@@ -179,7 +179,7 @@
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
                                     FontSize="14"
-                                    Text="{DynamicResource flowlauncher_plugin_websearch_enabled}" />
+                                    Text="{DynamicResource flowlauncher_plugin_websearch_enabled_label}" />
                                 <CheckBox
                                     Grid.Row="4"
                                     Grid.Column="1"

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
@@ -146,7 +146,7 @@
                         Margin="0,0,8,0"
                         IsChecked="{Binding Settings.EnableSuggestion}" />
                 </StackPanel>
-                <!--  Not sure why binding IsEnabled directly to Settings.EnableWebSaerchSuggestion is not working  -->
+                <!--  Not sure why binding IsEnabled directly to Settings.EnableWebSearchSuggestion is not working  -->
             </DockPanel>
         </Border>
     </Grid>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
@@ -69,23 +69,11 @@
                     <GridViewColumn
                         Width="130"
                         DisplayMemberBinding="{Binding ActionKeyword}"
-                        Header="{DynamicResource flowlauncher_plugin_websearch_action_keyword}">
-                        <GridViewColumn.CellTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding ActionKeyword}" />
-                            </DataTemplate>
-                        </GridViewColumn.CellTemplate>
-                    </GridViewColumn>
+                        Header="{DynamicResource flowlauncher_plugin_websearch_action_keyword}"/>
                     <GridViewColumn
                         Width="350"
                         DisplayMemberBinding="{Binding Title}"
-                        Header="{DynamicResource flowlauncher_plugin_websearch_title}">
-                        <GridViewColumn.CellTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding Title}" />
-                            </DataTemplate>
-                        </GridViewColumn.CellTemplate>
-                    </GridViewColumn>
+                        Header="{DynamicResource flowlauncher_plugin_websearch_title}"/>
                     <GridViewColumn Width="140" Header="{DynamicResource flowlauncher_plugin_websearch_enable}">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
@@ -94,7 +82,7 @@
                                         <Style TargetType="TextBlock">
                                             <Setter Property="Text" Value="{DynamicResource flowlauncher_plugin_websearch_false}" />
                                             <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Enabled, UpdateSourceTrigger=PropertyChanged}" Value="True">
+                                                <DataTrigger Binding="{Binding Status, UpdateSourceTrigger=PropertyChanged}" Value="True">
                                                     <Setter Property="Text" Value="{DynamicResource flowlauncher_plugin_websearch_true}" />
                                                 </DataTrigger>
                                             </Style.Triggers>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml.cs
@@ -96,27 +96,29 @@ namespace Flow.Launcher.Plugin.WebSearch
             var columnBinding = headerClicked.Column.DisplayMemberBinding as Binding;
             var sortBy = columnBinding?.Path.Path ?? headerClicked.Column.Header as string;
 
-            Sort(sortBy, direction);
+            if(sortBy != null) { 
+                Sort(sortBy, direction);
 
-            if (direction == ListSortDirection.Ascending)
-            {
-                headerClicked.Column.HeaderTemplate =
-                  Resources["HeaderTemplateArrowUp"] as DataTemplate;
-            }
-            else
-            {
-                headerClicked.Column.HeaderTemplate =
-                  Resources["HeaderTemplateArrowDown"] as DataTemplate;
-            }
+                if (direction == ListSortDirection.Ascending)
+                {
+                    headerClicked.Column.HeaderTemplate =
+                      Resources["HeaderTemplateArrowUp"] as DataTemplate;
+                }
+                else
+                {
+                    headerClicked.Column.HeaderTemplate =
+                      Resources["HeaderTemplateArrowDown"] as DataTemplate;
+                }
 
-            // Remove arrow from previously sorted header
-            if (_lastHeaderClicked != null && _lastHeaderClicked != headerClicked)
-            {
-                _lastHeaderClicked.Column.HeaderTemplate = null;
-            }
+                // Remove arrow from previously sorted header
+                if (_lastHeaderClicked != null && _lastHeaderClicked != headerClicked)
+                {
+                    _lastHeaderClicked.Column.HeaderTemplate = null;
+                }
 
-            _lastHeaderClicked = headerClicked;
-            _lastDirection = direction;
+                _lastHeaderClicked = headerClicked;
+                _lastDirection = direction;
+            }
         }
         private void Sort(string sortBy, ListSortDirection direction)
         {


### PR DESCRIPTION
## What's The PR
- Fix #1956 
- Fix #1948 
- Fix Enabled Label in Source Setting Window

## Test Case
- [x] No error should be displayed when clicking on the header of the icon column.
- [x] You should see the Enabled label in the Source Settings window.
- [x] The sort should work when you click on the header of the Status column
- [x] Status should show enabled/disabled in each language.