### PR TITLE
Add Grid Splitter for preview resizing

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -335,11 +335,9 @@
                 </Grid>
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition
-                            Width="0.85*"
-                            MinWidth="244"
-                            MaxWidth="340" />
+                        <ColumnDefinition Width="*" MinWidth="100" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="0.85*" MinWidth="244" />
                     </Grid.ColumnDefinitions>
                     <StackPanel
                         x:Name="ResultArea"
@@ -394,9 +392,16 @@
                             </ContentControl>
                         </Border>
                     </StackPanel>
+                    <GridSplitter
+                        Grid.Column="1"
+                        Width="5"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Stretch"
+                        Background="Transparent"
+                        ShowsPreview="True" />
                     <Grid
                         x:Name="Preview"
-                        Grid.Column="1"
+                        Grid.Column="2"
                         VerticalAlignment="Stretch"
                         Style="{DynamicResource PreviewArea}"
                         Visibility="{Binding PreviewVisible, Converter={StaticResource BoolToVisibilityConverter}}">

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -469,7 +469,7 @@ namespace Flow.Launcher.ViewModel
 
         private void HidePreview()
         {
-            ResultAreaColumn = 2;
+            ResultAreaColumn = 3;
             PreviewVisible = false;
         }
 


### PR DESCRIPTION
![resize](https://user-images.githubusercontent.com/6903107/224881935-5fa729cc-875c-4732-aafc-00702b5f6f80.gif)

## What's the PR
- Changed the size of the preview area to be resizable with mouse dragging.

## Test Case
- [ ] Each area should display correctly when preview is turned on and off.

## Memo
- The size is reset when turned on and off. As long as the process is alive, the size you changed will be retained.
- Is it a good idea to save this size? I'm having a little trouble with this.