### PR TITLE
Fix EmptyQueryMode when opened context menu

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1017,6 +1017,7 @@ namespace Flow.Launcher.ViewModel
             switch (Settings.LastQueryMode)
             {
                 case LastQueryMode.Empty:
+                    SelectedResults = Results;
                     ChangeQueryText(string.Empty);
                     await Task.Delay(100); //Time for change to opacity
                     break;


### PR DESCRIPTION
## What's The PR
- Resolve #2019 
- Fixes an issue where if you toggle flow while the context menu is open, the context menu is open when you reopen it.