### PR TITLE
Fix image cache and hash correspondence

### DIFF
--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -269,7 +269,7 @@ namespace Flow.Launcher.Infrastructure.Image
 
                     if (GuidToKey.TryGetValue(hash, out string key))
                     { // image already exists
-                        img = ImageCache[key, false] ?? img;
+                        img = ImageCache[key, loadFullImage] ?? img;
                     }
                     else
                     { // new guid


### PR DESCRIPTION
Related to #1727. Mapping between hash and (path, isfullimage) is incorrect.