### PR TITLE
Interim fix for notification platform unavailable error

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,6 +1,7 @@
 crowdin
 DWM
 workflows
+Wpf
 wpf
 actionkeyword
 stackoverflow

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -90,7 +90,9 @@
     </PackageReference>
     <PackageReference Include="InputSimulator" Version="1.0.4" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-    <PackageReference Include="ModernWpfUI" Version="0.9.6" />
+    <!-- ModernWpfUI v0.9.5 introduced WinRT changes that causes Notification platform unavailable error on some machines -->
+    <!-- https://github.com/Flow-Launcher/Flow.Launcher/issues/1772#issuecomment-1502440801 -->
+    <PackageReference Include="ModernWpfUI" Version="0.9.4" />
     <PackageReference Include="NHotkey.Wpf" Version="2.1.0" />
     <PackageReference Include="NuGet.CommandLine" Version="6.3.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Since we will be moving to a new UI framework in the future, this is an interim fix for notification platform unavailable error caused by ModernWpfUI version bump from https://github.com/Flow-Launcher/Flow.Launcher/pull/1773. 

ModernWpfUI v0.9.5 introduced [change around WinRT usage](https://github.com/Kinnara/ModernWpf/pull/451) that causes notification platform unavailable error for flow on some machines.

Context:

Tests:
Win 10:
- Notification shown for plugin data reload
- Notification shown for plugin already installed
- Notifications shown for plugin install process
- Plugin Store plugin install pop up is shown
- Resizing preview window
- Increasing/Decreasing width of search window via hotkey
- Increasing/Decreasing maximum displayed result rows via hotkey
Win 11:
Same tests as above
 
Close https://github.com/Flow-Launcher/Flow.Launcher/issues/1772