### PR TITLE
Revert Ctrl+Enter description

### DIFF
--- a/Flow.Launcher/Languages/es-419.xaml
+++ b/Flow.Launcher/Languages/es-419.xaml
@@ -346,7 +346,7 @@
     <system:String x:Key="HotkeyUpDownDesc">Atrás / Menú Contextual</system:String>
     <system:String x:Key="HotkeyLeftRightDesc">Navegación de Elemento</system:String>
     <system:String x:Key="HotkeyShiftEnterDesc">Abrir Menú Contextual</system:String>
-    <system:String x:Key="HotkeyCtrlEnterDesc">Open Containing Folder</system:String>
+    <system:String x:Key="HotkeyCtrlEnterDesc">Abrir Carpeta Contenedora</system:String>
     <system:String x:Key="HotkeyCtrlShiftEnterDesc">Run as Admin / Open Folder in Default File Manager</system:String>
     <system:String x:Key="HotkeyCtrlHDesc">Historial de Consultas</system:String>
     <system:String x:Key="HotkeyESCDesc">Volver al Resultado en el Menú Contextual</system:String>

--- a/Flow.Launcher/Languages/it.xaml
+++ b/Flow.Launcher/Languages/it.xaml
@@ -346,7 +346,7 @@
     <system:String x:Key="HotkeyUpDownDesc">Indietro / Menu contestuale</system:String>
     <system:String x:Key="HotkeyLeftRightDesc">Navigazione tra le voci</system:String>
     <system:String x:Key="HotkeyShiftEnterDesc">Apri il menu di scelta rapida</system:String>
-    <system:String x:Key="HotkeyCtrlEnterDesc">Open Containing Folder</system:String>
+    <system:String x:Key="HotkeyCtrlEnterDesc">Apri cartella superiore</system:String>
     <system:String x:Key="HotkeyCtrlShiftEnterDesc">Run as Admin / Open Folder in Default File Manager</system:String>
     <system:String x:Key="HotkeyCtrlHDesc">Cronologia Query</system:String>
     <system:String x:Key="HotkeyESCDesc">Torna al risultato nel menu contestuale</system:String>

--- a/Flow.Launcher/Languages/ko.xaml
+++ b/Flow.Launcher/Languages/ko.xaml
@@ -346,7 +346,7 @@
     <system:String x:Key="HotkeyUpDownDesc">뒤로/ 콘텍스트 메뉴</system:String>
     <system:String x:Key="HotkeyLeftRightDesc">아이템 이동</system:String>
     <system:String x:Key="HotkeyShiftEnterDesc">콘텍스트 메뉴 열기</system:String>
-    <system:String x:Key="HotkeyCtrlEnterDesc">Open Containing Folder</system:String>
+    <system:String x:Key="HotkeyCtrlEnterDesc">포함된 폴더 열기</system:String>
     <system:String x:Key="HotkeyCtrlShiftEnterDesc">Run as Admin / Open Folder in Default File Manager</system:String>
     <system:String x:Key="HotkeyCtrlHDesc">검색 기록</system:String>
     <system:String x:Key="HotkeyESCDesc">콘텍스트 메뉴에서 뒤로 가기</system:String>

--- a/Flow.Launcher/Languages/pt-pt.xaml
+++ b/Flow.Launcher/Languages/pt-pt.xaml
@@ -345,7 +345,7 @@ Queira por favor mover a pasta do seu perfil de {0} para {1}
     <system:String x:Key="HotkeyUpDownDesc">Recuar/Menu de contexto</system:String>
     <system:String x:Key="HotkeyLeftRightDesc">Navegação nos itens</system:String>
     <system:String x:Key="HotkeyShiftEnterDesc">Abrir menu de contexto</system:String>
-    <system:String x:Key="HotkeyCtrlEnterDesc">Open Containing Folder</system:String>
+    <system:String x:Key="HotkeyCtrlEnterDesc">Abrir pasta do resultado</system:String>
     <system:String x:Key="HotkeyCtrlShiftEnterDesc">Executar como administrador/Abrir pasta no gestor de ficheiros</system:String>
     <system:String x:Key="HotkeyCtrlHDesc">Histórico de consultas</system:String>
     <system:String x:Key="HotkeyESCDesc">Voltar aos resultados no menu de contexto</system:String>

--- a/Flow.Launcher/Languages/sk.xaml
+++ b/Flow.Launcher/Languages/sk.xaml
@@ -346,7 +346,7 @@
     <system:String x:Key="HotkeyUpDownDesc">Späť/kontextová ponuka</system:String>
     <system:String x:Key="HotkeyLeftRightDesc">Navigácia medzi položkami</system:String>
     <system:String x:Key="HotkeyShiftEnterDesc">Otvoriť kontextovú ponuku</system:String>
-    <system:String x:Key="HotkeyCtrlEnterDesc">Open Containing Folder</system:String>
+    <system:String x:Key="HotkeyCtrlEnterDesc">Otvoriť umiestnenie priečinka</system:String>
     <system:String x:Key="HotkeyCtrlShiftEnterDesc">Spustiť ako správca/Otvoriť priečinok v predvolenom správcovi súborov</system:String>
     <system:String x:Key="HotkeyCtrlHDesc">História dopytov</system:String>
     <system:String x:Key="HotkeyESCDesc">Návrat na výsledky z kontextovej ponuky</system:String>

--- a/Flow.Launcher/Languages/zh-cn.xaml
+++ b/Flow.Launcher/Languages/zh-cn.xaml
@@ -346,7 +346,7 @@
     <system:String x:Key="HotkeyUpDownDesc">返回/上下文菜单</system:String>
     <system:String x:Key="HotkeyLeftRightDesc">选项导航</system:String>
     <system:String x:Key="HotkeyShiftEnterDesc">打开上下文菜单</system:String>
-    <system:String x:Key="HotkeyCtrlEnterDesc">Open Containing Folder</system:String>
+    <system:String x:Key="HotkeyCtrlEnterDesc">打开所在目录</system:String>
     <system:String x:Key="HotkeyCtrlShiftEnterDesc">以管理员身份运行/在默认文件管理器中打开文件夹</system:String>
     <system:String x:Key="HotkeyCtrlHDesc">查询历史</system:String>
     <system:String x:Key="HotkeyESCDesc">返回查询界面</system:String>

--- a/Flow.Launcher/Languages/zh-tw.xaml
+++ b/Flow.Launcher/Languages/zh-tw.xaml
@@ -346,7 +346,7 @@
     <system:String x:Key="HotkeyUpDownDesc">返回 / 快捷選單</system:String>
     <system:String x:Key="HotkeyLeftRightDesc">Item Navigation</system:String>
     <system:String x:Key="HotkeyShiftEnterDesc">打開選單</system:String>
-    <system:String x:Key="HotkeyCtrlEnterDesc">Open Containing Folder</system:String>
+    <system:String x:Key="HotkeyCtrlEnterDesc">開啟檔案位置</system:String>
     <system:String x:Key="HotkeyCtrlShiftEnterDesc">Run as Admin / Open Folder in Default File Manager</system:String>
     <system:String x:Key="HotkeyCtrlHDesc">查詢歷史</system:String>
     <system:String x:Key="HotkeyESCDesc">Back to Result in Context Menu</system:String>


### PR DESCRIPTION
The `Ctrl+Enter` description has been modified in 9e5e213 and reverted in 2616b70. Reset this entry in localization files to commit e20ac838 to avoid translating it again.