### PR TITLE
Change default search window position to follow cursor

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -240,7 +240,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         public bool HideWhenDeactivated { get; set; } = true;
 
         [JsonConverter(typeof(JsonStringEnumConverter))]
-        public SearchWindowScreens SearchWindowScreen { get; set; } = SearchWindowScreens.RememberLastLaunchLocation;
+        public SearchWindowScreens SearchWindowScreen { get; set; } = SearchWindowScreens.Cursor;
         
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public SearchWindowAligns SearchWindowAlign { get; set; } = SearchWindowAligns.Center;


### PR DESCRIPTION
When starting up for the first time, the 'Remember Last Position' setting does not work well. Search window shows up top lefthand corner. This change makes it to follow the cursor, so users with multiple monitors using flow for the first time can benefit.

Relates to #1978

Before
![image](https://user-images.githubusercontent.com/26427004/235379358-eb765aff-1105-45c1-bdb1-8fd6adfb07f1.png)

After
![image](https://user-images.githubusercontent.com/26427004/235379419-e332cf74-5b02-4c9c-8ec2-91b509cf3f8c.png)
