### PR TITLE
Hide programs in startmenu/startup folder

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -466,7 +466,10 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 .SelectMany(p => EnumerateProgramsInDir(p, suffixes))
                 .Distinct();
 
+            var startupPaths = GetStartupPaths();
+            
             var programs = ExceptDisabledSource(allPrograms)
+                .Where(x => !startupPaths.Any(startup => FilesFolders.PathContains(startup, x)))
                 .Select(x => GetProgramFromPath(x, protocols));
             return programs;
         }
@@ -715,6 +718,14 @@ namespace Flow.Launcher.Plugin.Program.Programs
             var commonStartMenu = Environment.GetFolderPath(Environment.SpecialFolder.CommonStartMenu);
 
             return new[] { userStartMenu, commonStartMenu };
+        }
+
+        private static IEnumerable<string> GetStartupPaths()
+        {
+            var userStartup = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
+            var commonStartup = Environment.GetFolderPath(Environment.SpecialFolder.CommonStartup);
+
+            return new[] { userStartup, commonStartup };
         }
 
         public static void WatchProgramUpdate(Settings settings)


### PR DESCRIPTION
Cherry picked from #2103.

## Why?

1. Start menu doesn't include files in startup folder
2. they often create duplicate. many auto startups have args like `-silent`

## Tests

- Programs in `Start Menu\Programs\StartUp` are not shown in results.