### PR TITLE
Close Firefox bookmark database connection after loading 

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
@@ -43,6 +43,7 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
                 x => new Bookmark(x["title"] is DBNull ? string.Empty : x["title"].ToString(),
                     x["url"].ToString())
             ).ToList();
+            dbConnection.Close();
 
             return bookmarkList;
         }


### PR DESCRIPTION
~~Close #2120~~

Test:
~~- `places.sqlite` is not used by Flow process after loading bookmarks.~~

BTW: why disabled plugins still init?