### PR TITLE
Reduce CPU and disk usage during Program plugin init

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Main.cs
@@ -110,6 +110,8 @@ namespace Flow.Launcher.Plugin.Program
             var win32S = Win32.All(_settings);
             _win32s = win32S;
             ResetCache();
+            _win32Storage.Save(_win32s);
+            _settings.LastIndexTime = DateTime.Now;
         }
 
         public static void IndexUwpPrograms()
@@ -117,6 +119,8 @@ namespace Flow.Launcher.Plugin.Program
             var applications = UWP.All(_settings);
             _uwps = applications;
             ResetCache();
+            _uwpStorage.Save(_uwps);
+            _settings.LastIndexTime = DateTime.Now;
         }
 
         public static async Task IndexProgramsAsync()
@@ -131,7 +135,6 @@ namespace Flow.Launcher.Plugin.Program
                 Stopwatch.Normal("|Flow.Launcher.Plugin.Program.Main|UWPProgram index cost", IndexUwpPrograms);
             });
             await Task.WhenAll(a, b).ConfigureAwait(false);
-            _settings.LastIndexTime = DateTime.Today;
         }
 
         internal static void ResetCache()
@@ -199,7 +202,6 @@ namespace Flow.Launcher.Plugin.Program
                 _ = Task.Run(() =>
                 {
                     IndexUwpPrograms();
-                    _settings.LastIndexTime = DateTime.Today;
                 });
             }
             else if (_win32s.Any(x => x.UniqueIdentifier == programToDelete.UniqueIdentifier))
@@ -210,7 +212,6 @@ namespace Flow.Launcher.Plugin.Program
                 _ = Task.Run(() =>
                 {
                     IndexWin32Programs();
-                    _settings.LastIndexTime = DateTime.Today;
                 });
             }
         }

--- a/Plugins/Flow.Launcher.Plugin.Program/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Settings.cs
@@ -121,13 +121,6 @@ namespace Flow.Launcher.Plugin.Program
         public bool EnablePathSource { get; set; } = false;
         public bool EnableUWP { get; set; } = true;
 
-        public string CustomizedExplorer { get; set; } = Explorer;
-        public string CustomizedArgs { get; set; } = ExplorerArgs;
-
         internal const char SuffixSeparator = ';';
-
-        internal const string Explorer = "explorer";
-
-        internal const string ExplorerArgs = "%s";
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
@@ -87,18 +87,6 @@ namespace Flow.Launcher.Plugin.Program.Views
             }
         }
 
-        public string CustomizedExplorerPath
-        {
-            get => _settings.CustomizedExplorer;
-            set => _settings.CustomizedExplorer = value;
-        }
-
-        public string CustomizedExplorerArg
-        {
-            get => _settings.CustomizedArgs;
-            set => _settings.CustomizedArgs = value;
-        }
-
         public bool ShowUWPCheckbox => UWP.SupportUWP();
 
         public ProgramSetting(PluginInitContext context, Settings settings, Win32[] win32s, UWP.Application[] uwps)


### PR DESCRIPTION
## Changes

- Make use of cache. Add expiration time (30 hours) to program cache on disk. 
  - 24 hours is too short. If I turn on my PC about the same time everyday I'd have a 50% to index every time. 30 hours is basically bi-daily.
  - Note that it doesn't immediately refresh cache when it expires. i.e. If you keep Flow running for more than 30 hours it doesn't reindex. Next reindex is done on next startup. This is intended because this PR is focused on reducing CPU and disk usage during init.
- Stop indexing on init when cache on disk existing and not expired. Significantly reduce CPU and disk usage.
- Save cache right after indexing.

## Tests

- Cache can be saved and loaded.
- No indexing on init when cache is not expired.
- Indexing is done on a first-time startup.