### PR TITLE
Plugin Store search (should) work after refresh button clicked

### DIFF
--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -9,6 +9,7 @@ using Flow.Launcher.ViewModel;
 using ModernWpf;
 using ModernWpf.Controls;
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Security.Policy;
@@ -58,10 +59,22 @@ namespace Flow.Launcher
             pluginListView = (CollectionView)CollectionViewSource.GetDefaultView(Plugins.ItemsSource);
             pluginListView.Filter = PluginListFilter;
 
-            pluginStoreView = (CollectionView)CollectionViewSource.GetDefaultView(StoreListBox.ItemsSource); 
+            pluginStoreView = (CollectionView)CollectionViewSource.GetDefaultView(StoreListBox.ItemsSource);
             pluginStoreView.Filter = PluginStoreFilter;
 
+            viewModel.PropertyChanged += new PropertyChangedEventHandler(SettingsWindowViewModelChanged);
+
             InitializePosition();
+        }
+
+        private void SettingsWindowViewModelChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(viewModel.ExternalPlugins))
+            {
+                pluginStoreView = (CollectionView)CollectionViewSource.GetDefaultView(StoreListBox.ItemsSource);
+                pluginStoreView.Filter = PluginStoreFilter;
+                pluginStoreView.Refresh();
+            }
         }
 
         private void OnSelectPythonPathClick(object sender, RoutedEventArgs e)
@@ -257,9 +270,9 @@ namespace Flow.Launcher
         {
             var confirmResult = MessageBox.Show(
                 InternationalizationManager.Instance.GetTranslation("clearlogfolderMessage"),
-                InternationalizationManager.Instance.GetTranslation("clearlogfolder"), 
+                InternationalizationManager.Instance.GetTranslation("clearlogfolder"),
                 MessageBoxButton.YesNo);
-            
+
             if (confirmResult == MessageBoxResult.Yes)
             {
                 viewModel.ClearLogFolder();
@@ -390,7 +403,7 @@ namespace Flow.Launcher
         }
 
         #endregion
-        
+
         private CollectionView pluginListView;
         private CollectionView pluginStoreView;
 


### PR DESCRIPTION
Fixes #2049.

Hello everyone! This is my first time contributing to Flow Launcher, and I am very new at C# in general. My goal is (hopefully) get all the latest plugins into the store and show all the most up-to-date installed plugins, and allow the search function to work even after the refresh button is clicked. Can anyone check that the implementation is correct, and if not, let me know if there are any fixes? 

Thanks so much!