### PR TITLE
Fix: Add admin permissions when non-admin doesn't work

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.WindowsSettings/Helper/ResultHelper.cs
+++ b/Plugins/Flow.Launcher.Plugin.WindowsSettings/Helper/ResultHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -200,6 +201,21 @@ namespace Flow.Launcher.Plugin.WindowsSettings.Helper
             {
                 Process.Start(processStartInfo);
                 return true;
+            }
+            catch (Win32Exception)
+            {
+                try
+                {
+                    processStartInfo.UseShellExecute = true;
+                    processStartInfo.Verb = "runas";
+                    Process.Start(processStartInfo);
+                    return true;
+                }
+                catch (Exception exception)
+                {
+                    Log.Exception("can't open settings on elevated permission", exception, typeof(ResultHelper));
+                    return false;
+                }
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
Fixes #1396.

What I am trying to do in this PR is that we run the process as normal, and if the process throws an "elevated permission error" (belonging to Win32Exception), it tries again with elevated permissions, and if that doesn't work, we throw. My (hopeful) reasoning is that we don't want to elevate permissions right from the get-go and only elevate when we need to.

Again, I'm pretty new to the codebase and C# in general, so feedback is greatly appreciated!