### PR TITLE
Remove NuGet.CommandLine package dependency

### DIFF
--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -94,10 +94,6 @@
     <!-- https://github.com/Flow-Launcher/Flow.Launcher/issues/1772#issuecomment-1502440801 -->
     <PackageReference Include="ModernWpfUI" Version="0.9.4" />
     <PackageReference Include="NHotkey.Wpf" Version="2.1.0" />
-    <PackageReference Include="NuGet.CommandLine" Version="6.3.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" />
     <PackageReference Include="SharpVectors" Version="1.8.1" />
     <PackageReference Include="VirtualizingWrapPanel" Version="1.5.7" />

--- a/Scripts/post_build.ps1
+++ b/Scripts/post_build.ps1
@@ -71,7 +71,6 @@ function Pack-Squirrel-Installer ($path, $version, $output) {
     Write-Host "Packing: $spec"
     Write-Host "Input path:  $input"
 
-    New-Alias Nuget $env:USERPROFILE\.nuget\packages\NuGet.CommandLine\6.3.1\tools\NuGet.exe -Force
     # dotnet pack is not used because ran into issues, need to test installation and starting up if to use it.
     nuget pack $spec -Version $version -BasePath $input -OutputDirectory $output -Properties Configuration=Release
 


### PR DESCRIPTION
AppVeyor now [has the nuget CLI pre-installed](https://www.appveyor.com/docs/windows-images-software/#tools) in the build image we use (version 6.5.0 atm), so we no longer need to manually install and alias it in our build script.

closes #2057 