### PR TITLE
Improvements for re-queries

### DIFF
--- a/Flow.Launcher.Plugin/Query.cs
+++ b/Flow.Launcher.Plugin/Query.cs
@@ -30,6 +30,12 @@ namespace Flow.Launcher.Plugin
         public string RawQuery { get; internal init; }
 
         /// <summary>
+        /// Determines whether the query was forced to execute again.
+        /// When this property is true, plugins handling this query should avoid serving cached results.
+        /// </summary>
+        public bool IsForced { get; internal set; } = false;
+
+        /// <summary>
         /// Search part of a query.
         /// This will not include action keyword if exclusive plugin gets it, otherwise it should be same as RawQuery.
         /// Since we allow user to switch a exclusive plugin to generic plugin, 

--- a/Flow.Launcher.Plugin/Query.cs
+++ b/Flow.Launcher.Plugin/Query.cs
@@ -31,9 +31,10 @@ namespace Flow.Launcher.Plugin
 
         /// <summary>
         /// Determines whether the query was forced to execute again.
+        /// For example, the value will be true when the user presses Ctrl + R.
         /// When this property is true, plugins handling this query should avoid serving cached results.
         /// </summary>
-        public bool IsForced { get; internal set; } = false;
+        public bool IsReQuery { get; internal set; } = false;
 
         /// <summary>
         /// Search part of a query.

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -87,6 +87,10 @@
             Command="{Binding LoadContextMenuCommand}"
             Modifiers="Ctrl" />
         <KeyBinding
+            Key="R"
+            Command="{Binding ReQueryCommand}"
+            Modifiers="Ctrl" />
+        <KeyBinding
             Key="H"
             Command="{Binding LoadHistoryCommand}"
             Modifiers="Ctrl" />

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -210,7 +210,7 @@ namespace Flow.Launcher.ViewModel
         {
             if (SelectedIsFromQueryResults())
             {
-                QueryResults(reQuery: true);
+                QueryResults(isReQuery: true);
             }
         }
 
@@ -504,8 +504,8 @@ namespace Flow.Launcher.ViewModel
         /// but we don't want to move cursor to end when query is updated from TextBox
         /// </summary>
         /// <param name="queryText"></param>
-        /// <param name="reQuery">Force query even when Query Text doesn't change</param>
-        public void ChangeQueryText(string queryText, bool reQuery = false)
+        /// <param name="isReQuery">Force query even when Query Text doesn't change</param>
+        public void ChangeQueryText(string queryText, bool isReQuery = false)
         {
             Application.Current.Dispatcher.Invoke(() =>
             {
@@ -519,9 +519,9 @@ namespace Flow.Launcher.ViewModel
                     QueryTextCursorMovedToEnd = false;
 
                 }
-                else if (reQuery)
+                else if (isReQuery)
                 {
-                    Query(reQuery: true);
+                    Query(isReQuery: true);
                 }
                 QueryTextCursorMovedToEnd = true;
             });
@@ -621,11 +621,11 @@ namespace Flow.Launcher.ViewModel
 
         #region Query
 
-        public void Query(bool reQuery = false)
+        public void Query(bool isReQuery = false)
         {
             if (SelectedIsFromQueryResults())
             {
-                QueryResults(reQuery);
+                QueryResults(isReQuery);
             }
             else if (ContextMenuSelected())
             {
@@ -725,7 +725,7 @@ namespace Flow.Launcher.ViewModel
 
         private readonly IReadOnlyList<Result> _emptyResult = new List<Result>();
 
-        private async void QueryResults(bool reQuery = false)
+        private async void QueryResults(bool isReQuery = false)
         {
             _updateSource?.Cancel();
 
@@ -757,7 +757,7 @@ namespace Flow.Launcher.ViewModel
                 return;
 
             // Update the query's IsReQuery property to true if this is a re-query
-            query.IsReQuery = reQuery;
+            query.IsReQuery = isReQuery;
 
             // handle the exclusiveness of plugin using action keyword
             RemoveOldQueryResults(query);

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -512,7 +512,7 @@ namespace Flow.Launcher.ViewModel
                 }
                 else if (reQuery)
                 {
-                    Query();
+                    Query(reQuery: true);
                 }
                 QueryTextCursorMovedToEnd = true;
             });
@@ -612,11 +612,11 @@ namespace Flow.Launcher.ViewModel
 
         #region Query
 
-        public void Query()
+        public void Query(bool reQuery = false)
         {
             if (SelectedIsFromQueryResults())
             {
-                QueryResults();
+                QueryResults(reQuery);
             }
             else if (ContextMenuSelected())
             {
@@ -716,7 +716,7 @@ namespace Flow.Launcher.ViewModel
 
         private readonly IReadOnlyList<Result> _emptyResult = new List<Result>();
 
-        private async void QueryResults()
+        private async void QueryResults(bool reQuery = false)
         {
             _updateSource?.Cancel();
 
@@ -747,6 +747,8 @@ namespace Flow.Launcher.ViewModel
             if (currentCancellationToken.IsCancellationRequested)
                 return;
 
+            // Update the query's IsForced property to true if this is a re-query
+            query.IsForced = reQuery;
 
             // handle the exclusiveness of plugin using action keyword
             RemoveOldQueryResults(query);

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -202,6 +202,15 @@ namespace Flow.Launcher.ViewModel
             else
             {
                 SelectedResults = Results;
+            }
+        }
+
+        [RelayCommand]
+        private void ReQuery()
+        {
+            if (SelectedIsFromQueryResults())
+            {
+                QueryResults(reQuery: true);
             }
         }
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -756,8 +756,8 @@ namespace Flow.Launcher.ViewModel
             if (currentCancellationToken.IsCancellationRequested)
                 return;
 
-            // Update the query's IsForced property to true if this is a re-query
-            query.IsForced = reQuery;
+            // Update the query's IsReQuery property to true if this is a re-query
+            query.IsReQuery = reQuery;
 
             // handle the exclusiveness of plugin using action keyword
             RemoveOldQueryResults(query);


### PR DESCRIPTION
This quick PR introduces the following changes:

1. the `IsReQuery` property is added to the `Query` class, which will be set to `true` whenever a Query is re-executed.
2. the `Ctrl + R` key binding is added for quickly re-executing the current query.

This enables `Ctrl + R` to act as a "refresh" mechanism. When users type a query and the shown results seem out-of-date (for example, due to caching), they can hit `Ctrl + R` to get fresh results.

### Example use-case

The Github plugin caches all query results to avoid rate-limits (and because the Github API is pretty slow). When the user tries to list the issues for a repository, they are likely to get cached results, and therefore recently created issues may be missing. `Ctrl + R` can be used to signal the plugin to skip the cache and load the repository's issues from the API.
