### PR TITLE
Refactor clipboard copying

### DIFF
--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -40,7 +40,8 @@ namespace Flow.Launcher.Plugin
         void ShellRun(string cmd, string filename = "cmd.exe");
         
         /// <summary>
-        /// Copy Text to clipboard
+        /// If the passed in text is the path to a file or directory, the actual file/directory will
+        /// be copied to clipboard. Otherwise the text itself will be copied to clipboard.
         /// </summary>
         /// <param name="text">Text to save on clipboard</param>
         public void CopyToClipboard(string text);

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -38,13 +38,15 @@ namespace Flow.Launcher.Plugin
         /// <exception cref="FileNotFoundException">Thrown when unable to find the file specified in the command </exception>
         /// <exception cref="Win32Exception">Thrown when error occurs during the execution of the command </exception>
         void ShellRun(string cmd, string filename = "cmd.exe");
-        
+
         /// <summary>
-        /// If the passed in text is the path to a file or directory, the actual file/directory will
-        /// be copied to clipboard. Otherwise the text itself will be copied to clipboard.
+        /// Copies the passed in text and shows a message indicating whether the operation was completed successfully.
+        /// When directCopy is set to true and passed in text is the path to a file or directory,
+        /// the actual file/directory will be copied to clipboard. Otherwise the text itself will still be copied to clipboard.
         /// </summary>
         /// <param name="text">Text to save on clipboard</param>
-        public void CopyToClipboard(string text);
+        /// <param name="directCopy">When true it will directly copy the file/folder from the path specified in text</param>
+        public void CopyToClipboard(string text, bool directCopy = false);
 
         /// <summary>
         /// Save everything, all of Flow Launcher and plugins' data and settings

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -46,7 +46,10 @@ namespace Flow.Launcher.Plugin
         /// </summary>
         /// <param name="text">Text to save on clipboard</param>
         /// <param name="directCopy">When true it will directly copy the file/folder from the path specified in text</param>
-        public void CopyToClipboard(string text, bool directCopy = false);
+        /// <param name="showDefaultNotification">Whether to show the default notification from this method after copy is done. 
+        ///                                         It will show file/folder/text is copied successfully.
+        ///                                         Turn this off to show your own notification after copy is done.</param>>
+        public void CopyToClipboard(string text, bool directCopy = false, bool showDefaultNotification = true);
 
         /// <summary>
         /// Save everything, all of Flow Launcher and plugins' data and settings

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -63,8 +63,7 @@ namespace Flow.Launcher
             if (QueryTextBox.SelectionLength == 0 && result != null)
             {
                 string copyText = result.CopyText;
-                _viewModel.ResultCopy(copyText);
-
+                App.API.CopyToClipboard(copyText, directCopy: true);
             }
             else if (!string.IsNullOrEmpty(QueryTextBox.Text))
             {

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -67,7 +67,7 @@ namespace Flow.Launcher
             }
             else if (!string.IsNullOrEmpty(QueryTextBox.Text))
             {
-                System.Windows.Clipboard.SetDataObject(QueryTextBox.SelectedText);
+                App.API.CopyToClipboard(QueryTextBox.SelectedText, showDefaultNotification: false);
             }
         }
         

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -68,7 +68,7 @@ namespace Flow.Launcher
             }
             else if (!string.IsNullOrEmpty(QueryTextBox.Text))
             {
-                System.Windows.Clipboard.SetText(QueryTextBox.SelectedText);
+                System.Windows.Clipboard.SetDataObject(QueryTextBox.SelectedText);
             }
         }
         

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -24,6 +24,7 @@ using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.Storage;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Collections.Specialized;
 
 namespace Flow.Launcher
 {
@@ -116,10 +117,35 @@ namespace Flow.Launcher
             ShellCommand.Execute(startInfo);
         }
 
-        public void CopyToClipboard(string text)
+        public void CopyToClipboard(string stringToCopy, bool directCopy = false)
         {
-            _mainVM.ResultCopy(text);
+            if (string.IsNullOrEmpty(stringToCopy))
+                return;
+
+            var isFile = File.Exists(stringToCopy);
+            if (directCopy && (isFile || Directory.Exists(stringToCopy)))
+            {
+                var paths = new StringCollection
+                {
+                    stringToCopy
+                };
+
+                Clipboard.SetFileDropList(paths);
+
+                ShowMsg(
+                    $"{GetTranslation("copy")} {(isFile ? GetTranslation("fileTitle") : GetTranslation("folderTitle"))}",
+                    GetTranslation("completedSuccessfully"));
+            }
+            else
+            {
+                Clipboard.SetDataObject(stringToCopy);
+
+                ShowMsg(
+                    $"{GetTranslation("copy")} {GetTranslation("textTitle")}",
+                    GetTranslation("completedSuccessfully"));
+            }
         }
+    
 
         public void StartLoadingBar() => _mainVM.ProgressBarVisibility = Visibility.Visible;
 

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -117,7 +117,7 @@ namespace Flow.Launcher
             ShellCommand.Execute(startInfo);
         }
 
-        public void CopyToClipboard(string stringToCopy, bool directCopy = false)
+        public void CopyToClipboard(string stringToCopy, bool directCopy = false, bool showDefaultNotification = true)
         {
             if (string.IsNullOrEmpty(stringToCopy))
                 return;
@@ -132,20 +132,21 @@ namespace Flow.Launcher
 
                 Clipboard.SetFileDropList(paths);
 
-                ShowMsg(
-                    $"{GetTranslation("copy")} {(isFile ? GetTranslation("fileTitle") : GetTranslation("folderTitle"))}",
-                    GetTranslation("completedSuccessfully"));
+                if (showDefaultNotification)
+                    ShowMsg(
+                        $"{GetTranslation("copy")} {(isFile ? GetTranslation("fileTitle") : GetTranslation("folderTitle"))}",
+                        GetTranslation("completedSuccessfully"));
             }
             else
             {
                 Clipboard.SetDataObject(stringToCopy);
 
-                ShowMsg(
-                    $"{GetTranslation("copy")} {GetTranslation("textTitle")}",
-                    GetTranslation("completedSuccessfully"));
+                if (showDefaultNotification)
+                    ShowMsg(
+                        $"{GetTranslation("copy")} {GetTranslation("textTitle")}",
+                        GetTranslation("completedSuccessfully"));
             }
         }
-    
 
         public void StartLoadingBar() => _mainVM.ProgressBarVisibility = Visibility.Visible;
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1103,43 +1103,6 @@ namespace Flow.Launcher.ViewModel
             Results.AddResults(resultsForUpdates, token);
         }
 
-        /// <summary>
-        /// Copies the specified file or folder path to the clipboard, or the specified text if it is not a valid file or folder path.
-        /// Shows a message indicating whether the operation was completed successfully.
-        /// </summary>
-        /// <param name="stringToCopy">The file or folder path, or text to copy to the clipboard.</param>
-        /// <returns>Nothing.</returns>
-        public void ResultCopy(string stringToCopy)
-        {
-            if (string.IsNullOrEmpty(stringToCopy))
-                return;
-
-            var isFile = File.Exists(stringToCopy);
-            var isFolder = isFile ? false : Directory.Exists(stringToCopy); // No need to eval directory exists if determined that file exists 
-            if (isFile || isFolder)
-            {
-                var paths = new StringCollection
-                {
-                    stringToCopy
-                };
-
-                Clipboard.SetFileDropList(paths);
-                
-                App.API.ShowMsg(
-                    $"{App.API.GetTranslation("copy")} {(isFile ? App.API.GetTranslation("fileTitle") : App.API.GetTranslation("folderTitle"))}",
-                    App.API.GetTranslation("completedSuccessfully"));
-            }
-            else
-            {
-                Clipboard.SetDataObject(stringToCopy);
-                
-                App.API.ShowMsg(
-                    $"{App.API.GetTranslation("copy")} {App.API.GetTranslation("textTitle")}",
-                    App.API.GetTranslation("completedSuccessfully"));
-            }
-            return;
-        }
-
         #endregion
     }
 }

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1112,11 +1112,10 @@ namespace Flow.Launcher.ViewModel
         public void ResultCopy(string stringToCopy)
         {
             if (string.IsNullOrEmpty(stringToCopy))
-            {
                 return;
-            }
+
             var isFile = File.Exists(stringToCopy);
-            var isFolder = Directory.Exists(stringToCopy);
+            var isFolder = isFile ? false : Directory.Exists(stringToCopy); // No need to eval directory exists if determined that file exists 
             if (isFile || isFolder)
             {
                 var paths = new StringCollection
@@ -1125,6 +1124,7 @@ namespace Flow.Launcher.ViewModel
                 };
 
                 Clipboard.SetFileDropList(paths);
+                
                 App.API.ShowMsg(
                     $"{App.API.GetTranslation("copy")} {(isFile ? App.API.GetTranslation("fileTitle") : App.API.GetTranslation("folderTitle"))}",
                     App.API.GetTranslation("completedSuccessfully"));
@@ -1132,6 +1132,7 @@ namespace Flow.Launcher.ViewModel
             else
             {
                 Clipboard.SetDataObject(stringToCopy);
+                
                 App.API.ShowMsg(
                     $"{App.API.GetTranslation("copy")} {App.API.GetTranslation("textTitle")}",
                     App.API.GetTranslation("completedSuccessfully"));

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
@@ -174,7 +174,7 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
                     {
                         try
                         {
-                            Clipboard.SetDataObject(((BookmarkAttributes)selectedResult.ContextData).Url);
+                            context.API.CopyToClipboard(((BookmarkAttributes)selectedResult.ContextData).Url);
 
                             return true;
                         }

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
@@ -95,7 +95,7 @@ namespace Flow.Launcher.Plugin.Caculator
                             {
                                 try
                                 {
-                                    Clipboard.SetDataObject(newResult);
+                                    Context.API.CopyToClipboard(newResult);
                                     return true;
                                 }
                                 catch (ExternalException)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
@@ -124,7 +124,7 @@ namespace Flow.Launcher.Plugin.Explorer
                     {
                         try
                         {
-                            Clipboard.SetText(record.FullPath);
+                            Clipboard.SetDataObject(record.FullPath);
                             return true;
                         }
                         catch (Exception e)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
@@ -124,7 +124,7 @@ namespace Flow.Launcher.Plugin.Explorer
                     {
                         try
                         {
-                            Clipboard.SetDataObject(record.FullPath);
+                            Context.API.CopyToClipboard(record.FullPath);
                             return true;
                         }
                         catch (Exception e)
@@ -147,10 +147,7 @@ namespace Flow.Launcher.Plugin.Explorer
                     {
                         try
                         {
-                            Clipboard.SetFileDropList(new System.Collections.Specialized.StringCollection
-                            {
-                                record.FullPath
-                            });
+                            Context.API.CopyToClipboard(record.FullPath, directCopy: true);
                             return true;
                         }
                         catch (Exception e)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Main.cs
@@ -79,7 +79,7 @@ namespace Flow.Launcher.Plugin.Explorer
                             ? action
                             : _ =>
                             {
-                                Clipboard.SetDataObject(e.ToString());
+                                Context.API.CopyToClipboard(e.ToString());
                                 return new ValueTask<bool>(true);
                             }
                     }

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -84,7 +84,8 @@ namespace Flow.Launcher.Plugin.Shell
 
                                 Execute(Process.Start, PrepareProcessStartInfo(m, runAsAdministrator));
                                 return true;
-                            }
+                            },
+                            CopyText = m
                         }));
                     }
                 }
@@ -123,7 +124,8 @@ namespace Flow.Launcher.Plugin.Shell
 
                             Execute(Process.Start, PrepareProcessStartInfo(m.Key, runAsAdministrator));
                             return true;
-                        }
+                        },
+                        CopyText = m.Key
                     };
                     return ret;
                 }).Where(o => o != null);
@@ -152,7 +154,8 @@ namespace Flow.Launcher.Plugin.Shell
 
                     Execute(Process.Start, PrepareProcessStartInfo(cmd, runAsAdministrator));
                     return true;
-                }
+                },
+                CopyText = cmd
             };
 
             return result;
@@ -176,7 +179,8 @@ namespace Flow.Launcher.Plugin.Shell
 
                         Execute(Process.Start, PrepareProcessStartInfo(m.Key, runAsAdministrator));
                         return true;
-                    }
+                    },
+                    CopyText = m.Key
                 });
 
             if (_settings.ShowOnlyMostUsedCMDs)

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -406,7 +406,7 @@ namespace Flow.Launcher.Plugin.Shell
                     Title = context.API.GetTranslation("flowlauncher_plugin_cmd_copy"),
                     Action = c =>
                     {
-                        Clipboard.SetDataObject(selectedResult.Title);
+                        context.API.CopyToClipboard(selectedResult.Title);
                         return true;
                     },
                     IcoPath = "Images/copy.png",

--- a/Plugins/Flow.Launcher.Plugin.WindowsSettings/Helper/ContextMenuHelper.cs
+++ b/Plugins/Flow.Launcher.Plugin.WindowsSettings/Helper/ContextMenuHelper.cs
@@ -22,26 +22,6 @@ namespace Flow.Launcher.Plugin.WindowsSettings.Helper
         internal static List<Result> GetContextMenu(in Result result, in string assemblyName)
         {
             return new List<Result>(0);
-        }
-
-        /// <summary>
-        /// Copy the given text to the clipboard
-        /// </summary>
-        /// <param name="text">The text to copy to the clipboard</param>
-        /// <returns><see langword="true"/>The text successful copy to the clipboard, otherwise <see langword="false"/></returns>
-        private static bool TryToCopyToClipBoard(in string text)
-        {
-            try
-            {
-                Clipboard.Clear();
-                Clipboard.SetText(text);
-                return true;
-            }
-            catch (Exception exception)
-            {
-                Log.Exception("Can't copy to clipboard", exception, typeof(Main));
-                return false;
-            }
-        }
+        }        
     }
 }


### PR DESCRIPTION
**Context:**
Following on from #2143, further refactor and making copy consistent throughout flow.

**Changes:**
1. Updated CopyToClipboard API method
    a. Added directCopy parameter for directly copying files/folder
    b. Added showDefaultNotification parameter to allow caller to suppress the method's notification and provide its own
    c. Move actual copy code away from ViewModel, they do not need to live there
2. Nothing is using `TryToCopyToClipBoard` method, removed.
3. This error occurs occasionally when using Clipboard.SetText call rather than SetDataObject.
![image](https://github.com/Flow-Launcher/Flow.Launcher/assets/26427004/979beccd-01e3-435b-8c5f-3ff8ed53777e)
4. Added CopyText for Shell plugin

**Tested:**
1. Copy selected query does not show notification
2. Copy Bookmark plugin result copies the url
3. Copy Shell plugin result copies the command
5. Explorer Context Menu result 'Copy Path' copies the path not folder/file
6. Copy Explorer plugin result copies the folder
7. Copy Explorer plugin result copies the file
8. Checked no plugin is actually using CopyToClipboard API method aside from the default ones