### PR TITLE
plugin/shell: support Pwsh (PowerShell 7.x)

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -237,6 +237,19 @@ namespace Flow.Launcher.Plugin.Shell
                     break;
                 }
 
+                case Shell.Pwsh:
+                {
+                    info.FileName = "pwsh.exe";
+                    if (_settings.LeaveShellOpen)
+                    {
+                        info.ArgumentList.Add("-NoExit");
+                    }
+                    info.ArgumentList.Add("-Command");
+                    info.ArgumentList.Add(command);
+
+                    break;
+                }
+
                 case Shell.RunCommand:
                 {
                     var parts = command.Split(new[]

--- a/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
@@ -36,6 +36,6 @@ namespace Flow.Launcher.Plugin.Shell
         Cmd = 0,
         Powershell = 1,
         RunCommand = 2,
-
+        Pwsh = 3,
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml
@@ -41,6 +41,7 @@
             HorizontalAlignment="Left">
             <ComboBoxItem>CMD</ComboBoxItem>
             <ComboBoxItem>PowerShell</ComboBoxItem>
+            <ComboBoxItem>Pwsh</ComboBoxItem>
             <ComboBoxItem>RunCommand</ComboBoxItem>
         </ComboBox>
         <StackPanel Grid.Row="4" Orientation="Horizontal">

--- a/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -72,6 +72,7 @@ namespace Flow.Launcher.Plugin.Shell
             {
                 Shell.Cmd => 0,
                 Shell.Powershell => 1,
+                Shell.Pwsh => 2,
                 _ => ShellComboBox.Items.Count - 1
             };
 
@@ -81,6 +82,7 @@ namespace Flow.Launcher.Plugin.Shell
                 {
                     0 => Shell.Cmd,
                     1 => Shell.Powershell,
+                    2 => Shell.Pwsh,
                     _ => Shell.RunCommand
                 };
                 LeaveShellOpen.IsEnabled = _settings.Shell != Shell.RunCommand;

--- a/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -68,10 +68,21 @@ namespace Flow.Launcher.Plugin.Shell
                 _settings.ReplaceWinR = false;
             };
 
-            ShellComboBox.SelectedIndex = (int) _settings.Shell;
+            ShellComboBox.SelectedIndex = _settings.Shell switch
+            {
+                Shell.Cmd => 0,
+                Shell.Powershell => 1,
+                _ => ShellComboBox.Items.Count - 1
+            };
+
             ShellComboBox.SelectionChanged += (o, e) =>
             {
-                _settings.Shell = (Shell) ShellComboBox.SelectedIndex;
+                _settings.Shell = ShellComboBox.SelectedIndex switch
+                {
+                    0 => Shell.Cmd,
+                    1 => Shell.Powershell,
+                    _ => Shell.RunCommand
+                };
                 LeaveShellOpen.IsEnabled = _settings.Shell != Shell.RunCommand;
             };
 


### PR DESCRIPTION
Add `Pwsh` as a shell option. Powershell users would probably prefer to use Pwsh over the old `(Windows) Powershell` that ships with Windows.

This raises everyone's favorite problem: how to name each case to distinguish between v5 (`Windows Powershell`) and v7.x (`Powershell (Core)` or `Pwsh`). Thoughts welcome...

( changes partly picked from #1116 )