### PR TITLE
AppVeyor deployment enhancements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,15 +72,6 @@ deploy:
       secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
     artifact: Squirrel Installer, Portable Version, Squirrel nupkg, Squirrel RELEASES
     draft: true
-    force_update: true
     on:
       branch: master
-
-  - provider: GitHub
-    release: v$(flowVersion)
-    auth_token:
-      secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
-    artifact: Squirrel Installer, Portable Version, Squirrel nupkg, Squirrel RELEASES
-    force_update: true
-    on:
-      APPVEYOR_REPO_TAG: true
+      APPVEYOR_REPO_TAG: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,18 @@ deploy:
       branch: dev
 
   - provider: GitHub
+    repository: Flow-Launcher/Prereleases
+    release: v$(flowVersion)
+    description: 'This is a release candidate of v$(flowVersion)'
+    auth_token:
+      secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
+    artifact: Squirrel Installer, Portable Version, Squirrel nupkg, Squirrel RELEASES
+    force_update: true
+    on:
+      branch: master
+      APPVEYOR_REPO_TAG: false
+
+  - provider: GitHub
     release: v$(flowVersion)
     auth_token:
       secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,6 @@ init:
 - ps: |
       $version = new-object System.Version $env:APPVEYOR_BUILD_VERSION
       $env:flowVersion = "{0}.{1}.{2}" -f $version.Major, $version.Minor, $version.Build
-      if ($env:APPVEYOR_REPO_BRANCH -eq "dev")
-      {
-        $env:prereleaseTag = "{0}.{1}.{2}.{3}" -f $version.Major, $version.Minor, $version.Build, $version.Revision
-      }
 - sc config WSearch start= auto # Starts Windows Search service- Needed for running ExplorerTest
 - net start WSearch
 
@@ -57,7 +53,7 @@ deploy:
 
   - provider: GitHub
     repository: Flow-Launcher/Prereleases
-    release: v$(prereleaseTag)
+    release: v$(APPVEYOR_BUILD_VERSION)
     description: 'This is the early access build of our upcoming release. All changes contained here are reviewed, tested and stable to use.\n\nSee our [release](https://github.com/Flow-Launcher/Flow.Launcher/pulls?q=is%3Aopen+is%3Apr+label%3Arelease) Pull Request for details.\n\nFor latest production release visit [here](https://github.com/Flow-Launcher/Flow.Launcher/releases/latest)\n\nPlease report any bugs or issues over at the [main repository](https://github.com/Flow-Launcher/Flow.Launcher/issues)'
     auth_token:
       secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv


### PR DESCRIPTION
Starting a PR following the discussion in #2086 

with this modified setup:

1. on commit to master (ie when a release PR is merged), AppVeyor will:
  a. create a draft release on the main repository
  b. publish a release on the `Prereleases` repository (otherwise it falls behind when a stable version is published)
2. the draft release gets reviewed & tested, release notes are written
3. when the app is ready, the draft release can be published (manually). This should:
  a. trigger the WinGet release action
  b. create the git tag, which will trigger an AppVeyor build that will only deploy the `Flow.Launcher.Plugin` package to nuget (when it has been changed)

Some notes:

* releases are **only published once** (manually), **never force-updated** from a CI job... should resolve #2086 
* **during step 2**, hot-fixes can be applied to the master branch, **without bumping the app version**.
* the build-on-tag is still used for pushing to nuget, because: 
  1. we don't really care if it takes a few minutes more to deploy to nuget
  2. we want deployment to nuget to be the final step in the release process
  3. nuget packages are immutable: if we published on commit to master, we wouldn't be able to support hot-fixes 

sanity testing is still TODO but let me know what you think