### PR TITLE
feat: :sparkles: bind `Ctrl`+`W` and `Ctrl`+`S` to previous/next (#2189)

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -63,6 +63,10 @@
             Command="{Binding SelectNextItemCommand}"
             Modifiers="Ctrl" />
         <KeyBinding
+            Key="S"
+            Command="{Binding SelectNextItemCommand}"
+            Modifiers="Ctrl" />
+        <KeyBinding
             Key="D"
             Command="{Binding SelectNextPageCommand}"
             Modifiers="Ctrl" />
@@ -72,6 +76,10 @@
             Modifiers="Ctrl" />
         <KeyBinding
             Key="K"
+            Command="{Binding SelectPrevItemCommand}"
+            Modifiers="Ctrl" />
+        <KeyBinding
+            Key="W"
             Command="{Binding SelectPrevItemCommand}"
             Modifiers="Ctrl" />
         <KeyBinding


### PR DESCRIPTION
As per discussion #2189, this PR adds another key binding to select the next/previous results.

Adds `Ctrl`+`W` alongside the existing `Ctrl`+`P` and `Ctrl`+`K` bindings to select previous; and
adds `Ctrl`+`S` alongside the existing `Ctrl`+`N` and `Ctrl`+`J` bindings to select next.

Idea behind this is to make it easier to cycle through results when you only have your left hand; as the existing bindings/arrow keys are difficult to use in this case.