### PR TITLE
Added Animation Length slider

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -53,7 +53,6 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         public string ResultFontStretch { get; set; }
         public bool UseGlyphIcons { get; set; } = true;
         public bool UseAnimation { get; set; } = true;
-        public int AnimationLength { get; set; } = 360;
         public bool UseSound { get; set; } = true;
         public bool UseClock { get; set; } = true;
         public bool UseDate { get; set; } = false;
@@ -255,6 +254,10 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public LastQueryMode LastQueryMode { get; set; } = LastQueryMode.Selected;
 
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public AnimationSpeeds AnimationSpeed { get; set; } = AnimationSpeeds.Medium;
+        public int CustomAnimationLength { get; set; } = 360;
+
 
         // This needs to be loaded last by staying at the bottom
         public PluginsSettings PluginSettings { get; set; } = new PluginsSettings();
@@ -289,6 +292,14 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         CenterTop,
         LeftTop,
         RightTop,
+        Custom
+    }
+
+    public enum AnimationSpeeds
+    {
+        Slow,
+        Medium,
+        Fast,
         Custom
     }
 }

--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -53,6 +53,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         public string ResultFontStretch { get; set; }
         public bool UseGlyphIcons { get; set; } = true;
         public bool UseAnimation { get; set; } = true;
+        public int AnimationLength { get; set; } = 360;
         public bool UseSound { get; set; } = true;
         public bool UseClock { get; set; } = true;
         public bool UseDate { get; set; } = false;

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -157,6 +157,8 @@
     <system:String x:Key="SoundEffectTip">Play a small sound when the search window opens</system:String>
     <system:String x:Key="Animation">Animation</system:String>
     <system:String x:Key="AnimationTip">Use Animation in UI</system:String>
+    <system:String x:Key="animationLength">Animation Length (ms)</system:String>
+    <system:String x:Key="animationLengthToolTip">The length of the UI animation in milliseconds</system:String>
     <system:String x:Key="Clock">Clock</system:String>
     <system:String x:Key="Date">Date</system:String>
 

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -157,8 +157,12 @@
     <system:String x:Key="SoundEffectTip">Play a small sound when the search window opens</system:String>
     <system:String x:Key="Animation">Animation</system:String>
     <system:String x:Key="AnimationTip">Use Animation in UI</system:String>
-    <system:String x:Key="animationLength">Animation Length (ms)</system:String>
-    <system:String x:Key="animationLengthToolTip">The length of the UI animation in milliseconds</system:String>
+    <system:String x:Key="AnimationSpeed">Animation Speed</system:String>
+    <system:String x:Key="AnimationSpeedTip">The speed of the UI animation</system:String>
+    <system:String x:Key="AnimationSpeedSlow">Slow</system:String>
+    <system:String x:Key="AnimationSpeedMedium">Medium</system:String>
+    <system:String x:Key="AnimationSpeedFast">Fast</system:String>
+    <system:String x:Key="AnimationSpeedCustom">Custom</system:String>
     <system:String x:Key="Clock">Clock</system:String>
     <system:String x:Key="Date">Date</system:String>
 

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -383,7 +383,7 @@ namespace Flow.Launcher
             {
                 From = 0,
                 To = 1,
-                Duration = TimeSpan.FromSeconds(0.25),
+                Duration = TimeSpan.FromMilliseconds(_settings.AnimationLength * 2 / 3),
                 FillBehavior = FillBehavior.Stop
             };
 
@@ -391,7 +391,7 @@ namespace Flow.Launcher
             {
                 From = Top + 10,
                 To = Top,
-                Duration = TimeSpan.FromSeconds(0.25),
+                Duration = TimeSpan.FromMilliseconds(_settings.AnimationLength * 2 / 3),
                 FillBehavior = FillBehavior.Stop
             };
             var IconMotion = new DoubleAnimation
@@ -399,7 +399,7 @@ namespace Flow.Launcher
                 From = 12,
                 To = 0,
                 EasingFunction = easing,
-                Duration = TimeSpan.FromSeconds(0.36),
+                Duration = TimeSpan.FromMilliseconds(_settings.AnimationLength),
                 FillBehavior = FillBehavior.Stop
             };
 
@@ -408,7 +408,7 @@ namespace Flow.Launcher
                 From = 0,
                 To = 1,
                 EasingFunction = easing,
-                Duration = TimeSpan.FromSeconds(0.36),
+                Duration = TimeSpan.FromMilliseconds(_settings.AnimationLength),
                 FillBehavior = FillBehavior.Stop
             };
             double TargetIconOpacity = SearchIcon.Opacity; // Animation Target Opacity from Style
@@ -417,7 +417,7 @@ namespace Flow.Launcher
                 From = 0,
                 To = TargetIconOpacity,
                 EasingFunction = easing,
-                Duration = TimeSpan.FromSeconds(0.36),
+                Duration = TimeSpan.FromMilliseconds(_settings.AnimationLength),
                 FillBehavior = FillBehavior.Stop
             };
 
@@ -427,7 +427,7 @@ namespace Flow.Launcher
                 From = new Thickness(0, 12, right, 0),
                 To = new Thickness(0, 0, right, 0),
                 EasingFunction = easing,
-                Duration = TimeSpan.FromSeconds(0.36),
+                Duration = TimeSpan.FromMilliseconds(_settings.AnimationLength),
                 FillBehavior = FillBehavior.Stop
             };
 

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -24,6 +24,7 @@ using System.Windows.Data;
 using ModernWpf.Controls;
 using Key = System.Windows.Input.Key;
 using System.Media;
+using static Flow.Launcher.ViewModel.SettingWindowViewModel;
 
 namespace Flow.Launcher
 {
@@ -379,11 +380,19 @@ namespace Flow.Launcher
             CircleEase easing = new CircleEase();
             easing.EasingMode = EasingMode.EaseInOut;
 
+            var animationLength = _settings.AnimationSpeed switch
+            {
+                AnimationSpeeds.Slow => 560,
+                AnimationSpeeds.Medium => 360,
+                AnimationSpeeds.Fast => 160,
+                _ => _settings.CustomAnimationLength
+            };
+
             var WindowOpacity = new DoubleAnimation
             {
                 From = 0,
                 To = 1,
-                Duration = TimeSpan.FromMilliseconds(_settings.AnimationLength * 2 / 3),
+                Duration = TimeSpan.FromMilliseconds(animationLength * 2 / 3),
                 FillBehavior = FillBehavior.Stop
             };
 
@@ -391,7 +400,7 @@ namespace Flow.Launcher
             {
                 From = Top + 10,
                 To = Top,
-                Duration = TimeSpan.FromMilliseconds(_settings.AnimationLength * 2 / 3),
+                Duration = TimeSpan.FromMilliseconds(animationLength * 2 / 3),
                 FillBehavior = FillBehavior.Stop
             };
             var IconMotion = new DoubleAnimation
@@ -399,7 +408,7 @@ namespace Flow.Launcher
                 From = 12,
                 To = 0,
                 EasingFunction = easing,
-                Duration = TimeSpan.FromMilliseconds(_settings.AnimationLength),
+                Duration = TimeSpan.FromMilliseconds(animationLength),
                 FillBehavior = FillBehavior.Stop
             };
 
@@ -408,7 +417,7 @@ namespace Flow.Launcher
                 From = 0,
                 To = 1,
                 EasingFunction = easing,
-                Duration = TimeSpan.FromMilliseconds(_settings.AnimationLength),
+                Duration = TimeSpan.FromMilliseconds(animationLength),
                 FillBehavior = FillBehavior.Stop
             };
             double TargetIconOpacity = SearchIcon.Opacity; // Animation Target Opacity from Style
@@ -417,7 +426,7 @@ namespace Flow.Launcher
                 From = 0,
                 To = TargetIconOpacity,
                 EasingFunction = easing,
-                Duration = TimeSpan.FromMilliseconds(_settings.AnimationLength),
+                Duration = TimeSpan.FromMilliseconds(animationLength),
                 FillBehavior = FillBehavior.Stop
             };
 
@@ -427,7 +436,7 @@ namespace Flow.Launcher
                 From = new Thickness(0, 12, right, 0),
                 To = new Thickness(0, 0, right, 0),
                 EasingFunction = easing,
-                Duration = TimeSpan.FromMilliseconds(_settings.AnimationLength),
+                Duration = TimeSpan.FromMilliseconds(animationLength),
                 FillBehavior = FillBehavior.Stop
             };
 

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -2414,6 +2414,40 @@
                                                         </TextBlock>
                                                     </ItemsControl>
                                                 </Border>
+                                                <Border
+                                                    Margin="0"
+                                                    BorderThickness="0"
+                                                    Style="{DynamicResource SettingGroupBox}">
+                                                    <ItemsControl Style="{StaticResource SettingGrid}">
+                                                        <StackPanel Style="{StaticResource TextPanel}">
+                                                            <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource animationLength}" />
+                                                            <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource animationLengthToolTip}" />
+                                                        </StackPanel>
+                                                        <StackPanel Grid.Column="2" Orientation="Horizontal">
+                                                            <TextBlock
+                                                                Width="Auto"
+                                                                Margin="0,0,8,2"
+                                                                VerticalAlignment="Center"
+                                                                Foreground="{DynamicResource Color05B}"
+                                                                Text="{Binding ElementName=AnimationLengthValue, Path=Value, UpdateSourceTrigger=PropertyChanged}"
+                                                                TextAlignment="Right" />
+                                                            <Slider
+                                                                Name="AnimationLengthValue"
+                                                                Width="250"
+                                                                Margin="0,0,18,0"
+                                                                VerticalAlignment="Center"
+                                                                IsMoveToPointEnabled="True"
+                                                                IsSnapToTickEnabled="True"
+                                                                Maximum="2000"
+                                                                Minimum="100"
+                                                                TickFrequency="10"
+                                                                Value="{Binding AnimationLength, Mode=TwoWay}" />
+                                                        </StackPanel>
+                                                        <TextBlock Style="{StaticResource Glyph}">
+                                                            &#xe916;
+                                                        </TextBlock>
+                                                    </ItemsControl>
+                                                </Border>
                                                 <Separator
                                                     Width="Auto"
                                                     BorderThickness="1"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -2403,6 +2403,7 @@
                                                             <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource AnimationTip}" />
                                                         </StackPanel>
                                                         <ui:ToggleSwitch
+                                                            x:Name="Animation"
                                                             Grid.Row="0"
                                                             Grid.Column="2"
                                                             IsOn="{Binding UseAnimation, Mode=TwoWay}"
@@ -2414,66 +2415,86 @@
                                                         </TextBlock>
                                                     </ItemsControl>
                                                 </Border>
-                                                <Border
-                                                    Margin="0"
-                                                    BorderThickness="0"
-                                                    Style="{DynamicResource SettingGroupBox}">
+                                                <Separator
+                                                    Width="Auto"
+                                                    BorderThickness="1"
+                                                    Style="{StaticResource SettingSeparatorStyle}" />
+                                                <Border Margin="0" BorderThickness="0">
+                                                    <Border.Style>
+                                                        <Style BasedOn="{StaticResource SettingGroupBox}" TargetType="Border">
+                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding ElementName=Animation, Path=IsOn}" Value="True">
+                                                                    <Setter Property="Visibility" Value="Visible" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </Border.Style>
+
                                                     <ItemsControl Style="{StaticResource SettingGrid}">
                                                         <StackPanel Style="{StaticResource TextPanel}">
-                                                            <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource animationLength}" />
-                                                            <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource animationLengthToolTip}" />
+                                                            <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource AnimationSpeed}" />
+                                                            <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource AnimationSpeedTip}" />
                                                         </StackPanel>
                                                         <StackPanel Grid.Column="2" Orientation="Horizontal">
-                                                            <TextBlock
-                                                                Width="Auto"
-                                                                Margin="0,0,8,2"
-                                                                VerticalAlignment="Center"
-                                                                Foreground="{DynamicResource Color05B}"
-                                                                Text="{Binding ElementName=AnimationLengthValue, Path=Value, UpdateSourceTrigger=PropertyChanged}"
-                                                                TextAlignment="Right" />
-                                                            <Slider
-                                                                Name="AnimationLengthValue"
-                                                                Width="250"
+                                                            <ComboBox
+                                                                x:Name="AnimationSpeed"
+                                                                MinWidth="160"
                                                                 Margin="0,0,18,0"
                                                                 VerticalAlignment="Center"
-                                                                IsMoveToPointEnabled="True"
-                                                                IsSnapToTickEnabled="True"
-                                                                Maximum="2000"
-                                                                Minimum="100"
-                                                                TickFrequency="10"
-                                                                Value="{Binding AnimationLength, Mode=TwoWay}" />
+                                                                DisplayMemberPath="Display"
+                                                                FontSize="14"
+                                                                ItemsSource="{Binding AnimationSpeeds}"
+                                                                SelectedValue="{Binding Settings.AnimationSpeed}"
+                                                                SelectedValuePath="Value">
+                                                            </ComboBox>
+                                                            <StackPanel Margin="0,0,18,0" Orientation="Horizontal">
+                                                                <StackPanel.Style>
+                                                                    <Style TargetType="StackPanel">
+                                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                                        <Style.Triggers>
+                                                                            <DataTrigger Binding="{Binding ElementName=AnimationSpeed, Path=SelectedValue}" Value="{x:Static userSettings:AnimationSpeeds.Custom}">
+                                                                                <Setter Property="Visibility" Value="Visible" />
+                                                                            </DataTrigger>
+                                                                        </Style.Triggers>
+                                                                    </Style>
+                                                                </StackPanel.Style>
+                                                                <TextBox
+                                                                    Height="35"
+                                                                    MinWidth="80"
+                                                                    Text="{Binding Settings.CustomAnimationLength}"
+                                                                    TextWrapping="NoWrap" />
+                                                            </StackPanel>
                                                         </StackPanel>
                                                         <TextBlock Style="{StaticResource Glyph}">
                                                             &#xe916;
                                                         </TextBlock>
                                                     </ItemsControl>
                                                 </Border>
-                                                <Separator
-                                                    Width="Auto"
-                                                    BorderThickness="1"
-                                                    Style="{StaticResource SettingSeparatorStyle}" />
-                                                <Border
-                                                    Margin="0"
-                                                    BorderThickness="0"
-                                                    Style="{DynamicResource SettingGroupBox}">
-                                                    <ItemsControl Style="{StaticResource SettingGrid}">
-                                                        <StackPanel Style="{StaticResource TextPanel}">
-                                                            <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource SoundEffect}" />
-                                                            <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource SoundEffectTip}" />
-                                                        </StackPanel>
-                                                        <ui:ToggleSwitch
+                                            </StackPanel>
+                                        </Border>
+
+
+                                        <Border
+                                            Margin="0"
+                                            BorderThickness="0"
+                                            Style="{DynamicResource SettingGroupBox}">
+                                            <ItemsControl Style="{StaticResource SettingGrid}">
+                                                <StackPanel Style="{StaticResource TextPanel}">
+                                                    <TextBlock Style="{DynamicResource SettingTitleLabel}" Text="{DynamicResource SoundEffect}" />
+                                                    <TextBlock Style="{DynamicResource SettingSubTitleLabel}" Text="{DynamicResource SoundEffectTip}" />
+                                                </StackPanel>
+                                                <ui:ToggleSwitch
                                                             Grid.Row="0"
                                                             Grid.Column="2"
                                                             IsOn="{Binding UseSound, Mode=TwoWay}"
                                                             OffContent="{DynamicResource disable}"
                                                             OnContent="{DynamicResource enable}"
                                                             Style="{DynamicResource SideToggleSwitch}" />
-                                                        <TextBlock Style="{StaticResource Glyph}">
+                                                <TextBlock Style="{StaticResource Glyph}">
                                                             &#xe994;
-                                                        </TextBlock>
-                                                    </ItemsControl>
-                                                </Border>
-                                            </StackPanel>
+                                                </TextBlock>
+                                            </ItemsControl>
                                         </Border>
 
                                         <Border Margin="0,12,0,12" Style="{DynamicResource SettingGroupBox}">

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -598,6 +598,12 @@ namespace Flow.Launcher.ViewModel
             set => Settings.UseAnimation = value;
         }
 
+        public int AnimationLength
+        {
+            get => Settings.AnimationLength;
+            set => Settings.AnimationLength = value;
+        }
+
         public bool UseSound
         {
             get => Settings.UseSound;

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -598,10 +598,31 @@ namespace Flow.Launcher.ViewModel
             set => Settings.UseAnimation = value;
         }
 
-        public int AnimationLength
+        public class AnimationSpeed
         {
-            get => Settings.AnimationLength;
-            set => Settings.AnimationLength = value;
+            public string Display { get; set; }
+            public AnimationSpeeds Value { get; set; }
+        }
+
+        public List<AnimationSpeed> AnimationSpeeds
+        {
+            get
+            {
+                List<AnimationSpeed> speeds = new List<AnimationSpeed>();
+                var enums = (AnimationSpeeds[])Enum.GetValues(typeof(AnimationSpeeds));
+                foreach (var e in enums)
+                {
+                    var key = $"AnimationSpeed{e}";
+                    var display = _translater.GetTranslation(key);
+                    var m = new AnimationSpeed
+                    {
+                        Display = display,
+                        Value = e,
+                    };
+                    speeds.Add(m);
+                }
+                return speeds;
+            }
         }
 
         public bool UseSound


### PR DESCRIPTION
Added a slider in Appearance to adjust the length of the open animation for the launcher. 

By default the animation should be the same as it was previously (the first part of the animation is about 10ms shorter so that the ratio is simpler - 2/3 instead of 25/36).

Currently only has language support for English and the length is adjustable from 100ms to 2000ms in steps of 10ms.