### PR TITLE
fix: :bug: check autocomplete and copy text for `Result` equality

### DIFF
--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -172,9 +172,16 @@ namespace Flow.Launcher.Plugin
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            var hashcode = (Title?.GetHashCode() ?? 0) ^
-                           (SubTitle?.GetHashCode() ?? 0);
-            return hashcode;
+            unchecked
+            {
+                // 17 and 23 are prime numbers
+                int hashcode = 17;
+                hashcode = hashcode * 23 + (Title?.GetHashCode() ?? 0);
+                hashcode = hashcode * 23 + (SubTitle?.GetHashCode() ?? 0);
+                hashcode = hashcode * 23 + (AutoCompleteText?.GetHashCode() ?? 0);
+                hashcode = hashcode * 23 + (CopyText?.GetHashCode() ?? 0);
+                return hashcode;
+            }
         }
 
         /// <inheritdoc />

--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -172,16 +173,7 @@ namespace Flow.Launcher.Plugin
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            unchecked
-            {
-                // 17 and 23 are prime numbers
-                int hashcode = 17;
-                hashcode = hashcode * 23 + (Title?.GetHashCode() ?? 0);
-                hashcode = hashcode * 23 + (SubTitle?.GetHashCode() ?? 0);
-                hashcode = hashcode * 23 + (AutoCompleteText?.GetHashCode() ?? 0);
-                hashcode = hashcode * 23 + (CopyText?.GetHashCode() ?? 0);
-                return hashcode;
-            }
+            return HashCode.Combine(Title, SubTitle, AutoCompleteText, CopyText, IcoPath);
         }
 
         /// <inheritdoc />

--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -161,6 +161,8 @@ namespace Flow.Launcher.Plugin
 
             var equality = string.Equals(r?.Title, Title) &&
                            string.Equals(r?.SubTitle, SubTitle) &&
+                           string.Equals(r?.AutoCompleteText, AutoCompleteText) &&
+                           string.Equals(r?.CopyText, CopyText) &&
                            string.Equals(r?.IcoPath, IcoPath) &&
                            TitleHighlightData == r.TitleHighlightData;
 


### PR DESCRIPTION
Fixes #2201.

The current equality implementation for `Result` does not check for differences in `AutoCompleteText` or `CopyText`.