### PR TITLE
Fix artefact hash discrepancy for WinGet release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,12 +75,3 @@ deploy:
     force_update: true
     on:
       branch: master
-
-  - provider: GitHub
-    release: v$(flowVersion)
-    auth_token:
-      secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
-    artifact: Squirrel Installer, Portable Version, Squirrel nupkg, Squirrel RELEASES
-    force_update: true
-    on:
-      APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
Context:
Currently project is rebuilt and output artefacts re-uploaded after marking a draft release as latest. This creates a discrepancy for WinGet publish process. https://github.com/Flow-Launcher/Flow.Launcher/issues/2086

Solution:
Tag is created after marking a draft release as prerelease or latest. No need to upload the artefacts again on tag.

If changes need to occurr during release process, delete draft then merge new changes in.

Related #2185