### PR TITLE
Switch winget release action to manual

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,8 +1,7 @@
 name: Publish to Winget
 
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
As discussed in #2218 I have updated the winget release action to only fire manually, as a temporary solution to #2086