### PR TITLE
Change Winget Releaser job runner to `ubuntu-latest`

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -5,8 +5,7 @@ on:
 
 jobs:
   publish:
-    # Action can only be run on windows
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:


### PR DESCRIPTION
Winget Releaser has supported non-Windows runners for a while now, and the `ubuntu-latest` runner is generally faster.