### PR TITLE
Update Python to v3.11.4

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -103,3 +103,4 @@ Português
 Português (Brasil)
 Italiano
 Slovenský
+Droplex

--- a/Flow.Launcher.Core/ExternalPlugins/Environments/PythonEnvironment.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/Environments/PythonEnvironment.cs
@@ -16,7 +16,7 @@ namespace Flow.Launcher.Core.ExternalPlugins.Environments
 
         internal override string EnvPath => Path.Combine(DataLocation.PluginEnvironmentsPath, EnvName);
 
-        internal override string InstallPath => Path.Combine(EnvPath, "PythonEmbeddable-v3.8.9");
+        internal override string InstallPath => Path.Combine(EnvPath, "PythonEmbeddable-v3.11.4");
 
         internal override string ExecutablePath => Path.Combine(InstallPath, "pythonw.exe");
 
@@ -30,7 +30,8 @@ namespace Flow.Launcher.Core.ExternalPlugins.Environments
         {
             FilesFolders.RemoveFolderIfExists(InstallPath);
 
-            // Python 3.8.9 is used for Windows 7 compatibility
+            // Python 3.11.4 is no longer Windows 7 compatible. If user is on Win 7 and
+            // uses Python plugin they need to custom install and use v3.8.9
             DroplexPackage.Drop(App.python_3_11_4_embeddable, InstallPath).Wait();
 
             PluginsSettingsFilePath = ExecutablePath;

--- a/Flow.Launcher.Core/ExternalPlugins/Environments/PythonEnvironment.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/Environments/PythonEnvironment.cs
@@ -31,7 +31,7 @@ namespace Flow.Launcher.Core.ExternalPlugins.Environments
             FilesFolders.RemoveFolderIfExists(InstallPath);
 
             // Python 3.8.9 is used for Windows 7 compatibility
-            DroplexPackage.Drop(App.python_3_8_9_embeddable, InstallPath).Wait();
+            DroplexPackage.Drop(App.python_3_11_4_embeddable, InstallPath).Wait();
 
             PluginsSettingsFilePath = ExecutablePath;
         }

--- a/Flow.Launcher.Core/Flow.Launcher.Core.csproj
+++ b/Flow.Launcher.Core/Flow.Launcher.Core.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Droplex" Version="1.6.0" />
+    <PackageReference Include="Droplex" Version="1.7.0" />
     <PackageReference Include="FSharp.Core" Version="7.0.300" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
     <PackageReference Include="squirrel.windows" Version="1.5.2" NoWarn="NU1701" />


### PR DESCRIPTION
Context:
Close #2176

Changes:
Upgrade Embeddable Python used by Flow to v3.11.4 from 3.8.9.
Upgrade will be silent.

Tests:
- Only the Embeddable Python is upgraded, custom Python location set by user will not
- Automatically and silently upgraded to v3.11.4
- Tested all current Python plugins via this PR https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/pull/261, only one Python plugin is not compatible and failed running on v3.11.4

**TODO:** Update documentation