### PR TITLE
Publish installable default plugins to Store

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -104,3 +104,8 @@ Português (Brasil)
 Italiano
 Slovenský
 Droplex
+Preinstalled
+errormetadatafile
+noresult
+pluginsmanager
+alreadyexists

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -69,6 +69,7 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.BrowserBookmark"
           files: "Flow.Launcher.Plugin.BrowserBookmark.zip"
           tag_name: "v${{steps.updated-version-browserbookmark.outputs.prop}}"
+          body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
 
@@ -95,6 +96,7 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.Calculator"
           files: "Flow.Launcher.Plugin.Calculator.zip"
           tag_name: "v${{steps.updated-version-calculator.outputs.prop}}"
+          body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
 
@@ -121,6 +123,7 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.Explorer"
           files: "Flow.Launcher.Plugin.Explorer.zip"
           tag_name: "v${{steps.updated-version-explorer.outputs.prop}}"
+          body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
 
@@ -147,6 +150,7 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.PluginIndicator"
           files: "Flow.Launcher.Plugin.PluginIndicator.zip"
           tag_name: "v${{steps.updated-version-pluginindicator.outputs.prop}}"
+          body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
 
@@ -173,6 +177,7 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.PluginsManager"
           files: "Flow.Launcher.Plugin.PluginsManager.zip"
           tag_name: "v${{steps.updated-version-pluginsmanager.outputs.prop}}"
+          body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
 
@@ -199,6 +204,7 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.ProcessKiller"
           files: "Flow.Launcher.Plugin.ProcessKiller.zip"
           tag_name: "v${{steps.updated-version-processkiller.outputs.prop}}"
+          body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
 
@@ -225,6 +231,7 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.Program"
           files: "Flow.Launcher.Plugin.Program.zip"
           tag_name: "v${{steps.updated-version-program.outputs.prop}}"
+          body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
 
@@ -251,6 +258,7 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.Shell"
           files: "Flow.Launcher.Plugin.Shell.zip"
           tag_name: "v${{steps.updated-version-shell.outputs.prop}}"
+          body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
 
@@ -277,6 +285,7 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.Sys"
           files: "Flow.Launcher.Plugin.Sys.zip"
           tag_name: "v${{steps.updated-version-sys.outputs.prop}}"
+          body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
 
@@ -303,6 +312,7 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.Url"
           files: "Flow.Launcher.Plugin.Url.zip"
           tag_name: "v${{steps.updated-version-url.outputs.prop}}"
+          body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
 
@@ -329,6 +339,7 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.WebSearch"
           files: "Flow.Launcher.Plugin.WebSearch.zip"
           tag_name: "v${{steps.updated-version-websearch.outputs.prop}}"
+          body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
 
@@ -355,5 +366,6 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.WindowsSettings"
           files: "Flow.Launcher.Plugin.WindowsSettings.zip"
           tag_name: "v${{steps.updated-version-windowssettings.outputs.prop}}"
+          body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -34,6 +34,8 @@ jobs:
               - 'Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json'
             processkiller
               - 'Plugins/Flow.Launcher.Plugin.ProcessKiller/plugin.json'
+            program
+              - 'Plugins/Flow.Launcher.Plugin.Program/plugin.json'
 
       - name: Get BrowserBookmark Version
         if: steps.changes.outputs.browserbookmark == 'true'
@@ -187,5 +189,31 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.ProcessKiller"
           files: "Flow.Launcher.Plugin.ProcessKiller.zip"
           tag_name: "v${{steps.updated-version-processkiller.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+
+
+      - name: Get Program Version
+        if: steps.changes.outputs.program == 'true'
+        id: updated-version-program
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'Plugins/Flow.Launcher.Plugin.Program/plugin.json'
+          prop_path: 'Version'
+
+      - name: Build Program
+        if: steps.changes.outputs.program == 'true'
+        run: |
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.Program/Flow.Launcher.Plugin.Program.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.Program"
+          7z a -tzip "Flow.Launcher.Plugin.Program.zip" "./Flow.Launcher.Plugin.Program/*"
+          rm -r "Flow.Launcher.Plugin.Program"
+
+      - name: Publish Program
+        if: steps.changes.outputs.program == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: "Flow-Launcher/Flow.Launcher.Plugin.Program"
+          files: "Flow.Launcher.Plugin.Program.zip"
+          tag_name: "v${{steps.updated-version-program.outputs.prop}}"
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -40,6 +40,8 @@ jobs:
               - 'Plugins/Flow.Launcher.Plugin.Shell/plugin.json'
             sys
               - 'Plugins/Flow.Launcher.Plugin.Sys/plugin.json'
+            url
+              - 'Plugins/Flow.Launcher.Plugin.Url/plugin.json'
 
       - name: Get BrowserBookmark Version
         if: steps.changes.outputs.browserbookmark == 'true'
@@ -271,5 +273,31 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.Sys"
           files: "Flow.Launcher.Plugin.Sys.zip"
           tag_name: "v${{steps.updated-version-sys.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+
+
+      - name: Get Url Version
+        if: steps.changes.outputs.url == 'true'
+        id: updated-version-url
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'Plugins/Flow.Launcher.Plugin.Url/plugin.json'
+          prop_path: 'Version'
+
+      - name: Build Url
+        if: steps.changes.outputs.url == 'true'
+        run: |
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.Url/Flow.Launcher.Plugin.Url.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.Url"
+          7z a -tzip "Flow.Launcher.Plugin.Url.zip" "./Flow.Launcher.Plugin.Url/*"
+          rm -r "Flow.Launcher.Plugin.Url"
+
+      - name: Publish Url
+        if: steps.changes.outputs.url == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: "Flow-Launcher/Flow.Launcher.Plugin.Url"
+          files: "Flow.Launcher.Plugin.Url.zip"
+          tag_name: "v${{steps.updated-version-url.outputs.prop}}"
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -30,6 +30,8 @@ jobs:
               - 'Plugins/Flow.Launcher.Plugin.Explorer/plugin.json'
             pluginindicator:
               - 'Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json'
+            pluginsmanager:
+              - 'Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json'
 
       - name: Get BrowserBookmark Version
         if: steps.changes.outputs.browserbookmark == 'true'
@@ -131,5 +133,31 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.PluginIndicator"
           files: "Flow.Launcher.Plugin.PluginIndicator.zip"
           tag_name: "v${{steps.updated-version-pluginindicator.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+
+
+      - name: Get PluginsManager Version
+        if: steps.changes.outputs.pluginsmanager == 'true'
+        id: updated-version-pluginsmanager
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json'
+          prop_path: 'Version'
+
+      - name: Build PluginsManager
+        if: steps.changes.outputs.pluginsmanager == 'true'
+        run: |
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.PluginsManager/Flow.Launcher.Plugin.PluginsManager.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.PluginsManager"
+          7z a -tzip "Flow.Launcher.Plugin.PluginsManager.zip" "./Flow.Launcher.Plugin.PluginsManager/*"
+          rm -r "Flow.Launcher.Plugin.PluginsManager"
+
+      - name: Publish PluginsManager
+        if: steps.changes.outputs.pluginsmanager == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: "Flow-Launcher/Flow.Launcher.Plugin.PluginsManager"
+          files: "Flow.Launcher.Plugin.PluginsManager.zip"
+          tag_name: "v${{steps.updated-version-pluginsmanager.outputs.prop}}"
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -32,19 +32,19 @@ jobs:
               - 'Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json'
             pluginsmanager:
               - 'Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json'
-            processkiller
+            processkiller:
               - 'Plugins/Flow.Launcher.Plugin.ProcessKiller/plugin.json'
-            program
+            program:
               - 'Plugins/Flow.Launcher.Plugin.Program/plugin.json'
-            shell
+            shell:
               - 'Plugins/Flow.Launcher.Plugin.Shell/plugin.json'
-            sys
+            sys:
               - 'Plugins/Flow.Launcher.Plugin.Sys/plugin.json'
-            url
+            url:
               - 'Plugins/Flow.Launcher.Plugin.Url/plugin.json'
-            websearch
+            websearch:
               - 'Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json'
-            windowssettings
+            windowssettings:
               - 'Plugins/Flow.Launcher.Plugin.WindowsSettings/plugin.json'
 
       - name: Get BrowserBookmark Version

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -36,6 +36,8 @@ jobs:
               - 'Plugins/Flow.Launcher.Plugin.ProcessKiller/plugin.json'
             program
               - 'Plugins/Flow.Launcher.Plugin.Program/plugin.json'
+            shell
+              - 'Plugins/Flow.Launcher.Plugin.Shell/plugin.json'
 
       - name: Get BrowserBookmark Version
         if: steps.changes.outputs.browserbookmark == 'true'
@@ -215,5 +217,31 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.Program"
           files: "Flow.Launcher.Plugin.Program.zip"
           tag_name: "v${{steps.updated-version-program.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+
+
+      - name: Get Shell Version
+        if: steps.changes.outputs.shell == 'true'
+        id: updated-version-shell
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'Plugins/Flow.Launcher.Plugin.Shell/plugin.json'
+          prop_path: 'Version'
+
+      - name: Build Shell
+        if: steps.changes.outputs.shell == 'true'
+        run: |
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.Shell/Flow.Launcher.Plugin.Shell.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.Shell"
+          7z a -tzip "Flow.Launcher.Plugin.Shell.zip" "./Flow.Launcher.Plugin.Shell/*"
+          rm -r "Flow.Launcher.Plugin.Shell"
+
+      - name: Publish Shell
+        if: steps.changes.outputs.shell == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: "Flow-Launcher/Flow.Launcher.Plugin.Shell"
+          files: "Flow.Launcher.Plugin.Shell.zip"
+          tag_name: "v${{steps.updated-version-shell.outputs.prop}}"
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -24,6 +24,8 @@ jobs:
           filters: |
             browserbookmark:
               - 'Plugins/Flow.Launcher.Plugin.BrowserBookmark/plugin.json'
+            calculator:
+              - 'Plugins/Flow.Launcher.Plugin.Calculator/plugin.json'
 
       - name: Get BrowserBookmark Version
         if: steps.changes.outputs.browserbookmark == 'true'
@@ -47,5 +49,31 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.BrowserBookmark"
           files: "Flow.Launcher.Plugin.BrowserBookmark.zip"
           tag_name: "v${{steps.updated-version-browserbookmark.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+
+
+      - name: Get Calculator Version
+        if: steps.changes.outputs.calculator == 'true'
+        id: updated-version-calculator
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'Plugins/Flow.Launcher.Plugin.Calculator/plugin.json'
+          prop_path: 'Version'
+
+      - name: Build Calculator
+        if: steps.changes.outputs.calculator == 'true'
+        run: |
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.Calculator/Flow.Launcher.Plugin.Calculator.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.Calculator"
+          7z a -tzip "Flow.Launcher.Plugin.Calculator.zip" "./Flow.Launcher.Plugin.Calculator/*"
+          rm -r "Flow.Launcher.Plugin.Calculator"
+
+      - name: Publish Calculator
+        if: steps.changes.outputs.calculator == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: "Flow-Launcher/Flow.Launcher.Plugin.Calculator"
+          files: "Flow.Launcher.Plugin.Calculator.zip"
+          tag_name: "v${{steps.updated-version-calculator.outputs.prop}}"
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -44,6 +44,8 @@ jobs:
               - 'Plugins/Flow.Launcher.Plugin.Url/plugin.json'
             websearch
               - 'Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json'
+            windowssettings
+              - 'Plugins/Flow.Launcher.Plugin.WindowsSettings/plugin.json'
 
       - name: Get BrowserBookmark Version
         if: steps.changes.outputs.browserbookmark == 'true'
@@ -327,5 +329,31 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.WebSearch"
           files: "Flow.Launcher.Plugin.WebSearch.zip"
           tag_name: "v${{steps.updated-version-websearch.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+
+
+      - name: Get WindowsSettings Version
+        if: steps.changes.outputs.windowssettings == 'true'
+        id: updated-version-windowssettings
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'Plugins/Flow.Launcher.Plugin.WindowsSettings/plugin.json'
+          prop_path: 'Version'
+
+      - name: Build WindowsSettings
+        if: steps.changes.outputs.windowssettings == 'true'
+        run: |
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.WindowsSettings/Flow.Launcher.Plugin.WindowsSettings.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.WindowsSettings"
+          7z a -tzip "Flow.Launcher.Plugin.WindowsSettings.zip" "./Flow.Launcher.Plugin.WindowsSettings/*"
+          rm -r "Flow.Launcher.Plugin.WindowsSettings"
+
+      - name: Publish WindowsSettings
+        if: steps.changes.outputs.windowssettings == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: "Flow-Launcher/Flow.Launcher.Plugin.WindowsSettings"
+          files: "Flow.Launcher.Plugin.WindowsSettings.zip"
+          tag_name: "v${{steps.updated-version-windowssettings.outputs.prop}}"
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Build Program
         if: steps.changes.outputs.program == 'true'
         run: |
-          dotnet publish 'Plugins/Flow.Launcher.Plugin.Program/Flow.Launcher.Plugin.Program.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.Program"
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.Program/Flow.Launcher.Plugin.Program.csproj' --framework net7.0-windows10.0.19041.0  -c Release -o "Flow.Launcher.Plugin.Program"
           7z a -tzip "Flow.Launcher.Plugin.Program.zip" "./Flow.Launcher.Plugin.Program/*"
           rm -r "Flow.Launcher.Plugin.Program"
 

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -42,6 +42,8 @@ jobs:
               - 'Plugins/Flow.Launcher.Plugin.Sys/plugin.json'
             url
               - 'Plugins/Flow.Launcher.Plugin.Url/plugin.json'
+            websearch
+              - 'Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json'
 
       - name: Get BrowserBookmark Version
         if: steps.changes.outputs.browserbookmark == 'true'
@@ -299,5 +301,31 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.Url"
           files: "Flow.Launcher.Plugin.Url.zip"
           tag_name: "v${{steps.updated-version-url.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+
+
+      - name: Get WebSearch Version
+        if: steps.changes.outputs.websearch == 'true'
+        id: updated-version-websearch
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json'
+          prop_path: 'Version'
+
+      - name: Build WebSearch
+        if: steps.changes.outputs.websearch == 'true'
+        run: |
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.WebSearch/Flow.Launcher.Plugin.WebSearch.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.WebSearch"
+          7z a -tzip "Flow.Launcher.Plugin.WebSearch.zip" "./Flow.Launcher.Plugin.WebSearch/*"
+          rm -r "Flow.Launcher.Plugin.WebSearch"
+
+      - name: Publish WebSearch
+        if: steps.changes.outputs.websearch == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: "Flow-Launcher/Flow.Launcher.Plugin.WebSearch"
+          files: "Flow.Launcher.Plugin.WebSearch.zip"
+          tag_name: "v${{steps.updated-version-websearch.outputs.prop}}"
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -26,6 +26,8 @@ jobs:
               - 'Plugins/Flow.Launcher.Plugin.BrowserBookmark/plugin.json'
             calculator:
               - 'Plugins/Flow.Launcher.Plugin.Calculator/plugin.json'
+            explorer:
+              - 'Plugins/Flow.Launcher.Plugin.Explorer/plugin.json'
 
       - name: Get BrowserBookmark Version
         if: steps.changes.outputs.browserbookmark == 'true'
@@ -75,5 +77,31 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.Calculator"
           files: "Flow.Launcher.Plugin.Calculator.zip"
           tag_name: "v${{steps.updated-version-calculator.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+
+
+      - name: Get Explorer Version
+        if: steps.changes.outputs.explorer == 'true'
+        id: updated-version-explorer
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'Plugins/Flow.Launcher.Plugin.Explorer/plugin.json'
+          prop_path: 'Version'
+
+      - name: Build Explorer
+        if: steps.changes.outputs.explorer == 'true'
+        run: |
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.Explorer/Flow.Launcher.Plugin.Explorer.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.Explorer"
+          7z a -tzip "Flow.Launcher.Plugin.Explorer.zip" "./Flow.Launcher.Plugin.Explorer/*"
+          rm -r "Flow.Launcher.Plugin.Explorer"
+
+      - name: Publish Explorer
+        if: steps.changes.outputs.explorer == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: "Flow-Launcher/Flow.Launcher.Plugin.Explorer"
+          files: "Flow.Launcher.Plugin.Explorer.zip"
+          tag_name: "v${{steps.updated-version-explorer.outputs.prop}}"
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -1,0 +1,51 @@
+name: Publish Default Plugins
+
+on:
+  push:
+    branches: ['master']
+    paths: ['Plugins/**']
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 7.0.x
+
+      - name: Determine New Plugin Updates
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            browserbookmark:
+              - 'Plugins/Flow.Launcher.Plugin.BrowserBookmark/plugin.json'
+
+      - name: Get BrowserBookmark Version
+        if: steps.changes.outputs.browserbookmark == 'true'
+        id: updated-version-browserbookmark
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'Plugins/Flow.Launcher.Plugin.BrowserBookmark/plugin.json'
+          prop_path: 'Version'
+
+      - name: Build BrowserBookmark
+        if: steps.changes.outputs.browserbookmark == 'true'
+        run: |
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.BrowserBookmark/Flow.Launcher.Plugin.BrowserBookmark.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.BrowserBookmark"
+          7z a -tzip "Flow.Launcher.Plugin.BrowserBookmark.zip" "./Flow.Launcher.Plugin.BrowserBookmark/*"
+          rm -r "Flow.Launcher.Plugin.BrowserBookmark"
+
+      - name: Publish BrowserBookmark
+        if: steps.changes.outputs.browserbookmark == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: "Flow-Launcher/Flow.Launcher.Plugin.BrowserBookmark"
+          files: "Flow.Launcher.Plugin.BrowserBookmark.zip"
+          tag_name: "v${{steps.updated-version-browserbookmark.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -38,6 +38,8 @@ jobs:
               - 'Plugins/Flow.Launcher.Plugin.Program/plugin.json'
             shell
               - 'Plugins/Flow.Launcher.Plugin.Shell/plugin.json'
+            sys
+              - 'Plugins/Flow.Launcher.Plugin.Sys/plugin.json'
 
       - name: Get BrowserBookmark Version
         if: steps.changes.outputs.browserbookmark == 'true'
@@ -243,5 +245,31 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.Shell"
           files: "Flow.Launcher.Plugin.Shell.zip"
           tag_name: "v${{steps.updated-version-shell.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+
+
+      - name: Get Sys Version
+        if: steps.changes.outputs.sys == 'true'
+        id: updated-version-sys
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'Plugins/Flow.Launcher.Plugin.Sys/plugin.json'
+          prop_path: 'Version'
+
+      - name: Build Sys
+        if: steps.changes.outputs.sys == 'true'
+        run: |
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.Sys/Flow.Launcher.Plugin.Sys.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.Sys"
+          7z a -tzip "Flow.Launcher.Plugin.Sys.zip" "./Flow.Launcher.Plugin.Sys/*"
+          rm -r "Flow.Launcher.Plugin.Sys"
+
+      - name: Publish Sys
+        if: steps.changes.outputs.sys == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: "Flow-Launcher/Flow.Launcher.Plugin.Sys"
+          files: "Flow.Launcher.Plugin.Sys.zip"
+          tag_name: "v${{steps.updated-version-sys.outputs.prop}}"
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -28,6 +28,8 @@ jobs:
               - 'Plugins/Flow.Launcher.Plugin.Calculator/plugin.json'
             explorer:
               - 'Plugins/Flow.Launcher.Plugin.Explorer/plugin.json'
+            pluginindicator:
+              - 'Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json'
 
       - name: Get BrowserBookmark Version
         if: steps.changes.outputs.browserbookmark == 'true'
@@ -103,5 +105,31 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.Explorer"
           files: "Flow.Launcher.Plugin.Explorer.zip"
           tag_name: "v${{steps.updated-version-explorer.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+
+
+      - name: Get PluginIndicator Version
+        if: steps.changes.outputs.pluginindicator == 'true'
+        id: updated-version-pluginindicator
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json'
+          prop_path: 'Version'
+
+      - name: Build PluginIndicator
+        if: steps.changes.outputs.pluginindicator == 'true'
+        run: |
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.PluginIndicator/Flow.Launcher.Plugin.PluginIndicator.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.PluginIndicator"
+          7z a -tzip "Flow.Launcher.Plugin.PluginIndicator.zip" "./Flow.Launcher.Plugin.PluginIndicator/*"
+          rm -r "Flow.Launcher.Plugin.PluginIndicator"
+
+      - name: Publish PluginIndicator
+        if: steps.changes.outputs.pluginindicator == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: "Flow-Launcher/Flow.Launcher.Plugin.PluginIndicator"
+          files: "Flow.Launcher.Plugin.PluginIndicator.zip"
+          tag_name: "v${{steps.updated-version-pluginindicator.outputs.prop}}"
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -32,6 +32,8 @@ jobs:
               - 'Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json'
             pluginsmanager:
               - 'Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json'
+            processkiller
+              - 'Plugins/Flow.Launcher.Plugin.ProcessKiller/plugin.json'
 
       - name: Get BrowserBookmark Version
         if: steps.changes.outputs.browserbookmark == 'true'
@@ -159,5 +161,31 @@ jobs:
           repository: "Flow-Launcher/Flow.Launcher.Plugin.PluginsManager"
           files: "Flow.Launcher.Plugin.PluginsManager.zip"
           tag_name: "v${{steps.updated-version-pluginsmanager.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+
+
+      - name: Get ProcessKiller Version
+        if: steps.changes.outputs.processkiller == 'true'
+        id: updated-version-processkiller
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'Plugins/Flow.Launcher.Plugin.ProcessKiller/plugin.json'
+          prop_path: 'Version'
+
+      - name: Build ProcessKiller
+        if: steps.changes.outputs.processkiller == 'true'
+        run: |
+          dotnet publish 'Plugins/Flow.Launcher.Plugin.ProcessKiller/Flow.Launcher.Plugin.ProcessKiller.csproj' --framework net7.0-windows  -c Release -o "Flow.Launcher.Plugin.ProcessKiller"
+          7z a -tzip "Flow.Launcher.Plugin.ProcessKiller.zip" "./Flow.Launcher.Plugin.ProcessKiller/*"
+          rm -r "Flow.Launcher.Plugin.ProcessKiller"
+
+      - name: Publish ProcessKiller
+        if: steps.changes.outputs.processkiller == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: "Flow-Launcher/Flow.Launcher.Plugin.ProcessKiller"
+          files: "Flow.Launcher.Plugin.ProcessKiller.zip"
+          tag_name: "v${{steps.updated-version-processkiller.outputs.prop}}"
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -332,9 +332,9 @@ namespace Flow.Launcher.Plugin.PluginsManager
         {
             var author = url.Split('/')[3];
             var acceptedSource = "https://github.com";
-            var contructedUrlPart = string.Format("{0}/{1}/", acceptedSource, author);
+            var constructedUrlPart = string.Format("{0}/{1}/", acceptedSource, author);
 
-            return url.StartsWith(acceptedSource) && Context.API.GetAllPlugins().Any(x => x.Metadata.Website.StartsWith(contructedUrlPart));
+            return url.StartsWith(acceptedSource) && Context.API.GetAllPlugins().Any(x => x.Metadata.Website.StartsWith(constructedUrlPart));
         }
 
         internal async ValueTask<List<Result>> RequestInstallOrUpdate(string search, CancellationToken token, bool usePrimaryUrlOnly = false)

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -419,8 +419,30 @@ namespace Flow.Launcher.Plugin.PluginsManager
                         plugin.Name));
             }
 
-            var directory = string.IsNullOrEmpty(plugin.Version) ? $"{plugin.Name}-{Guid.NewGuid()}" : $"{plugin.Name}-{plugin.Version}";
-            var newPluginPath = Path.Combine(DataLocation.PluginsDirectory, directory);
+            var folderName = string.IsNullOrEmpty(plugin.Version) ? $"{plugin.Name}-{Guid.NewGuid()}" : $"{plugin.Name}-{plugin.Version}";
+
+            var defaultPluginIDs = new List<string>
+                                    {
+                                        "0ECADE17459B49F587BF81DC3A125110", // BrowserBookmark
+                                        "CEA0FDFC6D3B4085823D60DC76F28855", // Calculator
+                                        "572be03c74c642baae319fc283e561a8", // Explorer
+                                        "6A122269676E40EB86EB543B945932B9", // PluginIndicator
+                                        "9f8f9b14-2518-4907-b211-35ab6290dee7", // PluginsManager
+                                        "b64d0a79-329a-48b0-b53f-d658318a1bf6", // ProcessKiller
+                                        "791FC278BA414111B8D1886DFE447410", // Program
+                                        "D409510CD0D2481F853690A07E6DC426", // Shell
+                                        "CEA08895D2544B019B2E9C5009600DF4", // Sys
+                                        "0308FD86DE0A4DEE8D62B9B535370992", // URL
+                                        "565B73353DBF4806919830B9202EE3BF", // WebSearch
+                                        "5043CETYU6A748679OPA02D27D99677A" // WindowsSettings
+                                    };
+
+            // Treat default plugin differently, it needs to be removable along with each flow release
+            var installDirectory = !defaultPluginIDs.Any(x => x == plugin.ID)
+                                    ? DataLocation.PluginsDirectory
+                                    : Constant.PreinstalledDirectory;
+
+            var newPluginPath = Path.Combine(installDirectory, folderName);
 
             FilesFolders.CopyAll(pluginFolderPath, newPluginPath);
 


### PR DESCRIPTION
Context:
Allows the user to reinstall a default plugin from the Store instead of having to reinstall flow entirely.

Changes:
- All default plugins have their own [repo](https://github.com/orgs/Flow-Launcher/repositories?q=flow.launcher.plugin.&type=all&language=&sort=) for holding their releases
- Use workflow to publish plugins to their repo if their plugin.json is modified
- The actual installation code checks a plugin's ID against a list of default plugin IDs, if matches a default plugin's ID the install directory is changed to the program directory's plugin folder instead of the usual UserData location. This ensures that when flow is updated the default plugins are also reinstalled, otherwise if placed in UserData directory then will end up with duplicate default plugins.

Tests:
- Workflow only runs when changes are detected in Plugins folder
- Default plugins are published to their respective repositories when their plugin.json has been modified
- Default plugins are not published if their plugin.json has not been modified
- All installed default plugins work as expected
- A default plugin is installed in the program's directory instead of userdata's plugin directory

Close #1984 