### PR TITLE
Fix exclude path check for index search

### DIFF
--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -263,7 +263,7 @@ namespace Flow.Launcher.Plugin.SharedCommands
         }
 
         /// <summary>
-        /// Returns if <paramref name="parentPath"/> contains <paramref name="subPath"/>.
+        /// Returns if <paramref name="parentPath"/> contains <paramref name="subPath"/>. Equal paths are not considered to be contained by default.
         /// From https://stackoverflow.com/a/66877016
         /// </summary>
         /// <param name="parentPath">Parent path</param>

--- a/Flow.Launcher.Test/FilesFoldersTest.cs
+++ b/Flow.Launcher.Test/FilesFoldersTest.cs
@@ -47,7 +47,7 @@ namespace Flow.Launcher.Test
         [TestCase(@"c:\foo", @"c:\foo\", true)]
         public void GivenTwoPathsAreTheSame_WhenCheckPathContains_ThenShouldBeExpectedResult(string parentPath, string path, bool expectedResult)
         {
-            Assert.AreEqual(expectedResult, FilesFolders.PathContains(parentPath, path, expectedResult));
+            Assert.AreEqual(expectedResult, FilesFolders.PathContains(parentPath, path, allowEqual: expectedResult));
         }
     }
 }

--- a/Flow.Launcher.Test/FilesFoldersTest.cs
+++ b/Flow.Launcher.Test/FilesFoldersTest.cs
@@ -1,4 +1,4 @@
-using Flow.Launcher.Plugin.SharedCommands;
+﻿using Flow.Launcher.Plugin.SharedCommands;
 using NUnit.Framework;
 
 namespace Flow.Launcher.Test
@@ -33,21 +33,21 @@ namespace Flow.Launcher.Test
         [TestCase(@"c:\foo", @"c:\foo\..\bar\baz", false)]
         [TestCase(@"c:\bar", @"c:\foo\..\bar\baz", true)]
         [TestCase(@"c:\barr", @"c:\foo\..\bar\baz", false)]
-        // Equality
-        [TestCase(@"c:\foo", @"c:\foo", false)]
-        [TestCase(@"c:\foo\", @"c:\foo", false)]
-        [TestCase(@"c:\foo", @"c:\foo\", false)]
         public void GivenTwoPaths_WhenCheckPathContains_ThenShouldBeExpectedResult(string parentPath, string path, bool expectedResult)
         {
             Assert.AreEqual(expectedResult, FilesFolders.PathContains(parentPath, path));
         }
 
+        // Equality
+        [TestCase(@"c:\foo", @"c:\foo", false)]
+        [TestCase(@"c:\foo\", @"c:\foo", false)]
+        [TestCase(@"c:\foo", @"c:\foo\", false)]
         [TestCase(@"c:\foo", @"c:\foo", true)]
         [TestCase(@"c:\foo\", @"c:\foo", true)]
         [TestCase(@"c:\foo", @"c:\foo\", true)]
-        public void GivenTwoPathsAreTheSame_WhenCheckPathContains_ThenShouldBeTrue(string parentPath, string path, bool expectedResult)
+        public void GivenTwoPathsAreTheSame_WhenCheckPathContains_ThenShouldBeExpectedResult(string parentPath, string path, bool expectedResult)
         {
-            Assert.AreEqual(expectedResult, FilesFolders.PathContains(parentPath, path, true));
+            Assert.AreEqual(expectedResult, FilesFolders.PathContains(parentPath, path, expectedResult));
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -123,7 +123,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             }
 
             results.RemoveWhere(r => Settings.IndexSearchExcludedSubdirectoryPaths.Any(
-                excludedPath => FilesFolders.PathContains(excludedPath.Path, r.SubTitle)));
+                excludedPath => FilesFolders.PathContains(excludedPath.Path, r.SubTitle, true)));
 
             return results.ToList();
         }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -123,7 +123,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             }
 
             results.RemoveWhere(r => Settings.IndexSearchExcludedSubdirectoryPaths.Any(
-                excludedPath => FilesFolders.PathContains(excludedPath.Path, r.SubTitle, true)));
+                excludedPath => FilesFolders.PathContains(excludedPath.Path, r.SubTitle, allowEqual: true)));
 
             return results.ToList();
         }


### PR DESCRIPTION
Exclude path is broken because `FilesFolders.PathContains` doesn't return true when two paths are equal.

Tests:
- [x] When `c:\foo` is in exclude path, `c:\foo\x.txt` is excluded in search results.