### PR TITLE
Switch Bookmarks plugin to use Microsoft.Data.Sqlite

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
@@ -1,7 +1,7 @@
 ﻿using Flow.Launcher.Plugin.BrowserBookmark.Models;
+using Microsoft.Data.Sqlite;
 using System;
 using System.Collections.Generic;
-using System.Data.SQLite;
 using System.IO;
 using System.Linq;
 
@@ -33,11 +33,11 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
 
             // create the connection string and init the connection
             string dbPath = string.Format(dbPathFormat, placesPath);
-            using var dbConnection = new SQLiteConnection(dbPath);
+            using var dbConnection = new SqliteConnection(dbPath);
             // Open connection to the database file and execute the query
             dbConnection.Open();
-            var reader = new SQLiteCommand(queryAllBookmarks, dbConnection).ExecuteReader();
-
+            var reader = new SqliteCommand(queryAllBookmarks, dbConnection).ExecuteReader();
+            
             // return results in List<Bookmark> format
             bookmarkList = reader.Select(
                 x => new Bookmark(x["title"] is DBNull ? string.Empty : x["title"].ToString(),
@@ -133,7 +133,7 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
 
     public static class Extensions
     {
-        public static IEnumerable<T> Select<T>(this SQLiteDataReader reader, Func<SQLiteDataReader, T> projection)
+        public static IEnumerable<T> Select<T>(this SqliteDataReader reader, Func<SqliteDataReader, T> projection)
         {
             while (reader.Read())
             {

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
@@ -19,7 +19,7 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
               ORDER BY moz_places.visit_count DESC
             ";
 
-        private const string dbPathFormat = "Data Source ={0};Version=3;New=False;Compress=True;";
+        private const string dbPathFormat = "Data Source ={0}";
 
         protected static List<Bookmark> GetBookmarksFromPath(string placesPath)
         {

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Flow.Launcher.Plugin.BrowserBookmark.csproj
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Flow.Launcher.Plugin.BrowserBookmark.csproj
@@ -63,15 +63,4 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.10" />
   </ItemGroup>
 
-  <!--<Target Name="CopyDLLs" AfterTargets="Build">
-    <Message Text="Executing CopyDLLs task" Importance="High" />
-    <Copy SourceFiles="$(TargetDir)\runtimes\win-x64\native\SQLite.Interop.dll" DestinationFolder="$(TargetDir)\x64" />
-    <Copy SourceFiles="$(TargetDir)\runtimes\win-x86\native\SQLite.Interop.dll" DestinationFolder="$(TargetDir)\x86" />
-  </Target>
-
-  <Target Name="DeleteRuntimesFolder" AfterTargets="CopyDLLs">
-    <Message Text="Deleting runtimes folder" Importance="High" />
-    <RemoveDir Directories="$(TargetDir)\runtimes" />
-  </Target>-->
-
 </Project>

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Flow.Launcher.Plugin.BrowserBookmark.csproj
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Flow.Launcher.Plugin.BrowserBookmark.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -56,14 +56,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SQLite" Version="1.0.118" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Remove="Bookmark.cs" />
   </ItemGroup>
 
-  <Target Name="CopyDLLs" AfterTargets="Build">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.10" />
+  </ItemGroup>
+
+  <!--<Target Name="CopyDLLs" AfterTargets="Build">
     <Message Text="Executing CopyDLLs task" Importance="High" />
     <Copy SourceFiles="$(TargetDir)\runtimes\win-x64\native\SQLite.Interop.dll" DestinationFolder="$(TargetDir)\x64" />
     <Copy SourceFiles="$(TargetDir)\runtimes\win-x86\native\SQLite.Interop.dll" DestinationFolder="$(TargetDir)\x86" />
@@ -72,6 +72,6 @@
   <Target Name="DeleteRuntimesFolder" AfterTargets="CopyDLLs">
     <Message Text="Deleting runtimes folder" Importance="High" />
     <RemoveDir Directories="$(TargetDir)\runtimes" />
-  </Target>
+  </Target>-->
 
 </Project>

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Flow.Launcher.Plugin.BrowserBookmark.csproj
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Flow.Launcher.Plugin.BrowserBookmark.csproj
@@ -12,6 +12,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <UseWindowsForms>true</UseWindowsForms>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
In order to prepare a possible ARM64 release (see #2318) the first step would be probably to switch Bookmarks plugin to use a sqlite library available natively for ARM64. `System.Data.SQlite` which was used is quite old, so this PR switches to current `Microsoft.Data.Sqlite`, which is based on `SQLiteRawPCL` offering native sqlite library for many platforms.

The differences are in the connection string, as some parameters were not available for the newer nuget, and in the setting the default RuntimeID to `win-x64`, which can be overridden at a build step (e.g. to `win-arm64` if needed).

This PR also effectively removes support for 32-bit Windows, not sure if it is a problem.