### PR TITLE
Fix publish default plugins action not triggering

### DIFF
--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -2,7 +2,7 @@ name: Publish Default Plugins
 
 on:
   push:
-    branches: ['master']
+    branches: ['dev']
     paths: ['Plugins/**']
   workflow_dispatch:
 
@@ -46,6 +46,7 @@ jobs:
               - 'Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json'
             windowssettings:
               - 'Plugins/Flow.Launcher.Plugin.WindowsSettings/plugin.json'
+          base: 'master'
 
       - name: Get BrowserBookmark Version
         if: steps.changes.outputs.browserbookmark == 'true'


### PR DESCRIPTION
Currently not triggering due to the comparison is against the very last commit on master (because 'base' option is not set).

Fix publish default plugins action not triggering:
- Push trigger branch should be 'dev'
- Compare branch should be 'master'

This means once the plugin's plugin.json has been modified and merged into dev branch a publish event should occur which will compare this change between dev and master, and consequently pushes to the plugin's repo.