### PR TITLE
Ignore .lnk target file extension

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -313,7 +313,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 if (!string.IsNullOrEmpty(target) && File.Exists(target))
                 {
                     program.LnkResolvedPath = Path.GetFullPath(target);
-                    program.ExecutableName = Path.GetFileName(target);
+                    program.ExecutableName = Path.GetFileNameWithoutExtension(target);
 
                     var args = _helper.arguments;
                     if (!string.IsNullOrEmpty(args))


### PR DESCRIPTION
Fix #2366 

Currently `ExecutableName` property includes file extension like `.exe`. So query "ex" matches any ".exe" in `ExecutableName` property which is unnecessary for Program plugin.

Test:
- "Excel" is prioritized when querying "ex".