### PR TITLE
 Delay restart after installing/uninstalling/updating plugins

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -12,7 +12,6 @@ using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
 using ISavable = Flow.Launcher.Plugin.ISavable;
 using Flow.Launcher.Plugin.SharedCommands;
-using Mono.Cecil;
 using System.Text.Json;
 
 namespace Flow.Launcher.Core.Plugin

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -29,8 +29,7 @@ namespace Flow.Launcher.Core.Plugin
 
         public static IPublicAPI API { private set; get; }
 
-        // todo happlebao, this should not be public, the indicator function should be embeded 
-        public static PluginsSettings Settings;
+        private static PluginsSettings Settings;
         private static List<PluginMetadata> _metadatas;
 
         /// <summary>

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -107,7 +107,7 @@ namespace Flow.Launcher.Plugin
         /// </summary>
         /// <param name="title">Message title</param>
         /// <param name="subTitle">Message subtitle</param>
-        /// <param name="iconPath">Full path to icon</param>
+        /// <param name="iconPath">Message icon path (relative path to your plugin folder)</param>
         void ShowMsg(string title, string subTitle = "", string iconPath = "");
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Flow.Launcher.Plugin
         /// </summary>
         /// <param name="title">Message title</param>
         /// <param name="subTitle">Message subtitle</param>
-        /// <param name="iconPath">Full path to icon</param>
+        /// <param name="iconPath">Message icon path (relative path to your plugin folder)</param>
         /// <param name="useMainWindowAsOwner">when true will use main windows as the owner</param>
         void ShowMsg(string title, string subTitle, string iconPath, bool useMainWindowAsOwner = true);
 

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -107,7 +107,7 @@ namespace Flow.Launcher.Plugin
         /// </summary>
         /// <param name="title">Message title</param>
         /// <param name="subTitle">Message subtitle</param>
-        /// <param name="iconPath">Message icon path (relative path to your plugin folder)</param>
+        /// <param name="iconPath">Full path to icon</param>
         void ShowMsg(string title, string subTitle = "", string iconPath = "");
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Flow.Launcher.Plugin
         /// </summary>
         /// <param name="title">Message title</param>
         /// <param name="subTitle">Message subtitle</param>
-        /// <param name="iconPath">Message icon path (relative path to your plugin folder)</param>
+        /// <param name="iconPath">Full path to icon</param>
         /// <param name="useMainWindowAsOwner">when true will use main windows as the owner</param>
         void ShowMsg(string title, string subTitle, string iconPath, bool useMainWindowAsOwner = true);
 

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/ContextMenu.cs
@@ -13,6 +13,10 @@ namespace Flow.Launcher.Plugin.PluginsManager
             Context = context;
         }
 
+        private readonly GlyphInfo sourcecodeGlyph = new("/Resources/#Segoe Fluent Icons","\uE943");
+        private readonly GlyphInfo issueGlyph = new("/Resources/#Segoe Fluent Icons", "\ued15");
+        private readonly GlyphInfo manifestGlyph = new("/Resources/#Segoe Fluent Icons", "\uea37");
+
         public List<Result> LoadContextMenus(Result selectedResult)
         {
             if(selectedResult.ContextData is not UserPlugin pluginManifestInfo) 
@@ -36,6 +40,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                     Title = Context.API.GetTranslation("plugin_pluginsmanager_plugin_contextmenu_gotosourcecode_title"),
                     SubTitle = Context.API.GetTranslation("plugin_pluginsmanager_plugin_contextmenu_gotosourcecode_subtitle"),
                     IcoPath = "Images\\sourcecode.png",
+                    Glyph = sourcecodeGlyph,
                     Action = _ =>
                     {
                         Context.API.OpenUrl(pluginManifestInfo.UrlSourceCode);
@@ -47,6 +52,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                     Title = Context.API.GetTranslation("plugin_pluginsmanager_plugin_contextmenu_newissue_title"),
                     SubTitle = Context.API.GetTranslation("plugin_pluginsmanager_plugin_contextmenu_newissue_subtitle"),
                     IcoPath = "Images\\request.png",
+                    Glyph = issueGlyph,
                     Action = _ =>
                     {
                         // standard UrlSourceCode format in PluginsManifest's plugins.json file: https://github.com/jjw24/Flow.Launcher.Plugin.Putty/tree/master
@@ -63,6 +69,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                     Title = Context.API.GetTranslation("plugin_pluginsmanager_plugin_contextmenu_pluginsmanifest_title"),
                     SubTitle = Context.API.GetTranslation("plugin_pluginsmanager_plugin_contextmenu_pluginsmanifest_subtitle"),
                     IcoPath = "Images\\manifestsite.png",
+                    Glyph = manifestGlyph,
                     Action = _ =>
                     {
                         Context.API.OpenUrl("https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest");

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Flow.Launcher.Plugin.PluginsManager.csproj
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Flow.Launcher.Plugin.PluginsManager.csproj
@@ -36,8 +36,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
-  </ItemGroup>
 </Project>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
@@ -33,9 +33,9 @@
     <system:String x:Key="plugin_pluginsmanager_install_unknown_source_warning_title">Installing from an unknown source</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_unknown_source_warning">You are installing this plugin from an unknown source and it may contain potential risks!{0}{0}Please ensure you understand where this plugin is from and that it is safe.{0}{0}Would you like to continue still?{0}{0}(You can switch off this warning via settings)</system:String>
     
-    <system:String x:Key="plugin_pluginsmanager_install_success_no_restart">Plugin {0} successfully installed. Please manually restart Flow.</system:String>
-    <system:String x:Key="plugin_pluginsmanager_uninstall_success_no_restart">Plugin {0} successfully uninstalled. Please manually restart Flow.</system:String>
-    <system:String x:Key="plugin_pluginsmanager_update_success_no_restart">Plugin {0} successfully updated. Please manually restart Flow.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_success_no_restart">Plugin {0} successfully installed. Please restart Flow.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_uninstall_success_no_restart">Plugin {0} successfully uninstalled. Please restart Flow.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_success_no_restart">Plugin {0} successfully updated. Please restart Flow.</system:String>
 
     <!--  Plugin Infos  -->
     <system:String x:Key="plugin_pluginsmanager_plugin_name">Plugins Manager</system:String>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
@@ -8,7 +8,9 @@
     <system:String x:Key="plugin_pluginsmanager_download_success">Successfully downloaded {0}</system:String>
     <system:String x:Key="plugin_pluginsmanager_download_error">Error: Unable to download the plugin</system:String>
     <system:String x:Key="plugin_pluginsmanager_uninstall_prompt">{0} by {1} {2}{3}Would you like to uninstall this plugin? After the uninstallation Flow will automatically restart.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_uninstall_prompt_no_restart">{0} by {1} {2}{2}Would you like to uninstall this plugin?</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_prompt">{0} by {1} {2}{3}Would you like to install this plugin? After the installation Flow will automatically restart.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_install_prompt_no_restart">{0} by {1} {2}{2}Would you like to install this plugin?</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_title">Plugin Install</system:String>
     <system:String x:Key="plugin_pluginsmanager_installing_plugin">Installing Plugin</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_from_web">Download and install {0}</system:String>
@@ -21,15 +23,19 @@
     <system:String x:Key="plugin_pluginsmanager_update_noresult_title">No update available</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_noresult_subtitle">All plugins are up to date</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_prompt">{0} by {1} {2}{3}Would you like to update this plugin? After the update Flow will automatically restart.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_prompt_no_restart">{0} by {1} {2}{2}Would you like to update this plugin?</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_title">Plugin Update</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_exists">This plugin has an update, would you like to see it?</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_alreadyexists">This plugin is already installed</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_failed_title">Plugin Manifest Download Failed</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_failed_subtitle">Please check if you can connect to github.com. This error means you may not be able to install or update plugins.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_success_restart">Plugin {0} successfully updated. Restarting Flow, please wait...</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_unknown_source_warning_title">Installing from an unknown source</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_unknown_source_warning">You are installing this plugin from an unknown source and it may contain potential risks!{0}{0}Please ensure you understand where this plugin is from and that it is safe.{0}{0}Would you like to continue still?{0}{0}(You can switch off this warning via settings)</system:String>
-
-    <!--  Controls  -->
+    
+    <system:String x:Key="plugin_pluginsmanager_install_success_no_restart">Plugin {0} successfully installed. Please manually restart Flow.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_uninstall_success_no_restart">Plugin {0} successfully uninstalled. Please manually restart Flow.</system:String>
+    <system:String x:Key="plugin_pluginsmanager_update_success_no_restart">Plugin {0} successfully updated. Please manually restart Flow.</system:String>
 
     <!--  Plugin Infos  -->
     <system:String x:Key="plugin_pluginsmanager_plugin_name">Plugins Manager</system:String>
@@ -48,4 +54,5 @@
 
     <!--  Settings menu items  -->
     <system:String x:Key="plugin_pluginsmanager_plugin_settings_unknown_source">Install from unknown source warning</system:String>
+    <system:String x:Key="plugin_pluginsmanager_plugin_settings_auto_restart">Automatically restart Flow Launcher after installing/uninstalling/updating plugins</system:String>
 </ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Languages/en.xaml
@@ -20,6 +20,7 @@
     <system:String x:Key="plugin_pluginsmanager_install_error_duplicate">Error: A plugin which has the same or greater version with {0} already exists.</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_error_title">Error installing plugin</system:String>
     <system:String x:Key="plugin_pluginsmanager_install_error_subtitle">Error occurred while trying to install {0}</system:String>
+    <system:String x:Key="plugin_pluginsmanager_uninstall_error_title">Error uninstalling plugin</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_noresult_title">No update available</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_noresult_subtitle">All plugins are up to date</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_prompt">{0} by {1} {2}{3}Would you like to update this plugin? After the update Flow will automatically restart.</system:String>
@@ -36,7 +37,8 @@
     <system:String x:Key="plugin_pluginsmanager_install_success_no_restart">Plugin {0} successfully installed. Please restart Flow.</system:String>
     <system:String x:Key="plugin_pluginsmanager_uninstall_success_no_restart">Plugin {0} successfully uninstalled. Please restart Flow.</system:String>
     <system:String x:Key="plugin_pluginsmanager_update_success_no_restart">Plugin {0} successfully updated. Please restart Flow.</system:String>
-
+    <system:String x:Key="plugin_pluginsmanager_plugin_modified_error">Plugin {0} has already been modified. Please restart Flow before making any further changes.</system:String>
+   
     <!--  Plugin Infos  -->
     <system:String x:Key="plugin_pluginsmanager_plugin_name">Plugins Manager</system:String>
     <system:String x:Key="plugin_pluginsmanager_plugin_description">Management of installing, uninstalling or updating Flow Launcher plugins</system:String>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -188,6 +188,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                     on existingPlugin.Metadata.ID equals pluginFromManifest.ID
                 where existingPlugin.Metadata.Version.CompareTo(pluginFromManifest.Version) <
                       0 // if current version precedes manifest version
+                      && !PluginManager.PluginModified(existingPlugin.Metadata.ID)
                 select
                     new
                     {
@@ -317,6 +318,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
             var plugin = new UserPlugin
             {
+                // FIXME installing in store then install web ver 
                 ID = "",
                 Name = name,
                 Version = string.Empty,
@@ -380,7 +382,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
             var results =
                 PluginsManifest
                     .UserPlugins
-                    .Where(x => !PluginExists(x.ID))
+                    .Where(x => !PluginExists(x.ID) && !PluginManager.PluginModified(x.ID))
                     .Select(x =>
                         new Result
                         {

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -318,7 +318,6 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
             var plugin = new UserPlugin
             {
-                // FIXME installing in store then install web ver 
                 ID = "",
                 Name = name,
                 Version = string.Empty,

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -136,9 +136,6 @@ namespace Flow.Launcher.Plugin.PluginsManager
             {
                 await Http.DownloadAsync(plugin.UrlDownload, filePath).ConfigureAwait(false);
 
-                Context.API.ShowMsg(Context.API.GetTranslation("plugin_pluginsmanager_downloading_plugin"),
-                     string.Format(Context.API.GetTranslation("plugin_pluginsmanager_download_success"), plugin.Name));
-
                 Install(plugin, filePath);
             }
             catch (Exception e)
@@ -222,10 +219,6 @@ namespace Flow.Launcher.Plugin.PluginsManager
                                 {
                                     await Http.DownloadAsync(x.PluginNewUserPlugin.UrlDownload, downloadToFilePath)
                                         .ConfigureAwait(false);
-
-                                    Context.API.ShowMsg(
-                                        Context.API.GetTranslation("plugin_pluginsmanager_downloading_plugin"),
-                                        string.Format(Context.API.GetTranslation("plugin_pluginsmanager_download_success"), x.Name));
 
                                     Install(x.PluginNewUserPlugin, downloadToFilePath);
 

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -382,6 +382,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
             var results =
                 PluginsManifest
                     .UserPlugins
+                    .Where(x => !PluginExists(x.ID))
                     .Select(x =>
                         new Result
                         {

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -148,19 +148,19 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
                 Install(plugin, filePath);
             }
+            catch (HttpRequestException e)
+            {
+                Context.API.ShowMsgError(string.Format(Context.API.GetTranslation("plugin_pluginsmanager_downloading_plugin"), plugin.Name),
+                            Context.API.GetTranslation("plugin_pluginsmanager_download_error"));
+                Log.Exception("PluginsManager", "An error occurred while downloading plugin", e);
+                return;
+            }
             catch (Exception e)
             {
-                // TODO use toast to optimize error prompt
-                if (e is HttpRequestException)
-                    MessageBox.Show(Context.API.GetTranslation("plugin_pluginsmanager_download_error"),
-                        Context.API.GetTranslation("plugin_pluginsmanager_downloading_plugin"));
-
                 Context.API.ShowMsgError(Context.API.GetTranslation("plugin_pluginsmanager_install_error_title"),
                     string.Format(Context.API.GetTranslation("plugin_pluginsmanager_install_error_subtitle"),
                         plugin.Name));
-
-                Log.Exception("PluginsManager", "An error occurred while downloading plugin", e, "InstallOrUpdate");
-
+                Log.Exception("PluginsManager", "An error occurred while downloading plugin", e);
                 return;
             }
 

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -143,6 +143,11 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
             try
             {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+
                 await Http.DownloadAsync(plugin.UrlDownload, filePath).ConfigureAwait(false);
 
                 Install(plugin, filePath);
@@ -245,6 +250,11 @@ namespace Flow.Launcher.Plugin.PluginsManager
 
                                 _ = Task.Run(async delegate
                                 {
+                                    if (File.Exists(downloadToFilePath))
+                                    {
+                                        File.Delete(downloadToFilePath);
+                                    }
+
                                     await Http.DownloadAsync(x.PluginNewUserPlugin.UrlDownload, downloadToFilePath)
                                         .ConfigureAwait(false);
 

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -139,7 +139,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                 ? $"{plugin.Name}-{Guid.NewGuid()}.zip"
                 : $"{plugin.Name}-{plugin.Version}.zip";
 
-            var filePath = Path.Combine(DataLocation.PluginsDirectory, downloadFilename);
+            var filePath = Path.Combine(Path.GetTempPath(), downloadFilename);
 
             try
             {
@@ -240,7 +240,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                                     Context.API.GetTranslation("plugin_pluginsmanager_update_title"),
                                     MessageBoxButton.YesNo) == MessageBoxResult.Yes)
                             {
-                                var downloadToFilePath = Path.Combine(DataLocation.PluginsDirectory,
+                                var downloadToFilePath = Path.Combine(Path.GetTempPath(),
                                     $"{x.Name}-{x.NewVersion}.zip");
 
                                 _ = Task.Run(async delegate
@@ -414,6 +414,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
             try
             {
                 PluginManager.InstallPlugin(plugin, downloadedFilePath);
+                File.Delete(downloadedFilePath);
             }
             catch (FileNotFoundException e)
             {

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -388,7 +388,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                         {
                             Title = $"{x.Name} by {x.Author}",
                             SubTitle = x.Description,
-                            IcoPath = icoPath,
+                            IcoPath = x.IcoPath,
                             Action = e =>
                             {
                                 if (e.SpecialKeyState.CtrlPressed)

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -267,7 +267,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                                 }).ContinueWith(t =>
                                 {
                                     Log.Exception("PluginsManager", $"Update failed for {x.Name}",
-                                        t.Exception.InnerException, "RequestUpdate");
+                                        t.Exception.InnerException);
                                     Context.API.ShowMsg(
                                         Context.API.GetTranslation("plugin_pluginsmanager_install_error_title"),
                                         string.Format(
@@ -410,7 +410,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
         private void Install(UserPlugin plugin, string downloadedFilePath)
         {
             if (!File.Exists(downloadedFilePath))
-                return;
+                throw new FileNotFoundException($"Plugin {plugin.ID} zip file not found at {downloadedFilePath}", downloadedFilePath);
             try
             {
                 PluginManager.Install(plugin, downloadedFilePath);

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Settings.cs
@@ -9,5 +9,7 @@
         internal const string UpdateCommand = "update";
 
         public bool WarnFromUnknownSource { get; set; } = true;
+        
+        public bool AutoRestartAfterChanging { get; set; } = false;
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/ViewModels/SettingsViewModel.cs
@@ -17,5 +17,11 @@
             get => Settings.WarnFromUnknownSource;
             set => Settings.WarnFromUnknownSource = value;
         }
+
+        public bool AutoRestartAfterChanging
+        { 
+            get => Settings.AutoRestartAfterChanging;
+            set => Settings.AutoRestartAfterChanging = value;
+        }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Views/PluginsManagerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Views/PluginsManagerSettings.xaml
@@ -12,10 +12,22 @@
             <ColumnDefinition Width="400" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
+        </Grid.RowDefinitions>
         <CheckBox
             Grid.Column="0"
+            Grid.Row="0"
             Padding="8,0,0,0"
             Content="{DynamicResource plugin_pluginsmanager_plugin_settings_unknown_source}"
             IsChecked="{Binding WarnFromUnknownSource}" />
+        <CheckBox
+            Grid.Column="0"
+            Grid.Row="1"
+            Margin="0,20,0,0"
+            Padding="8,0,0,0"
+            Content="{DynamicResource plugin_pluginsmanager_plugin_settings_auto_restart}"
+            IsChecked="{Binding AutoRestartAfterChanging}" />
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Feature

- Delay restart after installing/uninstalling/updating plugins.

## Changes
### Core
-  **Move Install/Uninstall plugin logic to `Core.PluginManager`**
- Disallow modifying a plugin twice in a session.

### Plugins Manger
- New option for Plugins Manger: `AutoRestartAfterChanging`. Default is `false`. (Should we set to true to keep current behavior?)
- Exclude installed plugins from `pm install`
- Exclude modified(i.e. updated/installed/uninstalled in this session) plugins from `pm install` and `pm update` results
- Show plugin remote icons in `pm Install` results.
- Add glyphs for pm context menu
- Reduce messageboxes to improve consistency
- Fix #2419 

## Tests:
- [x] Different message boxes and notification are shown when `AutoRestartAfterChanging == false`.
- [x] plugins can be installed/uninstalled after restart
- [x] Uninstall a plugin, then install again before restarting not allowed.
- [x] Installing twice before restarting not allowed. 
- [x] Existing zip deleted when downloading zip.