### PR TITLE
Add Edge Workspace support

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
@@ -54,6 +54,7 @@ namespace Flow.Launcher.Plugin.BrowserBookmark
                 switch (subElement.GetProperty("type").GetString())
                 {
                     case "folder":
+                    case "workspace": // Edge Workspace
                         EnumerateFolderBookmark(subElement, bookmarks, source);
                         break;
                     default:


### PR DESCRIPTION
Fix #2158 #2375 

Fixes exception when loading Edge bookmark file with workspace feature enabled.

Tested:
- No errors when starting Flow, when Bookmark plugin and Edge's workspace enabled.
- Bookmarks in workspace can be indexed.