### PR TITLE
[ci skip] Fix missing dotnet and php dict

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -91,10 +91,10 @@ jobs:
         extra_dictionaries:
           cspell:software-terms/dict/softwareTerms.txt
           cspell:win32/src/win32.txt
-          cspell:php/php.txt
+          cspell:php/src/php.txt
           cspell:filetypes/filetypes.txt
           cspell:csharp/csharp.txt
-          cspell:dotnet/dotnet.txt
+          cspell:dotnet/src/dotnet.txt
           cspell:python/src/common/extra.txt
           cspell:python/src/python/python-lib.txt
           cspell:aws/aws.txt


### PR DESCRIPTION
Fix wrong dotnet and php dict file URL. See [here](https://github.com/Flow-Launcher/Flow.Launcher/actions/runs/6462190051/job/17543371187#step:2:462).

Tests:
- [php](https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20230509/dictionaries/php/src/php.txt) and [dotnet](https://raw.githubusercontent.com/check-spelling/cspell-dicts/v20230509/dictionaries/dotnet/src/dotnet.txt) are available.