### PR TITLE
Use FuzzySearch to search access links

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
@@ -13,20 +13,17 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
             if (string.IsNullOrEmpty(query.Search))
                 return new List<Result>();
 
-            string search = query.Search.ToLower();
-
-            var queriedAccessLinks =
-                accessLinks
-                .Where(x => x.Name.Contains(search, StringComparison.OrdinalIgnoreCase) || x.Path.Contains(search, StringComparison.OrdinalIgnoreCase))
+            return accessLinks
+                .Where(x => Main.Context.API.FuzzySearch(query.Search, x.Name).IsSearchPrecisionScoreMet() || Main.Context.API.FuzzySearch(query.Search, x.Path).IsSearchPrecisionScoreMet())
                 .OrderBy(x => x.Type)
-                .ThenBy(x => x.Name);
-
-            return queriedAccessLinks.Select(l => l.Type switch
-            {
-                ResultType.Folder => ResultManager.CreateFolderResult(l.Name, l.Path, l.Path, query, quickAccessResultScore),
-                ResultType.File => ResultManager.CreateFileResult(l.Path, query, quickAccessResultScore),
-                _ => throw new ArgumentOutOfRangeException()
-            }).ToList();
+                .ThenBy(x => x.Name)
+                .Select(l => l.Type switch
+                    {
+                        ResultType.Folder => ResultManager.CreateFolderResult(l.Name, l.Path, l.Path, query, quickAccessResultScore),
+                        ResultType.File => ResultManager.CreateFileResult(l.Path, query, quickAccessResultScore),
+                        _ => throw new ArgumentOutOfRangeException()
+                    })
+                .ToList();
         }
 
         internal static List<Result> AccessLinkListAll(Query query, IEnumerable<AccessLink> accessLinks)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -10,7 +10,7 @@
   "Name": "Explorer",
   "Description": "Find and manage files and folders via Windows Search or Everything",
   "Author": "Jeremy Wu",
-  "Version": "3.1.3",
+  "Version": "3.1.4",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",


### PR DESCRIPTION
## Feature

Use `StringMatcher.FuzzySearch()` to search Access links in Explorer plugin to improve search results, like allow searching in pinyin.

## Tests

- Access links can be fuzzy-searched.