### PR TITLE
Allowing setting change without template file

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -668,6 +668,7 @@ namespace Flow.Launcher.Core.Plugin
                     }
                 }
             }
+            Save();
         }
     }
 

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -646,10 +646,8 @@ namespace Flow.Launcher.Core.Plugin
 
             foreach (var (key, value) in settings)
             {
-                if (Settings.ContainsKey(key))
-                {
-                    Settings[key] = value;
-                }
+
+                Settings[key] = value;
                 if (_settingControls.ContainsKey(key))
                 {
 

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -645,7 +645,6 @@ namespace Flow.Launcher.Core.Plugin
 
             foreach (var (key, value) in settings)
             {
-
                 Settings[key] = value;
                 if (_settingControls.ContainsKey(key))
                 {

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -314,8 +314,7 @@ namespace Flow.Launcher.Core.Plugin
 
         public async Task InitSettingAsync()
         {
-            if (!File.Exists(SettingConfigurationPath))
-                return;
+
 
             if (File.Exists(SettingPath))
             {
@@ -323,20 +322,23 @@ namespace Flow.Launcher.Core.Plugin
                 Settings = await JsonSerializer.DeserializeAsync<Dictionary<string, object>>(fileStream, options);
             }
 
-            var deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
-            _settingsTemplate = deserializer.Deserialize<JsonRpcConfigurationModel>(await File.ReadAllTextAsync(SettingConfigurationPath));
-
-            Settings ??= new Dictionary<string, object>();
-
-            foreach (var (type, attribute) in _settingsTemplate.Body)
+            if (File.Exists(SettingConfigurationPath))
             {
-                if (type == "textBlock")
-                    continue;
-                if (!Settings.ContainsKey(attribute.Name))
+                var deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
+                _settingsTemplate = deserializer.Deserialize<JsonRpcConfigurationModel>(await File.ReadAllTextAsync(SettingConfigurationPath));
+
+
+                foreach (var (type, attribute) in _settingsTemplate.Body)
                 {
-                    Settings[attribute.Name] = attribute.DefaultValue;
+                    if (type == "textBlock")
+                        continue;
+                    if (!Settings.ContainsKey(attribute.Name))
+                    {
+                        Settings[attribute.Name] = attribute.DefaultValue;
+                    }
                 }
             }
+            Settings ??= new Dictionary<string, object>();
         }
 
         public virtual async Task InitAsync(PluginInitContext context)

--- a/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPlugin.cs
@@ -315,7 +315,6 @@ namespace Flow.Launcher.Core.Plugin
         public async Task InitSettingAsync()
         {
 
-
             if (File.Exists(SettingPath))
             {
                 await using var fileStream = File.OpenRead(SettingPath);


### PR DESCRIPTION
Currently JsonRPC based plugins returning `SettingsChange` in their result response will cause Flow Launcher to crash the plugin if they do not also have a `SettingsTemplate.yaml` file in the plugin's root directory. This is because the plugin's `Settings` dictionary is never initiated.

I moved the short circuit evaluation allowing the plugin's `Settings` to be loaded/initiated regardless if the plugin has a `SettingsTemplate.yaml` file.

Also we restrict settings changes for pre-existing keys, I removed the key check allowing new keys to be instantiated.
Lastly Flow Launcher now saves to file whenever the settings are updated.