### PR TITLE
Improve JsonRPC plugin settings

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginBase.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginBase.cs
@@ -126,8 +126,6 @@ namespace Flow.Launcher.Core.Plugin
 
         private async Task InitSettingAsync()
         {
-            if (!File.Exists(SettingConfigurationPath))
-                return;
 
             var deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .Build();

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginBase.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginBase.cs
@@ -126,12 +126,15 @@ namespace Flow.Launcher.Core.Plugin
 
         private async Task InitSettingAsync()
         {
+            JsonRpcConfigurationModel configuration = null;
+            if (File.Exists(SettingConfigurationPath))
+            {
+                var deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
+                configuration =
+                    deserializer.Deserialize<JsonRpcConfigurationModel>(
+                        await File.ReadAllTextAsync(SettingConfigurationPath));
+            }
 
-            var deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .Build();
-            var configuration =
-                deserializer.Deserialize<JsonRpcConfigurationModel>(
-                    await File.ReadAllTextAsync(SettingConfigurationPath));
 
             Settings ??= new JsonRPCPluginSettings
             {

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -83,6 +83,7 @@ namespace Flow.Launcher.Core.Plugin
                             break;
                     }
                 }
+                Save();
             }
         }
         

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -36,6 +36,11 @@ namespace Flow.Launcher.Core.Plugin
             _storage = new JsonStorage<Dictionary<string, object>>(SettingPath);
             Settings = await _storage.LoadAsync();
 
+            if (Settings != null)
+            {
+                return;
+            }
+
             foreach (var (type, attributes) in Configuration.Body) 
             {
                 if (attributes.Name == null)

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -63,10 +63,7 @@ namespace Flow.Launcher.Core.Plugin
 
             foreach (var (key, value) in settings)
             {
-                if (Settings.ContainsKey(key))
-                {
-                    Settings[key] = value;
-                }
+                Settings[key] = value;
 
                 if (SettingControls.TryGetValue(key, out var control))
                 {

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -83,8 +83,8 @@ namespace Flow.Launcher.Core.Plugin
                             break;
                     }
                 }
-                Save();
             }
+            Save();
         }
         
         public async Task SaveAsync()

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -10,7 +10,7 @@ namespace Flow.Launcher.Core.Plugin
 {
     public class JsonRPCPluginSettings
     {
-        public required JsonRpcConfigurationModel Configuration { get; init; }
+        public required JsonRpcConfigurationModel? Configuration { get; init; }
 
         public required string SettingPath { get; init; }
         public Dictionary<string, FrameworkElement> SettingControls { get; } = new();


### PR DESCRIPTION
# Problem

- JsonRPC plugins are unable to make settings changes unless they have a `SettingsTemplate.yaml` file.
- Plugin's are unable to initiate new setting keys
- Plugin settings are only saved to disk upon exit

#  Solution

- [X] Allow plugins without `SettingsTemplate.yaml` to change their settings
- [X] Remove logic restricting settings key creation
- [X] Save plugin settings to file when updated


