### PR TITLE
Ignore modifier key when using key + number to launch result

### DIFF
--- a/Flow.Launcher.Plugin/ActionContext.cs
+++ b/Flow.Launcher.Plugin/ActionContext.cs
@@ -50,5 +50,12 @@ namespace Flow.Launcher.Plugin
                    (AltPressed ? ModifierKeys.Alt : ModifierKeys.None) |
                    (WinPressed ? ModifierKeys.Windows : ModifierKeys.None);
         }
+
+        public static readonly SpecialKeyState Default = new () {
+            CtrlPressed = false,
+            ShiftPressed = false,
+            AltPressed = false,
+            WinPressed = false
+        };
     }
 }

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -285,7 +285,8 @@ namespace Flow.Launcher.ViewModel
             }
             var hideWindow = await result.ExecuteAsync(new ActionContext
                 {
-                    SpecialKeyState = GlobalHotkey.CheckModifiers()
+                    // not null means pressing modifier key + number, should ignore the modifier key
+                    SpecialKeyState = index is not null ? new SpecialKeyState() : GlobalHotkey.CheckModifiers()
                 })
                 .ConfigureAwait(false);
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -286,7 +286,7 @@ namespace Flow.Launcher.ViewModel
             var hideWindow = await result.ExecuteAsync(new ActionContext
                 {
                     // not null means pressing modifier key + number, should ignore the modifier key
-                    SpecialKeyState = index is not null ? new SpecialKeyState() : GlobalHotkey.CheckModifiers()
+                    SpecialKeyState = index is not null ? SpecialKeyState.Default : GlobalHotkey.CheckModifiers()
                 })
                 .ConfigureAwait(false);
 


### PR DESCRIPTION
## Changes

Fix the issue when pressing <kbd>Ctrl</kbd>+<kbd>Num</kbd> to open result, the <kbd>Ctrl</kbd>+<kbd>Enter</kbd> action is triggered. 
- close #2191
- close #2425

## Tests

(on Program and Explorer plugin)
- [x] <kbd>Ctrl</kbd>+<kbd>Num</kbd> no longer triggers the <kbd>Ctrl</kbd>+<kbd>Enter</kbd> action
- [x] <kbd>Ctrl</kbd>+<kbd>Num</kbd> opens the correct result.
- [x] <kbd>Ctrl</kbd>+(<kbd>Shift</kbd>+)<kbd>Mouse Left</kbd> (or <kbd>Enter</kbd>) triggers the correct action.