### PR TITLE
Revert SettingsChanges to SettingsChange for backwards compatibility

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonPRCModel.cs
+++ b/Flow.Launcher.Core/Plugin/JsonPRCModel.cs
@@ -25,7 +25,7 @@ namespace Flow.Launcher.Core.Plugin
     public record JsonRPCResponseModel(int Id, JsonRPCErrorModel Error = default) : JsonRPCBase(Id, Error);
     public record JsonRPCQueryResponseModel(int Id,
         [property: JsonPropertyName("result")] List<JsonRPCResult> Result,
-        IReadOnlyDictionary<string, object> SettingsChanges = null,
+        IReadOnlyDictionary<string, object> SettingsChange = null,
         string DebugMessage = "",
         JsonRPCErrorModel Error = default) : JsonRPCResponseModel(Id, Error);
 

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginBase.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginBase.cs
@@ -94,7 +94,7 @@ namespace Flow.Launcher.Core.Plugin
 
             results.AddRange(queryResponseModel.Result);
 
-            Settings?.UpdateSettings(queryResponseModel.SettingsChanges);
+            Settings?.UpdateSettings(queryResponseModel.SettingsChange);
 
             return results;
         }


### PR DESCRIPTION
# Reason

The `JsonRPCResponseModel` was inadvertently changed and may cause issues with backwards compatibility.

# Proposal

We revert the change to keep compatibility with older plugins.