### PR TITLE
Set default value of `AutoRestartAfterChanging` to `true`

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Settings.cs
@@ -10,6 +10,6 @@
 
         public bool WarnFromUnknownSource { get; set; } = true;
         
-        public bool AutoRestartAfterChanging { get; set; } = false;
+        public bool AutoRestartAfterChanging { get; set; } = true;
     }
 }


### PR DESCRIPTION
To keep the current behavior.