### PR TITLE
JsonRPCV2 Small revision

### DIFF
--- a/Flow.Launcher.Core/Flow.Launcher.Core.csproj
+++ b/Flow.Launcher.Core/Flow.Launcher.Core.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="FSharp.Core" Version="7.0.401" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
     <PackageReference Include="squirrel.windows" Version="1.5.2" NoWarn="NU1701" />
-    <PackageReference Include="StreamJsonRpc" Version="2.16.36" />
+    <PackageReference Include="StreamJsonRpc" Version="2.17.8" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
@@ -91,7 +91,7 @@ namespace Flow.Launcher.Core.Plugin
 
         private void SetupJsonRPC()
         {
-            var formatter = new JsonMessageFormatter();
+            var formatter = new SystemTextJsonFormatter { JsonSerializerOptions = RequestSerializeOption };
             var handler = new NewLineDelimitedMessageHandler(ClientPipe,
                 formatter);
 
@@ -100,10 +100,8 @@ namespace Flow.Launcher.Core.Plugin
             RPC.AddLocalRpcMethod("UpdateResults", new Action<string, JsonRPCQueryResponseModel>((rawQuery, response) =>
             {
                 var results = ParseResults(response);
-                ResultsUpdated?.Invoke(this, new ResultUpdatedEventArgs { Query = new Query()
-                {
-                    RawQuery = rawQuery
-                }, Results = results });
+                ResultsUpdated?.Invoke(this,
+                    new ResultUpdatedEventArgs { Query = new Query() { RawQuery = rawQuery }, Results = results });
             }));
             RPC.SynchronizationContext = null;
             RPC.StartListening();


### PR DESCRIPTION
- Update `StreamJsonRPC` and use `System.Text.Json` Formatter
- fix an error of triggering setting panel when configuration is null (I think it is caused by loading default json storage, which is not null)

The sample needs a small revision as now the message is passed with `camelCase` rather than `PascalCase` (which aligns with the behavior of v1)

[Lb0LD5a8.zip](https://github.com/Flow-Launcher/Flow.Launcher/files/13627033/Lb0LD5a8.zip)

