### PR TITLE
Strip newlines for multi line paste

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -221,6 +221,7 @@
                                 Visibility="Visible">
                                 <TextBox.CommandBindings>
                                     <CommandBinding Command="ApplicationCommands.Copy" Executed="OnCopy" />
+                                    <CommandBinding Command="ApplicationCommands.Paste" Executed="OnPaste" />
                                 </TextBox.CommandBindings>
                                 <TextBox.ContextMenu>
                                     <ContextMenu MinWidth="160">

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -71,6 +71,15 @@ namespace Flow.Launcher
                 App.API.CopyToClipboard(QueryTextBox.SelectedText, showDefaultNotification: false);
             }
         }
+
+        private void OnPaste(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (System.Windows.Clipboard.ContainsText())
+            {
+                _viewModel.QueryText = System.Windows.Clipboard.GetText().Replace("\n", String.Empty).Replace("\r", String.Empty);
+                e.Handled = true;
+            }
+        }
         
         private async void OnClosing(object sender, CancelEventArgs e)
         {

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -76,7 +76,7 @@ namespace Flow.Launcher
         {
             if (System.Windows.Clipboard.ContainsText())
             {
-                _viewModel.QueryText = System.Windows.Clipboard.GetText().Replace("\n", String.Empty).Replace("\r", String.Empty);
+                _viewModel.ChangeQueryText(System.Windows.Clipboard.GetText().Replace("\n", String.Empty).Replace("\r", String.Empty));
                 e.Handled = true;
             }
         }


### PR DESCRIPTION
Strip all newlines and return characters from texted pasted into Flow Launcher's textbox.

Addresses:
https://github.com/Flow-Launcher/Flow.Launcher/issues/2039
https://github.com/Flow-Launcher/Flow.Launcher/issues/2380
