### PR TITLE
ignore null datetimes for pluginstoreitem

### DIFF
--- a/Flow.Launcher.Core/ExternalPlugins/UserPlugin.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/UserPlugin.cs
@@ -14,8 +14,8 @@ namespace Flow.Launcher.Core.ExternalPlugins
         public string UrlDownload { get; set; }
         public string UrlSourceCode { get; set; }
         public string IcoPath { get; set; }
-        public DateTime LatestReleaseDate { get; set; }
-        public DateTime DateAdded { get; set; }
+        public DateTime? LatestReleaseDate { get; set; }
+        public DateTime? DateAdded { get; set; }
 
     }
 }


### PR DESCRIPTION
#2476 

Ignore any potential null value for struct (DateTime) which causes failed deserialization.

https://docs.microsoft.com/en-us/dotnet/api/System.Text.Json.Serialization.JsonIgnoreCondition?view=net-7.0
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/default-values