### PR TITLE
Update stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,11 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+env:
+  days-before-stale: 60
+  days-before-close: 7
+  exempt-issue-labels: 'keep-fresh'
+
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -16,11 +21,11 @@ jobs:
       - uses: actions/stale@v9
         with:
           stale-issue-message: 'This issue is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          days-before-stale: 45
-          days-before-close: 7
+          days-before-stale: ${{ env.days-before-stale }}
+          days-before-close: ${{ env.days-before-close }}
           days-before-pr-close: -1
           exempt-all-milestones: true
           close-issue-message: 'This issue was closed because it has been stale for 7 days with no activity. If you feel this issue still needs attention please feel free to reopen.'
           stale-pr-label: 'no-pr-activity'
-          exempt-issue-labels: 'keep-fresh'
+          exempt-issue-labels: ${{ env.exempt-issue-labels }}
           exempt-pr-labels: 'keep-fresh,awaiting-approval,work-in-progress'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-issue-message: 'This issue is stale because it has been open ${{ env.days-before-stale }} days with no activity. Remove stale label or comment or this will be closed in ${{ env.days-before-stale }} days.\n\nAlternatively this issue can be kept open by adding one of the following labels:\n${{ env.exempt-issue-labels }}'
           days-before-stale: ${{ env.days-before-stale }}
           days-before-close: ${{ env.days-before-close }}
           days-before-pr-close: -1


### PR DESCRIPTION
* Increases the number of days until a issue is marked as stale, as We seem to get a lot of issues that are still relevant but marked as stale.

* Include helpful message reminding Team members of the `keep-fresh` label.