### PR TITLE
Speed up context menu search

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -34,6 +34,8 @@ namespace Flow.Launcher.ViewModel
 
         private bool _isQueryRunning;
         private Query _lastQuery;
+        private Result lastContextMenuResult = new Result();
+        private List<Result> lastContextMenuResults = new List<Result>();
         private string _queryTextBeforeLeaveResults;
 
         private readonly FlowLauncherJsonStorage<History> _historyItemsStorage;
@@ -650,9 +652,34 @@ namespace Flow.Launcher.ViewModel
 
             if (selected != null) // SelectedItem returns null if selection is empty.
             {
-                var results = PluginManager.GetContextMenusForPlugin(selected);
-                results.Add(ContextMenuTopMost(selected));
-                results.Add(ContextMenuPluginInfo(selected.PluginID));
+                List<Result> results;
+                if (selected == lastContextMenuResult)
+                {
+                    // Use copy to keep the original results unchanged
+                    results = lastContextMenuResults.ConvertAll(result => new Result
+                    {
+                        Title = result.Title,
+                        SubTitle = result.SubTitle,
+                        IcoPath = result.IcoPath,
+                        PluginDirectory = result.PluginDirectory,
+                        Action = result.Action,
+                        ContextData = result.ContextData,
+                        Glyph = result.Glyph,
+                        OriginQuery = result.OriginQuery,
+                        Score = result.Score,
+                        AsyncAction = result.AsyncAction,
+                    });
+                }
+                else
+                {
+                    results = PluginManager.GetContextMenusForPlugin(selected);
+                    lastContextMenuResults = results;
+                    lastContextMenuResult = selected;
+                    results.Add(ContextMenuTopMost(selected));
+                    results.Add(ContextMenuPluginInfo(selected.PluginID));
+                }
+                
+
 
                 if (!string.IsNullOrEmpty(query))
                 {

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1052,6 +1052,8 @@ namespace Flow.Launcher.ViewModel
         {
             // Trick for no delay
             MainWindowOpacity = 0;
+            lastContextMenuResult = new Result();
+            lastContextMenuResults = new List<Result>();
 
             if (!SelectedIsFromQueryResults())
             {


### PR DESCRIPTION
## Concern
Flow Launcher currently rebuilds the context menu each time the query changes, leading to potential slowdowns. The process becomes even more sluggish if a context menu result requires a network call.

## Solution
Implement a memory cache for built results. This optimization ensures that querying the context menu becomes nearly instantaneous, and it enables the caching of expensive results.

## Drawbacks
The introduction of a memory cache may result in increased memory usage. However, this impact should be manageable, given that the machine would need to load these results initially. The trade-off is justified by the significant improvement in context menu querying speed and the ability to cache resource-intensive results.

## Examples

### Before
https://github.com/Flow-Launcher/Flow.Launcher/assets/535299/94dda425-c73e-47af-9126-2f15196e327c

### After
https://github.com/Flow-Launcher/Flow.Launcher/assets/535299/92153e6a-0461-4c2e-ab07-e82a862f6ebe

