### PR TITLE
Add open target for program shortcuts

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
@@ -73,6 +73,7 @@
     <system:String x:Key="flowlauncher_plugin_program_run_as_administrator">Run As Administrator</system:String>
     <system:String x:Key="flowlauncher_plugin_program_open_containing_folder">Open containing folder</system:String>
     <system:String x:Key="flowlauncher_plugin_program_disable_program">Disable this program from displaying</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_open_target_folder">Open target folder</system:String>
 
     <system:String x:Key="flowlauncher_plugin_program_plugin_name">Program</system:String>
     <system:String x:Key="flowlauncher_plugin_program_plugin_description">Search programs in Flow Launcher</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -261,7 +261,19 @@ namespace Flow.Launcher.Plugin.Program.Programs
                     },
                     IcoPath = "Images/folder.png",
                     Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\xe838"),
-                }
+                },
+                new Result
+                {
+                    Title = api.GetTranslation("flowlauncher_plugin_program_open_target_folder"),
+                    Action = _ =>
+                    {
+                        Main.Context.API.OpenDirectory(Path.GetDirectoryName(ExecutablePath), ExecutablePath);
+
+                        return true;
+                    },
+                    IcoPath = "Images/folder.png",
+                    Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\xe8de"),
+                },
             };
             return contextMenus;
         }

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -39,14 +39,19 @@ namespace Flow.Launcher.Plugin.Program.Programs
         public string FullPath { get; set; }
 
         /// <summary>
-        /// Path of the executable for .lnk, or the URL for .url. Arguments are included if any.
+        /// Path of the executable for .lnk, or the URL for .url
         /// </summary>
         public string LnkResolvedPath { get; set; }
 
         /// <summary>
-        /// Path of the actual executable file. Args are included.
+        /// Path of the actual executable file
         /// </summary>
         public string ExecutablePath => LnkResolvedPath ?? FullPath;
+
+        /// <summary>
+        /// Arguments for the executable.
+        /// </summary>
+        public string Args { get; set; }
 
         public string ParentDirectory { get; set; }
 
@@ -339,7 +344,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                     var args = _helper.arguments;
                     if (!string.IsNullOrEmpty(args))
                     {
-                        program.LnkResolvedPath += " " + args;
+                        program.Args = args;
                     }
 
                     var description = _helper.description;
@@ -636,7 +641,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
         private static IEnumerable<Win32> ProgramsHasher(IEnumerable<Win32> programs)
         {
             var startMenuPaths = GetStartMenuPaths();
-            return programs.GroupBy(p => p.ExecutablePath.ToLowerInvariant())
+            return programs.GroupBy(p => (p.ExecutablePath + p.Args).ToLowerInvariant())
                 .AsParallel()
                 .SelectMany(g =>
                 {

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -267,22 +267,28 @@ namespace Flow.Launcher.Plugin.Program.Programs
                     IcoPath = "Images/folder.png",
                     Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\xe838"),
                 },
-                new Result
-                {
-                    Title = api.GetTranslation("flowlauncher_plugin_program_open_target_folder"),
-                    Action = _ =>
-                    {
-                        Main.Context.API.OpenDirectory(Path.GetDirectoryName(ExecutablePath), ExecutablePath);
-
-                        return true;
-                    },
-                    IcoPath = "Images/folder.png",
-                    Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\xe8de"),
-                },
             };
+            if (Extension(FullPath) == ShortcutExtension)
+            {
+                contextMenus.Add(OpenTargetFolderContextMenuResult(api));
+            }
             return contextMenus;
         }
 
+        private Result OpenTargetFolderContextMenuResult(IPublicAPI api)
+        {
+            return new Result
+            {
+                Title = api.GetTranslation("flowlauncher_plugin_program_open_target_folder"),
+                Action = _ =>
+                {
+                    api.OpenDirectory(Path.GetDirectoryName(ExecutablePath), ExecutablePath);
+                    return true;
+                },
+                IcoPath = "Images/folder.png",
+                Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\xe8de"),
+            };
+        }
 
         public override string ToString()
         {


### PR DESCRIPTION
This PR closes #2390.

## Description
I added a new result in the context menu for programs to open the destination folder.
Only in `win32 ` this new result is added, because `UWP` work differently and have no links, so "open containing folder" already opens the correct location automatically

## Changes
Add `open target folder` option for programs