### PR TITLE
Prepend actionkeyword to suggestions

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -259,6 +259,12 @@ namespace Flow.Launcher.ViewModel
                 }
                 else if (!string.IsNullOrEmpty(SelectedResults.SelectedItem?.QuerySuggestionText))
                 {
+                    var defaultSuggestion = SelectedResults.SelectedItem.QuerySuggestionText;
+                    // check if result.actionkeywordassigned is empty
+                    if (!string.IsNullOrEmpty(result.ActionKeywordAssigned))
+                    {
+                        autoCompleteText = $"{result.ActionKeywordAssigned} {defaultSuggestion}";
+                    }
                     autoCompleteText = SelectedResults.SelectedItem.QuerySuggestionText;
                 }
 


### PR DESCRIPTION
When using tab suggestions it is more consistent to prepend the  `ActionKeyword` to the query. Currently the `ActionKeyword` is not added by default and can have unexpected results.