### PR TITLE
Fix: Explorer plugin's Windows Index search returning no results

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/WindowsIndex.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/WindowsIndex/WindowsIndex.cs
@@ -16,7 +16,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.WindowsIndex
     {
 
         // Reserved keywords in oleDB
-        private static Regex _reservedPatternMatcher = new(@"[`\@\＠\#\＃\＊\^,\&\＆\/\\\$\%_;\[\]]+", RegexOptions.Compiled);
+        private static Regex _reservedPatternMatcher = new(@"^[`\@\＠\#\＃\＊\^,\&\＆\/\\\$\%_;\[\]]+$", RegexOptions.Compiled);
 
         private static async IAsyncEnumerable<SearchResult> ExecuteWindowsIndexSearchAsync(string indexQueryString, string connectionString, [EnumeratorCancellation] CancellationToken token)
         {


### PR DESCRIPTION
Reverts https://github.com/Flow-Launcher/Flow.Launcher/pull/2492

Unfortunately this seems to break Windows index. Reverting to original regex allows results to populate once more.