### PR TITLE
Fix Nodejs plugins not working

### DIFF
--- a/Flow.Launcher.Core/Plugin/NodePlugin.cs
+++ b/Flow.Launcher.Core/Plugin/NodePlugin.cs
@@ -28,20 +28,21 @@ namespace Flow.Launcher.Core.Plugin
 
         protected override Task<Stream> RequestAsync(JsonRPCRequestModel request, CancellationToken token = default)
         {
-            _startInfo.ArgumentList[1] = JsonSerializer.Serialize(request);
+            _startInfo.ArgumentList[1] = JsonSerializer.Serialize(request, RequestSerializeOption);
             return ExecuteAsync(_startInfo, token);
         }
 
         protected override string Request(JsonRPCRequestModel rpcRequest, CancellationToken token = default)
         {
             // since this is not static, request strings will build up in ArgumentList if index is not specified
-            _startInfo.ArgumentList[1] = JsonSerializer.Serialize(rpcRequest);
+            _startInfo.ArgumentList[1] = JsonSerializer.Serialize(rpcRequest, RequestSerializeOption);
             return Execute(_startInfo);
         }
 
         public override async Task InitAsync(PluginInitContext context)
         {
             _startInfo.ArgumentList.Add(context.CurrentPluginMetadata.ExecuteFilePath);
+            _startInfo.ArgumentList.Add(string.Empty);
             _startInfo.WorkingDirectory = context.CurrentPluginMetadata.PluginDirectory;
             await base.InitAsync(context);
         }


### PR DESCRIPTION
Fixes #2553. Nodejs plugins currently aren't working. The reason is always the same: it throws an index out of bounds exception on line 31.
![Error screenshot 1 (npm)](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/cb268c7c-8aa3-4016-a284-b5fcd257563f)
![Error screenshot 2 (mdn)](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/67f606a0-2ae8-48f1-8ea4-7c8ce524b4b8)
![Error screenshot 3 (beat)](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/87a9f530-751d-4e9b-b68e-c39373fab2e6)
![Error screenshot 4 (hn)](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/0a0f0ca4-b845-41b0-a7bb-258f29c9a989)
![Error screenshot 5 (exception)](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/dfe4e02d-5710-4b30-b6b1-6fcf9144dc30)

I added line 45 just like in `PythonPlugin.cs` and this exception disappeared. Even though the exception disappeared, plugins still don't work, now for another reason: they except the JSON they receive to have lower-case keys, and they receive them capitalized (`Method` instead of `method`, `Parameters` instead of `parameters` etc). Now they just don't respond with anything.
![Error screenshot 6 (npm)](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/55449327-c07d-4950-80c1-5208d84e7294)

After I added the same serialization options that were used for C# and Python plugins (lines 31 and 38), Nodejs plugins started working:
![Success screenshot 1 (beat)](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/4393d9a0-e970-47de-b137-56f514591e18)
![Success screenshot 2 (hn)](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/d626990d-d0a5-4f2c-9ac1-3c969b12803d)
![Success screenshot 3 (npm)](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/1688700f-4c67-4bca-a4bf-aa5ef07eae47)
