### PR TITLE
Implement DuckDuckGo web search suggestions

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Settings.cs
@@ -197,7 +197,8 @@ namespace Flow.Launcher.Plugin.WebSearch
         public SuggestionSource[] Suggestions { get; set; } = {
             new Google(),
             new Baidu(),
-            new Bing()
+            new Bing(),
+            new DuckDuckGo()
         };
 
         [JsonIgnore]

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/DuckDuckGo.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SuggestionSources/DuckDuckGo.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Flow.Launcher.Infrastructure.Http;
+using Flow.Launcher.Infrastructure.Logger;
+using System.Net.Http;
+using System.Threading;
+using System.Text.Json;
+
+namespace Flow.Launcher.Plugin.WebSearch.SuggestionSources
+{
+    public class DuckDuckGo : SuggestionSource
+    {
+        public override async Task<List<string>> SuggestionsAsync(string query, CancellationToken token)
+        {
+            // When the search query is empty, DuckDuckGo returns `[]`. When it's not empty, it returns data
+            // in the following format: `["query", ["suggestion1", "suggestion2", ...]]`.
+            if (string.IsNullOrEmpty(query))
+            {
+                return new List<string>();
+            }
+
+            try
+            {
+                const string api = "https://duckduckgo.com/ac/?type=list&q=";
+
+                await using var resultStream = await Http.GetStreamAsync(api + Uri.EscapeDataString(query), token: token).ConfigureAwait(false);
+
+                using var json = await JsonDocument.ParseAsync(resultStream, cancellationToken: token);
+
+                var results = json.RootElement.EnumerateArray().ElementAt(1);
+
+                return results.EnumerateArray().Select(o => o.GetString()).ToList();
+
+            }
+            catch (Exception e) when (e is HttpRequestException or {InnerException: TimeoutException})
+            {
+                Log.Exception("|DuckDuckGo.Suggestions|Can't get suggestion from DuckDuckGo", e);
+                return null;
+            }
+            catch (JsonException e)
+            {
+                Log.Exception("|DuckDuckGo.Suggestions|can't parse suggestions", e);
+                return new List<string>();
+            }
+        }
+
+        public override string ToString()
+        {
+            return "DuckDuckGo";
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2554. I added DuckDuckGo to the list of web search completion providers. I copied the Google one, changed the name everywhere, changed the API address and correctly handled the situation with an empty query that DuckDuckGo handles differently than Google.
![Screenshot of web search suggestion providers](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/b912e708-a8b6-4558-bca3-d7ae00a1cedc)
![Screenshot of DuckDuckGo provider working](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/81dbf8a3-9252-4416-bbe2-10891c74b9b3)
