### PR TITLE
Remove short circuit check for empty Settings

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -37,7 +37,7 @@ namespace Flow.Launcher.Core.Plugin
             _storage = new JsonStorage<ConcurrentDictionary<string, object>>(SettingPath);
             Settings = await _storage.LoadAsync();
 
-            if (Settings != null || Configuration == null)
+            if (Configuration == null)
             {
                 return;
             }


### PR DESCRIPTION
Settings UI is not loading for newly installed plugins due.

A check for empty settings skips loading a plugin's settings UI if empty. However newly installed plugin's always have an empty settings file.

Tested with a newly installed plugin to verify it's settings UI was fully loaded.