### PR TITLE
fix node plugin, job object association, v2 context menu

### DIFF
--- a/Flow.Launcher.Core/Plugin/ExecutablePluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/ExecutablePluginV2.cs
@@ -12,15 +12,7 @@ namespace Flow.Launcher.Core.Plugin
 
         public ExecutablePluginV2(string filename)
         {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = filename,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true
-            };
+            StartInfo = new ProcessStartInfo { FileName = filename };
         }
-
     }
 }

--- a/Flow.Launcher.Core/Plugin/ExecutablePluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/ExecutablePluginV2.cs
@@ -14,5 +14,7 @@ namespace Flow.Launcher.Core.Plugin
         {
             StartInfo = new ProcessStartInfo { FileName = filename };
         }
+
+        protected override MessageHandlerType MessageHandler { get; } = MessageHandlerType.NewLineDelimited;
     }
 }

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
@@ -39,9 +39,23 @@ namespace Flow.Launcher.Core.Plugin
             }
         }
 
+        private JoinableTaskFactory JTF { get; } = new JoinableTaskFactory(new JoinableTaskContext());
+
         public override List<Result> LoadContextMenus(Result selectedResult)
         {
-            throw new NotImplementedException();
+            try
+            {
+                var res = JTF.Run(() => RPC.InvokeWithCancellationAsync<JsonRPCQueryResponseModel>("context_menu",
+                    new object[] { selectedResult.ContextData }));
+
+                var results = ParseResults(res);
+
+                return results;
+            }
+            catch
+            {
+                return new List<Result>();
+            }
         }
 
         public override async Task<List<Result>> QueryAsync(Query query, CancellationToken token)

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
@@ -49,7 +49,7 @@ namespace Flow.Launcher.Core.Plugin
             try
             {
                 var res = await RPC.InvokeWithCancellationAsync<JsonRPCQueryResponseModel>("query",
-                    new[] { query },
+                    new object[] { query, Settings.Inner },
                     token);
 
                 var results = ParseResults(res);

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
@@ -15,8 +15,6 @@ namespace Flow.Launcher.Core.Plugin
 {
     internal abstract class JsonRPCPluginV2 : JsonRPCPluginBase, IAsyncDisposable, IAsyncReloadable, IResultUpdated
     {
-        public abstract string SupportedLanguage { get; set; }
-
         public const string JsonRpc = "JsonRPC";
 
         protected abstract IDuplexPipe ClientPipe { get; set; }

--- a/Flow.Launcher.Core/Plugin/NodePluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/NodePluginV2.cs
@@ -24,5 +24,7 @@ namespace Flow.Launcher.Core.Plugin
             StartInfo.ArgumentList.Add(context.CurrentPluginMetadata.ExecuteFilePath);
             await base.InitAsync(context);
         }
+
+        protected override MessageHandlerType MessageHandler { get; } = MessageHandlerType.HeaderDelimited;
     }
 }

--- a/Flow.Launcher.Core/Plugin/NodePluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/NodePluginV2.cs
@@ -22,8 +22,6 @@ namespace Flow.Launcher.Core.Plugin
         public override async Task InitAsync(PluginInitContext context)
         {
             StartInfo.ArgumentList.Add(context.CurrentPluginMetadata.ExecuteFilePath);
-            StartInfo.ArgumentList.Add(string.Empty);
-            StartInfo.WorkingDirectory = context.CurrentPluginMetadata.PluginDirectory;
             await base.InitAsync(context);
         }
     }

--- a/Flow.Launcher.Core/Plugin/NodePluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/NodePluginV2.cs
@@ -10,21 +10,13 @@ namespace Flow.Launcher.Core.Plugin
     /// <summary>
     /// Execution of JavaScript & TypeScript plugins
     /// </summary>
-    internal class NodePluginV2 : ProcessStreamPluginV2
+    internal sealed class NodePluginV2 : ProcessStreamPluginV2
     {
         public NodePluginV2(string filename)
         {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = filename,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true
-            };
+            StartInfo = new ProcessStartInfo { FileName = filename, };
         }
 
-        public override string SupportedLanguage { get; set; }
         protected override ProcessStartInfo StartInfo { get; set; }
 
         public override async Task InitAsync(PluginInitContext context)

--- a/Flow.Launcher.Core/Plugin/PythonPluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/PythonPluginV2.cs
@@ -18,7 +18,6 @@ namespace Flow.Launcher.Core.Plugin
 {
     internal sealed class PythonPluginV2 : ProcessStreamPluginV2
     {
-        public override string SupportedLanguage { get; set; } = AllowedLanguage.Python;
         protected override ProcessStartInfo StartInfo { get; set; }
         
         public PythonPluginV2(string filename)
@@ -26,11 +25,6 @@ namespace Flow.Launcher.Core.Plugin
             StartInfo = new ProcessStartInfo
             {
                 FileName = filename,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                RedirectStandardInput = true
             };
 
             var path = Path.Combine(Constant.ProgramDirectory, JsonRpc);
@@ -38,6 +32,12 @@ namespace Flow.Launcher.Core.Plugin
 
             //Add -B flag to tell python don't write .py[co] files. Because .pyc contains location infos which will prevent python portable
             StartInfo.ArgumentList.Add("-B");
+        }
+        
+        public override async Task InitAsync(PluginInitContext context)
+        {
+            StartInfo.ArgumentList.Add(context.CurrentPluginMetadata.ExecuteFilePath);
+            await base.InitAsync(context);
         }
     }
 }

--- a/Flow.Launcher.Core/Plugin/PythonPluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/PythonPluginV2.cs
@@ -19,13 +19,10 @@ namespace Flow.Launcher.Core.Plugin
     internal sealed class PythonPluginV2 : ProcessStreamPluginV2
     {
         protected override ProcessStartInfo StartInfo { get; set; }
-        
+
         public PythonPluginV2(string filename)
         {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = filename,
-            };
+            StartInfo = new ProcessStartInfo { FileName = filename, };
 
             var path = Path.Combine(Constant.ProgramDirectory, JsonRpc);
             StartInfo.EnvironmentVariables["PYTHONPATH"] = path;
@@ -33,11 +30,13 @@ namespace Flow.Launcher.Core.Plugin
             //Add -B flag to tell python don't write .py[co] files. Because .pyc contains location infos which will prevent python portable
             StartInfo.ArgumentList.Add("-B");
         }
-        
+
         public override async Task InitAsync(PluginInitContext context)
         {
             StartInfo.ArgumentList.Add(context.CurrentPluginMetadata.ExecuteFilePath);
             await base.InitAsync(context);
         }
+
+        protected override MessageHandlerType MessageHandler { get; } = MessageHandlerType.NewLineDelimited;
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -196,7 +196,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                         FileName = FullPath,
                         WorkingDirectory = ParentDirectory,
                         UseShellExecute = true,
-                        Verb = runAsAdmin ? "runas" : ""
+                        Verb = runAsAdmin ? "runas" : "",
                     };
 
                     _ = Task.Run(() => Main.StartProcess(Process.Start, info));


### PR DESCRIPTION
~~- Fix Python plugin v2~~
- Fix Node plugin (we didn't redirect input before)
- Fix job process associate to the child process created by program plugin which causes the exit of flow causing the program being created exited.
- Fix JsonRPCV2 plugins setting not sent via query

~~I don't know when but somehow python plugin doesn't pass the required argument which will create start a empty python interactive. So anyone with a python plugin v2 will simply can't run flow...~~

It's not as bad as I anticipated. The argument will still being passed. It's just the place is weird.

- [x] The app opened with program plugin won't get killed after flow exit
- [x] Settings are sent
- [x] Node plugin can use https://www.npmjs.com/package/vscode-jsonrpc without issue
- [x] Context Menu