### PR TITLE
Added ctrl+shift+c

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -187,6 +187,10 @@
             Command="{Binding ToggleGameModeCommand}"
             Modifiers="Ctrl" />
         <KeyBinding
+            Key="C"
+            Modifiers="Ctrl+Shift"
+            Command="{Binding CopyAlternativeCommand}" />
+        <KeyBinding
             Key="{Binding PreviewHotkey, Converter={StaticResource StringToKeyBindingConverter}, ConverterParameter='key'}"
             Command="{Binding TogglePreviewCommand}"
             Modifiers="{Binding PreviewHotkey, Converter={StaticResource StringToKeyBindingConverter}, ConverterParameter='modifiers'}" />

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -371,6 +371,17 @@ namespace Flow.Launcher.ViewModel
         {
             GameModeStatus = !GameModeStatus;
         }
+        
+        [RelayCommand]
+        public void CopyAlternative()
+        {
+            var result = Results.SelectedItem?.Result?.CopyText;
+
+            if (result != null)
+            {
+                App.API.CopyToClipboard(result, directCopy: false);
+            }
+        }
 
         #endregion
 


### PR DESCRIPTION
Solves #2051 #2329 

When pressing ctrl+shift+c, instead of copying the file, it will only copy the path to it, as it's a commonly used shortcut.