### PR TITLE
Hide main window when dragging results

### DIFF
--- a/Flow.Launcher/ResultListBox.xaml.cs
+++ b/Flow.Launcher/ResultListBox.xaml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
@@ -136,6 +136,8 @@ namespace Flow.Launcher
                 return;
 
             isDragging = false;
+
+            App.API.HideMainWindow();
 
             var data = new DataObject(DataFormats.FileDrop, new[]
             {


### PR DESCRIPTION
Hide main window when dragging results, so users can see where they're dragging to.