### PR TITLE
Fix program indexing logic when cache is empty

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Main.cs
@@ -84,7 +84,7 @@ namespace Flow.Launcher.Plugin.Program
             Log.Info($"|Flow.Launcher.Plugin.Program.Main|Number of preload win32 programs <{_win32s.Length}>");
             Log.Info($"|Flow.Launcher.Plugin.Program.Main|Number of preload uwps <{_uwps.Length}>");
 
-            bool cacheEmpty = !_win32s.Any() && !_uwps.Any();
+            bool cacheEmpty = !_win32s.Any() || !_uwps.Any();
 
             if (cacheEmpty || _settings.LastIndexTime.AddHours(30) < DateTime.Now)
             {


### PR DESCRIPTION
https://github.com/Flow-Launcher/Flow.Launcher/pull/2508#issuecomment-2028550756

Reindex during initializing Program Plugin, when win32 OR uwp cache is empty, instead of both are empty.

Downside: When user choose not to index uwp in plugin settings, reindex is unnecessary.

Not dev only. it's in release as well.