### PR TITLE
Show target path in hover tooltip

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -183,6 +183,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                 Score = matchResult.Score,
                 TitleHighlightData = matchResult.MatchData,
                 ContextData = this,
+                TitleToolTip = $"{title}\n{ExecutablePath}",
                 Action = c =>
                 {
                     // Ctrl + Enter to open containing folder


### PR DESCRIPTION
![图片](https://github.com/Flow-Launcher/Flow.Launcher/assets/10308169/292784b9-b87b-422a-b890-3d5f18bf7259)

Show target path in result's hover tooltip. Continuation of #2508. 