### PR TITLE
Code cleanup: Flow.Launcher/{Converters,Helper}

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -58,7 +58,7 @@ dotnet_style_prefer_conditional_expression_over_return = true:silent
 ###############################
 # Style Definitions
 dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
-# Use PascalCase for constant fields  
+# Use PascalCase for constant fields
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
 dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
@@ -134,7 +134,7 @@ csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 csharp_using_directive_placement = outside_namespace:silent
 csharp_prefer_simple_using_statement = true:suggestion
-csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_namespace_declarations = file_scoped:silent
 csharp_style_prefer_method_group_conversion = true:silent
 csharp_style_expression_bodied_lambdas = true:silent
 csharp_style_expression_bodied_local_functions = false:silent

--- a/Flow.Launcher/Converters/BoolToIMEConversionModeConverter.cs
+++ b/Flow.Launcher/Converters/BoolToIMEConversionModeConverter.cs
@@ -3,39 +3,38 @@ using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Input;
 
-namespace Flow.Launcher.Converters
-{
-    internal class BoolToIMEConversionModeConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            return value switch
-            {
-                true => ImeConversionModeValues.Alphanumeric,
-                _ => ImeConversionModeValues.DoNotCare
-            };
-        }
+namespace Flow.Launcher.Converters;
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+internal class BoolToIMEConversionModeConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value switch
         {
-            throw new NotImplementedException();
-        }
+            true => ImeConversionModeValues.Alphanumeric,
+            _ => ImeConversionModeValues.DoNotCare
+        };
     }
 
-    internal class BoolToIMEStateConverter : IValueConverter
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            return value switch
-            {
-                true => InputMethodState.Off,
-                _ => InputMethodState.DoNotCare
-            };
-        }
+        throw new NotImplementedException();
+    }
+}
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+internal class BoolToIMEStateConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value switch
         {
-            throw new NotImplementedException();
-        }
+            true => InputMethodState.Off,
+            _ => InputMethodState.DoNotCare
+        };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Flow.Launcher/Converters/BoolToVisibilityConverter.cs
+++ b/Flow.Launcher/Converters/BoolToVisibilityConverter.cs
@@ -2,40 +2,39 @@
 using System.Windows;
 using System.Windows.Data;
 
-namespace Flow.Launcher.Converters
+namespace Flow.Launcher.Converters;
+
+public class BoolToVisibilityConverter : IValueConverter
 {
-    public class BoolToVisibilityConverter : IValueConverter
+    public object Convert(object value, System.Type targetType, object parameter, CultureInfo culture)
     {
-        public object Convert(object value, System.Type targetType, object parameter, CultureInfo culture)
+        return (value, parameter) switch
         {
-            return (value, parameter) switch
-            {
-                (true, not null) => Visibility.Collapsed,
-                (_, not null) => Visibility.Visible,
+            (true, not null) => Visibility.Collapsed,
+            (_, not null) => Visibility.Visible,
 
-                (true, null) => Visibility.Visible,
-                (_, null) => Visibility.Collapsed
-            };
-        }
-
-        public object ConvertBack(object value, System.Type targetType, object parameter, CultureInfo culture) => throw new System.InvalidOperationException();
+            (true, null) => Visibility.Visible,
+            (_, null) => Visibility.Collapsed
+        };
     }
 
-    public class SplitterConverter : IValueConverter
-    /* Prevents the dragging part of the preview area from working when preview is turned off. */
+    public object ConvertBack(object value, System.Type targetType, object parameter, CultureInfo culture) => throw new System.InvalidOperationException();
+}
+
+public class SplitterConverter : IValueConverter
+/* Prevents the dragging part of the preview area from working when preview is turned off. */
+{
+    public object Convert(object value, System.Type targetType, object parameter, CultureInfo culture)
     {
-        public object Convert(object value, System.Type targetType, object parameter, CultureInfo culture)
+        return (value, parameter) switch
         {
-            return (value, parameter) switch
-            {
-                (true, not null) => 0,
-                (_, not null) => 5,
+            (true, not null) => 0,
+            (_, not null) => 5,
 
-                (true, null) => 5,
-                (_, null) => 0
-            };
-        }
-
-        public object ConvertBack(object value, System.Type targetType, object parameter, CultureInfo culture) => throw new System.InvalidOperationException();
+            (true, null) => 5,
+            (_, null) => 0
+        };
     }
+
+    public object ConvertBack(object value, System.Type targetType, object parameter, CultureInfo culture) => throw new System.InvalidOperationException();
 }

--- a/Flow.Launcher/Converters/BorderClipConverter.cs
+++ b/Flow.Launcher/Converters/BorderClipConverter.cs
@@ -7,43 +7,41 @@ using System.Windows.Shapes;
 
 // For Clipping inside listbox item
 
-namespace Flow.Launcher.Converters
+namespace Flow.Launcher.Converters;
+
+public class BorderClipConverter : IMultiValueConverter
 {
-    public class BorderClipConverter : IMultiValueConverter
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
-        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        if (values is not [double width, double height, CornerRadius radius])
         {
-            if (values is not [double width, double height, CornerRadius radius])
-            {
-                return DependencyProperty.UnsetValue;
-            }
-
-            Path myPath = new Path();
-            if (width < Double.Epsilon || height < Double.Epsilon)
-            {
-                return Geometry.Empty;
-            }
-            var radiusHeight = radius.TopLeft;
-                
-            // Drawing Round box for bottom round, and rect for top area of listbox.
-            var corner = new RectangleGeometry(new Rect(0, 0, width, height), radius.TopLeft, radius.TopLeft);
-            var box = new RectangleGeometry(new Rect(0, 0, width, radiusHeight), 0, 0);
-                
-            GeometryGroup myGeometryGroup = new GeometryGroup();
-            myGeometryGroup.Children.Add(corner);
-            myGeometryGroup.Children.Add(box);
-                
-            CombinedGeometry c1 = new CombinedGeometry(GeometryCombineMode.Union, corner, box);
-            myPath.Data = c1;
-
-            myPath.Data.Freeze();
-            return myPath.Data;
+            return DependencyProperty.UnsetValue;
         }
 
-        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        Path myPath = new Path();
+        if (width < Double.Epsilon || height < Double.Epsilon)
         {
-            throw new NotSupportedException();
+            return Geometry.Empty;
         }
+        var radiusHeight = radius.TopLeft;
+
+        // Drawing Round box for bottom round, and rect for top area of listbox.
+        var corner = new RectangleGeometry(new Rect(0, 0, width, height), radius.TopLeft, radius.TopLeft);
+        var box = new RectangleGeometry(new Rect(0, 0, width, radiusHeight), 0, 0);
+
+        GeometryGroup myGeometryGroup = new GeometryGroup();
+        myGeometryGroup.Children.Add(corner);
+        myGeometryGroup.Children.Add(box);
+
+        CombinedGeometry c1 = new CombinedGeometry(GeometryCombineMode.Union, corner, box);
+        myPath.Data = c1;
+
+        myPath.Data.Freeze();
+        return myPath.Data;
     }
 
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
 }

--- a/Flow.Launcher/Converters/DateTimeFormatToNowConverter.cs
+++ b/Flow.Launcher/Converters/DateTimeFormatToNowConverter.cs
@@ -2,18 +2,17 @@
 using System.Globalization;
 using System.Windows.Data;
 
-namespace Flow.Launcher.Converters
-{
-    public class DateTimeFormatToNowConverter : IValueConverter
-    {
+namespace Flow.Launcher.Converters;
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            return value is not string format ? null : DateTime.Now.ToString(format);
-        }
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
+public class DateTimeFormatToNowConverter : IValueConverter
+{
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value is not string format ? null : DateTime.Now.ToString(format);
+    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Flow.Launcher/Converters/DiameterToCenterPointConverter.cs
+++ b/Flow.Launcher/Converters/DiameterToCenterPointConverter.cs
@@ -3,23 +3,22 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 
-namespace Flow.Launcher.Converters
+namespace Flow.Launcher.Converters;
+
+public class DiameterToCenterPointConverter : IValueConverter
 {
-    public class DiameterToCenterPointConverter : IValueConverter
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        if (value is double d)
         {
-            if (value is double d)
-            {
-                return new Point(d / 2, d / 2);
-            }
-
-            return new Point(0, 0);
+            return new Point(d / 2, d / 2);
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotSupportedException();
-        }
+        return new Point(0, 0);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
     }
 }

--- a/Flow.Launcher/Converters/HighlightTextConverter.cs
+++ b/Flow.Launcher/Converters/HighlightTextConverter.cs
@@ -5,45 +5,44 @@ using System.Windows;
 using System.Windows.Data;
 using System.Windows.Documents;
 
-namespace Flow.Launcher.Converters
+namespace Flow.Launcher.Converters;
+
+public class HighlightTextConverter : IMultiValueConverter
 {
-    public class HighlightTextConverter : IMultiValueConverter
+    public object Convert(object[] value, Type targetType, object parameter, CultureInfo cultureInfo)
     {
-        public object Convert(object[] value, Type targetType, object parameter, CultureInfo cultureInfo)
-        {
-            if (value.Length < 2)
-                return new Run(string.Empty);
-            
-            if (value[0] is not string text)
-                return new Run(string.Empty);
-            
-            if (value[1] is not List<int> { Count: > 0 } highlightData)
-                // No highlight data, just return the text
-                return new Run(text);
-            
-            var highlightStyle = (Style)Application.Current.FindResource("HighlightStyle");
-            var textBlock = new Span();
+        if (value.Length < 2)
+            return new Run(string.Empty);
 
-            for (var i = 0; i < text.Length; i++)
+        if (value[0] is not string text)
+            return new Run(string.Empty);
+
+        if (value[1] is not List<int> { Count: > 0 } highlightData)
+            // No highlight data, just return the text
+            return new Run(text);
+
+        var highlightStyle = (Style)Application.Current.FindResource("HighlightStyle");
+        var textBlock = new Span();
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            var currentCharacter = text.Substring(i, 1);
+            var run = new Run(currentCharacter)
             {
-                var currentCharacter = text.Substring(i, 1);
-                var run = new Run(currentCharacter)
-                {
-                    Style = ShouldHighlight(highlightData, i) ? highlightStyle : null
-                };
-                textBlock.Inlines.Add(run);
-            }
-            return textBlock;
+                Style = ShouldHighlight(highlightData, i) ? highlightStyle : null
+            };
+            textBlock.Inlines.Add(run);
         }
+        return textBlock;
+    }
 
-        public object[] ConvertBack(object value, Type[] targetType, object parameter, CultureInfo culture)
-        {
-            return new[] { DependencyProperty.UnsetValue, DependencyProperty.UnsetValue };
-        }
+    public object[] ConvertBack(object value, Type[] targetType, object parameter, CultureInfo culture)
+    {
+        return new[] { DependencyProperty.UnsetValue, DependencyProperty.UnsetValue };
+    }
 
-        private bool ShouldHighlight(List<int> highlightData, int index)
-        {
-            return highlightData.Contains(index);
-        }
+    private bool ShouldHighlight(List<int> highlightData, int index)
+    {
+        return highlightData.Contains(index);
     }
 }

--- a/Flow.Launcher/Converters/IconRadiusConverter.cs
+++ b/Flow.Launcher/Converters/IconRadiusConverter.cs
@@ -2,20 +2,19 @@
 using System.Globalization;
 using System.Windows.Data;
 
-namespace Flow.Launcher.Converters
-{
-    public class IconRadiusConverter : IMultiValueConverter
-    {
-        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (values is not [double size, bool isIconCircular])
-                throw new ArgumentException("IconRadiusConverter must have 2 parameters: [double, bool]");
+namespace Flow.Launcher.Converters;
 
-            return isIconCircular ? size / 2 : size;
-        }
-        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
-        {
-            throw new NotSupportedException();
-        }
+public class IconRadiusConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values is not [double size, bool isIconCircular])
+            throw new ArgumentException("IconRadiusConverter must have 2 parameters: [double, bool]");
+
+        return isIconCircular ? size / 2 : size;
+    }
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
     }
 }

--- a/Flow.Launcher/Converters/OpenResultHotkeyVisibilityConverter.cs
+++ b/Flow.Launcher/Converters/OpenResultHotkeyVisibilityConverter.cs
@@ -4,24 +4,23 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 
-namespace Flow.Launcher.Converters
+namespace Flow.Launcher.Converters;
+
+[ValueConversion(typeof(bool), typeof(Visibility))]
+public class OpenResultHotkeyVisibilityConverter : IValueConverter
 {
-    [ValueConversion(typeof(bool), typeof(Visibility))]
-    public class OpenResultHotkeyVisibilityConverter : IValueConverter
+    private const int MaxVisibleHotkeys = 10;
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        private const int MaxVisibleHotkeys = 10;
+        var number = int.MaxValue;
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            var number = int.MaxValue;
+        if (value is ListBoxItem listBoxItem
+            && ItemsControl.ItemsControlFromItemContainer(listBoxItem) is ListBox listBox)
+            number = listBox.ItemContainerGenerator.IndexFromContainer(listBoxItem) + 1;
 
-            if (value is ListBoxItem listBoxItem
-                && ItemsControl.ItemsControlFromItemContainer(listBoxItem) is ListBox listBox)
-                number = listBox.ItemContainerGenerator.IndexFromContainer(listBoxItem) + 1;
-
-            return number <= MaxVisibleHotkeys ? Visibility.Visible : Visibility.Collapsed;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new InvalidOperationException();
+        return number <= MaxVisibleHotkeys ? Visibility.Visible : Visibility.Collapsed;
     }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new InvalidOperationException();
 }

--- a/Flow.Launcher/Converters/OrdinalConverter.cs
+++ b/Flow.Launcher/Converters/OrdinalConverter.cs
@@ -3,23 +3,22 @@ using System.Globalization;
 using System.Windows.Controls;
 using System.Windows.Data;
 
-namespace Flow.Launcher.Converters
+namespace Flow.Launcher.Converters;
+
+public class OrdinalConverter : IValueConverter
 {
-    public class OrdinalConverter : IValueConverter
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        if (value is not ListBoxItem listBoxItem
+            || ItemsControl.ItemsControlFromItemContainer(listBoxItem) is not ListBox listBox)
         {
-            if (value is not ListBoxItem listBoxItem
-                || ItemsControl.ItemsControlFromItemContainer(listBoxItem) is not ListBox listBox)
-            {
-                return 0;
-            }
-
-            var res = listBox.ItemContainerGenerator.IndexFromContainer(listBoxItem) + 1;
-            return res == 10 ? 0 : res;  // 10th item => HOTKEY+0
-
+            return 0;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new InvalidOperationException();
+        var res = listBox.ItemContainerGenerator.IndexFromContainer(listBoxItem) + 1;
+        return res == 10 ? 0 : res;  // 10th item => HOTKEY+0
+
     }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new InvalidOperationException();
 }

--- a/Flow.Launcher/Converters/QuerySuggestionBoxConverter.cs
+++ b/Flow.Launcher/Converters/QuerySuggestionBoxConverter.cs
@@ -6,63 +6,62 @@ using System.Windows.Media;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.ViewModel;
 
-namespace Flow.Launcher.Converters
+namespace Flow.Launcher.Converters;
+
+public class QuerySuggestionBoxConverter : IMultiValueConverter
 {
-    public class QuerySuggestionBoxConverter : IMultiValueConverter
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
     {
-        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        // values[0] is TextBox: The textbox displaying the autocomplete suggestion
+        // values[1] is ResultViewModel: Currently selected item in the list
+        // values[2] is string: Query text
+        if (
+            values.Length != 3 ||
+            values[0] is not TextBox queryTextBox ||
+            values[1] is null ||
+            values[2] is not string queryText ||
+            string.IsNullOrEmpty(queryText)
+        )
+            return string.Empty;
+
+        if (values[1] is not ResultViewModel selectedItem)
+            return Binding.DoNothing;
+
+        try
         {
-            // values[0] is TextBox: The textbox displaying the autocomplete suggestion 
-            // values[1] is ResultViewModel: Currently selected item in the list
-            // values[2] is string: Query text
-            if (
-                values.Length != 3 ||
-                values[0] is not TextBox queryTextBox ||
-                values[1] is null ||
-                values[2] is not string queryText ||
-                string.IsNullOrEmpty(queryText)
-            )
+            var selectedResult = selectedItem.Result;
+            var selectedResultActionKeyword = string.IsNullOrEmpty(selectedResult.ActionKeywordAssigned) ? "" : selectedResult.ActionKeywordAssigned + " ";
+            var selectedResultPossibleSuggestion = selectedResultActionKeyword + selectedResult.Title;
+
+            if (!selectedResultPossibleSuggestion.StartsWith(queryText, StringComparison.CurrentCultureIgnoreCase))
                 return string.Empty;
-            
-            if (values[1] is not ResultViewModel selectedItem)
-                return Binding.DoNothing;
-
-            try
-            {
-                var selectedResult = selectedItem.Result;
-                var selectedResultActionKeyword = string.IsNullOrEmpty(selectedResult.ActionKeywordAssigned) ? "" : selectedResult.ActionKeywordAssigned + " ";
-                var selectedResultPossibleSuggestion = selectedResultActionKeyword + selectedResult.Title;
-
-                if (!selectedResultPossibleSuggestion.StartsWith(queryText, StringComparison.CurrentCultureIgnoreCase))
-                    return string.Empty;
 
 
-                // For AutocompleteQueryCommand.
-                // When user typed lower case and result title is uppercase, we still want to display suggestion
-                selectedItem.QuerySuggestionText = queryText + selectedResultPossibleSuggestion.Substring(queryText.Length);
+            // For AutocompleteQueryCommand.
+            // When user typed lower case and result title is uppercase, we still want to display suggestion
+            selectedItem.QuerySuggestionText = queryText + selectedResultPossibleSuggestion.Substring(queryText.Length);
 
-                // Check if Text will be larger than our QueryTextBox
-                Typeface typeface = new Typeface(queryTextBox.FontFamily, queryTextBox.FontStyle, queryTextBox.FontWeight, queryTextBox.FontStretch);
-                // TODO: Obsolete warning?
-                var ft = new FormattedText(queryTextBox.Text, CultureInfo.DefaultThreadCurrentCulture, System.Windows.FlowDirection.LeftToRight, typeface, queryTextBox.FontSize, Brushes.Black);
+            // Check if Text will be larger than our QueryTextBox
+            Typeface typeface = new Typeface(queryTextBox.FontFamily, queryTextBox.FontStyle, queryTextBox.FontWeight, queryTextBox.FontStretch);
+            // TODO: Obsolete warning?
+            var ft = new FormattedText(queryTextBox.Text, CultureInfo.DefaultThreadCurrentCulture, System.Windows.FlowDirection.LeftToRight, typeface, queryTextBox.FontSize, Brushes.Black);
 
-                var offset = queryTextBox.Padding.Right;
+            var offset = queryTextBox.Padding.Right;
 
-                if (ft.Width + offset > queryTextBox.ActualWidth || queryTextBox.HorizontalOffset != 0)
-                    return string.Empty;
-
-                return selectedItem.QuerySuggestionText;
-            }
-            catch (Exception e)
-            {
-                Log.Exception(nameof(QuerySuggestionBoxConverter), "fail to convert text for suggestion box", e);
+            if (ft.Width + offset > queryTextBox.ActualWidth || queryTextBox.HorizontalOffset != 0)
                 return string.Empty;
-            }
+
+            return selectedItem.QuerySuggestionText;
         }
-
-        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        catch (Exception e)
         {
-            throw new NotImplementedException();
+            Log.Exception(nameof(QuerySuggestionBoxConverter), "fail to convert text for suggestion box", e);
+            return string.Empty;
         }
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Flow.Launcher/Converters/StringToKeyBindingConverter.cs
+++ b/Flow.Launcher/Converters/StringToKeyBindingConverter.cs
@@ -3,28 +3,27 @@ using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Input;
 
-namespace Flow.Launcher.Converters
-{
-    class StringToKeyBindingConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            if (parameter is not string mode || value is not string hotkeyStr)
-                return null;
-            
-            var converter = new KeyGestureConverter();
-            var key = (KeyGesture)converter.ConvertFromString(hotkeyStr);
-            return mode switch
-            {
-                "key" => key?.Key,
-                "modifiers" => key?.Modifiers,
-                _ => null
-            };
-        }
+namespace Flow.Launcher.Converters;
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+class StringToKeyBindingConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (parameter is not string mode || value is not string hotkeyStr)
+            return null;
+
+        var converter = new KeyGestureConverter();
+        var key = (KeyGesture)converter.ConvertFromString(hotkeyStr);
+        return mode switch
         {
-            throw new NotImplementedException();
-        }
+            "key" => key?.Key,
+            "modifiers" => key?.Modifiers,
+            _ => null
+        };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Flow.Launcher/Converters/TextConverter.cs
+++ b/Flow.Launcher/Converters/TextConverter.cs
@@ -4,28 +4,27 @@ using System.Windows.Data;
 using Flow.Launcher.Core.Resource;
 using Flow.Launcher.ViewModel;
 
-namespace Flow.Launcher.Converters
-{
-    public class TextConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            var id = value?.ToString();
-            var translationKey = id switch
-            {
-                PluginStoreItemViewModel.NewRelease => "pluginStore_NewRelease",
-                PluginStoreItemViewModel.RecentlyUpdated => "pluginStore_RecentlyUpdated",
-                PluginStoreItemViewModel.None => "pluginStore_None",
-                PluginStoreItemViewModel.Installed => "pluginStore_Installed",
-                _ => null
-            };
-            
-            if (translationKey is null)
-                return id;
-            
-            return InternationalizationManager.Instance.GetTranslation(translationKey);
-        }
+namespace Flow.Launcher.Converters;
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new InvalidOperationException();
+public class TextConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var id = value?.ToString();
+        var translationKey = id switch
+        {
+            PluginStoreItemViewModel.NewRelease => "pluginStore_NewRelease",
+            PluginStoreItemViewModel.RecentlyUpdated => "pluginStore_RecentlyUpdated",
+            PluginStoreItemViewModel.None => "pluginStore_None",
+            PluginStoreItemViewModel.Installed => "pluginStore_Installed",
+            _ => null
+        };
+
+        if (translationKey is null)
+            return id;
+
+        return InternationalizationManager.Instance.GetTranslation(translationKey);
     }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new InvalidOperationException();
 }

--- a/Flow.Launcher/Helper/AutoStartup.cs
+++ b/Flow.Launcher/Helper/AutoStartup.cs
@@ -3,57 +3,56 @@ using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Logger;
 using Microsoft.Win32;
 
-namespace Flow.Launcher.Helper
+namespace Flow.Launcher.Helper;
+
+public class AutoStartup
 {
-    public class AutoStartup
+    private const string StartupPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
+
+    public static bool IsEnabled
     {
-        private const string StartupPath = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run";
-
-        public static bool IsEnabled
-        {
-            get
-            {
-                try
-                {
-                    using var key = Registry.CurrentUser.OpenSubKey(StartupPath, true);
-                    var path = key?.GetValue(Constant.FlowLauncher) as string;
-                    return path == Constant.ExecutablePath;
-                }
-                catch (Exception e)
-                {
-                    Log.Error("AutoStartup", $"Ignoring non-critical registry error (querying if enabled): {e}");
-                }
-
-                return false;
-            }
-        }
-
-        public static void Disable()
+        get
         {
             try
             {
                 using var key = Registry.CurrentUser.OpenSubKey(StartupPath, true);
-                key?.DeleteValue(Constant.FlowLauncher, false);
+                var path = key?.GetValue(Constant.FlowLauncher) as string;
+                return path == Constant.ExecutablePath;
             }
             catch (Exception e)
             {
-                Log.Error("AutoStartup", $"Failed to disable auto-startup: {e}");
-                throw;
+                Log.Error("AutoStartup", $"Ignoring non-critical registry error (querying if enabled): {e}");
             }
-        }
 
-        internal static void Enable()
+            return false;
+        }
+    }
+
+    public static void Disable()
+    {
+        try
         {
-            try
-            {
-                using var key = Registry.CurrentUser.OpenSubKey(StartupPath, true);
-                key?.SetValue(Constant.FlowLauncher, $"\"{Constant.ExecutablePath}\"");
-            }
-            catch (Exception e)
-            {
-                Log.Error("AutoStartup", $"Failed to enable auto-startup: {e}");
-                throw;
-            }
+            using var key = Registry.CurrentUser.OpenSubKey(StartupPath, true);
+            key?.DeleteValue(Constant.FlowLauncher, false);
+        }
+        catch (Exception e)
+        {
+            Log.Error("AutoStartup", $"Failed to disable auto-startup: {e}");
+            throw;
+        }
+    }
+
+    internal static void Enable()
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(StartupPath, true);
+            key?.SetValue(Constant.FlowLauncher, $"\"{Constant.ExecutablePath}\"");
+        }
+        catch (Exception e)
+        {
+            Log.Error("AutoStartup", $"Failed to enable auto-startup: {e}");
+            throw;
         }
     }
 }

--- a/Flow.Launcher/Helper/DWMDropShadow.cs
+++ b/Flow.Launcher/Helper/DWMDropShadow.cs
@@ -4,70 +4,69 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
 
-namespace Flow.Launcher.Helper
+namespace Flow.Launcher.Helper;
+
+public class DwmDropShadow
 {
-    public class DwmDropShadow
+
+    [DllImport("dwmapi.dll", PreserveSig = true)]
+    private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
+
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmExtendFrameIntoClientArea(IntPtr hWnd, ref Margins pMarInset);
+
+    /// <summary>
+    /// Drops a standard shadow to a WPF Window, even if the window isborderless. Only works with DWM (Vista and Seven).
+    /// This method is much more efficient than setting AllowsTransparency to true and using the DropShadow effect,
+    /// as AllowsTransparency involves a huge permormance issue (hardware acceleration is turned off for all the window).
+    /// </summary>
+    /// <param name="window">Window to which the shadow will be applied</param>
+    public static void DropShadowToWindow(Window window)
     {
-
-        [DllImport("dwmapi.dll", PreserveSig = true)]
-        private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
-
-        [DllImport("dwmapi.dll")]
-        private static extern int DwmExtendFrameIntoClientArea(IntPtr hWnd, ref Margins pMarInset);
-
-        /// <summary>
-        /// Drops a standard shadow to a WPF Window, even if the window isborderless. Only works with DWM (Vista and Seven).
-        /// This method is much more efficient than setting AllowsTransparency to true and using the DropShadow effect,
-        /// as AllowsTransparency involves a huge permormance issue (hardware acceleration is turned off for all the window).
-        /// </summary>
-        /// <param name="window">Window to which the shadow will be applied</param>
-        public static void DropShadowToWindow(Window window)
+        if (!DropShadow(window))
         {
-            if (!DropShadow(window))
-            {
-                window.SourceInitialized += window_SourceInitialized;
-            }
+            window.SourceInitialized += window_SourceInitialized;
         }
+    }
 
-        private static void window_SourceInitialized(object sender, EventArgs e) //fixed typo
+    private static void window_SourceInitialized(object sender, EventArgs e) //fixed typo
+    {
+        Window window = (Window)sender;
+
+        DropShadow(window);
+
+        window.SourceInitialized -= window_SourceInitialized;
+    }
+
+    /// <summary>
+    /// The actual method that makes API calls to drop the shadow to the window
+    /// </summary>
+    /// <param name="window">Window to which the shadow will be applied</param>
+    /// <returns>True if the method succeeded, false if not</returns>
+    private static bool DropShadow(Window window)
+    {
+        try
         {
-            Window window = (Window)sender;
+            WindowInteropHelper helper = new WindowInteropHelper(window);
+            int val = 2;
+            int ret1 = DwmSetWindowAttribute(helper.Handle, 2, ref val, 4);
 
-            DropShadow(window);
-
-            window.SourceInitialized -= window_SourceInitialized;
-        }
-
-        /// <summary>
-        /// The actual method that makes API calls to drop the shadow to the window
-        /// </summary>
-        /// <param name="window">Window to which the shadow will be applied</param>
-        /// <returns>True if the method succeeded, false if not</returns>
-        private static bool DropShadow(Window window)
-        {
-            try
+            if (ret1 == 0)
             {
-                WindowInteropHelper helper = new WindowInteropHelper(window);
-                int val = 2;
-                int ret1 = DwmSetWindowAttribute(helper.Handle, 2, ref val, 4);  
-
-                if (ret1 == 0)
-                {
-                    Margins m = new Margins { Bottom = 0, Left = 0, Right = 0, Top = 0 };
-                    int ret2 = DwmExtendFrameIntoClientArea(helper.Handle, ref m);
-                    return ret2 == 0;
-                }
-                else
-                {
-                    return false;
-                }
+                Margins m = new Margins { Bottom = 0, Left = 0, Right = 0, Top = 0 };
+                int ret2 = DwmExtendFrameIntoClientArea(helper.Handle, ref m);
+                return ret2 == 0;
             }
-            catch (Exception)
+            else
             {
-                // Probably dwmapi.dll not found (incompatible OS)
                 return false;
             }
         }
-
+        catch (Exception)
+        {
+            // Probably dwmapi.dll not found (incompatible OS)
+            return false;
+        }
     }
+
 }

--- a/Flow.Launcher/Helper/DataWebRequestFactory.cs
+++ b/Flow.Launcher/Helper/DataWebRequestFactory.cs
@@ -2,68 +2,67 @@
 using System.IO;
 using System.Net;
 
-namespace Flow.Launcher.Helper
+namespace Flow.Launcher.Helper;
+
+public class DataWebRequestFactory : IWebRequestCreate
 {
-    public class DataWebRequestFactory : IWebRequestCreate
+    class DataWebRequest : WebRequest
     {
-        class DataWebRequest : WebRequest
+        private readonly Uri _uri;
+
+        public DataWebRequest(Uri uri)
         {
-            private readonly Uri m_uri;
+            _uri = uri;
+        }
 
-            public DataWebRequest(Uri uri)
-            {
-                m_uri = uri;
-            }
+        public override WebResponse GetResponse()
+        {
+            return new DataWebResponse(_uri);
+        }
+    }
 
-            public override WebResponse GetResponse()
+    class DataWebResponse : WebResponse
+    {
+        private readonly string _contentType;
+        private readonly byte[] _data;
+
+        public DataWebResponse(Uri uri)
+        {
+            string uriString = uri.AbsoluteUri;
+
+            int commaIndex = uriString.IndexOf(',');
+            var headers = uriString.Substring(0, commaIndex).Split(';');
+            _contentType = headers[0];
+            string dataString = uriString.Substring(commaIndex + 1);
+            _data = Convert.FromBase64String(dataString);
+        }
+
+        public override string ContentType
+        {
+            get { return _contentType; }
+            set
             {
-                return new DataWebResponse(m_uri);
+                throw new NotSupportedException();
             }
         }
 
-        class DataWebResponse : WebResponse
+        public override long ContentLength
         {
-            private readonly string m_contentType;
-            private readonly byte[] m_data;
-
-            public DataWebResponse(Uri uri)
+            get { return _data.Length; }
+            set
             {
-                string uriString = uri.AbsoluteUri;
-
-                int commaIndex = uriString.IndexOf(',');
-                var headers = uriString.Substring(0, commaIndex).Split(';');
-                m_contentType = headers[0];
-                string dataString = uriString.Substring(commaIndex + 1);
-                m_data = Convert.FromBase64String(dataString);
-            }
-
-            public override string ContentType
-            {
-                get { return m_contentType; }
-                set
-                {
-                    throw new NotSupportedException();
-                }
-            }
-
-            public override long ContentLength
-            {
-                get { return m_data.Length; }
-                set
-                {
-                    throw new NotSupportedException();
-                }
-            }
-
-            public override Stream GetResponseStream()
-            {
-                return new MemoryStream(m_data);
+                throw new NotSupportedException();
             }
         }
 
-        public WebRequest Create(Uri uri)
+        public override Stream GetResponseStream()
         {
-            return new DataWebRequest(uri);
+            return new MemoryStream(_data);
         }
+    }
+
+    public WebRequest Create(Uri uri)
+    {
+        return new DataWebRequest(uri);
     }
 }

--- a/Flow.Launcher/Helper/ErrorReporting.cs
+++ b/Flow.Launcher/Helper/ErrorReporting.cs
@@ -4,45 +4,52 @@ using NLog;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Exception;
 
-namespace Flow.Launcher.Helper
+namespace Flow.Launcher.Helper;
+
+public static class ErrorReporting
 {
-    public static class ErrorReporting
+    private static void Report(Exception e)
     {
-        private static void Report(Exception e)
-        {
-            var logger = LogManager.GetLogger("UnHandledException");
-            logger.Fatal(ExceptionFormatter.FormatExcpetion(e));
-            var reportWindow = new ReportWindow(e);
-            reportWindow.Show();
-        }
+        var logger = LogManager.GetLogger("UnHandledException");
+        logger.Fatal(ExceptionFormatter.FormatExcpetion(e));
+        var reportWindow = new ReportWindow(e);
+        reportWindow.Show();
+    }
 
-        public static void UnhandledExceptionHandle(object sender, UnhandledExceptionEventArgs e)
-        {
-            //handle non-ui thread exceptions
-            Report((Exception)e.ExceptionObject);
-        }
+    public static void UnhandledExceptionHandle(object sender, UnhandledExceptionEventArgs e)
+    {
+        //handle non-ui thread exceptions
+        Report((Exception)e.ExceptionObject);
+    }
 
-        public static void DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
-        {
-            //handle ui thread exceptions
-            Report(e.Exception);
-            //prevent application exist, so the user can copy prompted error info
-            e.Handled = true;
-        }
-        
-        public static string RuntimeInfo()
-        {
-            var info = $"\nFlow Launcher version: {Constant.Version}" +
-                       $"\nOS Version: {ExceptionFormatter.GetWindowsFullVersionFromRegistry()}" +
-                       $"\nIntPtr Length: {IntPtr.Size}" +
-                       $"\nx64: {Environment.Is64BitOperatingSystem}";
-            return info;
-        }
+    public static void DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+    {
+        //handle ui thread exceptions
+        Report(e.Exception);
+        //prevent application exist, so the user can copy prompted error info
+        e.Handled = true;
+    }
 
-        public static string DependenciesInfo()
-        {
-            var info = $"\nPython Path: {Constant.PythonPath}\nNode Path: {Constant.NodePath}";
-            return info;
-        }
+    public static string RuntimeInfo()
+    {
+        var info =
+            $"""
+
+             Flow Launcher version: {Constant.Version}
+             OS Version: {ExceptionFormatter.GetWindowsFullVersionFromRegistry()}
+             IntPtr Length: {IntPtr.Size}
+             x64: {Environment.Is64BitOperatingSystem}
+             """;
+        return info;
+    }
+
+    public static string DependenciesInfo()
+    {
+        var info = $"""
+
+                    Python Path: {Constant.PythonPath}
+                    Node Path: {Constant.NodePath}
+                    """;
+        return info;
     }
 }

--- a/Flow.Launcher/Helper/SingleInstance.cs
+++ b/Flow.Launcher/Helper/SingleInstance.cs
@@ -12,375 +12,374 @@ using System.Windows;
 
 // http://blogs.microsoft.co.il/arik/2010/05/28/wpf-single-instance-application/
 // modified to allow single instace restart
-namespace Flow.Launcher.Helper
+namespace Flow.Launcher.Helper;
+
+internal enum WM
 {
-    internal enum WM
+    NULL = 0x0000,
+    CREATE = 0x0001,
+    DESTROY = 0x0002,
+    MOVE = 0x0003,
+    SIZE = 0x0005,
+    ACTIVATE = 0x0006,
+    SETFOCUS = 0x0007,
+    KILLFOCUS = 0x0008,
+    ENABLE = 0x000A,
+    SETREDRAW = 0x000B,
+    SETTEXT = 0x000C,
+    GETTEXT = 0x000D,
+    GETTEXTLENGTH = 0x000E,
+    PAINT = 0x000F,
+    CLOSE = 0x0010,
+    QUERYENDSESSION = 0x0011,
+    QUIT = 0x0012,
+    QUERYOPEN = 0x0013,
+    ERASEBKGND = 0x0014,
+    SYSCOLORCHANGE = 0x0015,
+    SHOWWINDOW = 0x0018,
+    ACTIVATEAPP = 0x001C,
+    SETCURSOR = 0x0020,
+    MOUSEACTIVATE = 0x0021,
+    CHILDACTIVATE = 0x0022,
+    QUEUESYNC = 0x0023,
+    GETMINMAXINFO = 0x0024,
+
+    WINDOWPOSCHANGING = 0x0046,
+    WINDOWPOSCHANGED = 0x0047,
+
+    CONTEXTMENU = 0x007B,
+    STYLECHANGING = 0x007C,
+    STYLECHANGED = 0x007D,
+    DISPLAYCHANGE = 0x007E,
+    GETICON = 0x007F,
+    SETICON = 0x0080,
+    NCCREATE = 0x0081,
+    NCDESTROY = 0x0082,
+    NCCALCSIZE = 0x0083,
+    NCHITTEST = 0x0084,
+    NCPAINT = 0x0085,
+    NCACTIVATE = 0x0086,
+    GETDLGCODE = 0x0087,
+    SYNCPAINT = 0x0088,
+    NCMOUSEMOVE = 0x00A0,
+    NCLBUTTONDOWN = 0x00A1,
+    NCLBUTTONUP = 0x00A2,
+    NCLBUTTONDBLCLK = 0x00A3,
+    NCRBUTTONDOWN = 0x00A4,
+    NCRBUTTONUP = 0x00A5,
+    NCRBUTTONDBLCLK = 0x00A6,
+    NCMBUTTONDOWN = 0x00A7,
+    NCMBUTTONUP = 0x00A8,
+    NCMBUTTONDBLCLK = 0x00A9,
+
+    SYSKEYDOWN = 0x0104,
+    SYSKEYUP = 0x0105,
+    SYSCHAR = 0x0106,
+    SYSDEADCHAR = 0x0107,
+    COMMAND = 0x0111,
+    SYSCOMMAND = 0x0112,
+
+    MOUSEMOVE = 0x0200,
+    LBUTTONDOWN = 0x0201,
+    LBUTTONUP = 0x0202,
+    LBUTTONDBLCLK = 0x0203,
+    RBUTTONDOWN = 0x0204,
+    RBUTTONUP = 0x0205,
+    RBUTTONDBLCLK = 0x0206,
+    MBUTTONDOWN = 0x0207,
+    MBUTTONUP = 0x0208,
+    MBUTTONDBLCLK = 0x0209,
+    MOUSEWHEEL = 0x020A,
+    XBUTTONDOWN = 0x020B,
+    XBUTTONUP = 0x020C,
+    XBUTTONDBLCLK = 0x020D,
+    MOUSEHWHEEL = 0x020E,
+
+
+    CAPTURECHANGED = 0x0215,
+
+    ENTERSIZEMOVE = 0x0231,
+    EXITSIZEMOVE = 0x0232,
+
+    IME_SETCONTEXT = 0x0281,
+    IME_NOTIFY = 0x0282,
+    IME_CONTROL = 0x0283,
+    IME_COMPOSITIONFULL = 0x0284,
+    IME_SELECT = 0x0285,
+    IME_CHAR = 0x0286,
+    IME_REQUEST = 0x0288,
+    IME_KEYDOWN = 0x0290,
+    IME_KEYUP = 0x0291,
+
+    NCMOUSELEAVE = 0x02A2,
+
+    DWMCOMPOSITIONCHANGED = 0x031E,
+    DWMNCRENDERINGCHANGED = 0x031F,
+    DWMCOLORIZATIONCOLORCHANGED = 0x0320,
+    DWMWINDOWMAXIMIZEDCHANGE = 0x0321,
+
+    #region Windows 7
+    DWMSENDICONICTHUMBNAIL = 0x0323,
+    DWMSENDICONICLIVEPREVIEWBITMAP = 0x0326,
+    #endregion
+
+    USER = 0x0400,
+
+    // This is the hard-coded message value used by WinForms for Shell_NotifyIcon.
+    // It's relatively safe to reuse.
+    TRAYMOUSEMESSAGE = 0x800, //WM_USER + 1024
+    APP = 0x8000
+}
+
+[SuppressUnmanagedCodeSecurity]
+internal static class NativeMethods
+{
+    /// <summary>
+    /// Delegate declaration that matches WndProc signatures.
+    /// </summary>
+    public delegate IntPtr MessageHandler(WM uMsg, IntPtr wParam, IntPtr lParam, out bool handled);
+
+    [DllImport("shell32.dll", EntryPoint = "CommandLineToArgvW", CharSet = CharSet.Unicode)]
+    private static extern IntPtr _CommandLineToArgvW([MarshalAs(UnmanagedType.LPWStr)] string cmdLine, out int numArgs);
+
+
+    [DllImport("kernel32.dll", EntryPoint = "LocalFree", SetLastError = true)]
+    private static extern IntPtr _LocalFree(IntPtr hMem);
+
+
+    public static string[] CommandLineToArgvW(string cmdLine)
     {
-        NULL = 0x0000,
-        CREATE = 0x0001,
-        DESTROY = 0x0002,
-        MOVE = 0x0003,
-        SIZE = 0x0005,
-        ACTIVATE = 0x0006,
-        SETFOCUS = 0x0007,
-        KILLFOCUS = 0x0008,
-        ENABLE = 0x000A,
-        SETREDRAW = 0x000B,
-        SETTEXT = 0x000C,
-        GETTEXT = 0x000D,
-        GETTEXTLENGTH = 0x000E,
-        PAINT = 0x000F,
-        CLOSE = 0x0010,
-        QUERYENDSESSION = 0x0011,
-        QUIT = 0x0012,
-        QUERYOPEN = 0x0013,
-        ERASEBKGND = 0x0014,
-        SYSCOLORCHANGE = 0x0015,
-        SHOWWINDOW = 0x0018,
-        ACTIVATEAPP = 0x001C,
-        SETCURSOR = 0x0020,
-        MOUSEACTIVATE = 0x0021,
-        CHILDACTIVATE = 0x0022,
-        QUEUESYNC = 0x0023,
-        GETMINMAXINFO = 0x0024,
+        IntPtr argv = IntPtr.Zero;
+        try
+        {
+            int numArgs = 0;
 
-        WINDOWPOSCHANGING = 0x0046,
-        WINDOWPOSCHANGED = 0x0047,
+            argv = _CommandLineToArgvW(cmdLine, out numArgs);
+            if (argv == IntPtr.Zero)
+            {
+                throw new Win32Exception();
+            }
+            var result = new string[numArgs];
 
-        CONTEXTMENU = 0x007B,
-        STYLECHANGING = 0x007C,
-        STYLECHANGED = 0x007D,
-        DISPLAYCHANGE = 0x007E,
-        GETICON = 0x007F,
-        SETICON = 0x0080,
-        NCCREATE = 0x0081,
-        NCDESTROY = 0x0082,
-        NCCALCSIZE = 0x0083,
-        NCHITTEST = 0x0084,
-        NCPAINT = 0x0085,
-        NCACTIVATE = 0x0086,
-        GETDLGCODE = 0x0087,
-        SYNCPAINT = 0x0088,
-        NCMOUSEMOVE = 0x00A0,
-        NCLBUTTONDOWN = 0x00A1,
-        NCLBUTTONUP = 0x00A2,
-        NCLBUTTONDBLCLK = 0x00A3,
-        NCRBUTTONDOWN = 0x00A4,
-        NCRBUTTONUP = 0x00A5,
-        NCRBUTTONDBLCLK = 0x00A6,
-        NCMBUTTONDOWN = 0x00A7,
-        NCMBUTTONUP = 0x00A8,
-        NCMBUTTONDBLCLK = 0x00A9,
+            for (int i = 0; i < numArgs; i++)
+            {
+                IntPtr currArg = Marshal.ReadIntPtr(argv, i * Marshal.SizeOf(typeof(IntPtr)));
+                result[i] = Marshal.PtrToStringUni(currArg);
+            }
 
-        SYSKEYDOWN = 0x0104,
-        SYSKEYUP = 0x0105,
-        SYSCHAR = 0x0106,
-        SYSDEADCHAR = 0x0107,
-        COMMAND = 0x0111,
-        SYSCOMMAND = 0x0112,
+            return result;
+        }
+        finally
+        {
 
-        MOUSEMOVE = 0x0200,
-        LBUTTONDOWN = 0x0201,
-        LBUTTONUP = 0x0202,
-        LBUTTONDBLCLK = 0x0203,
-        RBUTTONDOWN = 0x0204,
-        RBUTTONUP = 0x0205,
-        RBUTTONDBLCLK = 0x0206,
-        MBUTTONDOWN = 0x0207,
-        MBUTTONUP = 0x0208,
-        MBUTTONDBLCLK = 0x0209,
-        MOUSEWHEEL = 0x020A,
-        XBUTTONDOWN = 0x020B,
-        XBUTTONUP = 0x020C,
-        XBUTTONDBLCLK = 0x020D,
-        MOUSEHWHEEL = 0x020E,
-
-
-        CAPTURECHANGED = 0x0215,
-
-        ENTERSIZEMOVE = 0x0231,
-        EXITSIZEMOVE = 0x0232,
-
-        IME_SETCONTEXT = 0x0281,
-        IME_NOTIFY = 0x0282,
-        IME_CONTROL = 0x0283,
-        IME_COMPOSITIONFULL = 0x0284,
-        IME_SELECT = 0x0285,
-        IME_CHAR = 0x0286,
-        IME_REQUEST = 0x0288,
-        IME_KEYDOWN = 0x0290,
-        IME_KEYUP = 0x0291,
-
-        NCMOUSELEAVE = 0x02A2,
-
-        DWMCOMPOSITIONCHANGED = 0x031E,
-        DWMNCRENDERINGCHANGED = 0x031F,
-        DWMCOLORIZATIONCOLORCHANGED = 0x0320,
-        DWMWINDOWMAXIMIZEDCHANGE = 0x0321,
-
-        #region Windows 7
-        DWMSENDICONICTHUMBNAIL = 0x0323,
-        DWMSENDICONICLIVEPREVIEWBITMAP = 0x0326,
-        #endregion
-
-        USER = 0x0400,
-
-        // This is the hard-coded message value used by WinForms for Shell_NotifyIcon.
-        // It's relatively safe to reuse.
-        TRAYMOUSEMESSAGE = 0x800, //WM_USER + 1024
-        APP = 0x8000
+            IntPtr p = _LocalFree(argv);
+            // Otherwise LocalFree failed.
+            // Assert.AreEqual(IntPtr.Zero, p);
+        }
     }
 
-    [SuppressUnmanagedCodeSecurity]
-    internal static class NativeMethods
-    {
-        /// <summary>
-        /// Delegate declaration that matches WndProc signatures.
-        /// </summary>
-        public delegate IntPtr MessageHandler(WM uMsg, IntPtr wParam, IntPtr lParam, out bool handled);
+}
 
-        [DllImport("shell32.dll", EntryPoint = "CommandLineToArgvW", CharSet = CharSet.Unicode)]
-        private static extern IntPtr _CommandLineToArgvW([MarshalAs(UnmanagedType.LPWStr)] string cmdLine, out int numArgs);
+public interface ISingleInstanceApp
+{
+    void OnSecondAppStarted();
+}
 
+/// <summary>
+/// This class checks to make sure that only one instance of
+/// this application is running at a time.
+/// </summary>
+/// <remarks>
+/// Note: this class should be used with some caution, because it does no
+/// security checking. For example, if one instance of an app that uses this class
+/// is running as Administrator, any other instance, even if it is not
+/// running as Administrator, can activate it with command line arguments.
+/// For most apps, this will not be much of an issue.
+/// </remarks>
+public static class SingleInstance<TApplication>
+    where   TApplication: Application ,  ISingleInstanceApp
 
-        [DllImport("kernel32.dll", EntryPoint = "LocalFree", SetLastError = true)]
-        private static extern IntPtr _LocalFree(IntPtr hMem);
-
-
-        public static string[] CommandLineToArgvW(string cmdLine)
-        {
-            IntPtr argv = IntPtr.Zero;
-            try
-            {
-                int numArgs = 0;
-
-                argv = _CommandLineToArgvW(cmdLine, out numArgs);
-                if (argv == IntPtr.Zero)
-                {
-                    throw new Win32Exception();
-                }
-                var result = new string[numArgs];
-
-                for (int i = 0; i < numArgs; i++)
-                {
-                    IntPtr currArg = Marshal.ReadIntPtr(argv, i * Marshal.SizeOf(typeof(IntPtr)));
-                    result[i] = Marshal.PtrToStringUni(currArg);
-                }
-
-                return result;
-            }
-            finally
-            {
-
-                IntPtr p = _LocalFree(argv);
-                // Otherwise LocalFree failed.
-                // Assert.AreEqual(IntPtr.Zero, p);
-            }
-        }
-
-    } 
-
-    public interface ISingleInstanceApp 
-    { 
-         void OnSecondAppStarted(); 
-    } 
+{
+    #region Private Fields
 
     /// <summary>
-    /// This class checks to make sure that only one instance of 
-    /// this application is running at a time.
+    /// String delimiter used in channel names.
     /// </summary>
-    /// <remarks>
-    /// Note: this class should be used with some caution, because it does no
-    /// security checking. For example, if one instance of an app that uses this class
-    /// is running as Administrator, any other instance, even if it is not
-    /// running as Administrator, can activate it with command line arguments.
-    /// For most apps, this will not be much of an issue.
-    /// </remarks>
-    public static class SingleInstance<TApplication>  
-                where   TApplication: Application ,  ISingleInstanceApp 
-                                    
+    private const string Delimiter = ":";
+
+    /// <summary>
+    /// Suffix to the channel name.
+    /// </summary>
+    private const string ChannelNameSuffix = "SingeInstanceIPCChannel";
+
+    /// <summary>
+    /// Application mutex.
+    /// </summary>
+    internal static Mutex singleInstanceMutex;
+
+    #endregion
+
+    #region Public Properties
+
+    #endregion
+
+    #region Public Methods
+
+    /// <summary>
+    /// Checks if the instance of the application attempting to start is the first instance.
+    /// If not, activates the first instance.
+    /// </summary>
+    /// <returns>True if this is the first instance of the application.</returns>
+    public static bool InitializeAsFirstInstance( string uniqueName )
     {
-        #region Private Fields
+        // Build unique application Id and the IPC channel name.
+        string applicationIdentifier = uniqueName + Environment.UserName;
 
-        /// <summary>
-        /// String delimiter used in channel names.
-        /// </summary>
-        private const string Delimiter = ":";
+        string channelName = String.Concat(applicationIdentifier, Delimiter, ChannelNameSuffix);
 
-        /// <summary>
-        /// Suffix to the channel name.
-        /// </summary>
-        private const string ChannelNameSuffix = "SingeInstanceIPCChannel";
-
-        /// <summary>
-        /// Application mutex.
-        /// </summary>
-        internal static Mutex singleInstanceMutex;
-
-        #endregion
-
-        #region Public Properties
-
-        #endregion
-
-        #region Public Methods
-
-        /// <summary>
-        /// Checks if the instance of the application attempting to start is the first instance. 
-        /// If not, activates the first instance.
-        /// </summary>
-        /// <returns>True if this is the first instance of the application.</returns>
-        public static bool InitializeAsFirstInstance( string uniqueName )
+        // Create mutex based on unique application Id to check if this is the first instance of the application.
+        bool firstInstance;
+        singleInstanceMutex = new Mutex(true, applicationIdentifier, out firstInstance);
+        if (firstInstance)
         {
-            // Build unique application Id and the IPC channel name.
-            string applicationIdentifier = uniqueName + Environment.UserName;
-
-            string channelName = String.Concat(applicationIdentifier, Delimiter, ChannelNameSuffix);
-
-            // Create mutex based on unique application Id to check if this is the first instance of the application. 
-            bool firstInstance;
-            singleInstanceMutex = new Mutex(true, applicationIdentifier, out firstInstance);
-            if (firstInstance)
-            {
-                _ = CreateRemoteService(channelName);
-                return true;
-            }
-            else
-            {
-                _ = SignalFirstInstance(channelName);
-                return false;
-            }
+            _ = CreateRemoteService(channelName);
+            return true;
         }
-
-        /// <summary>
-        /// Cleans up single-instance code, clearing shared resources, mutexes, etc.
-        /// </summary>
-        public static void Cleanup()
+        else
         {
-            singleInstanceMutex?.ReleaseMutex();
+            _ = SignalFirstInstance(channelName);
+            return false;
         }
-
-        #endregion
-
-        #region Private Methods
-
-        /// <summary>
-        /// Gets command line args - for ClickOnce deployed applications, command line args may not be passed directly, they have to be retrieved.
-        /// </summary>
-        /// <returns>List of command line arg strings.</returns>
-        private static IList<string> GetCommandLineArgs( string uniqueApplicationName )
-        {
-            string[] args = null;
-
-            try
-            {
-                // The application was not clickonce deployed, get args from standard API's
-                args = Environment.GetCommandLineArgs();
-            }
-            catch (NotSupportedException)
-            {
-              
-                // The application was clickonce deployed
-                // Clickonce deployed apps cannot recieve traditional commandline arguments
-                // As a workaround commandline arguments can be written to a shared location before 
-                // the app is launched and the app can obtain its commandline arguments from the 
-                // shared location               
-                string appFolderPath = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), uniqueApplicationName);
-
-                string cmdLinePath = Path.Combine(appFolderPath, "cmdline.txt");
-                if (File.Exists(cmdLinePath))
-                {
-                    try
-                    {
-                        using (TextReader reader = new StreamReader(cmdLinePath, Encoding.Unicode))
-                        {
-                            args = NativeMethods.CommandLineToArgvW(reader.ReadToEnd());
-                        }
-
-                        File.Delete(cmdLinePath);
-                    }
-                    catch (IOException)
-                    {
-                    }
-                }
-            }
-
-            if (args == null)
-            {
-                args = new string[] { };
-            }
-
-            return new List<string>(args);
-        }
-
-        /// <summary>
-        /// Creates a remote server pipe for communication. 
-        /// Once receives signal from client, will activate first instance.
-        /// </summary>
-        /// <param name="channelName">Application's IPC channel name.</param>
-        private static async Task CreateRemoteService(string channelName)
-        {
-            using (NamedPipeServerStream pipeServer = new NamedPipeServerStream(channelName, PipeDirection.In))
-            {
-                while(true)
-                {
-                    // Wait for connection to the pipe
-                    await pipeServer.WaitForConnectionAsync();
-                    if (Application.Current != null)
-                    {
-                        // Do an asynchronous call to ActivateFirstInstance function
-                        Application.Current.Dispatcher.Invoke(ActivateFirstInstance);
-                    }
-                    // Disconect client
-                    pipeServer.Disconnect();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Creates a client pipe and sends a signal to server to launch first instance
-        /// </summary>
-        /// <param name="channelName">Application's IPC channel name.</param>
-        /// <param name="args">
-        /// Command line arguments for the second instance, passed to the first instance to take appropriate action.
-        /// </param>
-        private static async Task SignalFirstInstance(string channelName)
-        {
-            // Create a client pipe connected to server
-            using (NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", channelName, PipeDirection.Out))
-            {
-                // Connect to the available pipe
-                await pipeClient.ConnectAsync(0);
-            }
-        }
-
-        /// <summary>
-        /// Callback for activating first instance of the application.
-        /// </summary>
-        /// <param name="arg">Callback argument.</param>
-        /// <returns>Always null.</returns>
-        private static object ActivateFirstInstanceCallback(object o)
-        {
-            ActivateFirstInstance();
-            return null;
-        }
-
-        /// <summary>
-        /// Activates the first instance of the application with arguments from a second instance.
-        /// </summary>
-        /// <param name="args">List of arguments to supply the first instance of the application.</param>
-        private static void ActivateFirstInstance()
-        {
-            // Set main window state and process command line args
-            if (Application.Current == null)
-            {
-                return;
-            }
-
-            ((TApplication)Application.Current).OnSecondAppStarted();
-        }
-
-        #endregion
     }
+
+    /// <summary>
+    /// Cleans up single-instance code, clearing shared resources, mutexes, etc.
+    /// </summary>
+    public static void Cleanup()
+    {
+        singleInstanceMutex?.ReleaseMutex();
+    }
+
+    #endregion
+
+    #region Private Methods
+
+    /// <summary>
+    /// Gets command line args - for ClickOnce deployed applications, command line args may not be passed directly, they have to be retrieved.
+    /// </summary>
+    /// <returns>List of command line arg strings.</returns>
+    private static IList<string> GetCommandLineArgs( string uniqueApplicationName )
+    {
+        string[] args = null;
+
+        try
+        {
+            // The application was not clickonce deployed, get args from standard API's
+            args = Environment.GetCommandLineArgs();
+        }
+        catch (NotSupportedException)
+        {
+
+            // The application was clickonce deployed
+            // Clickonce deployed apps cannot recieve traditional commandline arguments
+            // As a workaround commandline arguments can be written to a shared location before
+            // the app is launched and the app can obtain its commandline arguments from the
+            // shared location
+            string appFolderPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), uniqueApplicationName);
+
+            string cmdLinePath = Path.Combine(appFolderPath, "cmdline.txt");
+            if (File.Exists(cmdLinePath))
+            {
+                try
+                {
+                    using (TextReader reader = new StreamReader(cmdLinePath, Encoding.Unicode))
+                    {
+                        args = NativeMethods.CommandLineToArgvW(reader.ReadToEnd());
+                    }
+
+                    File.Delete(cmdLinePath);
+                }
+                catch (IOException)
+                {
+                }
+            }
+        }
+
+        if (args == null)
+        {
+                args = new string[] { };
+        }
+
+        return new List<string>(args);
+    }
+
+    /// <summary>
+    /// Creates a remote server pipe for communication.
+    /// Once receives signal from client, will activate first instance.
+    /// </summary>
+    /// <param name="channelName">Application's IPC channel name.</param>
+    private static async Task CreateRemoteService(string channelName)
+    {
+        using (NamedPipeServerStream pipeServer = new NamedPipeServerStream(channelName, PipeDirection.In))
+        {
+            while(true)
+            {
+                // Wait for connection to the pipe
+                await pipeServer.WaitForConnectionAsync();
+                if (Application.Current != null)
+                {
+                    // Do an asynchronous call to ActivateFirstInstance function
+                    Application.Current.Dispatcher.Invoke(ActivateFirstInstance);
+                }
+                // Disconect client
+                pipeServer.Disconnect();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a client pipe and sends a signal to server to launch first instance
+    /// </summary>
+    /// <param name="channelName">Application's IPC channel name.</param>
+    /// <param name="args">
+    /// Command line arguments for the second instance, passed to the first instance to take appropriate action.
+    /// </param>
+    private static async Task SignalFirstInstance(string channelName)
+    {
+        // Create a client pipe connected to server
+        using (NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", channelName, PipeDirection.Out))
+        {
+            // Connect to the available pipe
+            await pipeClient.ConnectAsync(0);
+        }
+    }
+
+    /// <summary>
+    /// Callback for activating first instance of the application.
+    /// </summary>
+    /// <param name="arg">Callback argument.</param>
+    /// <returns>Always null.</returns>
+    private static object ActivateFirstInstanceCallback(object o)
+    {
+        ActivateFirstInstance();
+        return null;
+    }
+
+    /// <summary>
+    /// Activates the first instance of the application with arguments from a second instance.
+    /// </summary>
+    /// <param name="args">List of arguments to supply the first instance of the application.</param>
+    private static void ActivateFirstInstance()
+    {
+        // Set main window state and process command line args
+        if (Application.Current == null)
+        {
+            return;
+        }
+
+        ((TApplication)Application.Current).OnSecondAppStarted();
+    }
+
+    #endregion
 }

--- a/Flow.Launcher/Helper/SingleInstance.cs
+++ b/Flow.Launcher/Helper/SingleInstance.cs
@@ -12,372 +12,375 @@ using System.Windows;
 
 // http://blogs.microsoft.co.il/arik/2010/05/28/wpf-single-instance-application/
 // modified to allow single instace restart
-namespace Flow.Launcher.Helper;
-
-internal enum WM
+namespace Flow.Launcher.Helper
 {
-    NULL = 0x0000,
-    CREATE = 0x0001,
-    DESTROY = 0x0002,
-    MOVE = 0x0003,
-    SIZE = 0x0005,
-    ACTIVATE = 0x0006,
-    SETFOCUS = 0x0007,
-    KILLFOCUS = 0x0008,
-    ENABLE = 0x000A,
-    SETREDRAW = 0x000B,
-    SETTEXT = 0x000C,
-    GETTEXT = 0x000D,
-    GETTEXTLENGTH = 0x000E,
-    PAINT = 0x000F,
-    CLOSE = 0x0010,
-    QUERYENDSESSION = 0x0011,
-    QUIT = 0x0012,
-    QUERYOPEN = 0x0013,
-    ERASEBKGND = 0x0014,
-    SYSCOLORCHANGE = 0x0015,
-    SHOWWINDOW = 0x0018,
-    ACTIVATEAPP = 0x001C,
-    SETCURSOR = 0x0020,
-    MOUSEACTIVATE = 0x0021,
-    CHILDACTIVATE = 0x0022,
-    QUEUESYNC = 0x0023,
-    GETMINMAXINFO = 0x0024,
-
-    WINDOWPOSCHANGING = 0x0046,
-    WINDOWPOSCHANGED = 0x0047,
-
-    CONTEXTMENU = 0x007B,
-    STYLECHANGING = 0x007C,
-    STYLECHANGED = 0x007D,
-    DISPLAYCHANGE = 0x007E,
-    GETICON = 0x007F,
-    SETICON = 0x0080,
-    NCCREATE = 0x0081,
-    NCDESTROY = 0x0082,
-    NCCALCSIZE = 0x0083,
-    NCHITTEST = 0x0084,
-    NCPAINT = 0x0085,
-    NCACTIVATE = 0x0086,
-    GETDLGCODE = 0x0087,
-    SYNCPAINT = 0x0088,
-    NCMOUSEMOVE = 0x00A0,
-    NCLBUTTONDOWN = 0x00A1,
-    NCLBUTTONUP = 0x00A2,
-    NCLBUTTONDBLCLK = 0x00A3,
-    NCRBUTTONDOWN = 0x00A4,
-    NCRBUTTONUP = 0x00A5,
-    NCRBUTTONDBLCLK = 0x00A6,
-    NCMBUTTONDOWN = 0x00A7,
-    NCMBUTTONUP = 0x00A8,
-    NCMBUTTONDBLCLK = 0x00A9,
-
-    SYSKEYDOWN = 0x0104,
-    SYSKEYUP = 0x0105,
-    SYSCHAR = 0x0106,
-    SYSDEADCHAR = 0x0107,
-    COMMAND = 0x0111,
-    SYSCOMMAND = 0x0112,
-
-    MOUSEMOVE = 0x0200,
-    LBUTTONDOWN = 0x0201,
-    LBUTTONUP = 0x0202,
-    LBUTTONDBLCLK = 0x0203,
-    RBUTTONDOWN = 0x0204,
-    RBUTTONUP = 0x0205,
-    RBUTTONDBLCLK = 0x0206,
-    MBUTTONDOWN = 0x0207,
-    MBUTTONUP = 0x0208,
-    MBUTTONDBLCLK = 0x0209,
-    MOUSEWHEEL = 0x020A,
-    XBUTTONDOWN = 0x020B,
-    XBUTTONUP = 0x020C,
-    XBUTTONDBLCLK = 0x020D,
-    MOUSEHWHEEL = 0x020E,
-
-
-    CAPTURECHANGED = 0x0215,
-
-    ENTERSIZEMOVE = 0x0231,
-    EXITSIZEMOVE = 0x0232,
-
-    IME_SETCONTEXT = 0x0281,
-    IME_NOTIFY = 0x0282,
-    IME_CONTROL = 0x0283,
-    IME_COMPOSITIONFULL = 0x0284,
-    IME_SELECT = 0x0285,
-    IME_CHAR = 0x0286,
-    IME_REQUEST = 0x0288,
-    IME_KEYDOWN = 0x0290,
-    IME_KEYUP = 0x0291,
-
-    NCMOUSELEAVE = 0x02A2,
-
-    DWMCOMPOSITIONCHANGED = 0x031E,
-    DWMNCRENDERINGCHANGED = 0x031F,
-    DWMCOLORIZATIONCOLORCHANGED = 0x0320,
-    DWMWINDOWMAXIMIZEDCHANGE = 0x0321,
-
-    #region Windows 7
-    DWMSENDICONICTHUMBNAIL = 0x0323,
-    DWMSENDICONICLIVEPREVIEWBITMAP = 0x0326,
-    #endregion
-
-    USER = 0x0400,
-
-    // This is the hard-coded message value used by WinForms for Shell_NotifyIcon.
-    // It's relatively safe to reuse.
-    TRAYMOUSEMESSAGE = 0x800, //WM_USER + 1024
-    APP = 0x8000
-}
-
-[SuppressUnmanagedCodeSecurity]
-internal static class NativeMethods
-{
-    /// <summary>
-    /// Delegate declaration that matches WndProc signatures.
-    /// </summary>
-    public delegate IntPtr MessageHandler(WM uMsg, IntPtr wParam, IntPtr lParam, out bool handled);
-
-    [DllImport("shell32.dll", EntryPoint = "CommandLineToArgvW", CharSet = CharSet.Unicode)]
-    private static extern IntPtr _CommandLineToArgvW([MarshalAs(UnmanagedType.LPWStr)] string cmdLine, out int numArgs);
-
-
-    [DllImport("kernel32.dll", EntryPoint = "LocalFree", SetLastError = true)]
-    private static extern IntPtr _LocalFree(IntPtr hMem);
-
-
-    public static string[] CommandLineToArgvW(string cmdLine)
+    internal enum WM
     {
-        IntPtr argv = IntPtr.Zero;
-        try
-        {
-            int numArgs = 0;
+        NULL = 0x0000,
+        CREATE = 0x0001,
+        DESTROY = 0x0002,
+        MOVE = 0x0003,
+        SIZE = 0x0005,
+        ACTIVATE = 0x0006,
+        SETFOCUS = 0x0007,
+        KILLFOCUS = 0x0008,
+        ENABLE = 0x000A,
+        SETREDRAW = 0x000B,
+        SETTEXT = 0x000C,
+        GETTEXT = 0x000D,
+        GETTEXTLENGTH = 0x000E,
+        PAINT = 0x000F,
+        CLOSE = 0x0010,
+        QUERYENDSESSION = 0x0011,
+        QUIT = 0x0012,
+        QUERYOPEN = 0x0013,
+        ERASEBKGND = 0x0014,
+        SYSCOLORCHANGE = 0x0015,
+        SHOWWINDOW = 0x0018,
+        ACTIVATEAPP = 0x001C,
+        SETCURSOR = 0x0020,
+        MOUSEACTIVATE = 0x0021,
+        CHILDACTIVATE = 0x0022,
+        QUEUESYNC = 0x0023,
+        GETMINMAXINFO = 0x0024,
 
-            argv = _CommandLineToArgvW(cmdLine, out numArgs);
-            if (argv == IntPtr.Zero)
-            {
-                throw new Win32Exception();
-            }
-            var result = new string[numArgs];
+        WINDOWPOSCHANGING = 0x0046,
+        WINDOWPOSCHANGED = 0x0047,
 
-            for (int i = 0; i < numArgs; i++)
-            {
-                IntPtr currArg = Marshal.ReadIntPtr(argv, i * Marshal.SizeOf(typeof(IntPtr)));
-                result[i] = Marshal.PtrToStringUni(currArg);
-            }
+        CONTEXTMENU = 0x007B,
+        STYLECHANGING = 0x007C,
+        STYLECHANGED = 0x007D,
+        DISPLAYCHANGE = 0x007E,
+        GETICON = 0x007F,
+        SETICON = 0x0080,
+        NCCREATE = 0x0081,
+        NCDESTROY = 0x0082,
+        NCCALCSIZE = 0x0083,
+        NCHITTEST = 0x0084,
+        NCPAINT = 0x0085,
+        NCACTIVATE = 0x0086,
+        GETDLGCODE = 0x0087,
+        SYNCPAINT = 0x0088,
+        NCMOUSEMOVE = 0x00A0,
+        NCLBUTTONDOWN = 0x00A1,
+        NCLBUTTONUP = 0x00A2,
+        NCLBUTTONDBLCLK = 0x00A3,
+        NCRBUTTONDOWN = 0x00A4,
+        NCRBUTTONUP = 0x00A5,
+        NCRBUTTONDBLCLK = 0x00A6,
+        NCMBUTTONDOWN = 0x00A7,
+        NCMBUTTONUP = 0x00A8,
+        NCMBUTTONDBLCLK = 0x00A9,
 
-            return result;
-        }
-        finally
-        {
+        SYSKEYDOWN = 0x0104,
+        SYSKEYUP = 0x0105,
+        SYSCHAR = 0x0106,
+        SYSDEADCHAR = 0x0107,
+        COMMAND = 0x0111,
+        SYSCOMMAND = 0x0112,
 
-            IntPtr p = _LocalFree(argv);
-            // Otherwise LocalFree failed.
-            // Assert.AreEqual(IntPtr.Zero, p);
-        }
+        MOUSEMOVE = 0x0200,
+        LBUTTONDOWN = 0x0201,
+        LBUTTONUP = 0x0202,
+        LBUTTONDBLCLK = 0x0203,
+        RBUTTONDOWN = 0x0204,
+        RBUTTONUP = 0x0205,
+        RBUTTONDBLCLK = 0x0206,
+        MBUTTONDOWN = 0x0207,
+        MBUTTONUP = 0x0208,
+        MBUTTONDBLCLK = 0x0209,
+        MOUSEWHEEL = 0x020A,
+        XBUTTONDOWN = 0x020B,
+        XBUTTONUP = 0x020C,
+        XBUTTONDBLCLK = 0x020D,
+        MOUSEHWHEEL = 0x020E,
+
+
+        CAPTURECHANGED = 0x0215,
+
+        ENTERSIZEMOVE = 0x0231,
+        EXITSIZEMOVE = 0x0232,
+
+        IME_SETCONTEXT = 0x0281,
+        IME_NOTIFY = 0x0282,
+        IME_CONTROL = 0x0283,
+        IME_COMPOSITIONFULL = 0x0284,
+        IME_SELECT = 0x0285,
+        IME_CHAR = 0x0286,
+        IME_REQUEST = 0x0288,
+        IME_KEYDOWN = 0x0290,
+        IME_KEYUP = 0x0291,
+
+        NCMOUSELEAVE = 0x02A2,
+
+        DWMCOMPOSITIONCHANGED = 0x031E,
+        DWMNCRENDERINGCHANGED = 0x031F,
+        DWMCOLORIZATIONCOLORCHANGED = 0x0320,
+        DWMWINDOWMAXIMIZEDCHANGE = 0x0321,
+
+        #region Windows 7
+        DWMSENDICONICTHUMBNAIL = 0x0323,
+        DWMSENDICONICLIVEPREVIEWBITMAP = 0x0326,
+        #endregion
+
+        USER = 0x0400,
+
+        // This is the hard-coded message value used by WinForms for Shell_NotifyIcon.
+        // It's relatively safe to reuse.
+        TRAYMOUSEMESSAGE = 0x800, //WM_USER + 1024
+        APP = 0x8000
     }
 
-}
-
-public interface ISingleInstanceApp
-{
-    void OnSecondAppStarted();
-}
-
-/// <summary>
-/// This class checks to make sure that only one instance of
-/// this application is running at a time.
-/// </summary>
-/// <remarks>
-/// Note: this class should be used with some caution, because it does no
-/// security checking. For example, if one instance of an app that uses this class
-/// is running as Administrator, any other instance, even if it is not
-/// running as Administrator, can activate it with command line arguments.
-/// For most apps, this will not be much of an issue.
-/// </remarks>
-public static class SingleInstance<TApplication>
-    where   TApplication: Application ,  ISingleInstanceApp
-
-{
-    #region Private Fields
-
-    /// <summary>
-    /// String delimiter used in channel names.
-    /// </summary>
-    private const string Delimiter = ":";
-
-    /// <summary>
-    /// Suffix to the channel name.
-    /// </summary>
-    private const string ChannelNameSuffix = "SingeInstanceIPCChannel";
-
-    /// <summary>
-    /// Application mutex.
-    /// </summary>
-    internal static Mutex singleInstanceMutex;
-
-    #endregion
-
-    #region Public Properties
-
-    #endregion
-
-    #region Public Methods
-
-    /// <summary>
-    /// Checks if the instance of the application attempting to start is the first instance.
-    /// If not, activates the first instance.
-    /// </summary>
-    /// <returns>True if this is the first instance of the application.</returns>
-    public static bool InitializeAsFirstInstance( string uniqueName )
+    [SuppressUnmanagedCodeSecurity]
+    internal static class NativeMethods
     {
-        // Build unique application Id and the IPC channel name.
-        string applicationIdentifier = uniqueName + Environment.UserName;
+        /// <summary>
+        /// Delegate declaration that matches WndProc signatures.
+        /// </summary>
+        public delegate IntPtr MessageHandler(WM uMsg, IntPtr wParam, IntPtr lParam, out bool handled);
 
-        string channelName = String.Concat(applicationIdentifier, Delimiter, ChannelNameSuffix);
+        [DllImport("shell32.dll", EntryPoint = "CommandLineToArgvW", CharSet = CharSet.Unicode)]
+        private static extern IntPtr _CommandLineToArgvW([MarshalAs(UnmanagedType.LPWStr)] string cmdLine, out int numArgs);
 
-        // Create mutex based on unique application Id to check if this is the first instance of the application.
-        bool firstInstance;
-        singleInstanceMutex = new Mutex(true, applicationIdentifier, out firstInstance);
-        if (firstInstance)
+
+        [DllImport("kernel32.dll", EntryPoint = "LocalFree", SetLastError = true)]
+        private static extern IntPtr _LocalFree(IntPtr hMem);
+
+
+        public static string[] CommandLineToArgvW(string cmdLine)
         {
-            _ = CreateRemoteService(channelName);
-            return true;
-        }
-        else
-        {
-            _ = SignalFirstInstance(channelName);
-            return false;
-        }
-    }
-
-    /// <summary>
-    /// Cleans up single-instance code, clearing shared resources, mutexes, etc.
-    /// </summary>
-    public static void Cleanup()
-    {
-        singleInstanceMutex?.ReleaseMutex();
-    }
-
-    #endregion
-
-    #region Private Methods
-
-    /// <summary>
-    /// Gets command line args - for ClickOnce deployed applications, command line args may not be passed directly, they have to be retrieved.
-    /// </summary>
-    /// <returns>List of command line arg strings.</returns>
-    private static IList<string> GetCommandLineArgs( string uniqueApplicationName )
-    {
-        string[] args = null;
-
-        try
-        {
-            // The application was not clickonce deployed, get args from standard API's
-            args = Environment.GetCommandLineArgs();
-        }
-        catch (NotSupportedException)
-        {
-
-            // The application was clickonce deployed
-            // Clickonce deployed apps cannot recieve traditional commandline arguments
-            // As a workaround commandline arguments can be written to a shared location before
-            // the app is launched and the app can obtain its commandline arguments from the
-            // shared location
-            string appFolderPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), uniqueApplicationName);
-
-            string cmdLinePath = Path.Combine(appFolderPath, "cmdline.txt");
-            if (File.Exists(cmdLinePath))
+            IntPtr argv = IntPtr.Zero;
+            try
             {
-                try
+                int numArgs = 0;
+
+                argv = _CommandLineToArgvW(cmdLine, out numArgs);
+                if (argv == IntPtr.Zero)
                 {
-                    using TextReader reader = new StreamReader(cmdLinePath, Encoding.Unicode);
-                    args = NativeMethods.CommandLineToArgvW(reader.ReadToEnd());
+                    throw new Win32Exception();
+                }
+                var result = new string[numArgs];
 
-                    File.Delete(cmdLinePath);
-                }
-                catch (IOException)
+                for (int i = 0; i < numArgs; i++)
                 {
+                    IntPtr currArg = Marshal.ReadIntPtr(argv, i * Marshal.SizeOf(typeof(IntPtr)));
+                    result[i] = Marshal.PtrToStringUni(currArg);
                 }
+
+                return result;
+            }
+            finally
+            {
+
+                IntPtr p = _LocalFree(argv);
+                // Otherwise LocalFree failed.
+                // Assert.AreEqual(IntPtr.Zero, p);
             }
         }
 
-        if (args == null)
+    } 
+
+    public interface ISingleInstanceApp 
+    { 
+         void OnSecondAppStarted(); 
+    } 
+
+    /// <summary>
+    /// This class checks to make sure that only one instance of 
+    /// this application is running at a time.
+    /// </summary>
+    /// <remarks>
+    /// Note: this class should be used with some caution, because it does no
+    /// security checking. For example, if one instance of an app that uses this class
+    /// is running as Administrator, any other instance, even if it is not
+    /// running as Administrator, can activate it with command line arguments.
+    /// For most apps, this will not be much of an issue.
+    /// </remarks>
+    public static class SingleInstance<TApplication>  
+                where   TApplication: Application ,  ISingleInstanceApp 
+                                    
+    {
+        #region Private Fields
+
+        /// <summary>
+        /// String delimiter used in channel names.
+        /// </summary>
+        private const string Delimiter = ":";
+
+        /// <summary>
+        /// Suffix to the channel name.
+        /// </summary>
+        private const string ChannelNameSuffix = "SingeInstanceIPCChannel";
+
+        /// <summary>
+        /// Application mutex.
+        /// </summary>
+        internal static Mutex singleInstanceMutex;
+
+        #endregion
+
+        #region Public Properties
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Checks if the instance of the application attempting to start is the first instance. 
+        /// If not, activates the first instance.
+        /// </summary>
+        /// <returns>True if this is the first instance of the application.</returns>
+        public static bool InitializeAsFirstInstance( string uniqueName )
         {
+            // Build unique application Id and the IPC channel name.
+            string applicationIdentifier = uniqueName + Environment.UserName;
+
+            string channelName = String.Concat(applicationIdentifier, Delimiter, ChannelNameSuffix);
+
+            // Create mutex based on unique application Id to check if this is the first instance of the application. 
+            bool firstInstance;
+            singleInstanceMutex = new Mutex(true, applicationIdentifier, out firstInstance);
+            if (firstInstance)
+            {
+                _ = CreateRemoteService(channelName);
+                return true;
+            }
+            else
+            {
+                _ = SignalFirstInstance(channelName);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Cleans up single-instance code, clearing shared resources, mutexes, etc.
+        /// </summary>
+        public static void Cleanup()
+        {
+            singleInstanceMutex?.ReleaseMutex();
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        /// <summary>
+        /// Gets command line args - for ClickOnce deployed applications, command line args may not be passed directly, they have to be retrieved.
+        /// </summary>
+        /// <returns>List of command line arg strings.</returns>
+        private static IList<string> GetCommandLineArgs( string uniqueApplicationName )
+        {
+            string[] args = null;
+
+            try
+            {
+                // The application was not clickonce deployed, get args from standard API's
+                args = Environment.GetCommandLineArgs();
+            }
+            catch (NotSupportedException)
+            {
+              
+                // The application was clickonce deployed
+                // Clickonce deployed apps cannot recieve traditional commandline arguments
+                // As a workaround commandline arguments can be written to a shared location before 
+                // the app is launched and the app can obtain its commandline arguments from the 
+                // shared location               
+                string appFolderPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), uniqueApplicationName);
+
+                string cmdLinePath = Path.Combine(appFolderPath, "cmdline.txt");
+                if (File.Exists(cmdLinePath))
+                {
+                    try
+                    {
+                        using (TextReader reader = new StreamReader(cmdLinePath, Encoding.Unicode))
+                        {
+                            args = NativeMethods.CommandLineToArgvW(reader.ReadToEnd());
+                        }
+
+                        File.Delete(cmdLinePath);
+                    }
+                    catch (IOException)
+                    {
+                    }
+                }
+            }
+
+            if (args == null)
+            {
                 args = new string[] { };
+            }
+
+            return new List<string>(args);
         }
 
-        return new List<string>(args);
-    }
-
-    /// <summary>
-    /// Creates a remote server pipe for communication.
-    /// Once receives signal from client, will activate first instance.
-    /// </summary>
-    /// <param name="channelName">Application's IPC channel name.</param>
-    private static async Task CreateRemoteService(string channelName)
-    {
-        using (NamedPipeServerStream pipeServer = new NamedPipeServerStream(channelName, PipeDirection.In))
+        /// <summary>
+        /// Creates a remote server pipe for communication. 
+        /// Once receives signal from client, will activate first instance.
+        /// </summary>
+        /// <param name="channelName">Application's IPC channel name.</param>
+        private static async Task CreateRemoteService(string channelName)
         {
-            while(true)
+            using (NamedPipeServerStream pipeServer = new NamedPipeServerStream(channelName, PipeDirection.In))
             {
-                // Wait for connection to the pipe
-                await pipeServer.WaitForConnectionAsync();
-                if (Application.Current != null)
+                while(true)
                 {
-                    // Do an asynchronous call to ActivateFirstInstance function
-                    Application.Current.Dispatcher.Invoke(ActivateFirstInstance);
+                    // Wait for connection to the pipe
+                    await pipeServer.WaitForConnectionAsync();
+                    if (Application.Current != null)
+                    {
+                        // Do an asynchronous call to ActivateFirstInstance function
+                        Application.Current.Dispatcher.Invoke(ActivateFirstInstance);
+                    }
+                    // Disconect client
+                    pipeServer.Disconnect();
                 }
-                // Disconect client
-                pipeServer.Disconnect();
             }
         }
-    }
 
-    /// <summary>
-    /// Creates a client pipe and sends a signal to server to launch first instance
-    /// </summary>
-    /// <param name="channelName">Application's IPC channel name.</param>
-    /// <param name="args">
-    /// Command line arguments for the second instance, passed to the first instance to take appropriate action.
-    /// </param>
-    private static async Task SignalFirstInstance(string channelName)
-    {
-        // Create a client pipe connected to server
-        using (NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", channelName, PipeDirection.Out))
+        /// <summary>
+        /// Creates a client pipe and sends a signal to server to launch first instance
+        /// </summary>
+        /// <param name="channelName">Application's IPC channel name.</param>
+        /// <param name="args">
+        /// Command line arguments for the second instance, passed to the first instance to take appropriate action.
+        /// </param>
+        private static async Task SignalFirstInstance(string channelName)
         {
-            // Connect to the available pipe
-            await pipeClient.ConnectAsync(0);
-        }
-    }
-
-    /// <summary>
-    /// Callback for activating first instance of the application.
-    /// </summary>
-    /// <param name="arg">Callback argument.</param>
-    /// <returns>Always null.</returns>
-    private static object ActivateFirstInstanceCallback(object o)
-    {
-        ActivateFirstInstance();
-        return null;
-    }
-
-    /// <summary>
-    /// Activates the first instance of the application with arguments from a second instance.
-    /// </summary>
-    /// <param name="args">List of arguments to supply the first instance of the application.</param>
-    private static void ActivateFirstInstance()
-    {
-        // Set main window state and process command line args
-        if (Application.Current == null)
-        {
-            return;
+            // Create a client pipe connected to server
+            using (NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", channelName, PipeDirection.Out))
+            {
+                // Connect to the available pipe
+                await pipeClient.ConnectAsync(0);
+            }
         }
 
-        ((TApplication)Application.Current).OnSecondAppStarted();
-    }
+        /// <summary>
+        /// Callback for activating first instance of the application.
+        /// </summary>
+        /// <param name="arg">Callback argument.</param>
+        /// <returns>Always null.</returns>
+        private static object ActivateFirstInstanceCallback(object o)
+        {
+            ActivateFirstInstance();
+            return null;
+        }
 
-    #endregion
+        /// <summary>
+        /// Activates the first instance of the application with arguments from a second instance.
+        /// </summary>
+        /// <param name="args">List of arguments to supply the first instance of the application.</param>
+        private static void ActivateFirstInstance()
+        {
+            // Set main window state and process command line args
+            if (Application.Current == null)
+            {
+                return;
+            }
+
+            ((TApplication)Application.Current).OnSecondAppStarted();
+        }
+
+        #endregion
+    }
 }

--- a/Flow.Launcher/Helper/SingleInstance.cs
+++ b/Flow.Launcher/Helper/SingleInstance.cs
@@ -293,10 +293,8 @@ public static class SingleInstance<TApplication>
             {
                 try
                 {
-                    using (TextReader reader = new StreamReader(cmdLinePath, Encoding.Unicode))
-                    {
-                        args = NativeMethods.CommandLineToArgvW(reader.ReadToEnd());
-                    }
+                    using TextReader reader = new StreamReader(cmdLinePath, Encoding.Unicode);
+                    args = NativeMethods.CommandLineToArgvW(reader.ReadToEnd());
 
                     File.Delete(cmdLinePath);
                 }

--- a/Flow.Launcher/Helper/SingletonWindowOpener.cs
+++ b/Flow.Launcher/Helper/SingletonWindowOpener.cs
@@ -2,27 +2,26 @@
 using System.Linq;
 using System.Windows;
 
-namespace Flow.Launcher.Helper
-{
-    public static class SingletonWindowOpener
-    {
-        public static T Open<T>(params object[] args) where T : Window
-        {
-            var window = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.GetType() == typeof(T))
-                         ?? (T)Activator.CreateInstance(typeof(T), args);
-            
-            // Fix UI bug
-            // Add `window.WindowState = WindowState.Normal`
-            // If only use `window.Show()`, Settings-window doesn't show when minimized in taskbar 
-            // Not sure why this works tho
-            // Probably because, when `.Show()` fails, `window.WindowState == Minimized` (not `Normal`) 
-            // https://stackoverflow.com/a/59719760/4230390
-            window.WindowState = WindowState.Normal; 
-            window.Show();
-            
-            window.Focus();
+namespace Flow.Launcher.Helper;
 
-            return (T)window;
-        }
+public static class SingletonWindowOpener
+{
+    public static T Open<T>(params object[] args) where T : Window
+    {
+        var window = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.GetType() == typeof(T))
+                     ?? (T)Activator.CreateInstance(typeof(T), args);
+            
+        // Fix UI bug
+        // Add `window.WindowState = WindowState.Normal`
+        // If only use `window.Show()`, Settings-window doesn't show when minimized in taskbar 
+        // Not sure why this works tho
+        // Probably because, when `.Show()` fails, `window.WindowState == Minimized` (not `Normal`) 
+        // https://stackoverflow.com/a/59719760/4230390
+        window.WindowState = WindowState.Normal; 
+        window.Show();
+            
+        window.Focus();
+
+        return (T)window;
     }
 }

--- a/Flow.Launcher/Helper/SyntaxSugars.cs
+++ b/Flow.Launcher/Helper/SyntaxSugars.cs
@@ -1,24 +1,23 @@
 ﻿using System;
 
-namespace Flow.Launcher.Helper
-{
-    public static class SyntaxSugars
-    {
-        public static TResult CallOrRescueDefault<TResult>(Func<TResult> callback)
-        {
-            return CallOrRescueDefault(callback, default(TResult));
-        }
+namespace Flow.Launcher.Helper;
 
-        public static TResult CallOrRescueDefault<TResult>(Func<TResult> callback, TResult def)
+public static class SyntaxSugars
+{
+    public static TResult CallOrRescueDefault<TResult>(Func<TResult> callback)
+    {
+        return CallOrRescueDefault(callback, default(TResult));
+    }
+
+    public static TResult CallOrRescueDefault<TResult>(Func<TResult> callback, TResult def)
+    {
+        try
         {
-            try
-            {
-                return callback();
-            }
-            catch
-            {
-                return def;
-            }
+            return callback();
+        }
+        catch
+        {
+            return def;
         }
     }
 }

--- a/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
+++ b/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
@@ -5,44 +5,43 @@ using System.Text;
 using System.Windows.Media;
 using Microsoft.Win32;
 
-namespace Flow.Launcher.Helper
+namespace Flow.Launcher.Helper;
+
+public static class WallpaperPathRetrieval
 {
-    public static class WallpaperPathRetrieval
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern Int32 SystemParametersInfo(UInt32 action,
+        Int32 uParam, StringBuilder vParam, UInt32 winIni);
+    private static readonly UInt32 SPI_GETDESKWALLPAPER = 0x73;
+    private static int MAX_PATH = 260;
+
+    public static string GetWallpaperPath()
     {
-        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
-        private static extern Int32 SystemParametersInfo(UInt32 action,
-            Int32 uParam, StringBuilder vParam, UInt32 winIni);
-        private static readonly UInt32 SPI_GETDESKWALLPAPER = 0x73;
-        private static int MAX_PATH = 260;
+        var wallpaper = new StringBuilder(MAX_PATH);
+        SystemParametersInfo(SPI_GETDESKWALLPAPER, MAX_PATH, wallpaper, 0);
 
-        public static string GetWallpaperPath()
+        var str = wallpaper.ToString();
+        if (string.IsNullOrEmpty(str))
+            return null;
+
+        return str;
+    }
+
+    public static Color GetWallpaperColor()
+    {
+        RegistryKey key = Registry.CurrentUser.OpenSubKey(@"Control Panel\Colors", true);
+        var result = key?.GetValue("Background", null);
+        if (result is string strResult)
         {
-            var wallpaper = new StringBuilder(MAX_PATH);
-            SystemParametersInfo(SPI_GETDESKWALLPAPER, MAX_PATH, wallpaper, 0);
-
-            var str = wallpaper.ToString();
-            if (string.IsNullOrEmpty(str))
-                return null;
-
-            return str;
-        }
-
-        public static Color GetWallpaperColor()
-        {
-            RegistryKey key = Registry.CurrentUser.OpenSubKey("Control Panel\\Colors", true);
-            var result = key.GetValue(@"Background", null);
-            if (result != null && result is string)
+            try
             {
-                try
-                {
-                    var parts = result.ToString().Trim().Split(new[] {' '}, 3).Select(byte.Parse).ToList();
-                    return Color.FromRgb(parts[0], parts[1], parts[2]);
-                }
-                catch
-                {
-                }
+                var parts = strResult.Trim().Split(new[] {' '}, 3).Select(byte.Parse).ToList();
+                return Color.FromRgb(parts[0], parts[1], parts[2]);
             }
-            return Colors.Transparent;
+            catch
+            {
+            }
         }
+        return Colors.Transparent;
     }
 }

--- a/Flow.Launcher/Helper/WindowsInteropHelper.cs
+++ b/Flow.Launcher/Helper/WindowsInteropHelper.cs
@@ -8,156 +8,152 @@ using System.Windows.Interop;
 using System.Windows.Media;
 using Point = System.Windows.Point;
 
-namespace Flow.Launcher.Helper
+namespace Flow.Launcher.Helper;
+
+public class WindowsInteropHelper
 {
-    public class WindowsInteropHelper
+    private const int GWL_STYLE = -16; //WPF's Message code for Title Bar's Style
+    private const int WS_SYSMENU = 0x80000; //WPF's Message code for System Menu
+    private static IntPtr _hwnd_shell;
+    private static IntPtr _hwnd_desktop;
+
+    //Accessors for shell and desktop handlers
+    //Will set the variables once and then will return them
+    private static IntPtr HWND_SHELL
     {
-        private const int GWL_STYLE = -16; //WPF's Message code for Title Bar's Style 
-        private const int WS_SYSMENU = 0x80000; //WPF's Message code for System Menu
-        private static IntPtr _hwnd_shell;
-        private static IntPtr _hwnd_desktop;
-
-        //Accessors for shell and desktop handlers
-        //Will set the variables once and then will return them
-        private static IntPtr HWND_SHELL
+        get
         {
-            get
-            {
-                return _hwnd_shell != IntPtr.Zero ? _hwnd_shell : _hwnd_shell = GetShellWindow();
-            }
+            return _hwnd_shell != IntPtr.Zero ? _hwnd_shell : _hwnd_shell = GetShellWindow();
         }
-        private static IntPtr HWND_DESKTOP
+    }
+    private static IntPtr HWND_DESKTOP
+    {
+        get
         {
-            get
-            {
-                return _hwnd_desktop != IntPtr.Zero ? _hwnd_desktop : _hwnd_desktop = GetDesktopWindow();
-            }
+            return _hwnd_desktop != IntPtr.Zero ? _hwnd_desktop : _hwnd_desktop = GetDesktopWindow();
         }
+    }
 
-        [DllImport("user32.dll", SetLastError = true)]
-        internal static extern int GetWindowLong(IntPtr hWnd, int nIndex);
-        
-        [DllImport("user32.dll")]
-        internal static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+    [DllImport("user32.dll", SetLastError = true)]
+    internal static extern int GetWindowLong(IntPtr hWnd, int nIndex);
 
-        [DllImport("user32.dll")]
-        internal static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")]
+    internal static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
 
-        [DllImport("user32.dll")]
-        internal static extern IntPtr GetDesktopWindow();
+    [DllImport("user32.dll")]
+    internal static extern IntPtr GetForegroundWindow();
 
-        [DllImport("user32.dll")]
-        internal static extern IntPtr GetShellWindow();
+    [DllImport("user32.dll")]
+    internal static extern IntPtr GetDesktopWindow();
 
-        [DllImport("user32.dll", SetLastError = true)]
-        internal static extern int GetWindowRect(IntPtr hwnd, out RECT rc);
+    [DllImport("user32.dll")]
+    internal static extern IntPtr GetShellWindow();
 
-        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        internal static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+    [DllImport("user32.dll", SetLastError = true)]
+    internal static extern int GetWindowRect(IntPtr hwnd, out RECT rc);
 
-        [DllImport("user32.DLL")]
-        public static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter, string lpszClass, string lpszWindow);
+    [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    internal static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+    [DllImport("user32.DLL")]
+    public static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter, string lpszClass, string lpszWindow);
 
 
-        const string WINDOW_CLASS_CONSOLE = "ConsoleWindowClass";
-        const string WINDOW_CLASS_WINTAB = "Flip3D";
-        const string WINDOW_CLASS_PROGMAN = "Progman";
-        const string WINDOW_CLASS_WORKERW = "WorkerW";
+    const string WINDOW_CLASS_CONSOLE = "ConsoleWindowClass";
+    const string WINDOW_CLASS_WINTAB = "Flip3D";
+    const string WINDOW_CLASS_PROGMAN = "Progman";
+    const string WINDOW_CLASS_WORKERW = "WorkerW";
 
-        public static bool IsWindowFullscreen()
+    public static bool IsWindowFullscreen()
+    {
+        //get current active window
+        IntPtr hWnd = GetForegroundWindow();
+
+        if (hWnd.Equals(IntPtr.Zero))
         {
-            //get current active window
-            IntPtr hWnd = GetForegroundWindow();
-
-            if (!hWnd.Equals(IntPtr.Zero))
-            {
-                //if current active window is NOT desktop or shell
-                if (!(hWnd.Equals(HWND_DESKTOP) || hWnd.Equals(HWND_SHELL)))
-                {
-                    StringBuilder sb = new StringBuilder(256);
-                    GetClassName(hWnd, sb, sb.Capacity);
-                    string windowClass = sb.ToString();
-
-                    //for Win+Tab (Flip3D)
-                    if (windowClass == WINDOW_CLASS_WINTAB)
-                    {
-                        return false;
-                    }
-
-                    RECT appBounds;
-                    GetWindowRect(hWnd, out appBounds);
-
-                    //for console (ConsoleWindowClass), we have to check for negative dimensions
-                    if (windowClass == WINDOW_CLASS_CONSOLE)
-                    {
-                        return appBounds.Top < 0 && appBounds.Bottom < 0;
-                    }
-
-                    //for desktop (Progman or WorkerW, depends on the system), we have to check 
-                    if (windowClass == WINDOW_CLASS_PROGMAN || windowClass == WINDOW_CLASS_WORKERW)
-                    {
-                        IntPtr hWndDesktop = FindWindowEx(hWnd, IntPtr.Zero, "SHELLDLL_DefView", null);
-                        hWndDesktop = FindWindowEx(hWndDesktop, IntPtr.Zero, "SysListView32", "FolderView");
-                        if (!hWndDesktop.Equals(IntPtr.Zero))
-                        {
-                            return false;
-                        }
-                    }
-
-                    Rectangle screenBounds = Screen.FromHandle(hWnd).Bounds;
-                    if ((appBounds.Bottom - appBounds.Top) == screenBounds.Height && (appBounds.Right - appBounds.Left) == screenBounds.Width)
-                    {
-                        return true;
-                    }
-                }
-            }
-
             return false;
         }
 
-        /// <summary>
-        ///     disable windows toolbar's control box
-        ///     this will also disable system menu with Alt+Space hotkey
-        /// </summary>
-        public static void DisableControlBox(Window win)
+        //if current active window is desktop or shell, exit early
+        if (hWnd.Equals(HWND_DESKTOP) || hWnd.Equals(HWND_SHELL))
         {
-            var hwnd = new WindowInteropHelper(win).Handle;
-            SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) & ~WS_SYSMENU);
+            return false;
         }
 
-        /// <summary>
-        /// Transforms pixels to Device Independent Pixels used by WPF
-        /// </summary>
-        /// <param name="visual">current window, required to get presentation source</param>
-        /// <param name="unitX">horizontal position in pixels</param>
-        /// <param name="unitY">vertical position in pixels</param>
-        /// <returns>point containing device independent pixels</returns>
-        public static Point TransformPixelsToDIP(Visual visual, double unitX, double unitY)
+        StringBuilder sb = new StringBuilder(256);
+        GetClassName(hWnd, sb, sb.Capacity);
+        string windowClass = sb.ToString();
+
+        //for Win+Tab (Flip3D)
+        if (windowClass == WINDOW_CLASS_WINTAB)
         {
-            Matrix matrix;
-            var source = PresentationSource.FromVisual(visual);
-            if (source != null)
+            return false;
+        }
+
+        RECT appBounds;
+        GetWindowRect(hWnd, out appBounds);
+
+        //for console (ConsoleWindowClass), we have to check for negative dimensions
+        if (windowClass == WINDOW_CLASS_CONSOLE)
+        {
+            return appBounds.Top < 0 && appBounds.Bottom < 0;
+        }
+
+        //for desktop (Progman or WorkerW, depends on the system), we have to check
+        if (windowClass is WINDOW_CLASS_PROGMAN or WINDOW_CLASS_WORKERW)
+        {
+            IntPtr hWndDesktop = FindWindowEx(hWnd, IntPtr.Zero, "SHELLDLL_DefView", null);
+            hWndDesktop = FindWindowEx(hWndDesktop, IntPtr.Zero, "SysListView32", "FolderView");
+            if (!hWndDesktop.Equals(IntPtr.Zero))
             {
-                matrix = source.CompositionTarget.TransformFromDevice;
+                return false;
             }
-            else
-            {
-                using (var src = new HwndSource(new HwndSourceParameters()))
-                {
-                    matrix = src.CompositionTarget.TransformFromDevice;
-                }
-            }
-            return new Point((int)(matrix.M11 * unitX), (int)(matrix.M22 * unitY));
         }
 
+        Rectangle screenBounds = Screen.FromHandle(hWnd).Bounds;
+        return (appBounds.Bottom - appBounds.Top) == screenBounds.Height && (appBounds.Right - appBounds.Left) == screenBounds.Width;
+    }
 
-        [StructLayout(LayoutKind.Sequential)]
-        public struct RECT
+    /// <summary>
+    ///     disable windows toolbar's control box
+    ///     this will also disable system menu with Alt+Space hotkey
+    /// </summary>
+    public static void DisableControlBox(Window win)
+    {
+        var hwnd = new WindowInteropHelper(win).Handle;
+        SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) & ~WS_SYSMENU);
+    }
+
+    /// <summary>
+    /// Transforms pixels to Device Independent Pixels used by WPF
+    /// </summary>
+    /// <param name="visual">current window, required to get presentation source</param>
+    /// <param name="unitX">horizontal position in pixels</param>
+    /// <param name="unitY">vertical position in pixels</param>
+    /// <returns>point containing device independent pixels</returns>
+    public static Point TransformPixelsToDIP(Visual visual, double unitX, double unitY)
+    {
+        Matrix matrix;
+        var source = PresentationSource.FromVisual(visual);
+        if (source is not null)
         {
-            public int Left;
-            public int Top;
-            public int Right;
-            public int Bottom;
+            matrix = source.CompositionTarget.TransformFromDevice;
         }
+        else
+        {
+            using var src = new HwndSource(new HwndSourceParameters());
+            matrix = src.CompositionTarget.TransformFromDevice;
+        }
+        return new Point((int)(matrix.M11 * unitX), (int)(matrix.M22 * unitY));
+    }
+
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
     }
 }


### PR DESCRIPTION
- Switch from block-scoped namespaces to file-scoped
- Reduce nesting by early exiting functions
- Replace `using` block with `using` declaration
- Rename a few private variables for consistency

GitHub's diff viewer behaves weirdly on this one, so I'd recommend reviewing it in an IDE. I don't know about Visual Studio, but in Rider it looks fine.