### PR TITLE
Use Shell Execute for Shell Plugin RunCommand

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -264,6 +264,7 @@ namespace Flow.Launcher.Plugin.Shell
                             var arguments = parts[1];
                             info.FileName = filename;
                             info.ArgumentList.Add(arguments);
+                            info.UseShellExecute = true;
                         }
                         else
                         {


### PR DESCRIPTION
it would not behavior like win+r without this.

try `shell:startup`