### PR TITLE
Support Screen Reader

### DIFF
--- a/Flow.Launcher.Infrastructure/Constant.cs
+++ b/Flow.Launcher.Infrastructure/Constant.cs
@@ -7,6 +7,7 @@ namespace Flow.Launcher.Infrastructure
     public static class Constant
     {
         public const string FlowLauncher = "Flow.Launcher";
+        public const string FlowLauncherFullName = "Flow Launcher";
         public const string Plugins = "Plugins";
         public const string PluginMetadataFileName = "plugin.json";
 

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -188,8 +188,8 @@
             Modifiers="Ctrl" />
         <KeyBinding
             Key="C"
-            Modifiers="Ctrl+Shift"
-            Command="{Binding CopyAlternativeCommand}" />
+            Command="{Binding CopyAlternativeCommand}"
+            Modifiers="Ctrl+Shift" />
         <KeyBinding
             Key="{Binding PreviewHotkey, Converter={StaticResource StringToKeyBindingConverter}, ConverterParameter='key'}"
             Command="{Binding TogglePreviewCommand}"
@@ -216,6 +216,7 @@
                             <TextBox
                                 x:Name="QueryTextBox"
                                 AllowDrop="True"
+                                AutomationProperties.Name="{Binding Results.SelectedItem.Result.Title}"
                                 InputMethod.PreferredImeConversionMode="{Binding StartWithEnglishMode, Converter={StaticResource BoolToIMEConversionModeConverter}}"
                                 InputMethod.PreferredImeState="{Binding StartWithEnglishMode, Converter={StaticResource BoolToIMEStateConverter}}"
                                 PreviewDragOver="OnPreviewDragOver"

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -280,7 +280,6 @@ namespace Flow.Launcher
                 Visible = !_settings.HideNotifyIcon
             };
 
-            //var contextMenu = contextMenu;
 
             var openIcon = new FontIcon
             {

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -43,7 +43,7 @@ namespace Flow.Launcher
         private bool isProgressBarStoryboardPaused;
         private Settings _settings;
         private NotifyIcon _notifyIcon;
-        private ContextMenuStrip contextMenu;
+        private ContextMenu contextMenu = new ContextMenu();
         private MainViewModel _viewModel;
         private bool _animating;
         MediaPlayer animationSound = new MediaPlayer();
@@ -263,11 +263,11 @@ namespace Flow.Launcher
         private void UpdateNotifyIconText()
         {
             var menu = contextMenu;
-            //((MenuItem)menu.Items[0]).Header = InternationalizationManager.Instance.GetTranslation("iconTrayOpen") + " (" + _settings.Hotkey + ")";
-            //((MenuItem)menu.Items[1]).Header = InternationalizationManager.Instance.GetTranslation("GameMode");
-            //((MenuItem)menu.Items[2]).Header = InternationalizationManager.Instance.GetTranslation("PositionReset");
-            //((MenuItem)menu.Items[3]).Header = InternationalizationManager.Instance.GetTranslation("iconTraySettings");
-            //((MenuItem)menu.Items[4]).Header = InternationalizationManager.Instance.GetTranslation("iconTrayExit");
+            ((MenuItem)menu.Items[0]).Header = InternationalizationManager.Instance.GetTranslation("iconTrayOpen") + " (" + _settings.Hotkey + ")";
+            ((MenuItem)menu.Items[1]).Header = InternationalizationManager.Instance.GetTranslation("GameMode");
+            ((MenuItem)menu.Items[2]).Header = InternationalizationManager.Instance.GetTranslation("PositionReset");
+            ((MenuItem)menu.Items[3]).Header = InternationalizationManager.Instance.GetTranslation("iconTraySettings");
+            ((MenuItem)menu.Items[4]).Header = InternationalizationManager.Instance.GetTranslation("iconTrayExit");
 
         }
 
@@ -280,7 +280,7 @@ namespace Flow.Launcher
                 Visible = !_settings.HideNotifyIcon
             };
 
-            var contextMenu = new ContextMenu();
+            //var contextMenu = contextMenu;
 
             var openIcon = new FontIcon
             {

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -27,6 +27,8 @@ using System.Media;
 using static Flow.Launcher.ViewModel.SettingWindowViewModel;
 using DataObject = System.Windows.DataObject;
 using System.Windows.Media;
+using System.Windows.Interop;
+using System.Runtime.InteropServices;
 
 namespace Flow.Launcher
 {
@@ -34,11 +36,14 @@ namespace Flow.Launcher
     {
         #region Private Fields
 
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern IntPtr SetForegroundWindow(IntPtr hwnd);
+
         private readonly Storyboard _progressBarStoryboard = new Storyboard();
         private bool isProgressBarStoryboardPaused;
         private Settings _settings;
         private NotifyIcon _notifyIcon;
-        private ContextMenu contextMenu;
+        private ContextMenuStrip contextMenu;
         private MainViewModel _viewModel;
         private bool _animating;
         MediaPlayer animationSound = new MediaPlayer();
@@ -258,11 +263,11 @@ namespace Flow.Launcher
         private void UpdateNotifyIconText()
         {
             var menu = contextMenu;
-            ((MenuItem)menu.Items[0]).Header = InternationalizationManager.Instance.GetTranslation("iconTrayOpen") + " (" + _settings.Hotkey + ")";
-            ((MenuItem)menu.Items[1]).Header = InternationalizationManager.Instance.GetTranslation("GameMode");
-            ((MenuItem)menu.Items[2]).Header = InternationalizationManager.Instance.GetTranslation("PositionReset");
-            ((MenuItem)menu.Items[3]).Header = InternationalizationManager.Instance.GetTranslation("iconTraySettings");
-            ((MenuItem)menu.Items[4]).Header = InternationalizationManager.Instance.GetTranslation("iconTrayExit");
+            //((MenuItem)menu.Items[0]).Header = InternationalizationManager.Instance.GetTranslation("iconTrayOpen") + " (" + _settings.Hotkey + ")";
+            //((MenuItem)menu.Items[1]).Header = InternationalizationManager.Instance.GetTranslation("GameMode");
+            //((MenuItem)menu.Items[2]).Header = InternationalizationManager.Instance.GetTranslation("PositionReset");
+            //((MenuItem)menu.Items[3]).Header = InternationalizationManager.Instance.GetTranslation("iconTraySettings");
+            //((MenuItem)menu.Items[4]).Header = InternationalizationManager.Instance.GetTranslation("iconTrayExit");
 
         }
 
@@ -270,12 +275,12 @@ namespace Flow.Launcher
         {
             _notifyIcon = new NotifyIcon
             {
-                Text = Infrastructure.Constant.FlowLauncher,
+                Text = Infrastructure.Constant.FlowLauncherFullName,
                 Icon = Properties.Resources.app,
                 Visible = !_settings.HideNotifyIcon
             };
 
-            contextMenu = new ContextMenu();
+            var contextMenu = new ContextMenu();
 
             var openIcon = new FontIcon
             {
@@ -283,7 +288,8 @@ namespace Flow.Launcher
             };
             var open = new MenuItem
             {
-                Header = InternationalizationManager.Instance.GetTranslation("iconTrayOpen") + " (" + _settings.Hotkey + ")", Icon = openIcon
+                Header = InternationalizationManager.Instance.GetTranslation("iconTrayOpen") + " (" + _settings.Hotkey + ")",
+                Icon = openIcon
             };
             var gamemodeIcon = new FontIcon
             {
@@ -291,7 +297,8 @@ namespace Flow.Launcher
             };
             var gamemode = new MenuItem
             {
-                Header = InternationalizationManager.Instance.GetTranslation("GameMode"), Icon = gamemodeIcon
+                Header = InternationalizationManager.Instance.GetTranslation("GameMode"),
+                Icon = gamemodeIcon
             };
             var positionresetIcon = new FontIcon
             {
@@ -299,7 +306,8 @@ namespace Flow.Launcher
             };
             var positionreset = new MenuItem
             {
-                Header = InternationalizationManager.Instance.GetTranslation("PositionReset"), Icon = positionresetIcon
+                Header = InternationalizationManager.Instance.GetTranslation("PositionReset"),
+                Icon = positionresetIcon
             };
             var settingsIcon = new FontIcon
             {
@@ -307,7 +315,8 @@ namespace Flow.Launcher
             };
             var settings = new MenuItem
             {
-                Header = InternationalizationManager.Instance.GetTranslation("iconTraySettings"), Icon = settingsIcon
+                Header = InternationalizationManager.Instance.GetTranslation("iconTraySettings"),
+                Icon = settingsIcon
             };
             var exitIcon = new FontIcon
             {
@@ -315,7 +324,8 @@ namespace Flow.Launcher
             };
             var exit = new MenuItem
             {
-                Header = InternationalizationManager.Instance.GetTranslation("iconTrayExit"), Icon = exitIcon
+                Header = InternationalizationManager.Instance.GetTranslation("iconTrayExit"),
+                Icon = exitIcon
             };
 
             open.Click += (o, e) => _viewModel.ToggleFlowLauncher();
@@ -333,7 +343,6 @@ namespace Flow.Launcher
             contextMenu.Items.Add(settings);
             contextMenu.Items.Add(exit);
 
-            _notifyIcon.ContextMenuStrip = new ContextMenuStrip(); // it need for close the context menu. if not, context menu can't close. 
             _notifyIcon.MouseClick += (o, e) =>
             {
                 switch (e.Button)
@@ -341,9 +350,15 @@ namespace Flow.Launcher
                     case MouseButtons.Left:
                         _viewModel.ToggleFlowLauncher();
                         break;
-
                     case MouseButtons.Right:
+
                         contextMenu.IsOpen = true;
+                        // Get context menu handle and bring it to the foreground
+                        if (PresentationSource.FromVisual(contextMenu) is HwndSource hwndSource)
+                        {
+                            _ = SetForegroundWindow(hwndSource.Handle);
+                        }
+                        contextMenu.Focus();
                         break;
                 }
             };

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -67,6 +67,20 @@
                 </Setter.Value>
             </Setter>
         </Style>
+        <Style x:Key="SwitchFocusVisualStyleKey">
+            <Setter Property="Control.Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Rectangle
+                            Margin="-8,-4,-8,-4"
+                            RadiusX="5"
+                            RadiusY="5"
+                            Stroke="{DynamicResource Color05B}"
+                            StrokeThickness="2" />
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
         <Style x:Key="SettingGrid" TargetType="ItemsControl">
             <Setter Property="Focusable" Value="False" />
             <Setter Property="Margin" Value="0" />
@@ -137,6 +151,7 @@
             <Setter Property="Grid.Column" Value="2" />
             <Setter Property="FocusVisualMargin" Value="5" />
             <Setter Property="Width" Value="Auto" />
+            <Setter Property="FocusVisualStyle" Value="{DynamicResource SwitchFocusVisualStyleKey}" />
             <Setter Property="HorizontalAlignment" Value="Right" />
             <Setter Property="HorizontalContentAlignment" Value="Right" />
             <Setter Property="OffContent" Value="{DynamicResource disable}" />
@@ -447,7 +462,10 @@
                                 IsItemsHost="true"
                                 LastChildFill="False" />
                             <Border Grid.Column="1">
-                                <ContentPresenter Grid.Column="1" ContentSource="SelectedContent" />
+                                <ContentPresenter
+                                    x:Name="PART_SelectedContentHost"
+                                    Grid.Column="1"
+                                    ContentSource="SelectedContent" />
                             </Border>
                         </Grid>
                     </ControlTemplate>
@@ -693,7 +711,7 @@
                                 </ItemsControl>
                             </Border>
 
-                            <Border 
+                            <Border
                                 Margin="0,30,0,0"
                                 Padding="0"
                                 Style="{DynamicResource SettingGroupBox}">
@@ -720,7 +738,7 @@
                                                 <ComboBox
                                                     x:Name="SelectScreen"
                                                     MinWidth="160"
-                                                    Margin="0,0,18,0" 
+                                                    Margin="0,0,18,0"
                                                     VerticalAlignment="Center"
                                                     FontSize="14"
                                                     ItemsSource="{Binding ScreenNumbers}"
@@ -738,14 +756,12 @@
                                                 </ComboBox>
                                             </StackPanel>
                                             <TextBlock Style="{StaticResource Glyph}">
-                                            &#xe7f4;
+                                                &#xe7f4;
                                             </TextBlock>
                                         </ItemsControl>
                                     </Border>
 
-                                    <Separator
-                                        Width="Auto"
-                                        BorderThickness="1">
+                                    <Separator Width="Auto" BorderThickness="1">
                                         <Separator.Style>
                                             <Style BasedOn="{StaticResource SettingSeparatorStyle}" TargetType="Separator">
                                                 <Setter Property="Visibility" Value="Visible" />
@@ -758,9 +774,7 @@
                                         </Separator.Style>
                                     </Separator>
 
-                                    <Border
-                                        Margin="0"
-                                        BorderThickness="0">
+                                    <Border Margin="0" BorderThickness="0">
                                         <Border.Style>
                                             <Style BasedOn="{StaticResource SettingGroupBox}" TargetType="Border">
                                                 <Setter Property="Visibility" Value="Visible" />
@@ -786,8 +800,7 @@
                                                     FontSize="14"
                                                     ItemsSource="{Binding SearchWindowAligns}"
                                                     SelectedValue="{Binding Settings.SearchWindowAlign}"
-                                                    SelectedValuePath="Value">
-                                                </ComboBox>
+                                                    SelectedValuePath="Value" />
                                                 <StackPanel Margin="0,0,18,0" Orientation="Horizontal">
                                                     <StackPanel.Style>
                                                         <Style TargetType="StackPanel">
@@ -817,7 +830,7 @@
                                                 </StackPanel>
                                             </StackPanel>
                                             <TextBlock Style="{StaticResource Glyph}">
-                                            &#xe7f4;
+                                                &#xe7f4;
                                             </TextBlock>
                                         </ItemsControl>
                                     </Border>
@@ -2446,8 +2459,7 @@
                                                                 FontSize="14"
                                                                 ItemsSource="{Binding AnimationSpeeds}"
                                                                 SelectedValue="{Binding Settings.AnimationSpeed}"
-                                                                SelectedValuePath="Value">
-                                                            </ComboBox>
+                                                                SelectedValuePath="Value" />
                                                             <StackPanel Margin="0,0,18,0" Orientation="Horizontal">
                                                                 <StackPanel.Style>
                                                                     <Style TargetType="StackPanel">
@@ -2543,7 +2555,7 @@
                                                                 TickFrequency="1"
                                                                 Value="{Binding SoundEffectVolume, Mode=TwoWay}" />
                                                         </StackPanel>
-                                                        <TextBlock Style="{StaticResource Glyph}"> 
+                                                        <TextBlock Style="{StaticResource Glyph}">
                                                             &#xe994;
                                                         </TextBlock>
                                                     </ItemsControl>


### PR DESCRIPTION
## What's the PR
- Resolve https://github.com/Flow-Launcher/Flow.Launcher/issues/1919
- You can enter the TrayMenu from the keyboard.
- Changed Toggle Switch to be selectable with keyboard navigation.
- The title of the selected result item is screen-readable.
- This is a basic change, and we can use this as a reference to work with in the future.

## Test Case
- [x] You should be able to open and select the tray context menu with just the keyboard.
  - WIN+B -> Move to Flow Launcher Tray Icon -> Press the Context Key in Keboard -> Arrow or Tab
- Read the title of the resulting item in a screen reader (NVDA).

## Comment 
- This requires a lot of additional work, which we will continue to work on later.
  - Add screen reader properties to each setting item
  - Make context menu items readable
  - Allows settings to be set for what to read (including subtitle).