### PR TITLE
Change shellexecute for command without argument

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -264,7 +264,6 @@ namespace Flow.Launcher.Plugin.Shell
                             var arguments = parts[1];
                             info.FileName = filename;
                             info.ArgumentList.Add(arguments);
-                            info.UseShellExecute = true;
                         }
                         else
                         {
@@ -275,6 +274,8 @@ namespace Flow.Launcher.Plugin.Shell
                     {
                         info.FileName = command;
                     }
+
+                    info.UseShellExecute = true;
 
                     break;
                 }


### PR DESCRIPTION
Previous pr only change the behavior for a command with argument. This pr fixes it.