### PR TITLE
Handle duplicate hotkeys in HotkeyControlDialog

### DIFF
--- a/Flow.Launcher.Infrastructure/Hotkey/IHotkeySettings.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/IHotkeySettings.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+
+namespace Flow.Launcher.Infrastructure.Hotkey;
+
+public interface IHotkeySettings
+{
+    public List<RegisteredHotkeyData> RegisteredHotkeys { get; }
+}

--- a/Flow.Launcher.Infrastructure/Hotkey/IHotkeySettings.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/IHotkeySettings.cs
@@ -2,7 +2,16 @@
 
 namespace Flow.Launcher.Infrastructure.Hotkey;
 
+/// <summary>
+/// Interface that you should implement in your settings class to be able to pass it to
+/// <c>Flow.Launcher.HotkeyControlDialog</c>. It allows the dialog to display the hotkeys that have already been
+/// registered, and optionally provide a way to unregister them.
+/// </summary>
 public interface IHotkeySettings
 {
+    /// <summary>
+    /// A list of hotkeys that have already been registered. The dialog will display these hotkeys and provide a way to
+    /// unregister them.
+    /// </summary>
     public List<RegisteredHotkeyData> RegisteredHotkeys { get; }
 }

--- a/Flow.Launcher.Infrastructure/Hotkey/RegisteredHotkeyData.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/RegisteredHotkeyData.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Flow.Launcher.Infrastructure.Hotkey;
+
+#nullable enable
+
+public record RegisteredHotkeyData
+{
+    public HotkeyModel Hotkey { get; }
+    public string Description { get; }
+    public Action? RemoveHotkey { get; }
+
+    public RegisteredHotkeyData(string hotkey, string description, Action? removeHotkey = null)
+    {
+        Hotkey = new HotkeyModel(hotkey);
+        Description = description;
+        RemoveHotkey = removeHotkey;
+    }
+}

--- a/Flow.Launcher.Infrastructure/Hotkey/RegisteredHotkeyData.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/RegisteredHotkeyData.cs
@@ -4,16 +4,116 @@ namespace Flow.Launcher.Infrastructure.Hotkey;
 
 #nullable enable
 
+/// <summary>
+/// Represents a hotkey that has been registered. Used in <c>Flow.Launcher.HotkeyControlDialog</c> via
+/// <see cref="UserSettings"/> and <see cref="IHotkeySettings"/> to display errors if user tries to register a hotkey
+/// that has already been registered, and optionally provides a way to unregister the hotkey.
+/// </summary>
 public record RegisteredHotkeyData
 {
+    /// <summary>
+    /// <see cref="HotkeyModel"/> representation of this hotkey.
+    /// </summary>
     public HotkeyModel Hotkey { get; }
-    public string Description { get; }
+
+    /// <summary>
+    /// String key in the localization dictionary that represents this hotkey. For example, <c>ReloadPluginHotkey</c>,
+    /// which represents the string "Reload Plugins Data" in <c>en.xaml</c>
+    /// </summary>
+    public string DescriptionResourceKey { get; }
+
+    /// <summary>
+    /// Array of values that will replace <c>{0}</c>, <c>{1}</c>, <c>{2}</c>, etc. in the localized string found via
+    /// <see cref="DescriptionResourceKey"/>.
+    /// </summary>
+    public object?[] DescriptionFormatVariables { get; } = Array.Empty<object?>();
+
+    /// <summary>
+    /// An action that, when called, will unregister this hotkey. If it's <c>null</c>, it's assumed that
+    /// this hotkey can't be unregistered, and the "Overwrite" option will not appear in the hotkey dialog.
+    /// </summary>
     public Action? RemoveHotkey { get; }
 
-    public RegisteredHotkeyData(string hotkey, string description, Action? removeHotkey = null)
+    /// <summary>
+    /// Creates an instance of <c>RegisteredHotkeyData</c>. Assumes that the key specified in
+    /// <c>descriptionResourceKey</c> doesn't need any arguments for <c>string.Format</c>. If it does,
+    /// use one of the other constructors.
+    /// </summary>
+    /// <param name="hotkey">
+    /// The hotkey this class will represent.
+    /// Example values: <c>F1</c>, <c>Ctrl+Shift+Enter</c>
+    /// </param>
+    /// <param name="descriptionResourceKey">
+    /// The key in the localization dictionary that represents this hotkey. For example, <c>ReloadPluginHotkey</c>,
+    /// which represents the string "Reload Plugins Data" in <c>en.xaml</c>
+    /// </param>
+    /// <param name="removeHotkey">
+    /// An action that, when called, will unregister this hotkey. If it's <c>null</c>, it's assumed that this hotkey
+    /// can't be unregistered, and the "Overwrite" option will not appear in the hotkey dialog.
+    /// </param>
+    public RegisteredHotkeyData(string hotkey, string descriptionResourceKey, Action? removeHotkey = null)
     {
         Hotkey = new HotkeyModel(hotkey);
-        Description = description;
+        DescriptionResourceKey = descriptionResourceKey;
+        RemoveHotkey = removeHotkey;
+    }
+
+    /// <summary>
+    /// Creates an instance of <c>RegisteredHotkeyData</c>. Assumes that the key specified in
+    /// <c>descriptionResourceKey</c> needs exactly one argument for <c>string.Format</c>.
+    /// </summary>
+    /// <param name="hotkey">
+    /// The hotkey this class will represent.
+    /// Example values: <c>F1</c>, <c>Ctrl+Shift+Enter</c>
+    /// </param>
+    /// <param name="descriptionResourceKey">
+    /// The key in the localization dictionary that represents this hotkey. For example, <c>ReloadPluginHotkey</c>,
+    /// which represents the string "Reload Plugins Data" in <c>en.xaml</c>
+    /// </param>
+    /// <param name="descriptionFormatVariable">
+    /// The value that will replace <c>{0}</c> in the localized string found via <c>description</c>.
+    /// </param>
+    /// <param name="removeHotkey">
+    /// An action that, when called, will unregister this hotkey. If it's <c>null</c>, it's assumed that this hotkey
+    /// can't be unregistered, and the "Overwrite" option will not appear in the hotkey dialog.
+    /// </param>
+    public RegisteredHotkeyData(
+        string hotkey, string descriptionResourceKey, object? descriptionFormatVariable, Action? removeHotkey = null
+    )
+    {
+        Hotkey = new HotkeyModel(hotkey);
+        DescriptionResourceKey = descriptionResourceKey;
+        DescriptionFormatVariables = new[] { descriptionFormatVariable };
+        RemoveHotkey = removeHotkey;
+    }
+
+    /// <summary>
+    /// Creates an instance of <c>RegisteredHotkeyData</c>. Assumes that the key specified in
+    /// <paramref name="descriptionResourceKey"/> needs multiple arguments for <c>string.Format</c>.
+    /// </summary>
+    /// <param name="hotkey">
+    /// The hotkey this class will represent.
+    /// Example values: <c>F1</c>, <c>Ctrl+Shift+Enter</c>
+    /// </param>
+    /// <param name="descriptionResourceKey">
+    /// The key in the localization dictionary that represents this hotkey. For example, <c>ReloadPluginHotkey</c>,
+    /// which represents the string "Reload Plugins Data" in <c>en.xaml</c>
+    /// </param>
+    /// <param name="descriptionFormatVariables">
+    /// Array of values that will replace <c>{0}</c>, <c>{1}</c>, <c>{2}</c>, etc.
+    /// in the localized string found via <c>description</c>.
+    /// </param>
+    /// <param name="removeHotkey">
+    /// An action that, when called, will unregister this hotkey. If it's <c>null</c>, it's assumed that this hotkey
+    /// can't be unregistered, and the "Overwrite" option will not appear in the hotkey dialog.
+    /// </param>
+    public RegisteredHotkeyData(
+        string hotkey, string descriptionResourceKey, object?[] descriptionFormatVariables, Action? removeHotkey = null
+    )
+    {
+        Hotkey = new HotkeyModel(hotkey);
+        DescriptionResourceKey = descriptionResourceKey;
+        DescriptionFormatVariables = descriptionFormatVariables;
         RemoveHotkey = removeHotkey;
     }
 }

--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -4,13 +4,14 @@ using System.Collections.ObjectModel;
 using System.Drawing;
 using System.Text.Json.Serialization;
 using System.Windows;
+using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.SharedModels;
 using Flow.Launcher.ViewModel;
 
 namespace Flow.Launcher.Infrastructure.UserSettings
 {
-    public class Settings : BaseModel
+    public class Settings : BaseModel, IHotkeySettings
     {
         private string language = "en";
         private string _theme = Constant.DefaultTheme;
@@ -207,17 +208,17 @@ namespace Flow.Launcher.Infrastructure.UserSettings
 
         public double WindowLeft { get; set; }
         public double WindowTop { get; set; }
-        
+
         /// <summary>
         /// Custom left position on selected monitor
         /// </summary>
         public double CustomWindowLeft { get; set; } = 0;
-        
+
         /// <summary>
         /// Custom top position on selected monitor
         /// </summary>
         public double CustomWindowTop { get; set; } = 0;
-        
+
         public int MaxResultsToShow { get; set; } = 5;
         public int ActivateTimes { get; set; }
 
@@ -229,7 +230,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         [JsonIgnore]
         public ObservableCollection<BuiltinShortcutModel> BuiltinShortcuts { get; set; } = new()
         {
-            new BuiltinShortcutModel("{clipboard}", "shortcut_clipboard_description", Clipboard.GetText), 
+            new BuiltinShortcutModel("{clipboard}", "shortcut_clipboard_description", Clipboard.GetText),
             new BuiltinShortcutModel("{active_explorer_path}", "shortcut_active_explorer_path", FileExplorerHelper.GetActiveExplorerPath)
         };
 
@@ -253,7 +254,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
 
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public SearchWindowScreens SearchWindowScreen { get; set; } = SearchWindowScreens.Cursor;
-        
+
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public SearchWindowAligns SearchWindowAlign { get; set; } = SearchWindowAligns.Center;
 
@@ -273,6 +274,78 @@ namespace Flow.Launcher.Infrastructure.UserSettings
 
         // This needs to be loaded last by staying at the bottom
         public PluginsSettings PluginSettings { get; set; } = new PluginsSettings();
+
+        [JsonIgnore]
+        public List<RegisteredHotkeyData> RegisteredHotkeys
+        {
+            get
+            {
+                var list = new List<RegisteredHotkeyData>
+                {
+                    new("Escape", "Escape"), // TODO
+                    new("F5", "ReloadPluginHotkey"), // TODO
+                    new("Alt+Home", "Select last result"), // TODO
+                    new("Alt+End", "Select last result"), // TODO
+                    new("Ctrl+R", "Requery"), // TODO
+                    new("Ctrl+H", "ToggleHistoryHotkey"), // TODO
+                    new("Ctrl+OemCloseBrackets", "QuickWidthHotkey"), // TODO
+                    new("Ctrl+OemOpenBrackets", "QuickWidthHotkey"), // TODO
+                    new("Ctrl+OemPlus", "QuickHeightHotkey"), // TODO
+                    new("Ctrl+OemMinus", "QuickHeightHotkey"), // TODO
+                    new("Ctrl+Shift+Enter", "HotkeyCtrlShiftEnterDesc"), // TODO
+                    new("Shift+Enter", "OpenContextMenuHotkey"), // TODO
+                    new("Enter", "HotkeyRunDesc"), // TODO
+                    new("Ctrl+Enter", "Open result"), // TODO
+                    new("Alt+Enter", "Open result"), // TODO
+                    new("Ctrl+F12", "ToggleGameModeHotkey"), // TODO
+                    new("Ctrl+Shift+C", "Copy alternative"), // TODO
+
+                    new($"{OpenResultModifiers}+D1", "Open Result"), // TODO
+                    new($"{OpenResultModifiers}+D2", "Open Result"), // TODO
+                    new($"{OpenResultModifiers}+D3", "Open Result"), // TODO
+                    new($"{OpenResultModifiers}+D4", "Open Result"), // TODO
+                    new($"{OpenResultModifiers}+D5", "Open Result"), // TODO
+                    new($"{OpenResultModifiers}+D6", "Open Result"), // TODO
+                    new($"{OpenResultModifiers}+D7", "Open Result"), // TODO
+                    new($"{OpenResultModifiers}+D8", "Open Result"), // TODO
+                    new($"{OpenResultModifiers}+D9", "Open Result"), // TODO
+                    new($"{OpenResultModifiers}+D0", "Open Result"), // TODO
+                };
+
+                if(!string.IsNullOrEmpty(Hotkey))
+                    list.Add(new(Hotkey, "Open main window", () => Hotkey = "")); // TODO
+                if(!string.IsNullOrEmpty(PreviewHotkey))
+                    list.Add(new(PreviewHotkey, "Preview Hotkey", () => PreviewHotkey = "")); // TODO
+                if(!string.IsNullOrEmpty(AutoCompleteHotkey))
+                    list.Add(new(AutoCompleteHotkey, "AutoCompleteHotkey", () => AutoCompleteHotkey = "")); // TODO
+                if(!string.IsNullOrEmpty(AutoCompleteHotkey2))
+                    list.Add(new(AutoCompleteHotkey2, "AutoCompleteHotkey", () => AutoCompleteHotkey2 = "")); // TODO
+                if(!string.IsNullOrEmpty(SelectNextItemHotkey))
+                    list.Add(new(SelectNextItemHotkey, "SelectNextItemHotkey", () => SelectNextItemHotkey = "")); // TODO
+                if(!string.IsNullOrEmpty(SelectNextItemHotkey2))
+                    list.Add(new(SelectNextItemHotkey2, "SelectNextItemHotkey", () => SelectNextItemHotkey2 = "")); // TODO
+                if(!string.IsNullOrEmpty(SelectPrevItemHotkey))
+                    list.Add(new(SelectPrevItemHotkey, "SelectPrevItemHotkey", () => SelectPrevItemHotkey = "")); // TODO
+                if(!string.IsNullOrEmpty(SelectPrevItemHotkey2))
+                    list.Add(new(SelectPrevItemHotkey2, "SelectPrevItemHotkey", () => SelectPrevItemHotkey2 = "")); // TODO
+                if(!string.IsNullOrEmpty(SettingWindowHotkey))
+                    list.Add(new(SettingWindowHotkey, "SettingWindowHotkey", () => SettingWindowHotkey = "")); // TODO
+                if(!string.IsNullOrEmpty(OpenContextMenuHotkey))
+                    list.Add(new(OpenContextMenuHotkey, "OpenContextMenuHotkey", () => OpenContextMenuHotkey = "")); // TODO
+                if(!string.IsNullOrEmpty(SelectNextPageHotkey))
+                    list.Add(new(SelectNextPageHotkey, "SelectNextPageHotkey", () => SelectNextPageHotkey = "")); // TODO
+                if(!string.IsNullOrEmpty(SelectPrevPageHotkey))
+                    list.Add(new(SelectPrevPageHotkey, "SelectPrevPageHotkey", () => SelectPrevPageHotkey = "")); // TODO
+
+                foreach (var customPluginHotkey in CustomPluginHotkeys)
+                {
+                    if (!string.IsNullOrEmpty(customPluginHotkey.Hotkey))
+                        list.Add(new(customPluginHotkey.Hotkey, "Custom plugin hotkey", () => customPluginHotkey.Hotkey = "")); // TODO
+                }
+
+                return list;
+            }
+        }
     }
 
     public enum LastQueryMode
@@ -288,7 +361,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         Light,
         Dark
     }
-    
+
     public enum SearchWindowScreens
     {
         RememberLastLaunchLocation,
@@ -297,7 +370,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         Primary,
         Custom
     }
-    
+
     public enum SearchWindowAligns
     {
         Center,

--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -282,65 +282,69 @@ namespace Flow.Launcher.Infrastructure.UserSettings
             {
                 var list = new List<RegisteredHotkeyData>
                 {
-                    new("Escape", "Escape"), // TODO
-                    new("F5", "ReloadPluginHotkey"), // TODO
-                    new("Alt+Home", "Select last result"), // TODO
-                    new("Alt+End", "Select last result"), // TODO
-                    new("Ctrl+R", "Requery"), // TODO
-                    new("Ctrl+H", "ToggleHistoryHotkey"), // TODO
-                    new("Ctrl+OemCloseBrackets", "QuickWidthHotkey"), // TODO
-                    new("Ctrl+OemOpenBrackets", "QuickWidthHotkey"), // TODO
-                    new("Ctrl+OemPlus", "QuickHeightHotkey"), // TODO
-                    new("Ctrl+OemMinus", "QuickHeightHotkey"), // TODO
-                    new("Ctrl+Shift+Enter", "HotkeyCtrlShiftEnterDesc"), // TODO
-                    new("Shift+Enter", "OpenContextMenuHotkey"), // TODO
-                    new("Enter", "HotkeyRunDesc"), // TODO
-                    new("Ctrl+Enter", "Open result"), // TODO
-                    new("Alt+Enter", "Open result"), // TODO
-                    new("Ctrl+F12", "ToggleGameModeHotkey"), // TODO
-                    new("Ctrl+Shift+C", "Copy alternative"), // TODO
+                    new("Up", "HotkeyLeftRightDesc"),
+                    new("Down", "HotkeyLeftRightDesc"),
+                    new("Left", "HotkeyUpDownDesc"),
+                    new("Right", "HotkeyUpDownDesc"),
+                    new("Escape", "HotkeyESCDesc"),
+                    new("F5", "ReloadPluginHotkey"),
+                    new("Alt+Home", "HotkeySelectFirstResult"),
+                    new("Alt+End", "HotkeySelectLastResult"),
+                    new("Ctrl+R", "HotkeyRequery"),
+                    new("Ctrl+H", "ToggleHistoryHotkey"),
+                    new("Ctrl+OemCloseBrackets", "QuickWidthHotkey"),
+                    new("Ctrl+OemOpenBrackets", "QuickWidthHotkey"),
+                    new("Ctrl+OemPlus", "QuickHeightHotkey"),
+                    new("Ctrl+OemMinus", "QuickHeightHotkey"),
+                    new("Ctrl+Shift+Enter", "HotkeyCtrlShiftEnterDesc"),
+                    new("Shift+Enter", "OpenContextMenuHotkey"),
+                    new("Enter", "HotkeyRunDesc"),
+                    new("Ctrl+Enter", "OpenContainFolderHotkey"),
+                    new("Alt+Enter", "HotkeyOpenResult"),
+                    new("Ctrl+F12", "ToggleGameModeHotkey"),
+                    new("Ctrl+Shift+C", "CopyFilePathHotkey"),
 
-                    new($"{OpenResultModifiers}+D1", "Open Result"), // TODO
-                    new($"{OpenResultModifiers}+D2", "Open Result"), // TODO
-                    new($"{OpenResultModifiers}+D3", "Open Result"), // TODO
-                    new($"{OpenResultModifiers}+D4", "Open Result"), // TODO
-                    new($"{OpenResultModifiers}+D5", "Open Result"), // TODO
-                    new($"{OpenResultModifiers}+D6", "Open Result"), // TODO
-                    new($"{OpenResultModifiers}+D7", "Open Result"), // TODO
-                    new($"{OpenResultModifiers}+D8", "Open Result"), // TODO
-                    new($"{OpenResultModifiers}+D9", "Open Result"), // TODO
-                    new($"{OpenResultModifiers}+D0", "Open Result"), // TODO
+                    new($"{OpenResultModifiers}+D1", "HotkeyOpenResultN", 1),
+                    new($"{OpenResultModifiers}+D2", "HotkeyOpenResultN", 2),
+                    new($"{OpenResultModifiers}+D3", "HotkeyOpenResultN", 3),
+                    new($"{OpenResultModifiers}+D4", "HotkeyOpenResultN", 4),
+                    new($"{OpenResultModifiers}+D5", "HotkeyOpenResultN", 5),
+                    new($"{OpenResultModifiers}+D6", "HotkeyOpenResultN", 6),
+                    new($"{OpenResultModifiers}+D7", "HotkeyOpenResultN", 7),
+                    new($"{OpenResultModifiers}+D8", "HotkeyOpenResultN", 8),
+                    new($"{OpenResultModifiers}+D9", "HotkeyOpenResultN", 9),
+                    new($"{OpenResultModifiers}+D0", "HotkeyOpenResultN", 10)
                 };
 
                 if(!string.IsNullOrEmpty(Hotkey))
-                    list.Add(new(Hotkey, "Open main window", () => Hotkey = "")); // TODO
+                    list.Add(new(Hotkey, "flowlauncherHotkey", () => Hotkey = ""));
                 if(!string.IsNullOrEmpty(PreviewHotkey))
-                    list.Add(new(PreviewHotkey, "Preview Hotkey", () => PreviewHotkey = "")); // TODO
+                    list.Add(new(PreviewHotkey, "previewHotkey", () => PreviewHotkey = ""));
                 if(!string.IsNullOrEmpty(AutoCompleteHotkey))
-                    list.Add(new(AutoCompleteHotkey, "AutoCompleteHotkey", () => AutoCompleteHotkey = "")); // TODO
+                    list.Add(new(AutoCompleteHotkey, "autoCompleteHotkey", () => AutoCompleteHotkey = ""));
                 if(!string.IsNullOrEmpty(AutoCompleteHotkey2))
-                    list.Add(new(AutoCompleteHotkey2, "AutoCompleteHotkey", () => AutoCompleteHotkey2 = "")); // TODO
+                    list.Add(new(AutoCompleteHotkey2, "autoCompleteHotkey", () => AutoCompleteHotkey2 = ""));
                 if(!string.IsNullOrEmpty(SelectNextItemHotkey))
-                    list.Add(new(SelectNextItemHotkey, "SelectNextItemHotkey", () => SelectNextItemHotkey = "")); // TODO
+                    list.Add(new(SelectNextItemHotkey, "SelectNextItemHotkey", () => SelectNextItemHotkey = ""));
                 if(!string.IsNullOrEmpty(SelectNextItemHotkey2))
-                    list.Add(new(SelectNextItemHotkey2, "SelectNextItemHotkey", () => SelectNextItemHotkey2 = "")); // TODO
+                    list.Add(new(SelectNextItemHotkey2, "SelectNextItemHotkey", () => SelectNextItemHotkey2 = ""));
                 if(!string.IsNullOrEmpty(SelectPrevItemHotkey))
-                    list.Add(new(SelectPrevItemHotkey, "SelectPrevItemHotkey", () => SelectPrevItemHotkey = "")); // TODO
+                    list.Add(new(SelectPrevItemHotkey, "SelectPrevItemHotkey", () => SelectPrevItemHotkey = ""));
                 if(!string.IsNullOrEmpty(SelectPrevItemHotkey2))
-                    list.Add(new(SelectPrevItemHotkey2, "SelectPrevItemHotkey", () => SelectPrevItemHotkey2 = "")); // TODO
+                    list.Add(new(SelectPrevItemHotkey2, "SelectPrevItemHotkey", () => SelectPrevItemHotkey2 = ""));
                 if(!string.IsNullOrEmpty(SettingWindowHotkey))
-                    list.Add(new(SettingWindowHotkey, "SettingWindowHotkey", () => SettingWindowHotkey = "")); // TODO
+                    list.Add(new(SettingWindowHotkey, "SettingWindowHotkey", () => SettingWindowHotkey = ""));
                 if(!string.IsNullOrEmpty(OpenContextMenuHotkey))
-                    list.Add(new(OpenContextMenuHotkey, "OpenContextMenuHotkey", () => OpenContextMenuHotkey = "")); // TODO
+                    list.Add(new(OpenContextMenuHotkey, "OpenContextMenuHotkey", () => OpenContextMenuHotkey = ""));
                 if(!string.IsNullOrEmpty(SelectNextPageHotkey))
-                    list.Add(new(SelectNextPageHotkey, "SelectNextPageHotkey", () => SelectNextPageHotkey = "")); // TODO
+                    list.Add(new(SelectNextPageHotkey, "SelectNextPageHotkey", () => SelectNextPageHotkey = ""));
                 if(!string.IsNullOrEmpty(SelectPrevPageHotkey))
-                    list.Add(new(SelectPrevPageHotkey, "SelectPrevPageHotkey", () => SelectPrevPageHotkey = "")); // TODO
+                    list.Add(new(SelectPrevPageHotkey, "SelectPrevPageHotkey", () => SelectPrevPageHotkey = ""));
 
                 foreach (var customPluginHotkey in CustomPluginHotkeys)
                 {
                     if (!string.IsNullOrEmpty(customPluginHotkey.Hotkey))
-                        list.Add(new(customPluginHotkey.Hotkey, "Custom plugin hotkey", () => customPluginHotkey.Hotkey = "")); // TODO
+                        list.Add(new(customPluginHotkey.Hotkey, "customQueryHotkey", () => customPluginHotkey.Hotkey = ""));
                 }
 
                 return list;

--- a/Flow.Launcher/CustomQueryHotkeySetting.xaml
+++ b/Flow.Launcher/CustomQueryHotkeySetting.xaml
@@ -106,6 +106,7 @@
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         HorizontalContentAlignment="Left"
+                        HotkeySettings="{Binding Settings}"
                         DefaultHotkey="" />
                     <TextBlock
                         Grid.Row="1"

--- a/Flow.Launcher/CustomQueryHotkeySetting.xaml.cs
+++ b/Flow.Launcher/CustomQueryHotkeySetting.xaml.cs
@@ -15,13 +15,13 @@ namespace Flow.Launcher
         private SettingWindow _settingWidow;
         private bool update;
         private CustomPluginHotkey updateCustomHotkey;
-        private Settings _settings;
+        public Settings Settings { get; }
 
         public CustomQueryHotkeySetting(SettingWindow settingWidow, Settings settings)
         {
             _settingWidow = settingWidow;
+            Settings = settings;
             InitializeComponent();
-            _settings = settings;
         }
 
         private void BtnCancel_OnClick(object sender, RoutedEventArgs e)
@@ -33,13 +33,13 @@ namespace Flow.Launcher
         {
             if (!update)
             {
-                _settings.CustomPluginHotkeys ??= new ObservableCollection<CustomPluginHotkey>();
+                Settings.CustomPluginHotkeys ??= new ObservableCollection<CustomPluginHotkey>();
 
                 var pluginHotkey = new CustomPluginHotkey
                 {
                     Hotkey = HotkeyControl.CurrentHotkey.ToString(), ActionKeyword = tbAction.Text
                 };
-                _settings.CustomPluginHotkeys.Add(pluginHotkey);
+                Settings.CustomPluginHotkeys.Add(pluginHotkey);
 
                 HotKeyMapper.SetCustomQueryHotkey(pluginHotkey);
             }
@@ -59,7 +59,7 @@ namespace Flow.Launcher
 
         public void UpdateItem(CustomPluginHotkey item)
         {
-            updateCustomHotkey = _settings.CustomPluginHotkeys.FirstOrDefault(o =>
+            updateCustomHotkey = Settings.CustomPluginHotkeys.FirstOrDefault(o =>
                 o.ActionKeyword == item.ActionKeyword && o.Hotkey == item.Hotkey);
             if (updateCustomHotkey == null)
             {

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -12,6 +12,17 @@ namespace Flow.Launcher
 {
     public partial class HotkeyControl
     {
+        public IHotkeySettings HotkeySettings {
+            get { return (IHotkeySettings)GetValue(HotkeySettingsProperty); }
+            set { SetValue(HotkeySettingsProperty, value); }
+        }
+
+        public static readonly DependencyProperty HotkeySettingsProperty = DependencyProperty.Register(
+            nameof(HotkeySettings),
+            typeof(IHotkeySettings),
+            typeof(HotkeyControl),
+            new PropertyMetadata()
+        );
         public string WindowTitle {
             get { return (string)GetValue(WindowTitleProperty); }
             set { SetValue(WindowTitleProperty, value); }
@@ -122,7 +133,7 @@ namespace Flow.Launcher
                 HotKeyMapper.RemoveHotkey(Hotkey);
             }
 
-            var dialog = new HotkeyControlDialog(Hotkey, DefaultHotkey, WindowTitle);
+            var dialog = new HotkeyControlDialog(Hotkey, DefaultHotkey, HotkeySettings, WindowTitle);
             await dialog.ShowAsync();
             switch (dialog.ResultType)
             {

--- a/Flow.Launcher/HotkeyControlDialog.xaml
+++ b/Flow.Launcher/HotkeyControlDialog.xaml
@@ -106,6 +106,7 @@
                         Grid.Column="1"
                         x:Name="tbMsg"
                         Margin="0,0,0,2"
+                        Padding="0,0,8,0"
                         HorizontalAlignment="Left"
                         FontSize="13"
                         FontWeight="SemiBold"
@@ -127,6 +128,15 @@
                 Margin="10"
                 HorizontalAlignment="Center"
                 Orientation="Horizontal">
+                <Button
+                    x:Name="OverwriteBtn"
+                    Height="30"
+                    MinWidth="100"
+                    Margin="0,0,4,0"
+                    Click="Overwrite"
+                    Content="{DynamicResource commonOverwrite}"
+                    Visibility="Collapsed"
+                    Style="{StaticResource AccentButtonStyle}" />
                 <Button
                     x:Name="SaveBtn"
                     Height="30"

--- a/Flow.Launcher/HotkeyControlDialog.xaml
+++ b/Flow.Launcher/HotkeyControlDialog.xaml
@@ -82,7 +82,8 @@
             <Border
                 x:Name="Alert"
                 Width="420"
-                Height="50"
+                Padding="0, 10"
+                VerticalAlignment="Center"
                 HorizontalAlignment="Center"
                 Background="{DynamicResource InfoBarWarningBG}"
                 BorderBrush="{DynamicResource InfoBarBD}"
@@ -90,21 +91,26 @@
                 CornerRadius="5"
                 Visibility="Collapsed">
                 <Grid VerticalAlignment="Center">
-                    <StackPanel Orientation="Horizontal">
-                        <ui:FontIcon
-                            Margin="20,0,14,0"
-                            VerticalAlignment="Center"
-                            FontSize="15"
-                            Foreground="{DynamicResource InfoBarWarningIcon}"
-                            Glyph="&#xf167;" />
-                        <TextBlock
-                            x:Name="tbMsg"
-                            Margin="0,0,0,2"
-                            HorizontalAlignment="Left"
-                            FontSize="13"
-                            FontWeight="SemiBold"
-                            Foreground="{DynamicResource Color05B}" />
-                    </StackPanel>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:FontIcon
+                        Grid.Column="0"
+                        Margin="20,0,14,0"
+                        VerticalAlignment="Center"
+                        FontSize="15"
+                        Foreground="{DynamicResource InfoBarWarningIcon}"
+                        Glyph="&#xf167;" />
+                    <TextBlock
+                        Grid.Column="1"
+                        x:Name="tbMsg"
+                        Margin="0,0,0,2"
+                        HorizontalAlignment="Left"
+                        FontSize="13"
+                        FontWeight="SemiBold"
+                        TextWrapping="Wrap"
+                        Foreground="{DynamicResource Color05B}" />
                 </Grid>
             </Border>
 

--- a/Flow.Launcher/HotkeyControlDialog.xaml.cs
+++ b/Flow.Launcher/HotkeyControlDialog.xaml.cs
@@ -119,12 +119,16 @@ public partial class HotkeyControlDialog : ContentDialog
 
         if (_hotkeySettings.RegisteredHotkeys.FirstOrDefault(v => v.Hotkey == hotkey) is { } registeredHotkeyData)
         {
+            var description = string.Format(
+                InternationalizationManager.Instance.GetTranslation(registeredHotkeyData.DescriptionResourceKey),
+                registeredHotkeyData.DescriptionFormatVariables
+            );
             Alert.Visibility = Visibility.Visible;
             if (registeredHotkeyData.RemoveHotkey is not null)
             {
                 tbMsg.Text = string.Format(
                     InternationalizationManager.Instance.GetTranslation("hotkeyUnavailableEditable"),
-                    registeredHotkeyData.Description
+                    description
                 );
                 SaveBtn.IsEnabled = false;
                 SaveBtn.Visibility = Visibility.Collapsed;
@@ -136,7 +140,7 @@ public partial class HotkeyControlDialog : ContentDialog
             {
                 tbMsg.Text = string.Format(
                     InternationalizationManager.Instance.GetTranslation("hotkeyUnavailableUneditable"),
-                    registeredHotkeyData.Description
+                    description
                 );
                 SaveBtn.IsEnabled = false;
                 SaveBtn.Visibility = Visibility.Visible;

--- a/Flow.Launcher/HotkeyControlDialog.xaml.cs
+++ b/Flow.Launcher/HotkeyControlDialog.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Input;
 using Flow.Launcher.Core.Resource;
@@ -15,6 +16,28 @@ public partial class HotkeyControlDialog : ContentDialog
     public string WindowTitle { get; }
     public HotkeyModel CurrentHotkey { get; private set; }
     public ObservableCollection<string> KeysToDisplay { get; } = new();
+
+    private readonly Dictionary<HotkeyModel, string> StaticHotkeys = new()
+    {
+        [new HotkeyModel("Escape")] = "", // TODO
+        [new HotkeyModel("F5")] = "ReloadPluginHotkey",
+        [new HotkeyModel("Alt+Home")] = "Select first result", // TODO
+        [new HotkeyModel("Alt+End")] = "Select last result", // TODO
+        [new HotkeyModel("Ctrl+R")] = "Requery", // TODO
+        [new HotkeyModel("Ctrl+H")] = "ToggleHistoryHotkey",
+        [new HotkeyModel("Ctrl+OemCloseBrackets")] = "QuickWidthHotkey",
+        [new HotkeyModel("Ctrl+OemOpenBrackets")] = "QuickWidthHotkey",
+        [new HotkeyModel("Ctrl+OemPlus")] = "QuickHeightHotkey",
+        [new HotkeyModel("Ctrl+OemMinus")] = "QuickHeightHotkey",
+        [new HotkeyModel("Ctrl+Shift+Enter")] = "HotkeyCtrlShiftEnterDesc",
+        [new HotkeyModel("Shift+Enter")] = "OpenContextMenuHotkey",
+        [new HotkeyModel("Enter")] = "HotkeyRunDesc",
+        [new HotkeyModel("Ctrl+Enter")] = "Open result", // TODO
+        [new HotkeyModel("Alt+Enter")] = "Open result", // TODO
+        // TODO D0-D9 But not here since they're not completely static, they can be Ctrl+D0-D9, Alt+D0-D9, or Ctrl+Alt+D0-D9
+        [new HotkeyModel("Ctrl+F12")] = "ToggleGameModeHotkey",
+        [new HotkeyModel("Ctrl+Shift+C")] = "Copy alternative", // TODO
+    };
 
     public enum EResultType
     {
@@ -109,17 +132,33 @@ public partial class HotkeyControlDialog : ContentDialog
         if (tbMsg == null)
             return;
 
+
+        if (StaticHotkeys.TryGetValue((HotkeyModel)hotkey, out var staticHotkey))
+        {
+            ShowWarningAndDisableSaveButton(
+                string.Format(
+                    InternationalizationManager.Instance.GetTranslation("hotkeyUnavailableInUseStatic"),
+                    InternationalizationManager.Instance.GetTranslation(staticHotkey)
+                )
+            );
+            return;
+        }
         if (!CheckHotkeyAvailability(hotkey.Value, true))
         {
-            tbMsg.Text = InternationalizationManager.Instance.GetTranslation("hotkeyUnavailable");
-            Alert.Visibility = Visibility.Visible;
-            SaveBtn.IsEnabled = false;
+            ShowWarningAndDisableSaveButton(InternationalizationManager.Instance.GetTranslation("hotkeyUnavailable"));
         }
         else
         {
             Alert.Visibility = Visibility.Collapsed;
             SaveBtn.IsEnabled = true;
         }
+    }
+
+    private void ShowWarningAndDisableSaveButton(string message)
+    {
+        tbMsg.Text = message;
+        Alert.Visibility = Visibility.Visible;
+        SaveBtn.IsEnabled = false;
     }
 
     private static bool CheckHotkeyAvailability(HotkeyModel hotkey, bool validateKeyGesture) =>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -311,6 +311,8 @@
     <system:String x:Key="update">Update</system:String>
     <system:String x:Key="hotkeyRegTitle">Binding Hotkey</system:String>
     <system:String x:Key="hotkeyUnavailable">Current hotkey is unavailable.</system:String>
+    <system:String x:Key="hotkeyUnavailableInUseStatic">This hotkey is unavailable because it is reserved for Flow Launcher's functionality: {0}.</system:String>
+    <system:String x:Key="hotkeyUnavailableInUse">This hotkey is unavailable because it is already used for {0}.</system:String>
     <system:String x:Key="hotkeyRegGuide">Press the keys you want to use for this function.</system:String>
 
     <!--  Custom Query Shortcut Dialog  -->

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -398,6 +398,12 @@
     <system:String x:Key="HotkeyCtrlIDesc">Open Setting Window</system:String>
     <system:String x:Key="HotkeyF5Desc">Reload Plugin Data</system:String>
 
+    <system:String x:Key="HotkeySelectFirstResult">Select first result</system:String>
+    <system:String x:Key="HotkeySelectLastResult">Select last result</system:String>
+    <system:String x:Key="HotkeyRequery">Run current query again</system:String>
+    <system:String x:Key="HotkeyOpenResult">Open result</system:String>
+    <system:String x:Key="HotkeyOpenResultN">Open result #{0}</system:String>
+
     <system:String x:Key="RecommendWeather">Weather</system:String>
     <system:String x:Key="RecommendWeatherDesc">Weather in Google Result</system:String>
     <system:String x:Key="RecommendShell">&gt; ping 8.8.8.8</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -311,8 +311,8 @@
     <system:String x:Key="update">Update</system:String>
     <system:String x:Key="hotkeyRegTitle">Binding Hotkey</system:String>
     <system:String x:Key="hotkeyUnavailable">Current hotkey is unavailable.</system:String>
-    <system:String x:Key="hotkeyUnavailableInUseStatic">This hotkey is unavailable because it is reserved for Flow Launcher's functionality: {0}.</system:String>
-    <system:String x:Key="hotkeyUnavailableInUse">This hotkey is unavailable because it is already used for {0}.</system:String>
+    <system:String x:Key="hotkeyUnavailableUneditable">This hotkey is reserved for "{0}" and can't be used. Please choose another hotkey.</system:String>
+    <system:String x:Key="hotkeyUnavailableEditable">This hotkey is already in use by "{0}". If you press "Overwrite", it will be removed from "{0}".</system:String>
     <system:String x:Key="hotkeyRegGuide">Press the keys you want to use for this function.</system:String>
 
     <!--  Custom Query Shortcut Dialog  -->
@@ -325,6 +325,7 @@
 
     <!--  Common Action  -->
     <system:String x:Key="commonSave">Save</system:String>
+    <system:String x:Key="commonOverwrite">Overwrite</system:String>
     <system:String x:Key="commonCancel">Cancel</system:String>
     <system:String x:Key="commonReset">Reset</system:String>
     <system:String x:Key="commonDelete">Delete</system:String>

--- a/Flow.Launcher/Resources/Pages/WelcomePage2.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage2.xaml
@@ -115,6 +115,7 @@
                         ChangeHotkey="{Binding SetTogglingHotkeyCommand}"
                         DefaultHotkey="Alt+Space"
                         Hotkey="{Binding Settings.Hotkey}"
+                        HotkeySettings="{Binding Settings}"
                         ValidateKeyGesture="True"
                         WindowTitle="{DynamicResource flowlauncherHotkey}" />
                 </StackPanel>

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -2663,6 +2663,7 @@
                                             ChangeHotkey="{Binding SetTogglingHotkeyCommand}"
                                             DefaultHotkey="Alt+Space"
                                             Hotkey="{Binding Settings.Hotkey}"
+                                            HotkeySettings="{Binding Settings}"
                                             ValidateKeyGesture="True"
                                             WindowTitle="{DynamicResource flowlauncherHotkey}" />
                                     </cc:Card>
@@ -2676,6 +2677,7 @@
                                         <flowlauncher:HotkeyControl
                                             DefaultHotkey="F1"
                                             Hotkey="{Binding Settings.PreviewHotkey}"
+                                            HotkeySettings="{Binding Settings}"
                                             ValidateKeyGesture="False"
                                             WindowTitle="{DynamicResource previewHotkey}" />
                                     </cc:Card>
@@ -2776,6 +2778,7 @@
                                                 <flowlauncher:HotkeyControl
                                                     DefaultHotkey="Ctrl+I"
                                                     Hotkey="{Binding Settings.OpenContextMenuHotkey}"
+                                                    HotkeySettings="{Binding Settings}"
                                                     ValidateKeyGesture="False" />
                                             </cc:Card>
                                             <cc:Card
@@ -2792,6 +2795,7 @@
                                                 <flowlauncher:HotkeyControl
                                                     DefaultHotkey="Ctrl+I"
                                                     Hotkey="{Binding Settings.SettingWindowHotkey}"
+                                                    HotkeySettings="{Binding Settings}"
                                                     ValidateKeyGesture="False" />
                                             </cc:Card>
                                             <cc:Card
@@ -2814,6 +2818,7 @@
                                                 <flowlauncher:HotkeyControl
                                                     DefaultHotkey=""
                                                     Hotkey="{Binding Settings.SelectNextPageHotkey}"
+                                                    HotkeySettings="{Binding Settings}"
                                                     ValidateKeyGesture="False" />
                                             </cc:Card>
                                             <cc:Card
@@ -2823,6 +2828,7 @@
                                                 <flowlauncher:HotkeyControl
                                                     DefaultHotkey=""
                                                     Hotkey="{Binding Settings.SelectPrevPageHotkey}"
+                                                    HotkeySettings="{Binding Settings}"
                                                     ValidateKeyGesture="False" />
                                             </cc:Card>
 
@@ -2857,6 +2863,7 @@
                                             <flowlauncher:HotkeyControl
                                                 DefaultHotkey="Ctrl+Tab"
                                                 Hotkey="{Binding Settings.AutoCompleteHotkey}"
+                                                HotkeySettings="{Binding Settings}"
                                                 ValidateKeyGesture="False" />
                                         </cc:ExCard.SideContent>
                                         <cc:Card
@@ -2866,6 +2873,7 @@
                                             <flowlauncher:HotkeyControl
                                                 DefaultHotkey=""
                                                 Hotkey="{Binding Settings.AutoCompleteHotkey2}"
+                                                HotkeySettings="{Binding Settings}"
                                                 ValidateKeyGesture="False" />
                                         </cc:Card>
                                     </cc:ExCard>
@@ -2879,6 +2887,7 @@
                                             <flowlauncher:HotkeyControl
                                                 DefaultHotkey="Tab"
                                                 Hotkey="{Binding Settings.SelectNextItemHotkey}"
+                                                HotkeySettings="{Binding Settings}"
                                                 ValidateKeyGesture="False" />
                                         </cc:ExCard.SideContent>
                                         <cc:Card
@@ -2888,6 +2897,7 @@
                                             <flowlauncher:HotkeyControl
                                                 DefaultHotkey=""
                                                 Hotkey="{Binding Settings.SelectNextItemHotkey2}"
+                                                HotkeySettings="{Binding Settings}"
                                                 ValidateKeyGesture="False" />
                                         </cc:Card>
                                     </cc:ExCard>
@@ -2900,6 +2910,7 @@
                                             <flowlauncher:HotkeyControl
                                                 DefaultHotkey="Shift+Tab"
                                                 Hotkey="{Binding Settings.SelectPrevItemHotkey}"
+                                                HotkeySettings="{Binding Settings}"
                                                 ValidateKeyGesture="False" />
                                         </cc:ExCard.SideContent>
                                         <cc:Card
@@ -2909,6 +2920,7 @@
                                             <flowlauncher:HotkeyControl
                                                 DefaultHotkey=""
                                                 Hotkey="{Binding Settings.SelectPrevItemHotkey2}"
+                                                HotkeySettings="{Binding Settings}"
                                                 ValidateKeyGesture="False" />
                                         </cc:Card>
                                     </cc:ExCard>


### PR DESCRIPTION
## What's the PR
Now that users have the ability to customize many hotkeys in Flow Launcher, we should prevent them from accidentally using the same hotkey for multiple actions.

## Todo
- [x] Handle static hotkeys that the user can't change
- [x] Handle editable hotkeys
- [x] Detailed warning messages: why the hotkey can't be changed, what's already using the same hotkey
- [x] Figure out how to do hotkey name localization in `Flow.Launcher.Infrastructure.UserSettings.Settings`

## Things to consider
- ~~Maybe offer the ability to remove the other hotkey directly from the hotkey change dialog?~~
    Done.

