### PR TITLE
Fix SettingWindow's LeftTop Position when first launch

### DIFF
--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -446,7 +446,7 @@ namespace Flow.Launcher
 
         public void InitializePosition()
         {
-            if (settings.SettingWindowTop >= 0 && settings.SettingWindowLeft >= 0)
+            if (settings.SettingWindowTop == null)
             {
                 Top = settings.SettingWindowTop;
                 Left = settings.SettingWindowLeft;

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -448,13 +448,13 @@ namespace Flow.Launcher
         {
             if (settings.SettingWindowTop == null)
             {
-                Top = settings.SettingWindowTop;
-                Left = settings.SettingWindowLeft;
+                Top = WindowTop();
+                Left = WindowLeft();
             }
             else
             {
-                Top = WindowTop();
-                Left = WindowLeft();
+                Top = settings.SettingWindowTop;
+                Left = settings.SettingWindowLeft;
             }
             WindowState = settings.SettingWindowState;
         }


### PR DESCRIPTION
## What's The PR
- Fixed getting stuck in the upper left corner when opening the settings window after the first launch.
- If Setting Window Position is null, center the screen.

I think I made it this stupid for a reason, but I can't remember. 
Needs to be reviewed to see if null is acceptable.

## Test Case
When you open the settings window after the first launch with no settings, it is displayed in the center of the screen.