### PR TITLE
Block Mouse Hover event when Show / Keyboard Navigation

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -25,6 +25,7 @@
     LocationChanged="OnLocationChanged"
     Opacity="{Binding MainWindowOpacity, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
     PreviewKeyDown="OnKeyDown"
+    PreviewKeyUp="OnKeyUp"
     ResizeMode="NoResize"
     ShowInTaskbar="False"
     SizeToContent="Height"

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -47,6 +47,7 @@ namespace Flow.Launcher
         private MainViewModel _viewModel;
         private bool _animating;
         MediaPlayer animationSound = new MediaPlayer();
+        private bool isArrowKeyPressed = false;
 
         #endregion
 
@@ -109,9 +110,11 @@ namespace Flow.Launcher
         private void OnInitialized(object sender, EventArgs e)
         {
         }
-
         private void OnLoaded(object sender, RoutedEventArgs _)
         {
+            // MouseEventHandler
+            PreviewMouseMove += MainPreviewMouseMove;
+
             CheckFirstLaunch();
             HideStartup();
             // show notify icon when flowlauncher is hidden
@@ -406,6 +409,7 @@ namespace Flow.Launcher
             if (_animating)
                 return;
 
+            isArrowKeyPressed = true;
             _animating = true;
             UpdatePosition();
 
@@ -494,6 +498,7 @@ namespace Flow.Launcher
             windowsb.Completed += (_, _) => _animating = false;
             _settings.WindowLeft = Left;
             _settings.WindowTop = Top;
+            isArrowKeyPressed = false;
 
             if (QueryTextBox.Text.Length == 0)
             {
@@ -644,10 +649,12 @@ namespace Flow.Launcher
             switch (e.Key)
             {
                 case Key.Down:
+                    isArrowKeyPressed = true;
                     _viewModel.SelectNextItemCommand.Execute(null);
                     e.Handled = true;
                     break;
                 case Key.Up:
+                    isArrowKeyPressed = true;
                     _viewModel.SelectPrevItemCommand.Execute(null);
                     e.Handled = true;
                     break;
@@ -698,7 +705,21 @@ namespace Flow.Launcher
 
             }
         }
+        private void OnKeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Up || e.Key == Key.Down)
+            {
+                isArrowKeyPressed = false;
+            }
+        }
 
+        private void MainPreviewMouseMove(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            if (isArrowKeyPressed)
+            {
+                e.Handled = true; // Ignore Mouse Hover when press Arrowkeys
+            }
+        }
         public void PreviewReset()
         {
             _viewModel.ResetPreview();


### PR DESCRIPTION
## What's the PR
- Fix https://github.com/Flow-Launcher/Flow.Launcher/issues/2595
- When the window is visible, it blocks mouse hover events. 
- Fixes a situation where the mouse is recognized when the up or down arrow key is pressed and held while the mouse is over a window.

## Test Cases
- [x] If the animation is on and the mouse is moved while the animation is running, the mouse hover is not work.
- [x] In a situation with many results, hover should not work when the mouse is moved while holding down the up or down arrow key.