### PR TITLE
Program plugin: add option to hide uninstallers from results

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
@@ -32,6 +32,8 @@
     <system:String x:Key="flowlauncher_plugin_program_index_PATH_tooltip">When enabled, Flow will load programs from the PATH environment variable</system:String>
     <system:String x:Key="flowlauncher_plugin_program_enable_hidelnkpath">Hide app path</system:String>
     <system:String x:Key="flowlauncher_plugin_program_enable_hidelnkpath_tooltip">For executable files such as UWP or lnk, hide the file path from being visible</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable_hideuninstallers">Hide uninstallers</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_enable_hideuninstallers_tooltip">Hides programs with common uninstaller names, such as unins000.exe</system:String>
     <system:String x:Key="flowlauncher_plugin_program_enable_description">Search in Program Description</system:String>
     <system:String x:Key="flowlauncher_plugin_program_enable_description_tooltip">Flow will search program's description</system:String>
     <system:String x:Key="flowlauncher_plugin_program_suffixes_header">Suffixes</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Program/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Settings.cs
@@ -102,7 +102,7 @@ namespace Flow.Launcher.Plugin.Program
             // CustomSuffixes no longer contains custom suffixes
             // users has tweaked the settings
             // or this function has been executed once
-            if (UseCustomSuffixes == true || ProgramSuffixes == null) 
+            if (UseCustomSuffixes == true || ProgramSuffixes == null)
                 return;
             var suffixes = ProgramSuffixes.ToList();
             foreach(var item in BuiltinSuffixesStatus)
@@ -117,6 +117,7 @@ namespace Flow.Launcher.Plugin.Program
         public bool EnableStartMenuSource { get; set; } = true;
         public bool EnableDescription { get; set; } = false;
         public bool HideAppsPath { get; set; } = true;
+        public bool HideUninstallers { get; set; } = false;
         public bool EnableRegistrySource { get; set; } = true;
         public bool EnablePathSource { get; set; } = false;
         public bool EnableUWP { get; set; } = true;

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
@@ -86,6 +86,11 @@
                         IsChecked="{Binding HideAppsPath}"
                         ToolTip="{DynamicResource flowlauncher_plugin_program_enable_hidelnkpath_tooltip}" />
                     <CheckBox
+                        Margin="12 0 12 0"
+                        Content="{DynamicResource flowlauncher_plugin_program_enable_hideuninstallers}"
+                        IsChecked="{Binding HideUninstallers}"
+                        ToolTip="{DynamicResource flowlauncher_plugin_program_enable_hideuninstallers_tooltip}" />
+                    <CheckBox
                         Name="DescriptionEnabled"
                         Margin="12,0,12,0"
                         Content="{DynamicResource flowlauncher_plugin_program_enable_description}"

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
@@ -24,7 +24,7 @@ namespace Flow.Launcher.Plugin.Program.Views
         private ListSortDirection _lastDirection;
 
         // We do not save all program sources to settings, so using
-        // this as temporary holder for displaying all loaded programs sources. 
+        // this as temporary holder for displaying all loaded programs sources.
         internal static List<ProgramSource> ProgramSettingDisplayList { get; set; }
 
         public bool EnableDescription
@@ -44,6 +44,16 @@ namespace Flow.Launcher.Plugin.Program.Views
             {
                 Main.ResetCache();
                 _settings.HideAppsPath = value;
+            }
+        }
+
+        public bool HideUninstallers
+        {
+            get => _settings.HideUninstallers;
+            set
+            {
+                Main.ResetCache();
+                _settings.HideUninstallers = value;
             }
         }
 


### PR DESCRIPTION
Closes #2717.

This PR adds an option in Program plugin to hide uninstallers from results. It does so by filtering out common uninstaller file names if the program is of type `Win32`. For `UWPApp` it does nothing.

## Testing
- [x] Plugin successfully compiles and works after the changes
- [x] With the "Hide uninstallers" checkbox set in settings, I don't see any uninstallers in results
- [x] Without the checkbox, I see full results including uninstallers
