### PR TITLE
Improve plugins pane performance in settings

### DIFF
--- a/Flow.Launcher/Resources/Controls/InstalledPluginDisplay.xaml
+++ b/Flow.Launcher/Resources/Controls/InstalledPluginDisplay.xaml
@@ -93,42 +93,7 @@
         </Expander.Header>
 
         <StackPanel>
-            <Border
-                Width="Auto"
-                Height="52"
-                Margin="0"
-                Padding="0"
-                BorderThickness="0 1 0 0"
-                CornerRadius="0"
-                Style="{DynamicResource SettingGroupBox}"
-                Visibility="{Binding ActionKeywordsVisibility}">
-                <DockPanel Margin="22 0 18 0" VerticalAlignment="Center">
-                    <TextBlock
-                        Margin="48 0 10 0"
-                        DockPanel.Dock="Left"
-                        Style="{StaticResource Glyph}">
-                        &#xe819;
-                    </TextBlock>
-                    <TextBlock
-                        HorizontalAlignment="Left"
-                        VerticalAlignment="Center"
-                        DockPanel.Dock="Left"
-                        Style="{DynamicResource SettingTitleLabel}"
-                        Text="{DynamicResource actionKeywords}" />
-                    <Button
-                        Width="100"
-                        Height="34"
-                        Margin="5 0 0 0"
-                        HorizontalAlignment="Right"
-                        Command="{Binding SetActionKeywordsCommand}"
-                        Content="{Binding ActionKeywordsText}"
-                        Cursor="Hand"
-                        DockPanel.Dock="Right"
-                        FontWeight="Bold"
-                        ToolTip="{DynamicResource actionKeywordsTooltip}"
-                        Visibility="{Binding ActionKeywordsVisibility}" />
-                </DockPanel>
-            </Border>
+            <ContentControl Content="{Binding BottomPart1}" />
 
             <Border
                 BorderThickness="0 1 0 0"
@@ -150,75 +115,7 @@
                     Content="{Binding SettingControl}" />
             </Border>
 
-            <Border
-                Margin="0"
-                Padding="15 10"
-                VerticalAlignment="Center"
-                BorderThickness="0 1 0 0"
-                CornerRadius="0 0 5 5"
-                Style="{DynamicResource SettingGroupBox}">
-                <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
-                    <TextBlock
-                        Margin="10 0 0 0"
-                        VerticalAlignment="center"
-                        FontSize="11"
-                        Foreground="{DynamicResource PluginInfoColor}"
-                        Text="{DynamicResource author}" />
-                    <TextBlock
-                        Margin="5 0 0 0"
-                        VerticalAlignment="center"
-                        FontSize="11"
-                        Foreground="{DynamicResource PluginInfoColor}"
-                        Text="{Binding PluginPair.Metadata.Author}" />
-                    <TextBlock
-                        Margin="10 0 0 0"
-                        VerticalAlignment="Center"
-                        FontSize="11"
-                        Foreground="{DynamicResource PluginInfoColor}"
-                        Text="|" />
-                    <TextBlock
-                        Margin="10 0 5 0"
-                        VerticalAlignment="Center"
-                        FontSize="11"
-                        Foreground="{DynamicResource PluginInfoColor}"
-                        Text="{Binding Version}"
-                        ToolTip="{Binding InitAndQueryTime}"
-                        ToolTipService.InitialShowDelay="500" />
-                    <TextBlock
-                        Margin="5 0"
-                        VerticalAlignment="Center"
-                        FontSize="11"
-                        Foreground="{DynamicResource PluginInfoColor}"
-                        Text="|" />
-                    <TextBlock
-                        Margin="5 0 0 0"
-                        Style="{DynamicResource LinkBtnStyle}"
-                        Text="&#xe80f;"
-                        ToolTip="{DynamicResource plugin_query_web}">
-                        <TextBlock.InputBindings>
-                            <MouseBinding Command="{Binding OpenSourceCodeLinkCommand}" MouseAction="LeftClick" />
-                        </TextBlock.InputBindings>
-                    </TextBlock>
-                    <TextBlock
-                        Margin="10 0 0 0"
-                        Style="{DynamicResource LinkBtnStyle}"
-                        Text="&#xe74d;"
-                        ToolTip="{DynamicResource plugin_uninstall}">
-                        <TextBlock.InputBindings>
-                            <MouseBinding Command="{Binding OpenDeletePluginWindowCommand}" MouseAction="LeftClick" />
-                        </TextBlock.InputBindings>
-                    </TextBlock>
-                    <TextBlock
-                        Margin="10 0 5 0"
-                        Style="{DynamicResource LinkBtnStyle}"
-                        Text="&#xe8b7;"
-                        ToolTip="{DynamicResource pluginDirectory}">
-                        <TextBlock.InputBindings>
-                            <MouseBinding Command="{Binding OpenPluginDirectoryCommand}" MouseAction="LeftClick" />
-                        </TextBlock.InputBindings>
-                    </TextBlock>
-                </StackPanel>
-            </Border>
+            <ContentControl Content="{Binding BottomPart2}" />
         </StackPanel>
     </Expander>
 </UserControl>

--- a/Flow.Launcher/Resources/Controls/InstalledPluginDisplayBottomData.xaml
+++ b/Flow.Launcher/Resources/Controls/InstalledPluginDisplayBottomData.xaml
@@ -1,0 +1,81 @@
+﻿<UserControl
+    x:Class="Flow.Launcher.Resources.Controls.InstalledPluginDisplayBottomData"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewModel="clr-namespace:Flow.Launcher.ViewModel"
+    d:DataContext="{d:DesignInstance viewModel:PluginViewModel}"
+    d:DesignHeight="300"
+    d:DesignWidth="300"
+    mc:Ignorable="d">
+    <Border
+        Margin="0"
+        Padding="15 10"
+        VerticalAlignment="Center"
+        BorderThickness="0 1 0 0"
+        CornerRadius="0 0 5 5"
+        Style="{DynamicResource SettingGroupBox}">
+        <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
+            <TextBlock
+                Margin="10 0 0 0"
+                VerticalAlignment="center"
+                FontSize="11"
+                Foreground="{DynamicResource PluginInfoColor}"
+                Text="{DynamicResource author}" />
+            <TextBlock
+                Margin="5 0 0 0"
+                VerticalAlignment="center"
+                FontSize="11"
+                Foreground="{DynamicResource PluginInfoColor}"
+                Text="{Binding PluginPair.Metadata.Author}" />
+            <TextBlock
+                Margin="10 0 0 0"
+                VerticalAlignment="Center"
+                FontSize="11"
+                Foreground="{DynamicResource PluginInfoColor}"
+                Text="|" />
+            <TextBlock
+                Margin="10 0 5 0"
+                VerticalAlignment="Center"
+                FontSize="11"
+                Foreground="{DynamicResource PluginInfoColor}"
+                Text="{Binding Version}"
+                ToolTip="{Binding InitAndQueryTime}"
+                ToolTipService.InitialShowDelay="500" />
+            <TextBlock
+                Margin="5 0"
+                VerticalAlignment="Center"
+                FontSize="11"
+                Foreground="{DynamicResource PluginInfoColor}"
+                Text="|" />
+            <TextBlock
+                Margin="5 0 0 0"
+                Style="{DynamicResource LinkBtnStyle}"
+                Text="&#xe80f;"
+                ToolTip="{DynamicResource plugin_query_web}">
+                <TextBlock.InputBindings>
+                    <MouseBinding Command="{Binding OpenSourceCodeLinkCommand}" MouseAction="LeftClick" />
+                </TextBlock.InputBindings>
+            </TextBlock>
+            <TextBlock
+                Margin="10 0 0 0"
+                Style="{DynamicResource LinkBtnStyle}"
+                Text="&#xe74d;"
+                ToolTip="{DynamicResource plugin_uninstall}">
+                <TextBlock.InputBindings>
+                    <MouseBinding Command="{Binding OpenDeletePluginWindowCommand}" MouseAction="LeftClick" />
+                </TextBlock.InputBindings>
+            </TextBlock>
+            <TextBlock
+                Margin="10 0 5 0"
+                Style="{DynamicResource LinkBtnStyle}"
+                Text="&#xe8b7;"
+                ToolTip="{DynamicResource pluginDirectory}">
+                <TextBlock.InputBindings>
+                    <MouseBinding Command="{Binding OpenPluginDirectoryCommand}" MouseAction="LeftClick" />
+                </TextBlock.InputBindings>
+            </TextBlock>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Flow.Launcher/Resources/Controls/InstalledPluginDisplayBottomData.xaml.cs
+++ b/Flow.Launcher/Resources/Controls/InstalledPluginDisplayBottomData.xaml.cs
@@ -1,0 +1,11 @@
+﻿using System.Windows.Controls;
+
+namespace Flow.Launcher.Resources.Controls;
+
+public partial class InstalledPluginDisplayBottomData : UserControl
+{
+    public InstalledPluginDisplayBottomData()
+    {
+        InitializeComponent();
+    }
+}

--- a/Flow.Launcher/Resources/Controls/InstalledPluginDisplayKeyword.xaml
+++ b/Flow.Launcher/Resources/Controls/InstalledPluginDisplayKeyword.xaml
@@ -1,0 +1,47 @@
+﻿<UserControl
+    x:Class="Flow.Launcher.Resources.Controls.InstalledPluginDisplayKeyword"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewModel="clr-namespace:Flow.Launcher.ViewModel"
+    d:DataContext="{d:DesignInstance viewModel:PluginViewModel}"
+    d:DesignHeight="300"
+    d:DesignWidth="300"
+    mc:Ignorable="d">
+    <Border
+        Width="Auto"
+        Height="52"
+        Margin="0"
+        Padding="0"
+        BorderThickness="0 1 0 0"
+        CornerRadius="0"
+        Style="{DynamicResource SettingGroupBox}"
+        Visibility="{Binding ActionKeywordsVisibility}">
+        <DockPanel Margin="22 0 18 0" VerticalAlignment="Center">
+            <TextBlock
+                Margin="48 0 10 0"
+                DockPanel.Dock="Left"
+                Style="{StaticResource Glyph}">
+                &#xe819;
+            </TextBlock>
+            <TextBlock
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                DockPanel.Dock="Left"
+                Style="{DynamicResource SettingTitleLabel}"
+                Text="{DynamicResource actionKeywords}" />
+            <Button
+                Width="100"
+                Height="34"
+                Margin="5 0 0 0"
+                HorizontalAlignment="Right"
+                Command="{Binding SetActionKeywordsCommand}"
+                Content="{Binding ActionKeywordsText}"
+                Cursor="Hand"
+                DockPanel.Dock="Right"
+                FontWeight="Bold"
+                ToolTip="{DynamicResource actionKeywordsTooltip}" />
+        </DockPanel>
+    </Border>
+</UserControl>

--- a/Flow.Launcher/Resources/Controls/InstalledPluginDisplayKeyword.xaml.cs
+++ b/Flow.Launcher/Resources/Controls/InstalledPluginDisplayKeyword.xaml.cs
@@ -1,0 +1,11 @@
+﻿using System.Windows.Controls;
+
+namespace Flow.Launcher.Resources.Controls;
+
+public partial class InstalledPluginDisplayKeyword : UserControl
+{
+    public InstalledPluginDisplayKeyword()
+    {
+        InitializeComponent();
+    }
+}

--- a/Flow.Launcher/ViewModel/PluginViewModel.cs
+++ b/Flow.Launcher/ViewModel/PluginViewModel.cs
@@ -7,6 +7,7 @@ using Flow.Launcher.Core.Plugin;
 using System.Windows.Controls;
 using CommunityToolkit.Mvvm.Input;
 using Flow.Launcher.Core.Resource;
+using Flow.Launcher.Resources.Controls;
 
 namespace Flow.Launcher.ViewModel
 {
@@ -82,6 +83,12 @@ namespace Flow.Launcher.ViewModel
 
         private Control _settingControl;
         private bool _isExpanded;
+
+        private Control _bottomPart1;
+        public Control BottomPart1 => IsExpanded ? _bottomPart1 ??= new InstalledPluginDisplayKeyword() : null;
+
+        private Control _bottomPart2;
+        public Control BottomPart2 => IsExpanded ? _bottomPart2 ??= new InstalledPluginDisplayBottomData() : null;
 
         public bool HasSettingControl => PluginPair.Plugin is ISettingProvider;
         public Control SettingControl


### PR DESCRIPTION
## Changes
I extracted parts of the plugin display component that are only displayed when it's expanded (keyword, bottom part with author, version, directory etc.) into 2 separate controls. Now they render lazily, only after the plugin has been expanded. Before this change, only custom plugin settings were rendering lazily.

## Performance improvement
Time required to render my list of 31 plugins:

Before (700 ms):
![image](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/fb920e9e-c868-4380-b7f9-5e9bd76a8b29)

After (400 ms):
![image](https://github.com/Flow-Launcher/Flow.Launcher/assets/3993179/93dab89d-afce-4bb9-a89f-243cc5a5e89c)

## Testing
- [x] Plugins in the list expand correctly
- [x] Action keyword is displayed correctly and can be changed
- [x] Plugin author and version display correctly
- [x] Website, directory, uninstall icons perform correct actions on click

## Notes
This feels wrong to do, but I haven't managed to make virtualization work with plugins being able to expand, which changes their size. With virtualization enabled, it seems to work fine when using the scroll wheel, but if I try to use the scrollbar, the settings window freezes. This PR is the best working solution I have found.