### PR TITLE
DPI per Monitor

### DIFF
--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
-    <UseWindowsForms>true</UseWindowsForms>
+    <UseWindowsForms>false</UseWindowsForms>
     <StartupObject>Flow.Launcher.App</StartupObject>
     <ApplicationIcon>Resources\app.ico</ApplicationIcon>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Flow.Launcher/app.manifest
+++ b/Flow.Launcher/app.manifest
@@ -49,13 +49,12 @@
        DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
        to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
-  <!--
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
     </windowsSettings>
   </application>
-  -->
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <dependency>


### PR DESCRIPTION
## What's the PR
- ref https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process
- from https://github.com/microsoft/PowerToys/pull/32882
- Fixes blurry window when DPI is changed in dual monitor state.
- Previously, in two DPI states, the behavior was based on the DPI of one side, causing problems with sharpness on the other side. After this change, it will render to the DPI of each monitor.

## Test Case
- 10 You must have at least two monitors.
- 20 In an flow(dev), change the dpi to see what happens when you get a blurry state (175, 200, 225, 250...)
- 30 build this PR
- 40 goto 20