### PR TITLE
Always On Top

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -249,6 +249,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         }
         public bool LeaveCmdOpen { get; set; }
         public bool HideWhenDeactivated { get; set; } = true;
+        public bool AlwaysOnTop { get; set; } = false;
 
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public SearchWindowScreens SearchWindowScreen { get; set; } = SearchWindowScreens.Cursor;

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -27,6 +27,7 @@ using DataObject = System.Windows.DataObject;
 using System.Windows.Media;
 using System.Windows.Interop;
 using System.Runtime.InteropServices;
+using System.Diagnostics;
 
 namespace Flow.Launcher
 {
@@ -620,6 +621,14 @@ namespace Flow.Launcher
         {
             _settings.WindowLeft = Left;
             _settings.WindowTop = Top;
+
+            // Check if AlwaysOnTop is enabled
+            if (_settings.AlwaysOnTop)
+            {
+                _viewModel.ClearResults();
+                return; // If AlwaysOnTop is enabled, do nothing
+            }
+
             //This condition stops extra hide call when animator is on,
             // which causes the toggling to occasional hide instead of show.
             if (_viewModel.MainWindowVisibilityStatus)
@@ -629,13 +638,9 @@ namespace Flow.Launcher
                 // and always after Settings window is closed.
                 if (_settings.UseAnimation)
                     await Task.Delay(100);
-
-                if (_settings.HideWhenDeactivated)
-                {
-                    _viewModel.Hide();
-                }
             }
         }
+
 
         private void UpdatePosition()
         {

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
@@ -47,7 +47,7 @@
             </cc:Card>
 
             <cc:Card
-                Title="Always On Top Mode"
+                Title="Always On Top"
                 Margin="0 14 0 0"
                 Sub="When this setting is turned on, it will always operate in above mode. The “Hide Flow when focus is lost” setting and the “Last Query Style” setting are ignored.">
                 <ui:ToggleSwitch

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
@@ -46,6 +46,16 @@
                     OnContent="{DynamicResource enable}" />
             </cc:Card>
 
+            <cc:Card
+                Title="Always On Top Mode"
+                Margin="0 14 0 0"
+                Sub="When this setting is turned on, it will always operate in above mode. The “Hide Flow when focus is lost” setting and the “Last Query Style” setting are ignored.">
+                <ui:ToggleSwitch
+                    IsOn="{Binding Settings.AlwaysOnTop}"
+                    OffContent="{DynamicResource disable}"
+                    OnContent="{DynamicResource enable}" />
+            </cc:Card>
+
             <cc:Card Title="{DynamicResource hideFlowLauncherWhenLoseFocus}" Margin="0 14 0 0">
                 <ui:ToggleSwitch
                     IsOn="{Binding Settings.HideWhenDeactivated}"

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1199,16 +1199,55 @@ namespace Flow.Launcher.ViewModel
 
         #region Hotkey
 
+        public void ClearResults()
+        {
+            // Clear the selected results
+            SelectedResults.Clear();
+
+            // Clear any additional state related to results (e.g., user-selected records, history, etc.)
+            if (SelectedIsFromQueryResults())
+            {
+                ContextMenu.Clear();
+                History.Clear();
+                lastHistoryIndex = 1;
+            }
+
+            // Switch to results view
+            SelectedResults = Results;
+
+            // Clear query text
+            ChangeQueryText(string.Empty);
+        }
         public void ToggleFlowLauncher()
         {
-            if (!MainWindowVisibilityStatus)
+            if (Settings.AlwaysOnTop)
             {
                 Show();
+                ActivateWindow();
             }
             else
             {
-                Hide();
+                if (!MainWindowVisibilityStatus)
+                {
+                    Show();
+                }
+                else
+                {
+                    Hide();
+                }
             }
+        }
+
+        private void ActivateWindow()
+        {
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                // Bring the window to the foreground and activate it
+                if (Application.Current.MainWindow != null)
+                {
+                    Application.Current.MainWindow.Activate();
+                }
+            });
         }
 
         public void Show()
@@ -1226,7 +1265,13 @@ namespace Flow.Launcher.ViewModel
 
         public async void Hide()
         {
-            lastHistoryIndex = 1;
+            if (Settings.AlwaysOnTop)
+            {
+                // If AlwaysOnTop is enabled, clear results instead of hiding the window
+                ClearResults();
+                return;
+            }
+
             // Trick for no delay
             MainWindowOpacity = 0;
             lastContextMenuResult = new Result();


### PR DESCRIPTION
## What's the PR
- Resolve https://github.com/Flow-Launcher/Flow.Launcher/issues/1349, https://github.com/Flow-Launcher/Flow.Launcher/issues/1460

- Add the Always On Top feature
- If Always On Top is enabled, it ignores the Last Query Mode and HideDeactive settings.
- This feature should basically behave like Windows start menu's search or everything toolbar.
- This is a feature that JJWs always misunderstand. It's similar to the existing hidewhendeactiave disabled state, but always on top has a much different purpose. I think the hidewhendeactiave feature unnecessary, but I keep it because it can be useful in some very specific situations.  
- If user want to utilize it like a start menu or everything toolbar, user don't need a complicated “disable hidewhendeactive and enable emptyquery” setup.

## Todo
- [ ] Strings
- [ ] function to override this setting and hide the window (temporary)
- [ ] Shortcuts to turn this setting on and off
- [ ] Adding Exit to the Contextmenu

## ETC
- We can implement something completely EVERYTHING TOOLBAR-like by specifying a certain window height and position. In this case, we have a common misconception that the search bar needs to be below the results (which I've tested before and found to be possible). But we don't need to implement this, as long as we specify a specific height and position, and take care of displaying it in a specific place. 