### PR TITLE
Fix "always preview" card subtitle not displaying the hotkey in Settings — General

### DIFF
--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
@@ -137,7 +137,7 @@
                 Title="{DynamicResource AlwaysPreview}"
                 Margin="0 14 0 0"
                 Icon="&#xe8a1;"
-                Sub="{DynamicResource AlwaysPreviewToolTip}">
+                Sub="{Binding AlwaysPreviewToolTip}">
                 <ui:ToggleSwitch
                     IsOn="{Binding Settings.AlwaysPreview}"
                     OffContent="{DynamicResource disable}"


### PR DESCRIPTION
Now it displays the actual hotkey instead of `{0}`.