### PR TITLE
Settings: fix creating/editing custom shortcuts

### DIFF
--- a/Flow.Launcher/CustomShortcutSetting.xaml.cs
+++ b/Flow.Launcher/CustomShortcutSetting.xaml.cs
@@ -1,31 +1,34 @@
 ﻿using Flow.Launcher.Core.Resource;
-using Flow.Launcher.ViewModel;
 using System;
 using System.Windows;
 using System.Windows.Input;
+using Flow.Launcher.SettingPages.ViewModels;
 
 namespace Flow.Launcher
 {
     public partial class CustomShortcutSetting : Window
     {
+        private readonly SettingsPaneHotkeyViewModel _hotkeyVm;
         public string Key { get; set; } = String.Empty;
         public string Value { get; set; } = String.Empty;
-        private string originalKey { get; init; } = null;
-        private string originalValue { get; init; } = null;
-        private bool update { get; init; } = false;
+        private string originalKey { get; } = null;
+        private string originalValue { get; } = null;
+        private bool update { get; } = false;
 
-        public CustomShortcutSetting(SettingWindowViewModel vm)
+        public CustomShortcutSetting(SettingsPaneHotkeyViewModel vm)
         {
+            _hotkeyVm = vm;
             InitializeComponent();
         }
 
-        public CustomShortcutSetting(string key, string value)
+        public CustomShortcutSetting(string key, string value, SettingsPaneHotkeyViewModel vm)
         {
             Key = key;
             Value = value;
             originalKey = key;
             originalValue = value;
             update = true;
+            _hotkeyVm = vm;
             InitializeComponent();
         }
 
@@ -43,7 +46,7 @@ namespace Flow.Launcher
                 return;
             }
             // Check if key is modified or adding a new one
-            if ((update && originalKey != Key) || !update)
+            if (((update && originalKey != Key) || !update) && _hotkeyVm.DoesShortcutExist(Key))
             {
                 MessageBox.Show(InternationalizationManager.Instance.GetTranslation("duplicateShortcut"));
                 return;

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneHotkeyViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneHotkeyViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System.Linq;
+using System.Windows;
 using CommunityToolkit.Mvvm.Input;
 using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Helper;
@@ -114,7 +115,7 @@ public partial class SettingsPaneHotkeyViewModel : BaseModel
             return;
         }
 
-        var window = new CustomShortcutSetting(item.Key, item.Value);
+        var window = new CustomShortcutSetting(item.Key, item.Value, this);
         if (window.ShowDialog() is not true) return;
 
         var index = Settings.CustomShortcuts.IndexOf(item);
@@ -124,11 +125,17 @@ public partial class SettingsPaneHotkeyViewModel : BaseModel
     [RelayCommand]
     private void CustomShortcutAdd()
     {
-        var window = new CustomShortcutSetting(null);
+        var window = new CustomShortcutSetting(this);
         if (window.ShowDialog() is true)
         {
             var shortcut = new CustomShortcutModel(window.Key, window.Value);
             Settings.CustomShortcuts.Add(shortcut);
         }
+    }
+
+    internal bool DoesShortcutExist(string key)
+    {
+        return Settings.CustomShortcuts.Any(v => v.Key == key) ||
+               Settings.BuiltinShortcuts.Any(v => v.Key == key);
     }
 }


### PR DESCRIPTION
When splitting the settings window, I forgot to re-add the correct check for already existing shortcuts. It was always displaying a message saying that the shortcut already exists. This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced custom shortcut settings with improved shortcut validation to prevent duplicate shortcuts.

- **Bug Fixes**
  - Improved internal handling of shortcut settings to ensure consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->