### PR TITLE
Modify gitStream todo checks

### DIFF
--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -32,12 +32,12 @@ automations:
         args:
           comment: |
             This PR is {{ changes.ratio }}% new code.
-  # Post a comment that request changes for a PR that contains a TODO statement.
+  # Post a comment notifying that the PR contains a TODO statement.
   review_todo_comments:
     if:
-      - {{ source.diff.files | matchDiffLines(regex=r/^[+].*(TODO)|(todo)/) | some }}
+      - {{ source.diff.files | matchDiffLines(regex=r/^[+].*\b(TODO|todo)\b/) | some }}
     run:
-      - action: request-changes@v1
+      - action: add-comment@v1
         args:
           comment: |
             This PR contains a TODO statement. Please check to see if they should be removed.


### PR DESCRIPTION
What this PR does:

1. Doesn't request changes when encountering a TODO item in the PR. Now, it just posts a comment with a reminder about the TODO.
2. Fixes the TODO regex. Before, it would match only `TODO` (uppercase) in lines starting with a `+` or `todo` (lowercase) in any lines. Now it will always match only lines starting with a `+` (Thanks to @JohnTheGr8 for figuring this out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced automation to post comments for PRs containing TODO statements, improving review workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->