### PR TITLE
Fix Preview Panel Separator

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
@@ -58,6 +58,7 @@
                 </Style>
             </StackPanel.Style>
             <Rectangle
+                x:Name="PreviewSep"
                 Width="Auto"
                 Height="1"
                 Margin="0 0 5 0"
@@ -72,7 +73,23 @@
                 Height="1"
                 Margin="0 0 5 0"
                 HorizontalAlignment="Stretch"
-                Style="{DynamicResource SeparatorStyle}" />
+                Fill="{Binding ElementName=PreviewSep, Path=Fill}">
+                <Rectangle.Style>
+                    <Style TargetType="Rectangle">
+                        <Setter Property="Visibility" Value="Visible" />
+                        <Style.Triggers>
+                            <MultiDataTrigger>
+                                <MultiDataTrigger.Conditions>
+                                    <Condition Binding="{Binding FileSizeVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" Value="Collapsed" />
+                                    <Condition Binding="{Binding CreatedAtVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" Value="Collapsed" />
+                                    <Condition Binding="{Binding LastModifiedAtVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" Value="Collapsed" />
+                                </MultiDataTrigger.Conditions>
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </MultiDataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Rectangle.Style>
+            </Rectangle>
             <StackPanel Visibility="{Binding FileInfoVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}">
                 <Grid Margin="0 10 0 10">
                     <Grid.ColumnDefinitions>
@@ -84,7 +101,6 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-
                     <TextBlock
                         Grid.Row="0"
                         Grid.Column="0"


### PR DESCRIPTION
## What's the PR
- Add Style for hiding separator when turning off all "more info" state in preview panel
- The bottom separator should be hidden when no additional information is displayed.