### PR TITLE
Fix gitStream image request regex

### DIFF
--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -74,4 +74,4 @@ changes:
 
 has:
   screenshot_link: {{ pr.description | includes(regex=r/!\[.*\]\(.*(jpg|svg|png|gif|psd).*\)/) }}
-  image_uploaded: {{ pr.description | includes(regex=r/<img.*src.*(jpg|svg|png|gif|psd).*>/) }}
+  image_uploaded: {{ pr.description | includes(regex=r/(<img.*src.*(jpg|svg|png|gif|psd).*>)|!\[image\]\(.*github\.com.*\)/) }}


### PR DESCRIPTION
Fix gitStream image request regex- wasn't capturing pasted image