### PR TITLE
feat: Exclude certain File Types from the Index search result

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -64,7 +64,7 @@
     <system:String x:Key="plugin_explorer_Directory_Recursive_Search_Engine">Directory Recursive Search Engine</system:String>
     <system:String x:Key="plugin_explorer_Index_Search_Engine">Index Search Engine</system:String>
     <system:String x:Key="plugin_explorer_Open_Window_Index_Option">Open Windows Index Option</system:String>
-    <system:String x:Key="plugin_explorer_Excluded_File_Types">Ignored File Types (comma seperated)</system:String>
+    <system:String x:Key="plugin_explorer_Excluded_File_Types">Excluded File Types (comma seperated)</system:String>
     <system:String x:Key="plugin_explorer_Excluded_File_Types_Tooltip">For example: exe,jpg,png</system:String>
 
     <!--  Plugin Infos  -->

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -64,6 +64,8 @@
     <system:String x:Key="plugin_explorer_Directory_Recursive_Search_Engine">Directory Recursive Search Engine</system:String>
     <system:String x:Key="plugin_explorer_Index_Search_Engine">Index Search Engine</system:String>
     <system:String x:Key="plugin_explorer_Open_Window_Index_Option">Open Windows Index Option</system:String>
+    <system:String x:Key="plugin_explorer_Excluded_File_Types">Ignored File Types (comma seperated)</system:String>
+    <system:String x:Key="plugin_explorer_Excluded_File_Types_Tooltip">For example: exe,jpg,png</system:String>
 
     <!--  Plugin Infos  -->
     <system:String x:Key="plugin_explorer_plugin_name">Explorer</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -258,7 +258,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             string[] excludedFileTypes = Settings.ExcludedFileTypes.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             string fileExtension = Path.GetExtension(result.FullPath).TrimStart('.');
 
-            return excludedFileTypes.Contains(fileExtension);
+            return excludedFileTypes.Contains(fileExtension, StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -25,6 +25,8 @@ namespace Flow.Launcher.Plugin.Explorer
 
         public string ShellPath { get; set; } = "cmd";
 
+        public string ExcludedFileTypes { get; set; } = "";
+
 
         public bool UseLocationAsWorkingDir { get; set; } = false;
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -518,7 +518,8 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
             get => Settings.ExcludedFileTypes;
             set
             {
-                string sanitized = string.IsNullOrEmpty(value) ? value : value.Replace(" ", "").Replace(".", "");
+                // remove spaces and dots from the string before saving
+                string sanitized = string.IsNullOrEmpty(value) ? "" : value.Replace(" ", "").Replace(".", "");
                 Settings.ExcludedFileTypes = sanitized;
                 OnPropertyChanged();
             }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -513,6 +513,17 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
             }
         }
 
+        public string ExcludedFileTypes
+        {
+            get => Settings.ExcludedFileTypes;
+            set
+            {
+                string sanitized = string.IsNullOrEmpty(value) ? value : value.Replace(" ", "").Replace(".", "");
+                Settings.ExcludedFileTypes = sanitized;
+                OnPropertyChanged();
+            }
+        }
+
 
         #region Everything FastSortWarning
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -281,6 +281,7 @@
                                         <RowDefinition />
                                         <RowDefinition />
                                         <RowDefinition />
+                                        <RowDefinition />
                                     </Grid.RowDefinitions>
                                     <TextBlock
                                         Grid.Row="0"
@@ -333,6 +334,20 @@
                                         DisplayMemberPath="Description"
                                         ItemsSource="{Binding PathEnumerationEngines}"
                                         SelectedItem="{Binding SelectedPathEnumerationEngine}" />
+                                    <TextBlock
+                                        Grid.Row="3"
+                                        Grid.Column="0"
+                                        Margin="0 15 20 0"
+                                        VerticalAlignment="Center"
+                                        Text="{DynamicResource plugin_explorer_Excluded_File_Types}"
+                                        TextBlock.Foreground="{DynamicResource Color05B}" />
+                                    <TextBox
+                                        Grid.Row="3"
+                                        Grid.Column="1"
+                                        MinWidth="350"
+                                        Margin="0,9,0,6"
+                                        ToolTip="{DynamicResource plugin_explorer_Excluded_File_Types_Tooltip}"
+                                        Text="{Binding ExcludedFileTypes}" />
                                 </Grid>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
- User can add file types through Explorer Settings which should be ignored in search results.
- Partially fixes #2144 since there was another idea to filter certain folders.

![image](https://github.com/user-attachments/assets/1710a3c3-1a6c-4ff1-8bec-f3fb88822eb8)
