### PR TITLE
Pass MaxResult setting to EverythingApi

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Flow.Launcher.Plugin.Explorer.csproj
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Flow.Launcher.Plugin.Explorer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -48,6 +48,7 @@
     <PackageReference Include="System.Data.OleDb" Version="8.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="tlbimp-Microsoft.Search.Interop" Version="1.0.0" />
+    <PackageReference Include="ModernWpfUI" Version="0.9.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Flow.Launcher.Plugin.Explorer.csproj
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Flow.Launcher.Plugin.Explorer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -48,7 +48,6 @@
     <PackageReference Include="System.Data.OleDb" Version="8.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="tlbimp-Microsoft.Search.Interop" Version="1.0.0" />
-    <PackageReference Include="ModernWpfUI" Version="0.9.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -66,6 +66,8 @@
     <system:String x:Key="plugin_explorer_Open_Window_Index_Option">Open Windows Index Option</system:String>
     <system:String x:Key="plugin_explorer_Excluded_File_Types">Excluded File Types (comma seperated)</system:String>
     <system:String x:Key="plugin_explorer_Excluded_File_Types_Tooltip">For example: exe,jpg,png</system:String>
+    <system:String x:Key="plugin_explorer_Maximum_Results">Maximum results</system:String>
+    <system:String x:Key="plugin_explorer_Maximum_Results_Tooltip">The maximum number of results requested from active search engine</system:String>
 
     <!--  Plugin Infos  -->
     <system:String x:Key="plugin_explorer_plugin_name">Explorer</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingSearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingSearchManager.cs
@@ -64,7 +64,11 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             if (token.IsCancellationRequested)
                 yield break;
 
-            var option = new EverythingSearchOption(search, Settings.SortOption, IsFullPathSearch: Settings.EverythingSearchFullPath, IsRunCounterEnabled: Settings.EverythingEnableRunCount);
+            var option = new EverythingSearchOption(search, 
+                Settings.SortOption, 
+                MaxCount: Settings.MaxResult, 
+                IsFullPathSearch: Settings.EverythingSearchFullPath, 
+                IsRunCounterEnabled: Settings.EverythingEnableRunCount);
 
             await foreach (var result in EverythingApi.SearchAsync(option, token))
                 yield return result;
@@ -96,6 +100,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                 Settings.SortOption,
                 IsContentSearch: true,
                 ContentSearchKeyword: contentSearch,
+                MaxCount: Settings.MaxResult,
                 IsFullPathSearch: Settings.EverythingSearchFullPath,
                 IsRunCounterEnabled: Settings.EverythingEnableRunCount);
 
@@ -116,6 +121,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                 Settings.SortOption,
                 ParentPath: path,
                 IsRecursive: recursive,
+                MaxCount: Settings.MaxResult,
                 IsFullPathSearch: Settings.EverythingSearchFullPath,
                 IsRunCounterEnabled: Settings.EverythingEnableRunCount);
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -530,7 +530,7 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
             get => Settings.MaxResult;
             set
             {
-                Settings.MaxResult = Math.Clamp(value, 0, 10000);
+                Settings.MaxResult = Math.Clamp(value, 100, 10000);
                 OnPropertyChanged();
             }
         }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -525,12 +525,15 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
             }
         }
 
+        public int MaxResultLowerLimit => 100;
+        public int MaxResultUpperLimit => 100000;
+
         public int MaxResult
         {
             get => Settings.MaxResult;
             set
             {
-                Settings.MaxResult = Math.Clamp(value, 100, 10000);
+                Settings.MaxResult = Math.Clamp(value, MaxResultLowerLimit, MaxResultUpperLimit);
                 OnPropertyChanged();
             }
         }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -525,6 +525,16 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
             }
         }
 
+        public int MaxResult
+        {
+            get => Settings.MaxResult;
+            set
+            {
+                Settings.MaxResult = Math.Clamp(value, 0, 10000);
+                OnPropertyChanged();
+            }
+        }
+
 
         #region Everything FastSortWarning
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -364,6 +364,7 @@
                                         HorizontalAlignment="Left"
                                         VerticalAlignment="Center"
                                         PreviewTextInput="AllowOnlyNumericInput"
+                                        MaxLength="6"
                                         Text="{Binding MaxResult}"
                                         ToolTip="{DynamicResource plugin_explorer_Maximum_Results_Tooltip}"/>
                                 </Grid>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -363,6 +363,7 @@
                                         Margin="0,9,0,6"
                                         HorizontalAlignment="Left"
                                         VerticalAlignment="Center"
+                                        PreviewTextInput="AllowOnlyNumericInput"
                                         Text="{Binding MaxResult}"
                                         ToolTip="{DynamicResource plugin_explorer_Maximum_Results_Tooltip}"/>
                                 </Grid>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -360,15 +360,13 @@
                                         Grid.Row="4"
                                         Grid.Column="1"
                                         MinWidth="350"
-                                        Maximum="10000"
-                                        Minimum="0"
                                         Margin="0,9,0,6"
                                         HorizontalAlignment="Left"
                                         VerticalAlignment="Center"
                                         CornerRadius="4"
                                         SmallChange="10"
                                         SpinButtonPlacementMode="Inline"
-                                        Value="{Binding MaxResult}"
+                                        Value="{Binding MaxResult, Delay=100}"
                                         ToolTip="{DynamicResource plugin_explorer_Maximum_Results_Tooltip}"/>
                                 </Grid>
                             </StackPanel>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -282,6 +282,7 @@
                                         <RowDefinition />
                                         <RowDefinition />
                                         <RowDefinition />
+                                        <RowDefinition />
                                     </Grid.RowDefinitions>
                                     <TextBlock
                                         Grid.Row="0"
@@ -348,6 +349,27 @@
                                         Margin="0,9,0,6"
                                         ToolTip="{DynamicResource plugin_explorer_Excluded_File_Types_Tooltip}"
                                         Text="{Binding ExcludedFileTypes}" />
+                                    <TextBlock
+                                        Grid.Row="4"
+                                        Grid.Column="0"
+                                        Margin="0 15 20 0"
+                                        VerticalAlignment="Center"
+                                        Text="{DynamicResource plugin_explorer_Maximum_Results}"
+                                        TextBlock.Foreground="{DynamicResource Color05B}" />
+                                    <ui:NumberBox
+                                        Grid.Row="4"
+                                        Grid.Column="1"
+                                        MinWidth="350"
+                                        Maximum="10000"
+                                        Minimum="0"
+                                        Margin="0,9,0,6"
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Center"
+                                        CornerRadius="4"
+                                        SmallChange="10"
+                                        SpinButtonPlacementMode="Inline"
+                                        Value="{Binding MaxResult}"
+                                        ToolTip="{DynamicResource plugin_explorer_Maximum_Results_Tooltip}"/>
                                 </Grid>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal">

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -356,17 +356,14 @@
                                         VerticalAlignment="Center"
                                         Text="{DynamicResource plugin_explorer_Maximum_Results}"
                                         TextBlock.Foreground="{DynamicResource Color05B}" />
-                                    <ui:NumberBox
+                                    <TextBox
                                         Grid.Row="4"
                                         Grid.Column="1"
                                         MinWidth="350"
                                         Margin="0,9,0,6"
                                         HorizontalAlignment="Left"
                                         VerticalAlignment="Center"
-                                        CornerRadius="4"
-                                        SmallChange="10"
-                                        SpinButtonPlacementMode="Inline"
-                                        Value="{Binding MaxResult, Delay=100}"
+                                        Text="{Binding MaxResult}"
                                         ToolTip="{DynamicResource plugin_explorer_Maximum_Results_Tooltip}"/>
                                 </Grid>
                             </StackPanel>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml.cs
@@ -1,4 +1,4 @@
-using Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks;
+﻿using Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks;
 using Flow.Launcher.Plugin.Explorer.ViewModels;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -40,7 +40,7 @@ namespace Flow.Launcher.Plugin.Explorer.Views
         }
 
 
-        
+
         private void AccessLinkDragDrop(string containerName, DragEventArgs e)
         {
             var files = (string[])e.Data.GetData(DataFormats.FileDrop);
@@ -93,6 +93,11 @@ namespace Flow.Launcher.Plugin.Explorer.Views
         private void LbxExcludedPaths_OnDrop(object sender, DragEventArgs e)
         {
             AccessLinkDragDrop("IndexSearchExcludedPath", e);
+        }
+
+        private void AllowOnlyNumericInput(object sender, System.Windows.Input.TextCompositionEventArgs e)
+        {
+            e.Handled = e.Text.ToCharArray().Any(c => !char.IsDigit(c));
         }
     }
 }


### PR DESCRIPTION
`MaxResult` value in `Settings.json` was ignored for *Everything* searches. Pass the value to `EverythingApi` for all searches.

Fixes #2873.