### PR TITLE
Fix ClockText and DateText to use CurrentUICulture

### DIFF
--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
@@ -155,9 +155,9 @@ public partial class SettingsPaneThemeViewModel : BaseModel
         set => Settings.KeepMaxResults = value;
     }
 
-    public string ClockText => DateTime.Now.ToString(TimeFormat, CultureInfo.CurrentCulture);
+    public string ClockText => DateTime.Now.ToString(TimeFormat, CultureInfo.CurrentUICulture);
 
-    public string DateText => DateTime.Now.ToString(DateFormat, CultureInfo.CurrentCulture);
+    public string DateText => DateTime.Now.ToString(DateFormat, CultureInfo.CurrentUICulture);
 
     public bool UseGlyphIcons
     {


### PR DESCRIPTION
Fixes #2882.

Date and Time previews are using `CurrentCulture` which is incorrect.

In order to use the correct UI culture managed by FlowLauncher, they should be using `CurrentUICulture`.

### Before, with English selected under settings:
![image](https://github.com/user-attachments/assets/8ee2c7f5-f768-4e84-a515-e073c5a0d686)

### After, with English selected under settings:
![image](https://github.com/user-attachments/assets/97222f63-6e9d-48e9-b09f-97fa70c39cee)

### After, with Spanish selected under settings:
![image](https://github.com/user-attachments/assets/b8598997-5be3-4a04-9e20-6a72d3f50df6)
