### PR TITLE
Update default plugin publish target branch

### DIFF
--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -2,7 +2,7 @@ name: Publish Default Plugins
 
 on:
   push:
-    branches: ['dev']
+    branches: ['master']
     paths: ['Plugins/**']
   workflow_dispatch:
 


### PR DESCRIPTION
Change the target branch to master so default plugin updates will be published to the store only on new flow releases.

Fix #2891