### PR TITLE
Enhancement: new builtin shortcuts: active_office_file

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -231,7 +231,8 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         public ObservableCollection<BuiltinShortcutModel> BuiltinShortcuts { get; set; } = new()
         {
             new BuiltinShortcutModel("{clipboard}", "shortcut_clipboard_description", Clipboard.GetText),
-            new BuiltinShortcutModel("{active_explorer_path}", "shortcut_active_explorer_path", FileExplorerHelper.GetActiveExplorerPath)
+            new BuiltinShortcutModel("{active_explorer_path}", "shortcut_active_explorer_path", FileExplorerHelper.GetActiveExplorerPath),
+            new BuiltinShortcutModel("{active_office_file}", "shortcut_active_office_file", Helper.GetActiveOfficeFilePath)
         };
 
         public bool DontPromptUpdateMsg { get; set; }


### PR DESCRIPTION
Fixes #2936

Add new builtin shortcut `{active_office_file}` to quickly access the active office file.

* Add a new method `GetActiveOfficeFilePath` in `Flow.Launcher.Infrastructure/Helper.cs` to retrieve the active office file path.
* Add a new builtin shortcut `{active_office_file}` in `Flow.Launcher.Infrastructure/UserSettings/Settings.cs` to use the `GetActiveOfficeFilePath` method.
* Update the `BuiltinShortcuts` list in `Flow.Launcher.Infrastructure/UserSettings/Settings.cs` to include the new `{active_office_file}` shortcut.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Flow-Launcher/Flow.Launcher/issues/2936?shareId=7c345bf1-299a-4876-b5d5-03ff82f7a873).