### PR TITLE
Fix `inputWithFileBtn` not working in SettingsTemplate.yml

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -4,8 +4,15 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
+using System.Windows.Forms;
 using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin;
+using CheckBox = System.Windows.Controls.CheckBox;
+using ComboBox = System.Windows.Controls.ComboBox;
+using Control = System.Windows.Controls.Control;
+using Orientation = System.Windows.Controls.Orientation;
+using TextBox = System.Windows.Controls.TextBox;
+using UserControl = System.Windows.Controls.UserControl;
 
 namespace Flow.Launcher.Core.Plugin
 {
@@ -224,6 +231,7 @@ namespace Flow.Launcher.Core.Plugin
                         break;
                     }
                     case "inputWithFileBtn":
+                    case "inputWithFolderBtn":
                     {
                         var textBox = new TextBox()
                         {
@@ -241,6 +249,24 @@ namespace Flow.Launcher.Core.Plugin
                         var Btn = new System.Windows.Controls.Button()
                         {
                             Margin = new Thickness(10, 0, 0, 0), Content = "Browse"
+                        };
+
+                        Btn.Click += (_, _) =>
+                        {
+                            CommonDialog dialog = type switch
+                            {
+                                "inputWithFolderBtn" => new FolderBrowserDialog(),
+                                _ => new OpenFileDialog(),
+                            };
+                            if (dialog.ShowDialog() != DialogResult.OK) return;
+
+                            var path = dialog switch
+                            {
+                                FolderBrowserDialog folderDialog => folderDialog.SelectedPath,
+                                OpenFileDialog fileDialog => fileDialog.FileName,
+                            };
+                            textBox.Text = path;
+                            Settings[attribute.Name] = path;
                         };
 
                         var dockPanel = new DockPanel() { Margin = settingControlMargin };

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -253,7 +253,7 @@ namespace Flow.Launcher.Core.Plugin
 
                         Btn.Click += (_, _) =>
                         {
-                            CommonDialog dialog = type switch
+                            using CommonDialog dialog = type switch
                             {
                                 "inputWithFolderBtn" => new FolderBrowserDialog(),
                                 _ => new OpenFileDialog(),


### PR DESCRIPTION
Closes #3056.

The button in `inputWithFileBtn` in `SettingsTemplate.yml` wasn't working because the button was created and displayed, but it had no click listener attached.

While fixing this, I found out that it's not easily possible to make a dialog that would let the user selected either a file or a folder. It's always either a dialog for selecting only files or a dialog for selecting only folders. Considering this, I also added another type of possible input for JS/Python plugins: `inputWithFolderBtn`.

I added static imports (`using Checkbox = ...`, `using ComboBox = ...`, etc.) because I needed to add the import statement for `System.Windows.Forms`, but as soon as I added it, it started complaining about ambiguous imports: it didn't know whether it's supposed to use UI components from `System.Windows.Controls` or from `System.Windows.Forms`.

Screenshot after I correctly managed to pick a file and a folder after my changes:
![image](https://github.com/user-attachments/assets/4f1b4dbe-97a3-45a8-9f92-b4bfda9aaf00)

Plugin's `Settings.json` file after I ran the `Save Settings` command in Flow:
```json
{
  "folder": "Z:\\flow-launcher\\Flow.Launcher",
  "file": "Z:\\flow-launcher\\Flow.Launcher\\README.md"
}
```

If this gets merged, https://github.com/Flow-Launcher/docs/pull/89 also should get merged.
