### PR TITLE
Fix Style for Highcontrast mode

### DIFF
--- a/Flow.Launcher/App.xaml
+++ b/Flow.Launcher/App.xaml
@@ -20,6 +20,11 @@
                                 <ResourceDictionary Source="pack://application:,,,/Resources/Dark.xaml" />
                             </ResourceDictionary.MergedDictionaries>
                         </ResourceDictionary>
+                        <ResourceDictionary x:Key="HighContrast">
+                            <ResourceDictionary.MergedDictionaries>
+                                <ResourceDictionary Source="pack://application:,,,/Resources/Dark.xaml" />
+                            </ResourceDictionary.MergedDictionaries>
+                        </ResourceDictionary>
                     </ui:ThemeResources.ThemeDictionaries>
                 </ui:ThemeResources>
                 <ui:XamlControlsResources />


### PR DESCRIPTION
## What's the PR
- Fixed an issue where windows os built-in highcontrast mode caused by a crash or the context menu color does not come out properly
- Processes to just call the dark style when highcontrast mode is on

## Test Cases
- [x] It should come out as usual when I turned on high contrast mode in Windows.

## Comment
- Technically we need to support high contrast mod style separately, but this is currently difficult to make and we have a separate built-in theme system, so this kind of support is enough.