### PR TITLE
feat: Show favicons as Bookmarks icons

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
@@ -68,7 +68,7 @@ public class Main : ISettingProvider, IPlugin, IReloadable, IPluginI18n, IContex
                     {
                         Title = c.Name,
                         SubTitle = c.Url,
-                        IcoPath = @"Images\bookmark.png",
+                        IcoPath = $"https://www.google.com/s2/favicons?domain={c.Url}&sz=64",
                         Score = BookmarkLoader.MatchProgram(c, param).Score,
                         Action = _ =>
                         {
@@ -90,7 +90,7 @@ public class Main : ISettingProvider, IPlugin, IReloadable, IPluginI18n, IContex
                     {
                         Title = c.Name,
                         SubTitle = c.Url,
-                        IcoPath = @"Images\bookmark.png",
+                        IcoPath = $"https://www.google.com/s2/favicons?domain={c.Url}&sz=64",
                         Score = 5,
                         Action = _ =>
                         {


### PR DESCRIPTION
### **What's in the PR:**

_There was an issue asking for this change, but I couldn't find the related Github issue_ :\

I replaced the default bookmarks plugin icon with Google's favicon API to fetch and display favicons for each bookmark from their corresponding websites.

![image](https://github.com/user-attachments/assets/66e819a2-4447-4c15-8caa-e0ee0866be12)

**Known issue:**
- A broken icon is showing if the API fails to fetch an icon.
![image](https://github.com/user-attachments/assets/a3d77f2c-9930-4004-9b87-8b978ec83082)
