### PR TITLE
Reload Context

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
@@ -135,10 +135,9 @@ namespace Flow.Launcher.Core.Plugin
 
         public virtual async Task ReloadDataAsync()
         {
-            SetupJsonRPC();
             try
             {
-                await RPC.InvokeAsync("reload", Context);
+                await RPC.InvokeAsync("reload_data", Context);
             }
             catch (RemoteMethodNotFoundException e)
             {

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
@@ -138,7 +138,7 @@ namespace Flow.Launcher.Core.Plugin
             SetupJsonRPC();
             try
             {
-                await RPC.InvokeAsync("reload", context);
+                await RPC.InvokeAsync("reload", Context);
             }
             catch (RemoteMethodNotFoundException e)
             {

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
@@ -133,10 +133,16 @@ namespace Flow.Launcher.Core.Plugin
             RPC.StartListening();
         }
 
-        public virtual Task ReloadDataAsync()
+        public virtual async Task ReloadDataAsync()
         {
             SetupJsonRPC();
-            return Task.CompletedTask;
+            try
+            {
+                await RPC.InvokeAsync("reload", context);
+            }
+            catch (RemoteMethodNotFoundException e)
+            {
+            }
         }
 
         public virtual async ValueTask DisposeAsync()


### PR DESCRIPTION
There's a problem with the current implementation.
`Reload` will restart jsonrpc_v2 plugin, but not calling `initialize`. This may break the plugin state that are not what plugin developer may assume.

There are two solution:
- [ ] Still restart the jsonrpc_v2 plugins, but call the `initialize` whenever reload.
- [x] Don't restart, but call a `reload` request.

This will be a breaking change regardless, but given the relatively small number of v2 plugin now it should be fine.

@Flow-Launcher/team which one would you think is better?