### PR TITLE
Suggest fix regex in gitstream CM file

### DIFF
--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -10,7 +10,7 @@ triggers:
     branch:
       - l10n_dev
       - dev
-      - r/(?i)(Dependabot|Renovate)/
+      - r/([Dd]ependabot|[Rr]enovate)/
 
 
 automations:


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1ijFr6wJb6bw00lvWmnabixQfJQAD9Q%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=HOTZUVl)

This pull request includes a small change to the `.cm/gitstream.cm` file. The change updates the regular expression pattern used for matching branch names to be case-insensitive for "Dependabot" and "Renovate".

* [`.cm/gitstream.cm`](diffhunk://#diff-065a0926b6e84a4f4a9ccff59eecfa8960bd0fb2a013dfbb75e2770c35cbfb75L13-R13): Updated the regular expression pattern to match both uppercase and lowercase versions of "Dependabot" and "Renovate".