### PR TITLE
Fix possible content frame navigation issue in welcome window & setting window

### DIFF
--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -171,6 +171,7 @@
                     IsPaneToggleButtonVisible="False"
                     IsSettingsVisible="False"
                     IsTabStop="False"
+                    Loaded="NavView_Loaded"
                     OpenPaneLength="240"
                     PaneDisplayMode="Left"
                     SelectionChanged="NavigationView_SelectionChanged">

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -29,7 +29,6 @@ public partial class SettingWindow
         _api = api;
         InitializePosition();
         InitializeComponent();
-        NavView.SelectedItem = NavView.MenuItems[0]; /* Set First Page */
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -169,7 +168,11 @@ public partial class SettingWindow
         else
         {
             var selectedItem = (NavigationViewItem)args.SelectedItem;
-            if (selectedItem == null) return;
+            if (selectedItem == null)
+            {
+                NavView_Loaded(sender, null); /* Reset First Page */
+                return;
+            }
 
             var pageType = selectedItem.Name switch
             {
@@ -184,6 +187,23 @@ public partial class SettingWindow
             };
             ContentFrame.Navigate(pageType, paneData);
         }
+    }
+
+    private void NavView_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (ContentFrame.IsLoaded)
+        {
+            ContentFrame_Loaded(sender, e);
+        }
+        else
+        {
+            ContentFrame.Loaded += ContentFrame_Loaded;
+        }
+    }
+
+    private void ContentFrame_Loaded(object sender, RoutedEventArgs e)
+    {
+        NavView.SelectedItem ??= NavView.MenuItems[0]; /* Set First Page */
     }
 
     public record PaneData(Settings Settings, Updater Updater, IPortable Portable);

--- a/Flow.Launcher/WelcomeWindow.xaml
+++ b/Flow.Launcher/WelcomeWindow.xaml
@@ -43,12 +43,12 @@
                         Grid.Column="0"
                         Width="16"
                         Height="16"
-                        Margin="10,4,4,4"
+                        Margin="10 4 4 4"
                         RenderOptions.BitmapScalingMode="HighQuality"
                         Source="/Images/app.png" />
                     <TextBlock
                         Grid.Column="1"
-                        Margin="4,0,0,0"
+                        Margin="4 0 0 0"
                         VerticalAlignment="Center"
                         FontSize="12"
                         Foreground="{DynamicResource Color05B}"
@@ -82,6 +82,7 @@
                 <ui:Frame
                     x:Name="ContentFrame"
                     HorizontalAlignment="Stretch"
+                    Loaded="ContentFrame_Loaded"
                     ScrollViewer.CanContentScroll="True"
                     ScrollViewer.HorizontalScrollBarVisibility="Visible"
                     ScrollViewer.VerticalScrollBarVisibility="Visible">
@@ -97,7 +98,7 @@
             Grid.Row="1"
             Background="{DynamicResource Color00B}"
             BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
-            BorderThickness="0,1,0,0">
+            BorderThickness="0 1 0 0">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="130" />
@@ -111,7 +112,7 @@
                     VerticalAlignment="Center">
                     <TextBlock
                         Name="PageNavigation"
-                        Margin="0,2,0,0"
+                        Margin="0 2 0 0"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
                         FontSize="14"
@@ -124,20 +125,20 @@
                     Grid.Column="0"
                     Width="100"
                     Height="40"
-                    Margin="20,5,0,5"
+                    Margin="20 5 0 5"
                     Click="BtnCancel_OnClick"
                     Content="{DynamicResource Skip}"
                     DockPanel.Dock="Right"
                     FontSize="14" />
                 <DockPanel
                     Grid.Column="2"
-                    Margin="0,0,20,0"
+                    Margin="0 0 20 0"
                     VerticalAlignment="Stretch">
                     <Button
                         x:Name="NextButton"
                         Width="40"
                         Height="40"
-                        Margin="8,5,0,5"
+                        Margin="8 5 0 5"
                         Click="ForwardButton_Click"
                         Content="&#xe76c;"
                         DockPanel.Dock="Right"

--- a/Flow.Launcher/WelcomeWindow.xaml
+++ b/Flow.Launcher/WelcomeWindow.xaml
@@ -43,12 +43,12 @@
                         Grid.Column="0"
                         Width="16"
                         Height="16"
-                        Margin="10 4 4 4"
+                        Margin="10,4,4,4"
                         RenderOptions.BitmapScalingMode="HighQuality"
                         Source="/Images/app.png" />
                     <TextBlock
                         Grid.Column="1"
-                        Margin="4 0 0 0"
+                        Margin="4,0,0,0"
                         VerticalAlignment="Center"
                         FontSize="12"
                         Foreground="{DynamicResource Color05B}"
@@ -98,7 +98,7 @@
             Grid.Row="1"
             Background="{DynamicResource Color00B}"
             BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
-            BorderThickness="0 1 0 0">
+            BorderThickness="0,1,0,0">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="130" />
@@ -112,7 +112,7 @@
                     VerticalAlignment="Center">
                     <TextBlock
                         Name="PageNavigation"
-                        Margin="0 2 0 0"
+                        Margin="0,2,0,0"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
                         FontSize="14"
@@ -125,20 +125,20 @@
                     Grid.Column="0"
                     Width="100"
                     Height="40"
-                    Margin="20 5 0 5"
+                    Margin="20,5,0,5"
                     Click="BtnCancel_OnClick"
                     Content="{DynamicResource Skip}"
                     DockPanel.Dock="Right"
                     FontSize="14" />
                 <DockPanel
                     Grid.Column="2"
-                    Margin="0 0 20 0"
+                    Margin="0,0,20,0"
                     VerticalAlignment="Stretch">
                     <Button
                         x:Name="NextButton"
                         Width="40"
                         Height="40"
-                        Margin="8 5 0 5"
+                        Margin="8,5,0,5"
                         Click="ForwardButton_Click"
                         Content="&#xe76c;"
                         DockPanel.Dock="Right"

--- a/Flow.Launcher/WelcomeWindow.xaml.cs
+++ b/Flow.Launcher/WelcomeWindow.xaml.cs
@@ -17,7 +17,6 @@ namespace Flow.Launcher
             InitializeComponent();
             BackButton.IsEnabled = false;
             this.settings = settings;
-            ContentFrame.Navigate(PageTypeSelector(1), settings);
         }
 
         private NavigationTransitionInfo _transitionInfo = new SlideNavigationTransitionInfo()
@@ -102,9 +101,15 @@ namespace Flow.Launcher
             var tRequest = new TraversalRequest(FocusNavigationDirection.Next);
             textBox.MoveFocus(tRequest);
         }
+
         private void OnActivated(object sender, EventArgs e)
         {
             Keyboard.ClearFocus();
+        }
+
+        private void ContentFrame_Loaded(object sender, RoutedEventArgs e)
+        {
+            ContentFrame.Navigate(PageTypeSelector(1), settings); /* Set First Page */
         }
     }
 }


### PR DESCRIPTION
Long before, when I have upgraded Flow.Launcher to v1.19.x version, I encountered the setting window navigation issue like this:
![Screenshot 2024-11-21 214502](https://github.com/user-attachments/assets/4d5d744f-4af0-4ee1-af54-7f9208c9dc7d)
(Note: This is just a demo screenshot. I just cannot find the original screenshot. :( I forget to create a issue for this.)

Now, I fix this possible issue to make sure the navigation event will only happen after all ui components are loaded. (I guess this is the problem)