### PR TITLE
Add `.`, `./lib`, `./plugin` directories to path for Python plugins

### DIFF
--- a/Flow.Launcher.Core/Plugin/PythonPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/PythonPlugin.cs
@@ -26,6 +26,9 @@ namespace Flow.Launcher.Core.Plugin
 
             var path = Path.Combine(Constant.ProgramDirectory, JsonRPC);
             _startInfo.EnvironmentVariables["PYTHONPATH"] = path;
+            // Prevent Python from writing .py[co] files.
+            // Because .pyc contains location infos which will prevent python portable.
+            _startInfo.EnvironmentVariables["PYTHONDONTWRITEBYTECODE"] = "1";
 
             _startInfo.EnvironmentVariables["FLOW_VERSION"] = Constant.Version;
             _startInfo.EnvironmentVariables["FLOW_PROGRAM_DIRECTORY"] = Constant.ProgramDirectory;
@@ -76,15 +79,13 @@ namespace Flow.Launcher.Core.Plugin
                 // Plugins always expect the JSON data to be in the third argument
                 // (we're always setting it as _startInfo.ArgumentList[2] = ...).
                 _startInfo.ArgumentList.Add("");
-                // Because plugins always expect the JSON data to be in the third argument, and specifying -c <code>
-                // takes up two arguments, we have to move `-B` to the end.
-                _startInfo.ArgumentList.Add("-B");
             }
             // Run .pyz files as is
             else
             {
-                // -B flag is needed to tell python not to write .py[co] files.
-                // Because .pyc contains location infos which will prevent python portable
+                // No need for -B flag because we're using PYTHONDONTWRITEBYTECODE env variable now,
+                // but the plugins still expect data to be sent as the third argument, so we're keeping
+                // the flag here, even though it's not necessary anymore.
                 _startInfo.ArgumentList.Add("-B");
                 _startInfo.ArgumentList.Add(context.CurrentPluginMetadata.ExecuteFilePath);
                 // Plugins always expect the JSON data to be in the third argument

--- a/Flow.Launcher.Core/Plugin/PythonPlugin.cs
+++ b/Flow.Launcher.Core/Plugin/PythonPlugin.cs
@@ -58,6 +58,8 @@ namespace Flow.Launcher.Core.Plugin
             {
                 var rootDirectory = context.CurrentPluginMetadata.PluginDirectory;
                 var libDirectory = Path.Combine(rootDirectory, "lib");
+                var libPyWin32Directory = Path.Combine(libDirectory, "win32");
+                var libPyWin32LibDirectory = Path.Combine(libPyWin32Directory, "lib");
                 var pluginDirectory = Path.Combine(rootDirectory, "plugin");
 
                 // This makes it easier for plugin authors to import their own modules.
@@ -70,6 +72,8 @@ namespace Flow.Launcher.Core.Plugin
                      import sys
                      sys.path.append(r'{rootDirectory}')
                      sys.path.append(r'{libDirectory}')
+                     sys.path.append(r'{libPyWin32LibDirectory}')
+                     sys.path.append(r'{libPyWin32Directory}')
                      sys.path.append(r'{pluginDirectory}')
 
                      import runpy

--- a/Flow.Launcher.Core/Plugin/PythonPluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/PythonPluginV2.cs
@@ -26,9 +26,7 @@ namespace Flow.Launcher.Core.Plugin
 
             var path = Path.Combine(Constant.ProgramDirectory, JsonRpc);
             StartInfo.EnvironmentVariables["PYTHONPATH"] = path;
-
-            //Add -B flag to tell python don't write .py[co] files. Because .pyc contains location infos which will prevent python portable
-            StartInfo.ArgumentList.Add("-B");
+            StartInfo.EnvironmentVariables["PYTHONDONTWRITEBYTECODE"] = "1";
         }
 
         public override async Task InitAsync(PluginInitContext context)

--- a/Flow.Launcher.Core/Plugin/PythonPluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/PythonPluginV2.cs
@@ -36,6 +36,8 @@ namespace Flow.Launcher.Core.Plugin
             {
                 var rootDirectory = context.CurrentPluginMetadata.PluginDirectory;
                 var libDirectory = Path.Combine(rootDirectory, "lib");
+                var libPyWin32Directory = Path.Combine(libDirectory, "win32");
+                var libPyWin32LibDirectory = Path.Combine(libPyWin32Directory, "lib");
                 var pluginDirectory = Path.Combine(rootDirectory, "plugin");
                 var filePath = context.CurrentPluginMetadata.ExecuteFilePath;
 
@@ -49,6 +51,8 @@ namespace Flow.Launcher.Core.Plugin
                      import sys
                      sys.path.append(r'{rootDirectory}')
                      sys.path.append(r'{libDirectory}')
+                     sys.path.append(r'{libPyWin32LibDirectory}')
+                     sys.path.append(r'{libPyWin32Directory}')
                      sys.path.append(r'{pluginDirectory}')
                      
                      import runpy


### PR DESCRIPTION
# The problem
Currently, due to Flow Launcher using embedded Python by default, plugin directory doesn't get added to path. This causes inconvenience for plugin developers. The plugin development documentation for Python suggests using `./lib` for installing dependencies and `./plugin` for actual plugin code, but developers can't import anything from there because these directories are not in Python's path. They have to add them to path manually in every plugin before they can start importing their code. For example, FlowYouTube plugin:
```py
import sys
import os

plugindir = os.path.abspath(os.path.dirname(__file__))
sys.path.append(plugindir)
sys.path.append(os.path.join(plugindir, "lib"))
sys.path.append(os.path.join(plugindir, "plugin"))

# Only now you can import and use your actual code
from plugin.main import FlowYouTube
```

# The solution
We can't simply add these paths to `PYTHONPATH` env variable before starting the plugin because we're using embedded Python. It ignores this variable. Flow Launcher users also might be using their own Python installations, so we can't use any solution that would apply only to our embedded Python. So the easiest solution I came up with was instead of launching the files directly (like `python path/to/file.py`), run some code that Flow Launcher generates, adding these paths to Python's path, and only then run the actual plugin file via `runpy`:
```cs
StartInfo.ArgumentList.Add("-c");
StartInfo.ArgumentList.Add(
    $"""
     import sys
     sys.path.append(r'{rootDirectory}')
     sys.path.append(r'{libDirectory}')
     sys.path.append(r'{pluginDirectory}')
     
     import runpy
     runpy.run_path(r'{filePath}', None, '__main__')
     """
);
```

# Backwards compatibility
I tested this change with several plugins, with them still manually adding directories to path and with them simply importing things. From my tests it seemed like they all continued working normally. Worst case scenario I can see is that either:
* a plugin will have non-existent directories added to path, which shouldn't have any effect
* or a plugin will have the same directories added to path twice, which also shouldn't have any effect

Now, to the plugins I tried running. I tested the listed plugins before removing the code marked red in the code blocks and after. They all continued working like before.

## v1

### GitHub Quick Launcher
No changes here, it's released as a `.pyz` file.

### FlowYouTube
```diff
- import sys
- import os

- plugindir = os.path.abspath(os.path.dirname(__file__))
- sys.path.append(plugindir)
- sys.path.append(os.path.join(plugindir, "lib"))
- sys.path.append(os.path.join(plugindir, "plugin"))

from plugin.main import FlowYouTube

if __name__ == "__main__":
    FlowYouTube()
```

### Search-MDI
```diff
# -*- coding: utf-8 -*-
- import sys
- import os

- plugindir = os.path.abspath(os.path.dirname(__file__))
- sys.path.append(plugindir)
- sys.path.append(os.path.join(plugindir, "lib"))
- sys.path.append(os.path.join(plugindir, "plugin"))

from plugin.main import MDI

if __name__ == "__main__":
    MDI()
```

### ChatGPT
```diff
# -*- coding: utf-8 -*-

- import sys
- import os

- parent_folder_path = os.path.abspath(os.path.dirname(__file__))
- sys.path.append(parent_folder_path)
- sys.path.append(os.path.join(parent_folder_path, "lib"))
- sys.path.append(os.path.join(parent_folder_path, "plugin"))

from plugin.main import ChatGPT


if __name__ == "__main__":
    ChatGPT()
```

## v2
### My unreleased plugin I use to test my plugin API v2 library
```diff
- import sys
- import os

- rootDirectory = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
- libDirectory = os.path.join(rootDirectory, 'lib')
- pluginDirectory = os.path.join(rootDirectory, 'plugin')

- sys.path.append(rootDirectory)
- sys.path.append(libDirectory)
- sys.path.append(pluginDirectory)

from plugin import Plugin

class MyPlugin(Plugin):
    pass
```

# Notes
While doing this I encountered a problem. v1 plugins expect requests to be sent as the third argument. I couldn't make `-c <code>` work after the request because I think it was thinking that the request JSON was file name, so I had to move `-c <code>` to be the first two arguments. However, Python stops processing arguments after it encounters `-c <code>`, so I couldn't specify `-B` after it, and I couldn't specify `-B` before because `-c <code>` takes up two arguments and the third argument must be the request. So I replaced `-B` flag usage with the PYTHONDONTWRITEBYTECODE environment variable that does the same thing.