### PR TITLE
Fix possible result update issue for plugins with IResultUpdate interface

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1447,26 +1447,35 @@ namespace Flow.Launcher.ViewModel
             }
 #endif
 
-            foreach (var metaResults in resultsForUpdates)
+            try
             {
-                foreach (var result in metaResults.Results)
+                foreach (var metaResults in resultsForUpdates)
                 {
-                    if (_topMostRecord.IsTopMost(result))
+                    foreach (var result in metaResults.Results)
                     {
-                        result.Score = int.MaxValue;
-                    }
-                    else
-                    {
-                        var priorityScore = metaResults.Metadata.Priority * 150;
-                        result.Score += _userSelectedRecord.GetSelectedCount(result) + priorityScore;
+                        if (_topMostRecord.IsTopMost(result))
+                        {
+                            result.Score = int.MaxValue;
+                        }
+                        else
+                        {
+                            var priorityScore = metaResults.Metadata.Priority * 150;
+                            result.Score += _userSelectedRecord.GetSelectedCount(result) + priorityScore;
+                        }
                     }
                 }
+
+                // it should be the same for all results
+                bool reSelect = resultsForUpdates.First().ReSelectFirstResult;
+
+                Results.AddResults(resultsForUpdates, token, reSelect);
             }
-
-            // it should be the same for all results
-            bool reSelect = resultsForUpdates.First().ReSelectFirstResult;
-
-            Results.AddResults(resultsForUpdates, token, reSelect);
+            catch (InvalidOperationException e)
+            {
+                // Plugin with IResultUpdate interface can somtimes throw this exception
+                // Collection was modified; enumeration operation may not execute
+                Log.Exception($"{nameof(MainViewModel)}.{nameof(UpdateResultView)}|UpdateResultView failed", e);
+            }
         }
 
         #endregion

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -233,8 +233,11 @@ namespace Flow.Launcher.ViewModel
 
                     var token = e.Token == default ? _updateToken : e.Token;
 
-                    PluginManager.UpdatePluginMetadata(e.Results, pair.Metadata, e.Query);
-                    if (!_resultsUpdateChannelWriter.TryWrite(new ResultsForUpdate(e.Results, pair.Metadata, e.Query,
+                    // make a copy of results to avoid plugin change the result when updating view model
+                    var resultsCopy = e.Results.ToList();
+
+                    PluginManager.UpdatePluginMetadata(resultsCopy, pair.Metadata, e.Query);
+                    if (!_resultsUpdateChannelWriter.TryWrite(new ResultsForUpdate(resultsCopy, pair.Metadata, e.Query,
                             token)))
                     {
                         Log.Error("MainViewModel", "Unable to add item to Result Update Queue");

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1447,35 +1447,26 @@ namespace Flow.Launcher.ViewModel
             }
 #endif
 
-            try
+            foreach (var metaResults in resultsForUpdates)
             {
-                foreach (var metaResults in resultsForUpdates)
+                foreach (var result in metaResults.Results)
                 {
-                    foreach (var result in metaResults.Results)
+                    if (_topMostRecord.IsTopMost(result))
                     {
-                        if (_topMostRecord.IsTopMost(result))
-                        {
-                            result.Score = int.MaxValue;
-                        }
-                        else
-                        {
-                            var priorityScore = metaResults.Metadata.Priority * 150;
-                            result.Score += _userSelectedRecord.GetSelectedCount(result) + priorityScore;
-                        }
+                        result.Score = int.MaxValue;
+                    }
+                    else
+                    {
+                        var priorityScore = metaResults.Metadata.Priority * 150;
+                        result.Score += _userSelectedRecord.GetSelectedCount(result) + priorityScore;
                     }
                 }
-
-                // it should be the same for all results
-                bool reSelect = resultsForUpdates.First().ReSelectFirstResult;
-
-                Results.AddResults(resultsForUpdates, token, reSelect);
             }
-            catch (InvalidOperationException e)
-            {
-                // Plugin with IResultUpdate interface can somtimes throw this exception
-                // Collection was modified; enumeration operation may not execute
-                Log.Exception($"{nameof(MainViewModel)}.{nameof(UpdateResultView)}|UpdateResultView failed", e);
-            }
+
+            // it should be the same for all results
+            bool reSelect = resultsForUpdates.First().ReSelectFirstResult;
+
+            Results.AddResults(resultsForUpdates, token, reSelect);
         }
 
         #endregion

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -85,7 +85,7 @@ namespace Flow.Launcher.Plugin.WebSearch
 
                 ResultsUpdated?.Invoke(this, new ResultUpdatedEventArgs
                 {
-                    Results = results.ToList(),
+                    Results = results,
                     Query = query
                 });
 

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -85,7 +85,7 @@ namespace Flow.Launcher.Plugin.WebSearch
 
                 ResultsUpdated?.Invoke(this, new ResultUpdatedEventArgs
                 {
-                    Results = results,
+                    Results = results.ToList(),
                     Query = query
                 });
 


### PR DESCRIPTION
# Issue
This issue could happen when calling `ResultsUpdated.Invoke` event in `IResultUpdate` interface so fast that main view model cannot complete update event (still execute foreach sentence).

# Example
Take `WebSearch` plugin for example, I change its `QueryAsync` function to this:
```
public async Task<List<Result>> QueryAsync(Query query, CancellationToken token)
{
    var results = new List<Result>();

    for (var i = 0; i < 1000; i++)
    {
        var result = new Result
        {
            Title = $"{i}",
            SubTitle = $"{i}",
            Score = i
        };

        results.Add(result);

        // here we update the results very fast and call results update event
        ResultsUpdated?.Invoke(this, new ResultUpdatedEventArgs
        {
            Results = results,
            Query = query
        });
    }

    return results;
}
```

And I can catch the exception in `UpdateResultView` function of `MainViewModel`:
![Screenshot 2024-12-08 091833](https://github.com/user-attachments/assets/dbdea0b0-56e5-48ce-9075-ef5006d51341)

## Solution

The key of the problem is that this plugin has not tell the developer to do thread-safe operation in `QueryAsync` (like return a copy of the list as the `Results` in `ResultUpdatedEventArgs`). So the developer will possibly return the same `List` to the `ResultUpdatedEventArgs` and the result of the `QueryAsync` function. I think there are two solutions for this.

### Solution 1

Update the `IResultUpdate` documents and ask developers to return the copy of the list as the parameter of `ResultUpdatedEventArgs`.

Take the above example, I can change its `QueryAsync` function to this:

```
var resultsCopy = results.ToList();

ResultsUpdated?.Invoke(this, new ResultUpdatedEventArgs
{
    Results = resultsCopy,
    Query = query
});
```

### Solution 2

Wrap the update codes in `UpdateResultView` with try catch, it is what my PR does.

### Solution 3

For example, you can change the definition of the `ResultUpdatedEventArgs` so that developer won't return the same `List` like this:

```
public class ResultUpdatedEventArgs : EventArgs
{
    public ConcurrentBag<Result> Results;  // thread-safe
    public Query Query;
    public CancellationToken Token { get; init; }
}
```