### PR TITLE
ci: fix permissions + migrate to fresher action (Pr Assign)

### DIFF
--- a/.github/workflows/pr_assignee.yml
+++ b/.github/workflows/pr_assignee.yml
@@ -1,8 +1,5 @@
 name: Assign PR to creator
 
-# Due to GitHub token limitation, only able to assign org members not authors from forks.
-# https://github.com/thomaseizinger/assign-pr-creator-action/issues/3
-
 on:
   pull_request:
     types: [opened]

--- a/.github/workflows/pr_assignee.yml
+++ b/.github/workflows/pr_assignee.yml
@@ -1,7 +1,7 @@
 name: Assign PR to creator
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
     branches-ignore:
       - l10n_dev

--- a/.github/workflows/pr_assignee.yml
+++ b/.github/workflows/pr_assignee.yml
@@ -9,11 +9,14 @@ on:
     branches-ignore:
       - l10n_dev
 
+permissions:
+  pull-requests: write
+
 jobs:
   automation:
     runs-on: ubuntu-latest
     steps:
     - name: Assign PR to creator
-      uses: thomaseizinger/assign-pr-creator-action@v1.0.0
+      uses: toshimaru/auto-author-assign@v2.1.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_milestone.yml
+++ b/.github/workflows/pr_milestone.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   automation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- added permissions, so it should fix `Resource not accessible by integration`
- migration from https://github.com/thomaseizinger/assign-pr-creator-action (archived from oct. 2023) to https://github.com/toshimaru/auto-author-assign (last commit 6 months ago)