### PR TITLE
Add preserve last action keyword options

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -62,7 +62,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         public double ItemHeightSize { get; set; } = 58;
         public double QueryBoxFontSize { get; set; } = 20;
         public double ResultItemFontSize { get; set; } = 16;
-        public double ResultSubItemFontSize { get; set; } = 13; 
+        public double ResultSubItemFontSize { get; set; } = 13;
         public string QueryBoxFont { get; set; } = FontFamily.GenericSansSerif.Name;
         public string QueryBoxFontStyle { get; set; }
         public string QueryBoxFontWeight { get; set; }
@@ -187,7 +187,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         public bool ShouldUsePinyin { get; set; } = false;
 
         public bool AlwaysPreview { get; set; } = false;
-        
+
         public bool AlwaysStartEn { get; set; } = false;
 
         private SearchPrecisionScore _querySearchPrecision = SearchPrecisionScore.Regular;
@@ -370,7 +370,9 @@ namespace Flow.Launcher.Infrastructure.UserSettings
     {
         Selected,
         Empty,
-        Preserved
+        Preserved,
+        ActionKeywordPreserved,
+        ActionKeywordSelected
     }
 
     public enum ColorSchemes

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -67,6 +67,8 @@
     <system:String x:Key="LastQueryPreserved">Preserve Last Query</system:String>
     <system:String x:Key="LastQuerySelected">Select last Query</system:String>
     <system:String x:Key="LastQueryEmpty">Empty last Query</system:String>
+    <system:String x:Key="LastQueryActionKeywordPreserved">Preserve Last Action Keyword</system:String>
+    <system:String x:Key="LastQueryActionKeywordSelected">Select Last Action Keyword</system:String>
     <system:String x:Key="KeepMaxResults">Fixed Window Height</system:String>
     <system:String x:Key="KeepMaxResultsToolTip">The window height is not adjustable by dragging.</system:String>
     <system:String x:Key="maxShowResults">Maximum results shown</system:String>

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -771,7 +771,7 @@ namespace Flow.Launcher.ViewModel
         public string Image => Constant.QueryTextBoxIconImagePath;
 
         public bool StartWithEnglishMode => Settings.AlwaysStartEn;
-        
+
         #endregion
 
         #region Preview
@@ -833,7 +833,7 @@ namespace Flow.Launcher.ViewModel
         }
 
         private void HidePreview()
-        {            
+        {
             if (PluginManager.UseExternalPreview())
                 CloseExternalPreview();
 
@@ -912,7 +912,7 @@ namespace Flow.Launcher.ViewModel
                     break;
             }
         }
-        
+
         private void UpdatePreview()
         {
             switch (PluginManager.UseExternalPreview())
@@ -1400,6 +1400,16 @@ namespace Flow.Launcher.ViewModel
                     if (Settings.UseAnimation)
                         await Task.Delay(100);
                     LastQuerySelected = false;
+                    break;
+                case LastQueryMode.ActionKeywordPreserved or LastQueryMode.ActionKeywordSelected:
+                    var newQuery = _lastQuery.ActionKeyword;
+                    if (!string.IsNullOrEmpty(newQuery))
+                        newQuery += " ";
+                    ChangeQueryText(newQuery);
+                    if (Settings.UseAnimation)
+                        await Task.Delay(100);
+                    if (Settings.LastQueryMode == LastQueryMode.ActionKeywordSelected)
+                        LastQuerySelected = false;
                     break;
                 default:
                     throw new ArgumentException($"wrong LastQueryMode: <{Settings.LastQueryMode}>");


### PR DESCRIPTION
Closes #3116. My IDE also removed a bunch of unnecessary whitespace when I edited these files. I thought it's not a big deal and that whitespace should have been removed anyway, so I didn't exclude those changes from the PR.

# What it is
These changes introduce two new options to Last Query Style in settings: "Preserve Last Action Keyword" and "Select Last Action Keyword". They work just like "Preserve/Select Last Query", but only for action keywords, not for whole queries. With these options, when there is an action keyword, the next time the user opens Flow Launcher, the query is set to `keyword ` (with a space after it, so the user can immediately begin typing). If the last query didn't have an action keyword, the query is set to an empty string.

# Testing
I've tested:
* That the previous options still work after my changes
* New options work as expected:
  * Preserve Last Action Keyword before the window hides
    ![image](https://github.com/user-attachments/assets/f8006d56-8b06-40f0-90d1-a5643d9f2419)
  * Preserve Last Action Keyword after the window hides and re-appears
    ![image](https://github.com/user-attachments/assets/dd2744cd-9359-4380-a3b5-5058c3f1e862)
  * Select Last Action Keyword before the window hides
    ![image](https://github.com/user-attachments/assets/f8006d56-8b06-40f0-90d1-a5643d9f2419)
  * Select Last Action Keyword after the window hides and re-appears
    ![image](https://github.com/user-attachments/assets/8c984f90-7013-409d-a647-206710972a7d)

