### PR TITLE
Add options for setting result on top & keeping result order

### DIFF
--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -269,6 +269,11 @@ namespace Flow.Launcher.Plugin
         public bool AddSelectedCount { get; set; } = true;
 
         /// <summary>
+        /// Maximum score. This can be useful when set one result to the top by default. This is the score for the results set to the topmost by users.
+        /// </summary>
+        public const int MaxScore = int.MaxValue;
+
+        /// <summary>
         /// Info of the preview section of a <see cref="Result"/>
         /// </summary>
         public record PreviewInfo

--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -264,6 +264,11 @@ namespace Flow.Launcher.Plugin
         public PreviewInfo Preview { get; set; } = PreviewInfo.Default;
 
         /// <summary>
+        /// Determines if the selected count should be added to the score
+        /// </summary>
+        public bool AddSelectedCount { get; set; } = true;
+
+        /// <summary>
         /// Info of the preview section of a <see cref="Result"/>
         /// </summary>
         public record PreviewInfo

--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -264,7 +264,7 @@ namespace Flow.Launcher.Plugin
         public PreviewInfo Preview { get; set; } = PreviewInfo.Default;
 
         /// <summary>
-        /// Determines if the selected count should be added to the score
+        /// Determines if the user selection count should be added to the score. This can be useful when set to false to allow the result sequence order to be the same everytime instead of changing based on selection.
         /// </summary>
         public bool AddSelectedCount { get; set; } = true;
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1471,9 +1471,9 @@ namespace Flow.Launcher.ViewModel
                 {
                     if (_topMostRecord.IsTopMost(result))
                     {
-                        result.Score = int.MaxValue;
+                        result.Score = Result.MaxScore;
                     }
-                    else if (result.Score != int.MaxValue)
+                    else if (result.Score != Result.MaxScore)
                     {
                         var priorityScore = metaResults.Metadata.Priority * 150;
                         result.Score += result.AddSelectedCount ?

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1476,7 +1476,9 @@ namespace Flow.Launcher.ViewModel
                     else if (result.Score != int.MaxValue)
                     {
                         var priorityScore = metaResults.Metadata.Priority * 150;
-                        result.Score += _userSelectedRecord.GetSelectedCount(result) + priorityScore;
+                        result.Score += result.AddSelectedCount ?
+                            _userSelectedRecord.GetSelectedCount(result) + priorityScore :
+                            priorityScore;
                     }
                 }
             }

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1473,7 +1473,7 @@ namespace Flow.Launcher.ViewModel
                     {
                         result.Score = int.MaxValue;
                     }
-                    else
+                    else if (result.Score != int.MaxValue)
                     {
                         var priorityScore = metaResults.Metadata.Priority * 150;
                         result.Score += _userSelectedRecord.GetSelectedCount(result) + priorityScore;


### PR DESCRIPTION
1. Fix user result set max value issue

If one plugin set the score of one result to int.MaxValue, `FL` should not add selected count & priority score.

Generally, this plugin want this result to the top of the query list.

2. Add support for removing selected count from score
 
If one plugin want to force the sequence of its results, it can set the `AddSelectedCount` to false so that `FL` will not add selected count.

Like one plugin with many query items which needs to allow user to set the sequence manually (order by datatime, etc.).