### PR TITLE
add CopyText keys to the open containing/target folders results in programs plugin 

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/UWPPackage.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/UWPPackage.cs
@@ -488,6 +488,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                     },
                     IcoPath = "Images/folder.png",
                     Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\xe838"),
+                    CopyText = Location,
                 }
             };
 

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/Win32.cs
@@ -267,6 +267,7 @@ namespace Flow.Launcher.Plugin.Program.Programs
                     },
                     IcoPath = "Images/folder.png",
                     Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\xe838"),
+                    CopyText = ParentDirectory,
                 },
             };
             if (Extension(FullPath) == ShortcutExtension)
@@ -278,16 +279,18 @@ namespace Flow.Launcher.Plugin.Program.Programs
 
         private Result OpenTargetFolderContextMenuResult(IPublicAPI api)
         {
+            var ParentDirectory = Path.GetDirectoryName(ExecutablePath);
             return new Result
             {
                 Title = api.GetTranslation("flowlauncher_plugin_program_open_target_folder"),
                 Action = _ =>
                 {
-                    api.OpenDirectory(Path.GetDirectoryName(ExecutablePath), ExecutablePath);
+                    api.OpenDirectory(ParentDirectory, ExecutablePath);
                     return true;
                 },
                 IcoPath = "Images/folder.png",
                 Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\xe8de"),
+                CopyText = ParentDirectory,
             };
         }
 


### PR DESCRIPTION
This PR adds the `CopyText` key to the `Open Containing Folder` and `Open Target Folder` results that show up in the context menus generated by the programs plugin.

*creating this as a draft PR so I can hopefully use appveyor to test it*