### PR TITLE
New API for Customizing Equal Rules for Results & Fix Result Clone Issue

### DIFF
--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -203,6 +203,17 @@ namespace Flow.Launcher.Plugin
                 TitleHighlightData = TitleHighlightData,
                 OriginQuery = OriginQuery,
                 PluginDirectory = PluginDirectory,
+                ContextData = ContextData,
+                PluginID = PluginID,
+                TitleToolTip = TitleToolTip,
+                SubTitleToolTip = SubTitleToolTip,
+                PreviewPanel = PreviewPanel,
+                ProgressBar = ProgressBar,
+                ProgressBarColor = ProgressBarColor,
+                Preview = Preview,
+                AddSelectedCount = AddSelectedCount,
+                GetTitleKey = GetTitleKey,
+                GetSubTitleKey = GetSubTitleKey,
             };
         }
 

--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -13,7 +12,6 @@ namespace Flow.Launcher.Plugin
     /// </summary>
     public class Result
     {
-
         private string _pluginDirectory;
 
         private string _icoPath;
@@ -102,7 +100,6 @@ namespace Flow.Launcher.Plugin
         /// Information for Glyph Icon (Prioritized than IcoPath/Icon if user enable Glyph Icons)
         /// </summary>
         public GlyphInfo Glyph { get; init; }
-
 
         /// <summary>
         /// An action to take in the form of a function call when the result has been selected.
@@ -272,6 +269,26 @@ namespace Flow.Launcher.Plugin
         /// Maximum score. This can be useful when set one result to the top by default. This is the score for the results set to the topmost by users.
         /// </summary>
         public const int MaxScore = int.MaxValue;
+
+        /// <summary>
+        /// An action to get the key of the title. This is used when FL checks whether the result is the topmost record. Or FL calculates the hashcode of the result for user selected records.
+        /// This can be useful when your plugin will change the title of the result dynamically.
+        /// </summary>
+        /// <remarks>
+        /// The function is invoked with the title of the result as the only parameter.
+        /// Its result determines the key of the title.
+        /// </remarks>
+        public Func<string, string> GetTitleKey { get; set; } = null;
+
+        /// <summary>
+        /// An action to get the key of the subtitle. This is used when FL checks whether the result is the topmost record. Or FL calculates the hashcode of the result for user selected records.
+        /// This can be useful when your plugin will change the subtitle of the result dynamically.
+        /// </summary>
+        /// <remarks>
+        /// The function is invoked with the subtitle of the result as the only parameter.
+        /// Its result determines the key of the subtitle.
+        /// </remarks>
+        public Func<string, string> GetSubTitleKey { get; set; } = null;
 
         /// <summary>
         /// Info of the preview section of a <see cref="Result"/>

--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -52,8 +52,14 @@ namespace Flow.Launcher.Storage
 
         public bool Equals(Result r)
         {
-            return Title == r.Title
-                && SubTitle == r.SubTitle
+            var titleEqual = r.GetTitleKey != null ?
+                r.GetTitleKey(Title) == r.GetTitleKey(r.Title) :
+                Title == r.Title;
+            var subTitleEqual = r.GetSubTitleKey != null ?
+                r.GetSubTitleKey(SubTitle) == r.GetSubTitleKey(r.SubTitle) :
+                SubTitle == r.SubTitle;
+            return titleEqual
+                && subTitleEqual
                 && PluginID == r.PluginID;
         }
     }

--- a/Flow.Launcher/Storage/UserSelectedRecord.cs
+++ b/Flow.Launcher/Storage/UserSelectedRecord.cs
@@ -15,7 +15,6 @@ namespace Flow.Launcher.Storage
         [JsonInclude, JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Dictionary<string, int> records { get; private set; }
 
-
         public UserSelectedRecord()
         {
             recordsWithQuery = new Dictionary<int, int>();
@@ -45,8 +44,8 @@ namespace Flow.Launcher.Storage
 
         private static int GenerateResultHashCode(Result result)
         {
-            int hashcode = GenerateStaticHashCode(result.Title);
-            return GenerateStaticHashCode(result.SubTitle, hashcode);
+            int hashcode = GenerateStaticHashCode(result.GetTitleKey != null ? result.GetTitleKey(result.Title) : result.Title);
+            return GenerateStaticHashCode(result.GetSubTitleKey != null ? result.GetSubTitleKey(result.SubTitle) : result.SubTitle, hashcode);
         }
 
         private static int GenerateQueryAndResultHashCode(Query query, Result result)
@@ -58,8 +57,8 @@ namespace Flow.Launcher.Storage
 
             int hashcode = GenerateStaticHashCode(query.ActionKeyword);
             hashcode = GenerateStaticHashCode(query.Search, hashcode);
-            hashcode = GenerateStaticHashCode(result.Title, hashcode);
-            hashcode = GenerateStaticHashCode(result.SubTitle, hashcode);
+            hashcode = GenerateStaticHashCode(result.GetTitleKey != null ? result.GetTitleKey(result.Title) : result.Title, hashcode);
+            hashcode = GenerateStaticHashCode(result.GetSubTitleKey != null ? result.GetSubTitleKey(result.SubTitle) : result.SubTitle, hashcode);
 
             return hashcode;
         }


### PR DESCRIPTION
# New API for Customizing Equal Rules for Results
`GetTitleKey` and `GetSubTitleKey` are the actions to get the key of the title or the subtitle.

These keys will be used when FL checks whether the result is the topmost record.

Or FL calculates the hashcode of the result for user selected records.

This is useful if one plugin needs to change the title or the subtitle of one record dynamically.

E.g. The records of plugin `Edge Workspace` have subtitles which can change based on the tab number of the edge workspace, but FL should regard these records as the same. (Full issue in https://github.com/cspotcode/Flow.Launcher.Plugin.EdgeWorkspaces/issues/3)

> Because #3112 is in the 1.20.0 milestone, so I have not change the codes related to this.

# Fix Result Clone Issue
I find that some properties are not cloned when calling `Clone` function in the `Result`, so I fix this clone issue.