### PR TITLE
do not try catch the error for jsonrpc v2

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginV2.cs
@@ -26,54 +26,33 @@ namespace Flow.Launcher.Core.Plugin
 
         protected override async Task<bool> ExecuteResultAsync(JsonRPCResult result)
         {
-            try
-            {
-                var res = await RPC.InvokeAsync<JsonRPCExecuteResponse>(result.JsonRPCAction.Method,
-                    argument: result.JsonRPCAction.Parameters);
+            var res = await RPC.InvokeAsync<JsonRPCExecuteResponse>(result.JsonRPCAction.Method,
+                argument: result.JsonRPCAction.Parameters);
 
-                return res.Hide;
-            }
-            catch
-            {
-                return false;
-            }
+            return res.Hide;
         }
 
         private JoinableTaskFactory JTF { get; } = new JoinableTaskFactory(new JoinableTaskContext());
 
         public override List<Result> LoadContextMenus(Result selectedResult)
         {
-            try
-            {
-                var res = JTF.Run(() => RPC.InvokeWithCancellationAsync<JsonRPCQueryResponseModel>("context_menu",
-                    new object[] { selectedResult.ContextData }));
+            var res = JTF.Run(() => RPC.InvokeWithCancellationAsync<JsonRPCQueryResponseModel>("context_menu",
+                new object[] { selectedResult.ContextData }));
 
-                var results = ParseResults(res);
+            var results = ParseResults(res);
 
-                return results;
-            }
-            catch
-            {
-                return new List<Result>();
-            }
+            return results;
         }
 
         public override async Task<List<Result>> QueryAsync(Query query, CancellationToken token)
         {
-            try
-            {
-                var res = await RPC.InvokeWithCancellationAsync<JsonRPCQueryResponseModel>("query",
-                    new object[] { query, Settings.Inner },
-                    token);
+            var res = await RPC.InvokeWithCancellationAsync<JsonRPCQueryResponseModel>("query",
+                new object[] { query, Settings.Inner },
+                token);
 
-                var results = ParseResults(res);
+            var results = ParseResults(res);
 
-                return results;
-            }
-            catch
-            {
-                return new List<Result>();
-            }
+            return results;
         }
 
 


### PR DESCRIPTION
We shouldn't try catch the error when querying, but instead should let flow handle it.