### PR TITLE
New API for Record Key of Results & Fix Result Clone Issue

### DIFF
--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -185,6 +185,16 @@ namespace Flow.Launcher.Plugin
                 TitleHighlightData = TitleHighlightData,
                 OriginQuery = OriginQuery,
                 PluginDirectory = PluginDirectory,
+                ContextData = ContextData,
+                PluginID = PluginID,
+                TitleToolTip = TitleToolTip,
+                SubTitleToolTip = SubTitleToolTip,
+                PreviewPanel = PreviewPanel,
+                ProgressBar = ProgressBar,
+                ProgressBarColor = ProgressBarColor,
+                Preview = Preview,
+                AddSelectedCount = AddSelectedCount,
+                RecordKey = RecordKey
             };
         }
 
@@ -251,6 +261,13 @@ namespace Flow.Launcher.Plugin
         /// Maximum score. This can be useful when set one result to the top by default. This is the score for the results set to the topmost by users.
         /// </summary>
         public const int MaxScore = int.MaxValue;
+
+        /// <summary>
+        /// The key to identify the record. This is used when FL checks whether the result is the topmost record. Or FL calculates the hashcode of the result for user selected records.
+        /// This can be useful when your plugin will change the Title or SubTitle of the result dynamically.
+        /// If the plugin does not specific this, FL just uses Title and SubTitle to identify this result.
+        /// </summary>
+        public string RecordKey { get; set; } = string.Empty;
 
         /// <summary>
         /// Info of the preview section of a <see cref="Result"/>

--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -33,7 +33,8 @@ namespace Flow.Launcher.Storage
             {
                 PluginID = result.PluginID,
                 Title = result.Title,
-                SubTitle = result.SubTitle
+                SubTitle = result.SubTitle,
+                RecordKey = result.RecordKey
             };
             records.AddOrUpdate(result.OriginQuery.RawQuery, record, (key, oldValue) => record);
         }
@@ -49,12 +50,21 @@ namespace Flow.Launcher.Storage
         public string Title { get; set; }
         public string SubTitle { get; set; }
         public string PluginID { get; set; }
+        public string RecordKey { get; set; }
 
         public bool Equals(Result r)
         {
-            return Title == r.Title
-                && SubTitle == r.SubTitle
-                && PluginID == r.PluginID;
+            if (string.IsNullOrEmpty(RecordKey) || string.IsNullOrEmpty(r.RecordKey))
+            {
+                return Title == r.Title
+                    && SubTitle == r.SubTitle
+                    && PluginID == r.PluginID;
+            }
+            else
+            {
+                return RecordKey == r.RecordKey
+                    && PluginID == r.PluginID;
+            }
         }
     }
 }

--- a/Flow.Launcher/Storage/UserSelectedRecord.cs
+++ b/Flow.Launcher/Storage/UserSelectedRecord.cs
@@ -15,7 +15,6 @@ namespace Flow.Launcher.Storage
         [JsonInclude, JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public Dictionary<string, int> records { get; private set; }
 
-
         public UserSelectedRecord()
         {
             recordsWithQuery = new Dictionary<int, int>();
@@ -45,8 +44,15 @@ namespace Flow.Launcher.Storage
 
         private static int GenerateResultHashCode(Result result)
         {
-            int hashcode = GenerateStaticHashCode(result.Title);
-            return GenerateStaticHashCode(result.SubTitle, hashcode);
+            if (string.IsNullOrEmpty(result.RecordKey))
+            {
+                int hashcode = GenerateStaticHashCode(result.Title);
+                return GenerateStaticHashCode(result.SubTitle, hashcode);
+            }
+            else
+            {
+                return GenerateStaticHashCode(result.RecordKey);
+            }
         }
 
         private static int GenerateQueryAndResultHashCode(Query query, Result result)
@@ -58,8 +64,16 @@ namespace Flow.Launcher.Storage
 
             int hashcode = GenerateStaticHashCode(query.ActionKeyword);
             hashcode = GenerateStaticHashCode(query.Search, hashcode);
-            hashcode = GenerateStaticHashCode(result.Title, hashcode);
-            hashcode = GenerateStaticHashCode(result.SubTitle, hashcode);
+
+            if (string.IsNullOrEmpty(result.RecordKey))
+            {
+                hashcode = GenerateStaticHashCode(result.Title, hashcode);
+                hashcode = GenerateStaticHashCode(result.SubTitle, hashcode);
+            }
+            else
+            {
+                hashcode = GenerateStaticHashCode(result.RecordKey, hashcode);
+            }
 
             return hashcode;
         }


### PR DESCRIPTION
# Add `RecordKey` for `Result` class.

* The key to identify the record. This is used when FL checks whether the result is the topmost record. Or FL calculates the hashcode of the result for user selected records.
* This can be useful when your plugin will change the Title or SubTitle of the result dynamically.
* If the plugin does not specific this, FL just uses Title and SubTitle to identify this result.

E.g. The records of plugin `Edge Workspace` have subtitles which can change based on the tab number of the edge workspace, but FL should regard these records as the same. (Full issue in https://github.com/cspotcode/Flow.Launcher.Plugin.EdgeWorkspaces/issues/3)

More details in #3178.

# Advantages

* `Title` and `SubTitle` of the `Result` should be the properties for display, and `RecordKey` can be the property for identification. That way one plugin can specify any unique key, and FL will use it, ignoring title and subtitle. Plugin can get full control and can modify title or subtitle without breaking `TopmostRecord` and `UserSelectedRecord`.

* A nullable identification field / RecordKey is also easier for non-C# plugins because it avoids extra RPC calling between C# and the external process. And in the case of Edge Workspaces, the Edge browser already assigns each workspace a unique UUID, so we can use that value for RecordKey.