### PR TITLE
Improve context menu item action response & Fix origin query null exception

### DIFF
--- a/Flow.Launcher.Plugin/Query.cs
+++ b/Flow.Launcher.Plugin/Query.cs
@@ -1,22 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Flow.Launcher.Plugin
 {
     public class Query
     {
         public Query() { }
-
-        [Obsolete("Use the default Query constructor.")]
-        public Query(string rawQuery, string search, string[] terms, string[] searchTerms, string actionKeyword = "")
-        {
-            Search = search;
-            RawQuery = rawQuery;
-            SearchTerms = searchTerms;
-            ActionKeyword = actionKeyword;
-        }
 
         /// <summary>
         /// Raw query, this includes action keyword if it has

--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -12,6 +12,8 @@ namespace Flow.Launcher.Storage
 
         internal bool IsTopMost(Result result)
         {
+            // origin query is null when user select the context menu item directly of one item from query list
+            // in this case, we do not need to check if the result is top most
             if (records.IsEmpty || result.OriginQuery == null ||
                 !records.TryGetValue(result.OriginQuery.RawQuery, out var value))
             {

--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -26,11 +26,25 @@ namespace Flow.Launcher.Storage
 
         internal void Remove(Result result)
         {
+            // origin query is null when user select the context menu item directly of one item from query list
+            // in this case, we do not need to remove the record
+            if (result.OriginQuery == null)
+            {
+                return;
+            }
+
             records.Remove(result.OriginQuery.RawQuery, out _);
         }
 
         internal void AddOrUpdate(Result result)
         {
+            // origin query is null when user select the context menu item directly of one item from query list
+            // in this case, we do not need to add or update the record
+            if (result.OriginQuery == null)
+            {
+                return;
+            }
+
             var record = new Record
             {
                 PluginID = result.PluginID,
@@ -38,11 +52,6 @@ namespace Flow.Launcher.Storage
                 SubTitle = result.SubTitle
             };
             records.AddOrUpdate(result.OriginQuery.RawQuery, record, (key, oldValue) => record);
-        }
-
-        public void Load(Dictionary<string, Record> dictionary)
-        {
-            records = new ConcurrentDictionary<string, Record>(dictionary);
         }
     }
 

--- a/Flow.Launcher/Storage/UserSelectedRecord.cs
+++ b/Flow.Launcher/Storage/UserSelectedRecord.cs
@@ -51,6 +51,8 @@ namespace Flow.Launcher.Storage
 
         private static int GenerateQueryAndResultHashCode(Query query, Result result)
         {
+            // query is null when user select the context menu item directly of one item from query list
+            // so we only need to consider the result
             if (query == null)
             {
                 return GenerateResultHashCode(result);

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1273,6 +1273,8 @@ namespace Flow.Launcher.ViewModel
                     {
                         _topMostRecord.Remove(result);
                         App.API.ShowMsg(InternationalizationManager.Instance.GetTranslation("success"));
+                        App.API.BackToQueryResults();
+                        App.API.ReQuery();
                         return false;
                     }
                 };
@@ -1289,6 +1291,8 @@ namespace Flow.Launcher.ViewModel
                     {
                         _topMostRecord.AddOrUpdate(result);
                         App.API.ShowMsg(InternationalizationManager.Instance.GetTranslation("success"));
+                        App.API.BackToQueryResults();
+                        App.API.ReQuery();
                         return false;
                     }
                 };

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -396,11 +396,15 @@ namespace Flow.Launcher.ViewModel
                 })
                 .ConfigureAwait(false);
 
-
             if (SelectedIsFromQueryResults())
             {
                 _userSelectedRecord.Add(result);
-                _history.Add(result.OriginQuery.RawQuery);
+                // origin query is null when user select the context menu item directly of one item from query list
+                // so we don't want to add it to history
+                if (result.OriginQuery != null)
+                {
+                    _history.Add(result.OriginQuery.RawQuery);
+                }
                 lastHistoryIndex = 1;
             }
 
@@ -985,9 +989,9 @@ namespace Flow.Launcher.ViewModel
             {
                 List<Result> results;
 
-                    results = PluginManager.GetContextMenusForPlugin(selected);
-                    results.Add(ContextMenuTopMost(selected));
-                    results.Add(ContextMenuPluginInfo(selected.PluginID));
+                results = PluginManager.GetContextMenusForPlugin(selected);
+                results.Add(ContextMenuTopMost(selected));
+                results.Add(ContextMenuPluginInfo(selected.PluginID));
 
                 if (!string.IsNullOrEmpty(query))
                 {

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -34,8 +34,6 @@ namespace Flow.Launcher.ViewModel
 
         private bool _isQueryRunning;
         private Query _lastQuery;
-        private Result lastContextMenuResult = new Result();
-        private List<Result> lastContextMenuResults = new List<Result>();
         private string _queryTextBeforeLeaveResults;
 
         private readonly FlowLauncherJsonStorage<History> _historyItemsStorage;
@@ -986,19 +984,10 @@ namespace Flow.Launcher.ViewModel
             if (selected != null) // SelectedItem returns null if selection is empty.
             {
                 List<Result> results;
-                if (selected == lastContextMenuResult)
-                {
-                    results = lastContextMenuResults;
-                }
-                else
-                {
+
                     results = PluginManager.GetContextMenusForPlugin(selected);
-                    lastContextMenuResults = results;
-                    lastContextMenuResult = selected;
                     results.Add(ContextMenuTopMost(selected));
                     results.Add(ContextMenuPluginInfo(selected.PluginID));
-                }
-
 
                 if (!string.IsNullOrEmpty(query))
                 {
@@ -1381,8 +1370,6 @@ namespace Flow.Launcher.ViewModel
             lastHistoryIndex = 1;
             // Trick for no delay
             MainWindowOpacity = 0;
-            lastContextMenuResult = new Result();
-            lastContextMenuResults = new List<Result>();
 
             if (ExternalPreviewVisible)
                 CloseExternalPreview();

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
@@ -242,6 +242,7 @@ namespace Flow.Launcher.Plugin.Explorer
                                 var name = "Plugin: Folder";
                                 var message = $"File not found: {e.Message}";
                                 Context.API.ShowMsgError(name, message);
+                                return false;
                             }
 
                             return true;

--- a/Plugins/Flow.Launcher.Plugin.Program/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Main.cs
@@ -264,6 +264,8 @@ namespace Flow.Launcher.Plugin.Program
                             Context.API.GetTranslation("flowlauncher_plugin_program_disable_dlgtitle_success"),
                             Context.API.GetTranslation(
                                 "flowlauncher_plugin_program_disable_dlgtitle_success_message"));
+                        Context.API.BackToQueryResults();
+                        Context.API.ReQuery();
                         return false;
                     },
                     IcoPath = "Images/disable.png",


### PR DESCRIPTION
# 1. Feature: Improve context menu item action response

For those actions in the FL and Program plugin (Pin / Unpin record to the topmost; Disable one program), when you click those records, like pin / unpin it to the topmost without closing the FL, the search bar will be empty and you must need to click `esc` to return back to the query list before any other actions.

Now with new API `BackToQueryList` (#3087), we can improve those behavious.

What's more, we need to remove the context menu cache feature, it can cause the cache of the original wrong context menu.

By the way, I do not think context menu caching is a good idea because the plugin with dynamic context menu will have a bad experience if user open the context menu of the same record twice.

## Test

Original:

![Screenshot 2025-01-26 195656](https://github.com/user-attachments/assets/49d08f1d-9b35-4378-bae2-215f0542d044)

Now:

https://github.com/user-attachments/assets/b3b3f752-7222-4e3d-8b7f-f9daf3003779

After you clicked the one record to pin / unpin it to the topmost, it will automatically return back to the query list.

# 2. Fix: Fix origin query null exception

**Note: This fix can make the test of the feature above work, so it is included in this PR!**

When user select the context menu item directly of one item from query list, the origin query is null. (No idea why this happens but it happens) And we need to add null check for this.

![Screenshot 2025-01-26 202331](https://github.com/user-attachments/assets/c2e4c1d7-ec51-41a4-bca0-f9dfc3a4c0f2)
