### PR TITLE
Fix setting window freeze issue & Improve singleton window opener

### DIFF
--- a/Flow.Launcher/Helper/SingletonWindowOpener.cs
+++ b/Flow.Launcher/Helper/SingletonWindowOpener.cs
@@ -10,16 +10,29 @@ public static class SingletonWindowOpener
     {
         var window = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.GetType() == typeof(T))
                      ?? (T)Activator.CreateInstance(typeof(T), args);
-            
+
         // Fix UI bug
         // Add `window.WindowState = WindowState.Normal`
         // If only use `window.Show()`, Settings-window doesn't show when minimized in taskbar 
         // Not sure why this works tho
         // Probably because, when `.Show()` fails, `window.WindowState == Minimized` (not `Normal`) 
         // https://stackoverflow.com/a/59719760/4230390
-        window.WindowState = WindowState.Normal; 
-        window.Show();
-            
+        // Ensure the window is not minimized before showing it
+        if (window.WindowState == WindowState.Minimized)
+        {
+            window.WindowState = WindowState.Normal;
+        }
+
+        // Ensure the window is visible
+        if (!window.IsVisible)
+        {
+            window.Show();
+        }
+        else
+        {
+            window.Activate(); // Bring the window to the foreground if already open
+        }
+
         window.Focus();
 
         return (T)window;

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -34,11 +34,11 @@ public partial class SettingWindow
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
         RefreshMaximizeRestoreButton();
-        // Fix (workaround) for the window freezes after lock screen (Win+L)
+        // Fix (workaround) for the window freezes after lock screen (Win+L) or sleep
         // https://stackoverflow.com/questions/4951058/software-rendering-mode-wpf
         HwndSource hwndSource = PresentationSource.FromVisual(this) as HwndSource;
         HwndTarget hwndTarget = hwndSource.CompositionTarget;
-        hwndTarget.RenderMode = RenderMode.Default;
+        hwndTarget.RenderMode = RenderMode.SoftwareOnly;  // Must use software only render mode here
 
         InitializePosition();
     }


### PR DESCRIPTION
Fix setting window freeze issue after lock screen (Win+L) or sleep (Some commits seem to change the codes that try to fix this issue 😢)
Improve singleton window opener

Already tested on my computer and it works well now!

Related issue: #3139, #3169, #3187