### PR TITLE
add BackToQueryResults to JsonRPCPublicAPI

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCV2Models/JsonRPCPublicAPI.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCV2Models/JsonRPCPublicAPI.cs
@@ -173,5 +173,10 @@ namespace Flow.Launcher.Core.Plugin.JsonRPCV2Models
         {
             _api.OpenAppUri(appUri);
         }
+
+        public void BackToQueryResults()
+        {
+            _api.BackToQueryResults();
+        }
     }
 }


### PR DESCRIPTION
#3087 created the `BackToQueryResults` API method, but didn't make it accessible to Jsonrpc-v2 plugins, so this pr lets jsonrpc v2 plugins use the api method