### PR TITLE
Fix unix directory seperator issue

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Constants.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Constants.cs
@@ -22,7 +22,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         internal const string WindowsIndexErrorImagePath = "Images\\index_error2.png";
         internal const string GeneralSearchErrorImagePath = "Images\\robot_error.png";
 
-
         internal const string ToolTipOpenDirectory = "Ctrl + Enter to open the directory";
 
         internal const string ToolTipOpenContainingFolder = "Ctrl + Enter to open the containing folder";
@@ -30,6 +29,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         internal const char AllFilesFolderSearchWildcard = '>';
 
         internal const string DefaultContentSearchActionKeyword = "doc:";
+
+        internal const char UnixDirectorySeparator = '/';
 
         internal const char DirectorySeparator = '\\';
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Constants.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Constants.cs
@@ -31,8 +31,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
         internal const string DefaultContentSearchActionKeyword = "doc:";
 
-        internal const char UnixDirectorySeparator = '/';
-
         internal const char DirectorySeparator = '\\';
 
         internal const string WindowsIndexingOptions = "srchadmin.dll";

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Constants.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Constants.cs
@@ -31,6 +31,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
         internal const string DefaultContentSearchActionKeyword = "doc:";
 
+        internal const char UnixDirectorySeparator = '/';
+
         internal const char DirectorySeparator = '\\';
 
         internal const string WindowsIndexingOptions = "srchadmin.dll";

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
@@ -1,4 +1,4 @@
-﻿using Flow.Launcher.Infrastructure.Logger;
+using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Plugin.SharedCommands;
 using System;
 using System.Collections.Generic;
@@ -12,9 +12,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo
     {
         internal static IEnumerable<SearchResult> TopLevelDirectorySearch(Query query, string search, CancellationToken token)
         {
-            // if user uses the unix directory separator, we need to convert it to windows directory separator
-            search = search.Replace(Constants.UnixDirectorySeparator, Constants.DirectorySeparator);
-
             var criteria = ConstructSearchCriteria(search);
 
             if (search.LastIndexOf(Constants.AllFilesFolderSearchWildcard) >

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/DirectoryInfo/DirectoryInfoSearch.cs
@@ -1,4 +1,4 @@
-using Flow.Launcher.Infrastructure.Logger;
+﻿using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Plugin.SharedCommands;
 using System;
 using System.Collections.Generic;
@@ -12,6 +12,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search.DirectoryInfo
     {
         internal static IEnumerable<SearchResult> TopLevelDirectorySearch(Query query, string search, CancellationToken token)
         {
+            // if user uses the unix directory separator, we need to convert it to windows directory separator
+            search = search.Replace(Constants.UnixDirectorySeparator, Constants.DirectorySeparator);
+
             var criteria = ConstructSearchCriteria(search);
 
             if (search.LastIndexOf(Constants.AllFilesFolderSearchWildcard) >

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/SearchManager.cs
@@ -187,6 +187,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             var needToExpand = EnvironmentVariables.HasEnvironmentVar(querySearch);
             var path = needToExpand ? Environment.ExpandEnvironmentVariables(querySearch) : querySearch;
 
+            // if user uses the unix directory separator, we need to convert it to windows directory separator
+            path = path.Replace(Constants.UnixDirectorySeparator, Constants.DirectorySeparator);
+
             // Check that actual location exists, otherwise directory search will throw directory not found exception
             if (!FilesFolders.ReturnPreviousDirectoryIfIncompleteString(path).LocationExists())
                 return results.ToList();


### PR DESCRIPTION
Fix issue when user uses forward slash as directory seperator, like C:\Test/Test.

Related issue in #3229.