### PR TITLE
Fix main window resize border thickness issue

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -37,7 +37,7 @@
     mc:Ignorable="d">
     <!--  WindowChrome  -->
     <WindowChrome.WindowChrome>
-        <WindowChrome CaptionHeight="9" ResizeBorderThickness="32 4 32 32" />
+        <WindowChrome CaptionHeight="9" />
     </WindowChrome.WindowChrome>
     <Window.Resources>
         <converters:QuerySuggestionBoxConverter x:Key="QuerySuggestionBoxConverter" />


### PR DESCRIPTION
# Issue

Because adding drop shadow effect will change the margin of the window border, we need to update the resize thickness of the window chrome to correct set the resize border. Otherwise, scrollbar selection is unable to work because resize area override it.

* Related issue: #3185

# Test

Regardless of whether the shadow effect is enabled, the window border remains outside the resizing area.

https://github.com/user-attachments/assets/5619dccf-d8ae-464d-b036-a10d40a5bc34