### PR TITLE
Fix Plugin Store Page Refresh Issue

### DIFF
--- a/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
@@ -1,4 +1,4 @@
-using Flow.Launcher.Infrastructure.Logger;
+﻿using Flow.Launcher.Infrastructure.Logger;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -27,7 +27,7 @@ namespace Flow.Launcher.Core.ExternalPlugins
             {
                 await manifestUpdateLock.WaitAsync(token).ConfigureAwait(false);
 
-                if (UserPlugins == null || usePrimaryUrlOnly || DateTime.Now.Subtract(lastFetchedAt) >= fetchTimeout)
+                if (UserPlugins == null || UserPlugins.Count == 0 || usePrimaryUrlOnly || DateTime.Now.Subtract(lastFetchedAt) >= fetchTimeout)
                 {
                     var results = await mainPluginStore.FetchAsync(token, usePrimaryUrlOnly).ConfigureAwait(false);
 

--- a/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
@@ -21,7 +21,7 @@ namespace Flow.Launcher.Core.ExternalPlugins
 
         public static List<UserPlugin> UserPlugins { get; private set; }
 
-        public static async Task UpdateManifestAsync(CancellationToken token = default, bool usePrimaryUrlOnly = false)
+        public static async Task<bool> UpdateManifestAsync(CancellationToken token = default, bool usePrimaryUrlOnly = false)
         {
             try
             {
@@ -36,6 +36,8 @@ namespace Flow.Launcher.Core.ExternalPlugins
                     {
                         UserPlugins = results;
                         lastFetchedAt = DateTime.Now;
+
+                        return true;
                     }
                 }
             }
@@ -47,6 +49,8 @@ namespace Flow.Launcher.Core.ExternalPlugins
             {
                 manifestUpdateLock.Release();
             }
+
+            return false;
         }
     }
 }

--- a/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
@@ -27,12 +27,16 @@ namespace Flow.Launcher.Core.ExternalPlugins
             {
                 await manifestUpdateLock.WaitAsync(token).ConfigureAwait(false);
 
-                if (UserPlugins == null || UserPlugins.Count == 0 || usePrimaryUrlOnly || DateTime.Now.Subtract(lastFetchedAt) >= fetchTimeout)
+                if (UserPlugins == null || usePrimaryUrlOnly || DateTime.Now.Subtract(lastFetchedAt) >= fetchTimeout)
                 {
                     var results = await mainPluginStore.FetchAsync(token, usePrimaryUrlOnly).ConfigureAwait(false);
 
-                    UserPlugins = results;
-                    lastFetchedAt = DateTime.Now;
+                    // If the results are empty, we shouldn't update the manifest because the results are invalid.
+                    if (results.Count != 0)
+                    {
+                        UserPlugins = results;
+                        lastFetchedAt = DateTime.Now;
+                    }
                 }
             }
             catch (Exception e)

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
@@ -13,8 +13,8 @@ public partial class SettingsPanePluginStoreViewModel : BaseModel
 {
     public string FilterText { get; set; } = string.Empty;
 
-    public IList<PluginStoreItemViewModel> ExternalPlugins => PluginsManifest.UserPlugins
-        .Select(p => new PluginStoreItemViewModel(p))
+    public IList<PluginStoreItemViewModel> ExternalPlugins => 
+        PluginsManifest.UserPlugins?.Select(p => new PluginStoreItemViewModel(p))
         .OrderByDescending(p => p.Category == PluginStoreItemViewModel.NewRelease)
         .ThenByDescending(p => p.Category == PluginStoreItemViewModel.RecentlyUpdated)
         .ThenByDescending(p => p.Category == PluginStoreItemViewModel.None)

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
@@ -24,8 +24,10 @@ public partial class SettingsPanePluginStoreViewModel : BaseModel
     [RelayCommand]
     private async Task RefreshExternalPluginsAsync()
     {
-        await PluginsManifest.UpdateManifestAsync();
-        OnPropertyChanged(nameof(ExternalPlugins));
+        if (await PluginsManifest.UpdateManifestAsync())
+        {
+            OnPropertyChanged(nameof(ExternalPlugins));
+        }
     }
 
     public bool SatisfiesFilter(PluginStoreItemViewModel plugin)


### PR DESCRIPTION
# Fix Plugin Store Page Refresh Issue

When reupdating the plugins manifest, the user plugins cannot be updated which causes plugin store page cannot be refreshed when clicking the refresh button.

If the count of the `UserPlugin` is zero, FL has not loaded the plugins correctly so we need to re-fetch the plugins.

Related issue:
![image](https://github.com/user-attachments/assets/48d0fc7b-3f0a-414f-97fb-1fcd30898c4d)

# Test

Original:

https://github.com/user-attachments/assets/19709a5b-1cfa-494e-8a31-c2ce3e1a1cc4

Now:

https://github.com/user-attachments/assets/b0c714a5-7fda-49bd-b801-ce2561573c42