### PR TITLE
Improve explorer path parse when path ends with backslash

### DIFF
--- a/Flow.Launcher.Infrastructure/FileExplorerHelper.cs
+++ b/Flow.Launcher.Infrastructure/FileExplorerHelper.cs
@@ -15,7 +15,20 @@ namespace Flow.Launcher.Infrastructure
         {
             var explorerWindow = GetActiveExplorer();
             string locationUrl = explorerWindow?.LocationURL;
-            return !string.IsNullOrEmpty(locationUrl) ? new Uri(locationUrl).LocalPath + "\\" : null;
+            return !string.IsNullOrEmpty(locationUrl) ? GetDirectoryPath(new Uri(locationUrl).LocalPath) : null;
+        }
+
+        /// <summary>
+        /// Get directory path from a file path
+        /// </summary>
+        private static string GetDirectoryPath(string path)
+        {
+            if (!path.EndsWith("\\"))
+            {
+                return path + "\\";
+            }
+
+            return path;
         }
 
         /// <summary>


### PR DESCRIPTION
# Improve explorer path parse when path ends with backslash

If the path from the active explorer is already end with backslash, do not add backslash to it.

# Test

If the active explorer path is `C:\`, adding `\` to it will cause issues.

Original:
![Screenshot 2025-02-12 095953](https://github.com/user-attachments/assets/83a00df6-623b-433e-a747-dd6d42b5c763)

New:
![Screenshot 2025-02-12 101953](https://github.com/user-attachments/assets/b30a327f-4440-49db-8bf0-79e79ea3b163)