### PR TITLE
Fix Exception When Getting Thumbnails

### DIFF
--- a/Flow.Launcher.Infrastructure/Image/ThumbnailReader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ThumbnailReader.cs
@@ -31,6 +31,8 @@ namespace Flow.Launcher.Infrastructure.Image
 
         private static readonly Guid GUID_IShellItem = typeof(IShellItem).GUID;
 
+        private static readonly HRESULT S_ExtractionFailed = (HRESULT)0x8004B200;
+
         public static BitmapSource GetThumbnail(string fileName, int width, int height, ThumbnailOptions options)
         {
             HBITMAP hBitmap = GetHBitmap(Path.GetFullPath(fileName), width, height, options);
@@ -77,12 +79,12 @@ namespace Flow.Launcher.Infrastructure.Image
                 {
                     imageFactory.GetImage(size, (SIIGBF)options, &hBitmap);
                 }
-                catch (COMException)
+                catch (COMException ex) when (ex.HResult == S_ExtractionFailed && options == ThumbnailOptions.ThumbnailOnly)
                 {
-                    // Fallback to IconOnly for COM exceptions
+                    // Fallback to IconOnly if ThumbnailOnly fails
                     imageFactory.GetImage(size, (SIIGBF)ThumbnailOptions.IconOnly, &hBitmap);
                 }
-                catch (FileNotFoundException)
+                catch (FileNotFoundException) when (options == ThumbnailOptions.ThumbnailOnly)
                 {
                     // Fallback to IconOnly if files cannot be found
                     imageFactory.GetImage(size, (SIIGBF)ThumbnailOptions.IconOnly, &hBitmap);

--- a/Flow.Launcher.Infrastructure/Image/ThumbnailReader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ThumbnailReader.cs
@@ -79,12 +79,12 @@ namespace Flow.Launcher.Infrastructure.Image
                 }
                 catch (COMException)
                 {
-                    // Fallback to IconOnly if ThumbnailOnly fails
+                    // Fallback to IconOnly for COM exceptions
                     imageFactory.GetImage(size, (SIIGBF)ThumbnailOptions.IconOnly, &hBitmap);
                 }
                 catch (FileNotFoundException)
                 {
-                    // Fallback to IconOnly if ThumbnailOnly fails
+                    // Fallback to IconOnly if files cannot be found
                     imageFactory.GetImage(size, (SIIGBF)ThumbnailOptions.IconOnly, &hBitmap);
                 }
             }

--- a/Flow.Launcher.Infrastructure/Image/ThumbnailReader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ThumbnailReader.cs
@@ -31,8 +31,6 @@ namespace Flow.Launcher.Infrastructure.Image
 
         private static readonly Guid GUID_IShellItem = typeof(IShellItem).GUID;
 
-        private static readonly HRESULT S_ExtractionFailed = (HRESULT)0x8004B200;
-
         public static BitmapSource GetThumbnail(string fileName, int width, int height, ThumbnailOptions options)
         {
             HBITMAP hBitmap = GetHBitmap(Path.GetFullPath(fileName), width, height, options);
@@ -79,7 +77,12 @@ namespace Flow.Launcher.Infrastructure.Image
                 {
                     imageFactory.GetImage(size, (SIIGBF)options, &hBitmap);
                 }
-                catch (COMException ex) when (ex.HResult == S_ExtractionFailed && options == ThumbnailOptions.ThumbnailOnly)
+                catch (COMException)
+                {
+                    // Fallback to IconOnly if ThumbnailOnly fails
+                    imageFactory.GetImage(size, (SIIGBF)ThumbnailOptions.IconOnly, &hBitmap);
+                }
+                catch (FileNotFoundException)
                 {
                     // Fallback to IconOnly if ThumbnailOnly fails
                     imageFactory.GetImage(size, (SIIGBF)ThumbnailOptions.IconOnly, &hBitmap);


### PR DESCRIPTION
# Fix issue in getting thumbnails function

For some files in the recycle bin, we may encounter issue like this:
![Screenshot 2025-02-16 134936](https://github.com/user-attachments/assets/358d893a-0018-42df-985d-8f0c60d6f8c0)

This can cause:
![Screenshot 2025-02-16 223918](https://github.com/user-attachments/assets/d501a160-be15-4ae5-a792-78cfa9b1af3d)

# Test
![Screenshot 2025-02-16 224108](https://github.com/user-attachments/assets/162bf098-1791-4aef-8719-489a571eafe7)