### PR TITLE
Fix Issue that Plugin Cannot Cache Records

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -281,7 +281,7 @@ namespace Flow.Launcher.Core.Plugin
             return results;
         }
 
-        public static void UpdatePluginMetadata(List<Result> results, PluginMetadata metadata, Query query)
+        public static void UpdatePluginMetadata(IReadOnlyList<Result> results, PluginMetadata metadata, Query query)
         {
             foreach (var r in results)
             {

--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -266,8 +266,9 @@ namespace Flow.Launcher.Plugin
         /// The key to identify the record. This is used when FL checks whether the result is the topmost record. Or FL calculates the hashcode of the result for user selected records.
         /// This can be useful when your plugin will change the Title or SubTitle of the result dynamically.
         /// If the plugin does not specific this, FL just uses Title and SubTitle to identify this result.
+        /// Note: Because old data does not have this key, we should use null as the default value for consistency.
         /// </summary>
-        public string RecordKey { get; set; } = string.Empty;
+        public string RecordKey { get; set; } = null;
 
         /// <summary>
         /// Info of the preview section of a <see cref="Result"/>

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1494,7 +1494,7 @@ namespace Flow.Launcher.ViewModel
                 {
                     if (_topMostRecord.IsTopMost(result))
                     {
-                        result.Score = 100000; //Result.MaxScore;
+                        result.Score = Result.MaxScore;
                     }
                     else
                     {

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1196,9 +1196,18 @@ namespace Flow.Launcher.ViewModel
 
                 currentCancellationToken.ThrowIfCancellationRequested();
 
-                results ??= _emptyResult;
+                IReadOnlyList<Result> resultsCopy;
+                if (results == null)
+                {
+                    resultsCopy = _emptyResult;
+                }
+                else
+                {
+                    // make a copy of results to avoid possible issue that FL changes some properties of the records, like score, etc.
+                    resultsCopy = DeepCloneResults(results);
+                }
 
-                if (!_resultsUpdateChannelWriter.TryWrite(new ResultsForUpdate(results, plugin.Metadata, query,
+                if (!_resultsUpdateChannelWriter.TryWrite(new ResultsForUpdate(resultsCopy, plugin.Metadata, query,
                         currentCancellationToken, reSelect)))
                 {
                     Log.Error("MainViewModel", "Unable to add item to Result Update Queue");

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1499,9 +1499,28 @@ namespace Flow.Launcher.ViewModel
                     else
                     {
                         var priorityScore = metaResults.Metadata.Priority * 150;
-                        result.Score += result.AddSelectedCount ?
-                            _userSelectedRecord.GetSelectedCount(result) + priorityScore :
-                            priorityScore;
+                        if (result.AddSelectedCount)
+                        {
+                            if ((long)result.Score + _userSelectedRecord.GetSelectedCount(result) + priorityScore > Result.MaxScore)
+                            {
+                                result.Score = Result.MaxScore;
+                            }
+                            else
+                            {
+                                result.Score += _userSelectedRecord.GetSelectedCount(result) + priorityScore;
+                            }
+                        }
+                        else
+                        {
+                            if ((long)result.Score + priorityScore > Result.MaxScore)
+                            {
+                                result.Score = Result.MaxScore;
+                            }
+                            else
+                            {
+                                result.Score += priorityScore;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Use null as default value for record key

* Because old data does not have this key, we should use null as the default value for consistency.

# Deep clone result list before updating results

* Because FL will change the score property of the results during results update, so before we update the results, we need to deep clone the result list, so that plugin can cache them for performance improvement (like Flow.Launcher.Plugin.Program).

This can fix issue in #3203. Tested.