### PR TITLE
Enable the use of Win hotkey to trigger flow

### DIFF
--- a/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
@@ -167,11 +167,10 @@ namespace Flow.Launcher.Infrastructure.Hotkey
                 case Key.RightCtrl:
                 case Key.LeftShift:
                 case Key.RightShift:
+                case Key.LWin:
+                case Key.RWin:
                 case Key.None:
                     return false;
-                case Key.LWin when ModifierKeys == ModifierKeys.Windows:
-                case Key.RWin when ModifierKeys == ModifierKeys.Windows:
-                    return true;
                 default:
                     if (validateKeyGestrue)
                     {

--- a/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
@@ -169,8 +169,8 @@ namespace Flow.Launcher.Infrastructure.Hotkey
                 case Key.RightShift:
                 case Key.None:
                     return false;
-                case Key.LWin:
-                case Key.RWin:
+                case Key.LWin when ModifierKeys == ModifierKeys.Windows:
+                case Key.RWin when ModifierKeys == ModifierKeys.Windows:
                     return true;
                 default:
                     if (validateKeyGestrue)

--- a/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
+++ b/Flow.Launcher.Infrastructure/Hotkey/HotkeyModel.cs
@@ -167,10 +167,11 @@ namespace Flow.Launcher.Infrastructure.Hotkey
                 case Key.RightCtrl:
                 case Key.LeftShift:
                 case Key.RightShift:
-                case Key.LWin:
-                case Key.RWin:
                 case Key.None:
                     return false;
+                case Key.LWin:
+                case Key.RWin:
+                    return true;
                 default:
                     if (validateKeyGestrue)
                     {

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -83,6 +83,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="ChefKeys" Version="0.1.2" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Fody" Version="6.5.4">
       <PrivateAssets>all</PrivateAssets>

--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -6,6 +6,8 @@ using NHotkey.Wpf;
 using Flow.Launcher.Core.Resource;
 using Flow.Launcher.ViewModel;
 using Flow.Launcher.Core;
+using ChefKeys;
+using System.Globalization;
 
 namespace Flow.Launcher.Helper;
 
@@ -29,15 +31,40 @@ internal static class HotKeyMapper
             _mainViewModel.ToggleFlowLauncher();
     }
 
+    internal static void OnToggleHotkeyWithChefKeys()
+    {
+        if (!_mainViewModel.ShouldIgnoreHotkeys())
+            _mainViewModel.ToggleFlowLauncher();
+    }
+
     private static void SetHotkey(string hotkeyStr, EventHandler<HotkeyEventArgs> action)
     {
+        if (hotkeyStr == "LWin" || hotkeyStr == "RWin")
+        {
+            SetWithChefKeys(hotkeyStr);
+            return;
+        }
+
         var hotkey = new HotkeyModel(hotkeyStr);
         SetHotkey(hotkey, action);
+    }
+
+    private static void SetWithChefKeys(string hotkeyStr)
+    {
+        ChefKeysManager.RegisterHotkey(hotkeyStr, hotkeyStr, OnToggleHotkeyWithChefKeys);
+        ChefKeysManager.Start();
     }
 
     internal static void SetHotkey(HotkeyModel hotkey, EventHandler<HotkeyEventArgs> action)
     {
         string hotkeyStr = hotkey.ToString();
+
+        if (hotkeyStr == "LWin" || hotkeyStr == "RWin")
+        {
+            SetWithChefKeys(hotkeyStr);
+            return;
+        }
+
         try
         {
             HotkeyManager.Current.AddOrReplace(hotkeyStr, hotkey.CharKey, hotkey.ModifierKeys, action);
@@ -52,10 +79,22 @@ internal static class HotKeyMapper
 
     internal static void RemoveHotkey(string hotkeyStr)
     {
+        if (hotkeyStr == "LWin" || hotkeyStr == "RWin")
+        {
+            RemoveWithChefKeys(hotkeyStr);
+            return;
+        }
+
         if (!string.IsNullOrEmpty(hotkeyStr))
         {
             HotkeyManager.Current.Remove(hotkeyStr);
         }
+    }
+
+    private static void RemoveWithChefKeys(string hotkeyStr)
+    {
+        ChefKeysManager.UnregisterHotkey(hotkeyStr);
+        ChefKeysManager.Stop();
     }
 
     internal static void LoadCustomPluginHotkey()

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -154,7 +154,15 @@ namespace Flow.Launcher
         {
             if (triggerValidate)
             {
-                bool hotkeyAvailable = CheckHotkeyAvailability(keyModel, ValidateKeyGesture);
+                bool hotkeyAvailable = false;
+                if (keyModel.ToString() == "LWin" || keyModel.ToString() == "RWin")
+                {
+                    hotkeyAvailable = true;
+                }
+                else
+                {
+                    hotkeyAvailable = CheckHotkeyAvailability(keyModel, ValidateKeyGesture);
+                }
 
                 if (!hotkeyAvailable)
                 {

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -155,6 +155,7 @@ namespace Flow.Launcher
             if (triggerValidate)
             {
                 bool hotkeyAvailable = false;
+                // TODO: This is a temporary way to enforce changing only the open flow hotkey to Win, and will be removed by PR #3157
                 if (keyModel.ToString() == "LWin" || keyModel.ToString() == "RWin")
                 {
                     hotkeyAvailable = true;

--- a/Flow.Launcher/HotkeyControlDialog.xaml.cs
+++ b/Flow.Launcher/HotkeyControlDialog.xaml.cs
@@ -34,6 +34,8 @@ public partial class HotkeyControlDialog : ContentDialog
     public string ResultValue { get; private set; } = string.Empty;
     public static string EmptyHotkey => InternationalizationManager.Instance.GetTranslation("none");
 
+    private static bool isOpenFlowHotkey;
+
     public HotkeyControlDialog(string hotkey, string defaultHotkey, IHotkeySettings hotkeySettings, string windowTitle = "")
     {
         WindowTitle = windowTitle switch
@@ -47,6 +49,10 @@ public partial class HotkeyControlDialog : ContentDialog
         SetKeysToDisplay(CurrentHotkey);
 
         InitializeComponent();
+
+        isOpenFlowHotkey = _hotkeySettings.RegisteredHotkeys
+                             .Any(x => x.DescriptionResourceKey == "flowlauncherHotkey" 
+                                    && x.Hotkey.ToString() == hotkey);
 
         ChefKeysManager.StartMenuEnableBlocking = true;
         ChefKeysManager.Start();
@@ -181,8 +187,13 @@ public partial class HotkeyControlDialog : ContentDialog
         }
     }
 
-    private static bool CheckHotkeyAvailability(HotkeyModel hotkey, bool validateKeyGesture) =>
-        hotkey.Validate(validateKeyGesture) && HotKeyMapper.CheckAvailability(hotkey);
+    private static bool CheckHotkeyAvailability(HotkeyModel hotkey, bool validateKeyGesture)
+    {
+        if (isOpenFlowHotkey && (hotkey.ToString() == "LWin" || hotkey.ToString() == "RWin"))
+            return true;
+
+        return hotkey.Validate(validateKeyGesture) && HotKeyMapper.CheckAvailability(hotkey);
+    }
 
     private void Overwrite(object sender, RoutedEventArgs e)
     {

--- a/Flow.Launcher/HotkeyControlDialog.xaml.cs
+++ b/Flow.Launcher/HotkeyControlDialog.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Input;
+using ChefKeys;
 using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Helper;
 using Flow.Launcher.Infrastructure.Hotkey;
@@ -46,6 +47,9 @@ public partial class HotkeyControlDialog : ContentDialog
         SetKeysToDisplay(CurrentHotkey);
 
         InitializeComponent();
+
+        ChefKeysManager.StartMenuEnableBlocking = true;
+        ChefKeysManager.Start();
     }
 
     private void Reset(object sender, RoutedEventArgs routedEventArgs)
@@ -61,12 +65,18 @@ public partial class HotkeyControlDialog : ContentDialog
 
     private void Cancel(object sender, RoutedEventArgs routedEventArgs)
     {
+        ChefKeysManager.StartMenuEnableBlocking = false;
+        ChefKeysManager.Stop();
+
         ResultType = EResultType.Cancel;
         Hide();
     }
 
     private void Save(object sender, RoutedEventArgs routedEventArgs)
     {
+        ChefKeysManager.StartMenuEnableBlocking = false;
+        ChefKeysManager.Stop();
+
         if (KeysToDisplay.Count == 1 && KeysToDisplay[0] == EmptyHotkey)
         {
             ResultType = EResultType.Delete;
@@ -84,6 +94,9 @@ public partial class HotkeyControlDialog : ContentDialog
 
         //when alt is pressed, the real key should be e.SystemKey
         Key key = e.Key == Key.System ? e.SystemKey : e.Key;
+
+        if (ChefKeysManager.StartMenuBlocked && key.ToString() == ChefKeysManager.StartMenuSimulatedKey)
+            return;
 
         SpecialKeyState specialKeyState = GlobalHotkey.CheckModifiers();
 

--- a/Flow.Launcher/HotkeyControlDialog.xaml.cs
+++ b/Flow.Launcher/HotkeyControlDialog.xaml.cs
@@ -50,6 +50,7 @@ public partial class HotkeyControlDialog : ContentDialog
 
         InitializeComponent();
 
+        // TODO: This is a temporary way to enforce changing only the open flow hotkey to Win, and will be removed by PR #3157
         isOpenFlowHotkey = _hotkeySettings.RegisteredHotkeys
                              .Any(x => x.DescriptionResourceKey == "flowlauncherHotkey" 
                                     && x.Hotkey.ToString() == hotkey);


### PR DESCRIPTION
Split from #3157, this PR focuses exclusively on letting the LWin/RWin to be used for opening flow. It is split so I can add this feature in while I work on the support for key combinations.

Source code for ChefKeys that handles the Win key operations in this change is available at https://github.com/jjw24/ChefKeys.

Most of this code is temporary and will be replaced by PR 3157.

Tested:
- LWin can open flow
- Can not use Win key as part of a combo (will be handled in the other PR)
- Can only use the Win key for open Flow hotkey and not for other hotkey actions
- Once Win key is not used ChefKeys is stopped.
- ChefKeys is only started if Win key is used

Close https://github.com/Flow-Launcher/Flow.Launcher/issues/662, https://github.com/Flow-Launcher/Flow.Launcher/issues/2709, https://github.com/Flow-Launcher/Flow.Launcher/issues/1358