### PR TITLE
Make Message box Window to be Topmost

### DIFF
--- a/Flow.Launcher.Core/MessageBoxEx.xaml
+++ b/Flow.Launcher.Core/MessageBoxEx.xaml
@@ -12,6 +12,7 @@
     Foreground="{DynamicResource PopupTextColor}"
     ResizeMode="NoResize"
     SizeToContent="Height"
+    Topmost="True"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
     <WindowChrome.WindowChrome>


### PR DESCRIPTION
When we disable `Hide FL when loss focus` option, we need to make `MessageBoxEx` window topmost so that it can show in the top.

Already tested.