### PR TITLE
Improve Progress Box Design

### DIFF
--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -322,17 +322,16 @@ namespace Flow.Launcher.Plugin
         public MessageBoxResult ShowMsgBox(string messageBoxText, string caption = "", MessageBoxButton button = MessageBoxButton.OK, MessageBoxImage icon = MessageBoxImage.None, MessageBoxResult defaultResult = MessageBoxResult.OK);
 
         /// <summary>
-        /// Displays a standardised Flow message box.
-        /// If there is issue when showing the message box, it will return null.
+        /// Displays a standardised Flow progress box.
         /// </summary>
-        /// <param name="caption">The caption of the message box.</param>
+        /// <param name="caption">The caption of the progress box.</param>
         /// <param name="reportProgressAsync">
         /// Time-consuming task function, whose input is the action to report progress.
         /// The input of the action is the progress value which is a double value between 0 and 100.
         /// If there are any exceptions, this action will be null.
         /// </param>
-        /// <param name="forceClosed">When user closes the progress box manually by button or esc key, this action will be called.</param>
-        /// <returns>A progress box interface.</returns>
-        public Task ShowProgressBoxAsync(string caption, Func<Action<double>, Task> reportProgressAsync, Action forceClosed = null);
+        /// <param name="cancelProgress">When user cancel the progress, this action will be called.</param>
+        /// <returns></returns>
+        public Task ShowProgressBoxAsync(string caption, Func<Action<double>, Task> reportProgressAsync, Action cancelProgress = null);
     }
 }

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -367,6 +367,7 @@
     <system:String x:Key="commonOK">OK</system:String>
     <system:String x:Key="commonYes">Yes</system:String>
     <system:String x:Key="commonNo">No</system:String>
+    <system:String x:Key="commonBackground">Background</system:String>
 
     <!--  Crash Reporter  -->
     <system:String x:Key="reportWindow_version">Version</system:String>

--- a/Flow.Launcher/ProgressBoxEx.xaml
+++ b/Flow.Launcher/ProgressBoxEx.xaml
@@ -41,7 +41,7 @@
                         Grid.Column="1"
                         Click="Button_Minimize"
                         RenderOptions.EdgeMode="Aliased"
-                        Style="{DynamicResource TitleBarCloseButtonStyle}">
+                        Style="{DynamicResource TitleBarButtonStyle}">
                         <Path
                             Width="46"
                             Height="32"

--- a/Flow.Launcher/ProgressBoxEx.xaml
+++ b/Flow.Launcher/ProgressBoxEx.xaml
@@ -12,6 +12,7 @@
     Foreground="{DynamicResource PopupTextColor}"
     ResizeMode="NoResize"
     SizeToContent="Height"
+    Topmost="True"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
     <WindowChrome.WindowChrome>

--- a/Flow.Launcher/ProgressBoxEx.xaml
+++ b/Flow.Launcher/ProgressBoxEx.xaml
@@ -35,9 +35,32 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <Button
                         Grid.Column="1"
+                        Click="Button_Minimize"
+                        RenderOptions.EdgeMode="Aliased"
+                        Style="{DynamicResource TitleBarCloseButtonStyle}">
+                        <Path
+                            Width="46"
+                            Height="32"
+                            Data="M 18,15 H 28"
+                            Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                            StrokeThickness="1">
+                            <Path.Style>
+                                <Style TargetType="Path">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                            <Setter Property="Opacity" Value="0.5" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Path.Style>
+                        </Path>
+                    </Button>
+                    <Button
+                        Grid.Column="2"
                         Click="Button_Cancel"
                         Style="{StaticResource TitleBarCloseButtonStyle}">
                         <Path
@@ -95,10 +118,16 @@
                 VerticalAlignment="Center"
                 Orientation="Horizontal">
                 <Button
+                    x:Name="btnBackground"
+                    MinWidth="120"
+                    Margin="5 0 5 0"
+                    Click="Button_Background"
+                    Content="{DynamicResource commonBackground}" />
+                <Button
                     x:Name="btnCancel"
                     MinWidth="120"
                     Margin="5 0 5 0"
-                    Click="Button_Click"
+                    Click="Button_Cancel"
                     Content="{DynamicResource commonCancel}" />
             </WrapPanel>
         </Border>

--- a/Flow.Launcher/ProgressBoxEx.xaml.cs
+++ b/Flow.Launcher/ProgressBoxEx.xaml.cs
@@ -95,14 +95,19 @@ namespace Flow.Launcher
             ForceClose();
         }
 
-        private void Button_Click(object sender, RoutedEventArgs e)
+        private void Button_Cancel(object sender, RoutedEventArgs e)
         {
             ForceClose();
         }
 
-        private void Button_Cancel(object sender, RoutedEventArgs e)
+        private void Button_Minimize(object sender, RoutedEventArgs e)
         {
-            ForceClose();
+            WindowState = WindowState.Minimized;
+        }
+
+        private void Button_Background(object sender, RoutedEventArgs e)
+        {
+            Hide();
         }
 
         private void ForceClose()

--- a/Flow.Launcher/ProgressBoxEx.xaml.cs
+++ b/Flow.Launcher/ProgressBoxEx.xaml.cs
@@ -8,15 +8,15 @@ namespace Flow.Launcher
 {
     public partial class ProgressBoxEx : Window
     {
-        private readonly Action _forceClosed;
+        private readonly Action _cancelProgress;
 
-        private ProgressBoxEx(Action forceClosed)
+        private ProgressBoxEx(Action cancelProgress)
         {
-            _forceClosed = forceClosed;
+            _cancelProgress = cancelProgress;
             InitializeComponent();
         }
 
-        public static async Task ShowAsync(string caption, Func<Action<double>, Task> reportProgressAsync, Action forceClosed = null)
+        public static async Task ShowAsync(string caption, Func<Action<double>, Task> reportProgressAsync, Action cancelProgress = null)
         {
             ProgressBoxEx prgBox = null;
             try
@@ -25,7 +25,7 @@ namespace Flow.Launcher
                 {
                     await Application.Current.Dispatcher.InvokeAsync(() =>
                     {
-                        prgBox = new ProgressBoxEx(forceClosed)
+                        prgBox = new ProgressBoxEx(cancelProgress)
                         {
                             Title = caption
                         };
@@ -35,7 +35,7 @@ namespace Flow.Launcher
                 }
                 else
                 {
-                    prgBox = new ProgressBoxEx(forceClosed)
+                    prgBox = new ProgressBoxEx(cancelProgress)
                     {
                         Title = caption
                     };
@@ -113,7 +113,7 @@ namespace Flow.Launcher
         private void ForceClose()
         {
             Close();
-            _forceClosed?.Invoke();
+            _cancelProgress?.Invoke();
         }
     }
 }

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -324,7 +324,7 @@ namespace Flow.Launcher
         public MessageBoxResult ShowMsgBox(string messageBoxText, string caption = "", MessageBoxButton button = MessageBoxButton.OK, MessageBoxImage icon = MessageBoxImage.None, MessageBoxResult defaultResult = MessageBoxResult.OK) =>
             MessageBoxEx.Show(messageBoxText, caption, button, icon, defaultResult);
 
-        public Task ShowProgressBoxAsync(string caption, Func<Action<double>, Task> reportProgressAsync, Action forceClosed = null) => ProgressBoxEx.ShowAsync(caption, reportProgressAsync, forceClosed);
+        public Task ShowProgressBoxAsync(string caption, Func<Action<double>, Task> reportProgressAsync, Action cancelProgress = null) => ProgressBoxEx.ShowAsync(caption, reportProgressAsync, cancelProgress);
 
         #endregion
 


### PR DESCRIPTION
# Add minimize & background button for progress box & Set progress box topmost

* Minimize button is for users to temporarily hide progress box for this progress when they do not want to check the progress for now. They can view progress if they want from taskbar.

* Background button is for users to permanently hide progress for this progress when they do not care the progress. This will **not** cancel the progress. (It is different from cancel button & close button which is used to cancel the progress.)

* Set progress box topmost since we support to temporarily and permanently hide this window now.

# Test

Original:
![Screenshot 2025-02-22 190132](https://github.com/user-attachments/assets/ffec4820-f440-49f6-96c3-71e9f1041fd8)

New:
![Screenshot 2025-02-22 190249](https://github.com/user-attachments/assets/79b0374b-bafe-4cdd-a1d4-676c1f408973)
