### PR TITLE
Fix Dependency Injection Issue

### DIFF
--- a/Flow.Launcher.Infrastructure/AutoStartup.cs
+++ b/Flow.Launcher.Infrastructure/AutoStartup.cs
@@ -2,12 +2,11 @@
 using System.IO;
 using System.Linq;
 using System.Security.Principal;
-using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Logger;
 using Microsoft.Win32;
 using Microsoft.Win32.TaskScheduler;
 
-namespace Flow.Launcher.Helper;
+namespace Flow.Launcher.Infrastructure;
 
 public class AutoStartup
 {
@@ -32,7 +31,7 @@ public class AutoStartup
                 var path = key?.GetValue(Constant.FlowLauncher) as string;
                 return path == Constant.ExecutablePath;
             }
-            catch (Exception e)
+            catch (System.Exception e)
             {
                 Log.Error("AutoStartup", $"Ignoring non-critical registry error (querying if enabled): {e}");
             }
@@ -59,7 +58,7 @@ public class AutoStartup
 
                 return true;
             }
-            catch (Exception e)
+            catch (System.Exception e)
             {
                 Log.Error("AutoStartup", $"Failed to check logon task: {e}");
             }
@@ -110,7 +109,7 @@ public class AutoStartup
                 key?.DeleteValue(Constant.FlowLauncher, false);
             }
         }
-        catch (Exception e)
+        catch (System.Exception e)
         {
             Log.Error("AutoStartup", $"Failed to disable auto-startup: {e}");
             throw;
@@ -131,7 +130,7 @@ public class AutoStartup
                 key?.SetValue(Constant.FlowLauncher, $"\"{Constant.ExecutablePath}\"");
             }
         }
-        catch (Exception e)
+        catch (System.Exception e)
         {
             Log.Error("AutoStartup", $"Failed to enable auto-startup: {e}");
             throw;
@@ -159,7 +158,7 @@ public class AutoStartup
             TaskService.Instance.RootFolder.RegisterTaskDefinition(LogonTaskName, td);
             return true;
         }
-        catch (Exception e)
+        catch (System.Exception e)
         {
             Log.Error("AutoStartup", $"Failed to schedule logon task: {e}");
             return false;
@@ -174,7 +173,7 @@ public class AutoStartup
             taskService.RootFolder.DeleteTask(LogonTaskName);
             return true;
         }
-        catch (Exception e)
+        catch (System.Exception e)
         {
             Log.Error("AutoStartup", $"Failed to unschedule logon task: {e}");
             return false;

--- a/Flow.Launcher.Infrastructure/Flow.Launcher.Infrastructure.csproj
+++ b/Flow.Launcher.Infrastructure/Flow.Launcher.Infrastructure.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0-windows</TargetFramework>
@@ -68,6 +68,7 @@
     <PackageReference Include="NLog" Version="4.7.10" />
     <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageReference Include="TaskScheduler" Version="2.11.0" />
     <!--ToolGood.Words.Pinyin v3.0.2.6 results in high memory usage when search with pinyin is enabled-->
     <!--Bumping to it or higher needs to test and ensure this is no longer a problem-->
     <PackageReference Include="ToolGood.Words.Pinyin" Version="3.0.1.4" />

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -165,17 +165,17 @@ namespace Flow.Launcher
         {
             // we try to enable auto-startup on first launch, or reenable if it was removed
             // but the user still has the setting set
-            if (_settings.StartFlowLauncherOnSystemStartup && !Helper.AutoStartup.IsEnabled)
+            if (_settings.StartFlowLauncherOnSystemStartup && !Infrastructure.AutoStartup.IsEnabled)
             {
                 try
                 {
                     if (_settings.UseLogonTaskForStartup)
                     {
-                        Helper.AutoStartup.EnableViaLogonTask();
+                        Infrastructure.AutoStartup.EnableViaLogonTask();
                     }
                     else
                     {
-                        Helper.AutoStartup.EnableViaRegistry();
+                        Infrastructure.AutoStartup.EnableViaRegistry();
                     }
                 }
                 catch (Exception e)

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -102,8 +102,8 @@ namespace Flow.Launcher
                 await imageLoadertask;
 
                 var mainVM = Ioc.Default.GetRequiredService<MainViewModel>();
+                ((PublicAPIInstance)API).Initialize(mainVM);
                 var window = new MainWindow(_settings, mainVM);
-
                 Log.Info($"|App.OnStartup|Dependencies Info:{ErrorReporting.DependenciesInfo()}");
 
                 Current.MainWindow = window;

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -44,7 +44,7 @@ namespace Flow.Launcher
             }
             catch (Exception e)
             {
-                MessageBoxEx.Show($"Cannot load setting storage: {e}");
+                MessageBox.Show($"Cannot load setting storage: {e}");
             }
 
             // Configure the dependency injection container
@@ -68,7 +68,7 @@ namespace Flow.Launcher
             }
             catch (Exception e)
             {
-                MessageBoxEx.Show($"Cannot configure dependency injection container: {e}");
+                MessageBox.Show($"Cannot configure dependency injection container: {e}");
             }
 
             // Initialize the public API and Settings first
@@ -79,7 +79,7 @@ namespace Flow.Launcher
             }
             catch (Exception e)
             {
-                MessageBoxEx.Show($"Cannot initialize public API and settings: {e}");
+                MessageBox.Show($"Cannot initialize public API and settings: {e}");
             }
         }
 

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -35,31 +35,52 @@ namespace Flow.Launcher
         public App()
         {
             // Initialize settings
-            var storage = new FlowLauncherJsonStorage<Settings>();
-            _settings = storage.Load();
-            _settings.SetStorage(storage);
-            _settings.WMPInstalled = WindowsMediaPlayerHelper.IsWindowsMediaPlayerInstalled();
+            try
+            {
+                var storage = new FlowLauncherJsonStorage<Settings>();
+                _settings = storage.Load();
+                _settings.SetStorage(storage);
+                _settings.WMPInstalled = WindowsMediaPlayerHelper.IsWindowsMediaPlayerInstalled();
+            }
+            catch (Exception e)
+            {
+                MessageBoxEx.Show($"Cannot load setting storage: {e}");
+            }
 
             // Configure the dependency injection container
-            var host = Host.CreateDefaultBuilder()
-                .UseContentRoot(AppContext.BaseDirectory)
-                .ConfigureServices(services => services
-                    .AddSingleton(_ => _settings)
-                    .AddSingleton(sp => new Updater(sp.GetRequiredService<IPublicAPI>(), Launcher.Properties.Settings.Default.GithubRepo))
-                    .AddSingleton<Portable>()
-                    .AddSingleton<SettingWindowViewModel>()
-                    .AddSingleton<IAlphabet, PinyinAlphabet>()
-                    .AddSingleton<StringMatcher>()
-                    .AddSingleton<Internationalization>()
-                    .AddSingleton<IPublicAPI, PublicAPIInstance>()
-                    .AddSingleton<MainViewModel>()
-                    .AddSingleton<Theme>()
-                ).Build();
-            Ioc.Default.ConfigureServices(host.Services);
+            try
+            {
+                var host = Host.CreateDefaultBuilder()
+                    .UseContentRoot(AppContext.BaseDirectory)
+                    .ConfigureServices(services => services
+                        .AddSingleton(_ => _settings)
+                        .AddSingleton(sp => new Updater(sp.GetRequiredService<IPublicAPI>(), Launcher.Properties.Settings.Default.GithubRepo))
+                        .AddSingleton<Portable>()
+                        .AddSingleton<SettingWindowViewModel>()
+                        .AddSingleton<IAlphabet, PinyinAlphabet>()
+                        .AddSingleton<StringMatcher>()
+                        .AddSingleton<Internationalization>()
+                        .AddSingleton<IPublicAPI, PublicAPIInstance>()
+                        .AddSingleton<MainViewModel>()
+                        .AddSingleton<Theme>()
+                    ).Build();
+                Ioc.Default.ConfigureServices(host.Services);
+            }
+            catch (Exception e)
+            {
+                MessageBoxEx.Show($"Cannot configure dependency injection container: {e}");
+            }
 
             // Initialize the public API and Settings first
-            API = Ioc.Default.GetRequiredService<IPublicAPI>();
-            _settings.Initialize();
+            try
+            {
+                API = Ioc.Default.GetRequiredService<IPublicAPI>();
+                _settings.Initialize();
+            }
+            catch (Exception e)
+            {
+                MessageBoxEx.Show($"Cannot initialize public API and settings: {e}");
+            }
         }
 
         [STAThread]

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -44,7 +44,7 @@ namespace Flow.Launcher
             }
             catch (Exception e)
             {
-                ShowErrorMsgBox("Cannot load setting storage, please check local data directory", e);
+                ShowErrorMsgBoxAndFailFast("Cannot load setting storage, please check local data directory", e);
                 return;
             }
 
@@ -69,7 +69,7 @@ namespace Flow.Launcher
             }
             catch (Exception e)
             {
-                ShowErrorMsgBox("Cannot configure dependency injection container, please open new issue in Flow.Launcher", e);
+                ShowErrorMsgBoxAndFailFast("Cannot configure dependency injection container, please open new issue in Flow.Launcher", e);
                 return;
             }
 
@@ -81,14 +81,18 @@ namespace Flow.Launcher
             }
             catch (Exception e)
             {
-                ShowErrorMsgBox("Cannot initialize api and settings, please open new issue in Flow.Launcher", e);
+                ShowErrorMsgBoxAndFailFast("Cannot initialize api and settings, please open new issue in Flow.Launcher", e);
                 return;
             }
         }
 
-        private static void ShowErrorMsgBox(string caption, Exception e)
+        private static void ShowErrorMsgBoxAndFailFast(string message, Exception e)
         {
-            MessageBox.Show(e.ToString(), caption, MessageBoxButton.OK, MessageBoxImage.Error);
+            // Firstly show users the message
+            MessageBox.Show(e.ToString(), message, MessageBoxButton.OK, MessageBoxImage.Error);
+
+            // Flow cannot construct its App instance, so ensure Flow crashes w/ the exception info.
+            Environment.FailFast(message, e);
         }
 
         [STAThread]

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -44,7 +44,8 @@ namespace Flow.Launcher
             }
             catch (Exception e)
             {
-                MessageBox.Show($"Cannot load setting storage: {e}");
+                ShowErrorMsgBox("Cannot load setting storage, please check local data directory", e);
+                return;
             }
 
             // Configure the dependency injection container
@@ -68,7 +69,8 @@ namespace Flow.Launcher
             }
             catch (Exception e)
             {
-                MessageBox.Show($"Cannot configure dependency injection container: {e}");
+                ShowErrorMsgBox("Cannot configure dependency injection container, please open new issue in Flow.Launcher", e);
+                return;
             }
 
             // Initialize the public API and Settings first
@@ -79,8 +81,14 @@ namespace Flow.Launcher
             }
             catch (Exception e)
             {
-                MessageBox.Show($"Cannot initialize public API and settings: {e}");
+                ShowErrorMsgBox("Cannot initialize api and settings, please open new issue in Flow.Launcher", e);
+                return;
             }
+        }
+
+        private static void ShowErrorMsgBox(string caption, Exception e)
+        {
+            MessageBox.Show(e.ToString(), caption, MessageBoxButton.OK, MessageBoxImage.Error);
         }
 
         [STAThread]

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -91,8 +91,9 @@
     </PackageReference>
     <PackageReference Include="InputSimulator" Version="1.0.4" />
     <!-- Do not upgrade Microsoft.Extensions.DependencyInjection and Microsoft.Extensions.Hosting since we are .Net7.0 -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <!-- TaskScheduler seems to be incompatible with 7.0.x version, so we use 6.0.x -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.2" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">
       <PrivateAssets>all</PrivateAssets>

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -104,7 +104,6 @@
     <PackageReference Include="NHotkey.Wpf" Version="3.0.0" />
     <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" />
     <PackageReference Include="SemanticVersioning" Version="3.0.0" />
-    <PackageReference Include="TaskScheduler" Version="2.11.0" />
     <PackageReference Include="VirtualizingWrapPanel" Version="2.1.1" />
   </ItemGroup>
 

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -91,9 +91,8 @@
     </PackageReference>
     <PackageReference Include="InputSimulator" Version="1.0.4" />
     <!-- Do not upgrade Microsoft.Extensions.DependencyInjection and Microsoft.Extensions.Hosting since we are .Net7.0 -->
-    <!-- TaskScheduler seems to be incompatible with 7.0.x version, so we use 6.0.x -->
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">
       <PrivateAssets>all</PrivateAssets>

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -34,16 +34,21 @@ namespace Flow.Launcher
     public class PublicAPIInstance : IPublicAPI
     {
         private readonly Settings _settings;
-        private readonly MainViewModel _mainVM;
+        private MainViewModel _mainVM;
 
-        #region Constructor
+        #region Constructor & Initialization
 
-        public PublicAPIInstance(Settings settings, MainViewModel mainVM)
+        public PublicAPIInstance(Settings settings)
         {
             _settings = settings;
-            _mainVM = mainVM;
             GlobalHotkey.hookedKeyboardCallback = KListener_hookedKeyboardCallback;
             WebRequest.RegisterPrefix("data", new DataWebRequestFactory());
+        }
+        
+        // We must initialize mainVM later to avoid dispatcher thread issue
+        public void Initialize(MainViewModel mainVM)
+        {
+            _mainVM = mainVM;
         }
 
         #endregion

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneGeneralViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneGeneralViewModel.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using Flow.Launcher.Core;
 using Flow.Launcher.Core.Configuration;
 using Flow.Launcher.Core.Resource;
-using Flow.Launcher.Helper;
+using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.SharedModels;


### PR DESCRIPTION
* We should not create MainViewModel when creating api instance because it can cause strange issue which makes all functions related to `_mainVM` in api instance cannot work (Tested)
* Add exception message box in App constructor (Tested)
* Fix `System.PlatformNotSupportedException` (In progess: https://github.com/dahall/TaskScheduler/issues/1001)