### PR TITLE
Add preview background in welcome page 2

### DIFF
--- a/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
@@ -2,11 +2,12 @@
 using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Infrastructure.UserSettings;
 using System;
-using System.Windows;
-using System.Windows.Media;
 using System.Windows.Navigation;
 using CommunityToolkit.Mvvm.Input;
 using Flow.Launcher.ViewModel;
+using System.IO;
+using System.Windows.Media.Imaging;
+using System.Windows.Media;
 
 namespace Flow.Launcher.Resources.Pages
 {
@@ -28,6 +29,28 @@ namespace Flow.Launcher.Resources.Pages
         private static void SetTogglingHotkey(HotkeyModel hotkey)
         {
             HotKeyMapper.SetHotkey(hotkey, HotKeyMapper.OnToggleHotkey);
+        }
+
+        public Brush PreviewBackground
+        {
+            get
+            {
+                var wallpaper = WallpaperPathRetrieval.GetWallpaperPath();
+                if (wallpaper is not null && File.Exists(wallpaper))
+                {
+                    var memStream = new MemoryStream(File.ReadAllBytes(wallpaper));
+                    var bitmap = new BitmapImage();
+                    bitmap.BeginInit();
+                    bitmap.StreamSource = memStream;
+                    bitmap.DecodePixelWidth = 800;
+                    bitmap.DecodePixelHeight = 600;
+                    bitmap.EndInit();
+                    return new ImageBrush(bitmap) { Stretch = Stretch.UniformToFill };
+                }
+
+                var wallpaperColor = WallpaperPathRetrieval.GetWallpaperColor();
+                return new SolidColorBrush(wallpaperColor);
+            }
         }
     }
 }


### PR DESCRIPTION
# Add preview background in welcome page 2

There is `Background="{Binding PreviewBackground}"` in `WelcomePage2.xaml`, but I cannot find this in `WelcomePage2.xaml.cs`, so I believe this brush seems to have been left out.

# Test

![image](https://github.com/user-attachments/assets/40ac2d07-3c94-4047-bee4-cb81773af9dc)