### PR TITLE
New API for StringMatcherKey of Results

### DIFF
--- a/Flow.Launcher.Infrastructure/StringMatcher.cs
+++ b/Flow.Launcher.Infrastructure/StringMatcher.cs
@@ -228,7 +228,7 @@ namespace Flow.Launcher.Infrastructure
             return new MatchResult(false, UserSettingSearchPrecision);
         }
 
-        private bool IsAcronym(string stringToCompare, int compareStringIndex)
+        private static bool IsAcronym(string stringToCompare, int compareStringIndex)
         {
             if (IsAcronymChar(stringToCompare, compareStringIndex) || IsAcronymNumber(stringToCompare, compareStringIndex))
                 return true;
@@ -237,7 +237,7 @@ namespace Flow.Launcher.Infrastructure
         }
 
         // When counting acronyms, treat a set of numbers as one acronym ie. Visual 2019 as 2 acronyms instead of 5
-        private bool IsAcronymCount(string stringToCompare, int compareStringIndex)
+        private static bool IsAcronymCount(string stringToCompare, int compareStringIndex)
         {
             if (IsAcronymChar(stringToCompare, compareStringIndex))
                 return true;

--- a/Flow.Launcher.Plugin/Result.cs
+++ b/Flow.Launcher.Plugin/Result.cs
@@ -271,6 +271,13 @@ namespace Flow.Launcher.Plugin
         public string RecordKey { get; set; } = null;
 
         /// <summary>
+        /// The key to be compared with the user input for fuzzy search.
+        /// This can be useful when the plugin wants to provide a different string for fuzzy search.
+        /// If the plugin does not specific this, FL just uses Title and SubTitle to compare with the user input.
+        /// </summary>
+        public string StringMatcherKey { get; set; }
+
+        /// <summary>
         /// Info of the preview section of a <see cref="Result"/>
         /// </summary>
         public record PreviewInfo


### PR DESCRIPTION
StringMatcherKey is the key to be compared with the user input for fuzzy search.

This can be useful when the plugin wants to provide a different string for fuzzy search.

If the plugin does not specific this, FL just uses Title and SubTitle to compare with the user input.

For a plugin like Obsidian, the user would expect title and note content to match the string, we can set this property with title and note content.