### PR TITLE
Fix issue that mainVM fails to work

### DIFF
--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -135,6 +135,7 @@ namespace Flow.Launcher
                 await imageLoadertask;
 
                 var mainVM = Ioc.Default.GetRequiredService<MainViewModel>();
+                ((PublicAPIInstance)API).Initialize(mainVM);
                 var window = new MainWindow(_settings, mainVM);
 
                 Log.Info($"|App.OnStartup|Dependencies Info:{ErrorReporting.DependenciesInfo()}");

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -34,16 +34,21 @@ namespace Flow.Launcher
     public class PublicAPIInstance : IPublicAPI
     {
         private readonly Settings _settings;
-        private readonly MainViewModel _mainVM;
+        private MainViewModel _mainVM;
 
-        #region Constructor
+        #region Constructor & Initialization
 
-        public PublicAPIInstance(Settings settings, MainViewModel mainVM)
+        public PublicAPIInstance(Settings settings)
         {
             _settings = settings;
-            _mainVM = mainVM;
             GlobalHotkey.hookedKeyboardCallback = KListener_hookedKeyboardCallback;
             WebRequest.RegisterPrefix("data", new DataWebRequestFactory());
+        }
+
+        // We must initialize mainVM later to avoid unknown issue that _mainVM fails to work
+        public void Initialize(MainViewModel mainVM)
+        {
+            _mainVM = mainVM;
         }
 
         #endregion


### PR DESCRIPTION
# From #3275.

We should not create `MainViewModel` when creating API instance in constructor because it can cause unknown issue that makes all functions related to _mainVM in API instance cannot work.

# Test

Originally (Tested in VMWare, installed latest dev branch version 65f85cf)

https://github.com/user-attachments/assets/9fe90d8a-edef-45cb-9b71-3fafa12db3a2

Because installing & uninstalling plugins need _mainVM to `ChangeQuery` and `ShowWindow` so nothing happens when _mainVM fails to work.

After

