### PR TITLE
Fix API instance create twice issue & Make PluginManager.API private

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -29,7 +29,9 @@ namespace Flow.Launcher.Core.Plugin
         public static readonly HashSet<PluginPair> GlobalPlugins = new();
         public static readonly Dictionary<string, PluginPair> NonGlobalPlugins = new();
 
-        public static IPublicAPI API { get; private set; } = Ioc.Default.GetRequiredService<IPublicAPI>();
+        // We should not initialize API in static constructor because it will create another API instance
+        private static IPublicAPI api = null;
+        private static IPublicAPI API => api ??= Ioc.Default.GetRequiredService<IPublicAPI>();
 
         private static PluginsSettings Settings;
         private static List<PluginMetadata> _metadatas;

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -438,7 +438,7 @@ namespace Flow.Launcher
             if (_settings.FirstLaunch)
             {
                 _settings.FirstLaunch = false;
-                PluginManager.API.SaveAppAllSettings();
+                App.API.SaveAppAllSettings();
                 OpenWelcomeWindow();
             }
         }

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using CommunityToolkit.Mvvm.Input;
 using Flow.Launcher.Core;
-using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.UserSettings;
@@ -77,7 +76,7 @@ public partial class SettingsPaneAboutViewModel : BaseModel
     [RelayCommand]
     private void OpenSettingsFolder()
     {
-        PluginManager.API.OpenDirectory(Path.Combine(DataLocation.DataDirectory(), Constant.Settings));
+        App.API.OpenDirectory(Path.Combine(DataLocation.DataDirectory(), Constant.Settings));
     }
 
     [RelayCommand]
@@ -85,7 +84,7 @@ public partial class SettingsPaneAboutViewModel : BaseModel
     {
         string settingsFolderPath = Path.Combine(DataLocation.DataDirectory(), Constant.Settings);
         string parentFolderPath = Path.GetDirectoryName(settingsFolderPath);
-        PluginManager.API.OpenDirectory(parentFolderPath);
+        App.API.OpenDirectory(parentFolderPath);
     }
 
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Navigation;
-using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.SettingPages.ViewModels;
 using Flow.Launcher.ViewModel;
 
@@ -49,7 +48,7 @@ public partial class SettingsPanePluginStore
 
     private void Hyperlink_OnRequestNavigate(object sender, RequestNavigateEventArgs e)
     {
-        PluginManager.API.OpenUrl(e.Uri.AbsoluteUri);
+        App.API.OpenUrl(e.Uri.AbsoluteUri);
         e.Handled = true;
     }
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -442,7 +442,7 @@ namespace Flow.Launcher.ViewModel
         [RelayCommand]
         private void SelectHelp()
         {
-            PluginManager.API.OpenUrl("https://www.flowlauncher.com/docs/#/usage-tips");
+            App.API.OpenUrl("https://www.flowlauncher.com/docs/#/usage-tips");
         }
 
         [RelayCommand]

--- a/Flow.Launcher/ViewModel/PluginViewModel.cs
+++ b/Flow.Launcher/ViewModel/PluginViewModel.cs
@@ -134,20 +134,20 @@ namespace Flow.Launcher.ViewModel
         {
             var directory = PluginPair.Metadata.PluginDirectory;
             if (!string.IsNullOrEmpty(directory))
-                PluginManager.API.OpenDirectory(directory);
+                App.API.OpenDirectory(directory);
         }
 
         [RelayCommand]
         private void OpenSourceCodeLink()
         {
-            PluginManager.API.OpenUrl(PluginPair.Metadata.Website);
+            App.API.OpenUrl(PluginPair.Metadata.Website);
         }
 
         [RelayCommand]
         private void OpenDeletePluginWindow()
         {
-            PluginManager.API.ChangeQuery($"{PluginManagerActionKeyword} uninstall {PluginPair.Metadata.Name}".Trim(), true);
-            PluginManager.API.ShowMainWindow();
+            App.API.ChangeQuery($"{PluginManagerActionKeyword} uninstall {PluginPair.Metadata.Name}".Trim(), true);
+            App.API.ShowMainWindow();
         }
 
         public static bool IsActionKeywordRegistered(string newActionKeyword) => PluginManager.ActionKeywordRegistered(newActionKeyword);


### PR DESCRIPTION
# From #3296 

We should not initialize API in static constructor or it will create another API instance.