### PR TITLE
Remove unneccessary CreateSettingPanel by introducing need check

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginBase.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginBase.cs
@@ -34,7 +34,7 @@ namespace Flow.Launcher.Core.Plugin
     /// Represent the plugin that using JsonPRC
     /// every JsonRPC plugin should has its own plugin instance
     /// </summary>
-    internal abstract class JsonRPCPluginBase : IAsyncPlugin, IContextMenu, ISettingProvider, ISavable
+    public abstract class JsonRPCPluginBase : IAsyncPlugin, IContextMenu, ISettingProvider, ISavable
     {
         protected PluginInitContext Context;
         public const string JsonRPC = "JsonRPC";
@@ -155,6 +155,11 @@ namespace Flow.Launcher.Core.Plugin
         public void Save()
         {
             Settings?.Save();
+        }
+
+        public bool NeedCreateSettingPanel()
+        {
+            return Settings.NeedCreateSettingPanel();
         }
 
         public Control CreateSettingPanel()

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -109,10 +109,15 @@ namespace Flow.Launcher.Core.Plugin
             _storage.Save();
         }
 
+        public bool NeedCreateSettingPanel()
+        {
+            // If there are no settings or the settings configuration is empty, return null
+            return Settings != null && Configuration != null && Configuration.Body.Count != 0;
+        }
+
         public Control CreateSettingPanel()
         {
-            if (Settings == null || Settings.Count == 0)
-                return null;
+            // No need to check if NeedCreateSettingPanel is true because CreateSettingPanel will only be called if it's true
 
             var settingWindow = new UserControl();
             var mainPanel = new Grid { Margin = settingPanelMargin, VerticalAlignment = VerticalAlignment.Center };

--- a/Flow.Launcher/ViewModel/PluginViewModel.cs
+++ b/Flow.Launcher/ViewModel/PluginViewModel.cs
@@ -90,13 +90,13 @@ namespace Flow.Launcher.ViewModel
         private Control _bottomPart2;
         public Control BottomPart2 => IsExpanded ? _bottomPart2 ??= new InstalledPluginDisplayBottomData() : null;
 
-        public bool HasSettingControl => PluginPair.Plugin is ISettingProvider settingProvider && settingProvider.CreateSettingPanel() != null;
+        public bool HasSettingControl => PluginPair.Plugin is ISettingProvider && (PluginPair.Plugin is not JsonRPCPluginBase jsonRPCPluginBase || jsonRPCPluginBase.NeedCreateSettingPanel());
         public Control SettingControl
             => IsExpanded
                 ? _settingControl
-                    ??= PluginPair.Plugin is not ISettingProvider settingProvider
-                        ? null
-                        : settingProvider.CreateSettingPanel()
+                    ??= HasSettingControl
+                        ? ((ISettingProvider)PluginPair.Plugin).CreateSettingPanel()
+                        : null
                 : null;
         private ImageSource _image = ImageLoader.MissingImage;
 


### PR DESCRIPTION
# Remove unneccessary CreateSettingPanel by introducing need check

Follow on with #3260, we can use `NeedCreateSettingPanel` function to check if we need to create settings panel to remove unnecessary calling of `CreateSettingPanel`.

# Test

* JsonRPC plugins can create settings panels correctly.
* JsonRPC plugins will not call `CreateSettingPanel` when their `SettingsTemplate.yaml` files do not have any configurations.