### PR TITLE
Fix Possible Plugin Initialization Issue

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -165,7 +165,8 @@ namespace Flow.Launcher.Core.Plugin
         {
             var failedPlugins = new ConcurrentQueue<PluginPair>();
 
-            var InitTasks = AllPlugins.Select(pair => Task.Run(async delegate
+            // Some plugins should not be initialized in task, so we cannot use Task.WhenAll here
+            foreach (var pair in AllPlugins)
             {
                 try
                 {
@@ -182,9 +183,7 @@ namespace Flow.Launcher.Core.Plugin
                     pair.Metadata.Disabled = true;
                     failedPlugins.Enqueue(pair);
                 }
-            }));
-
-            await Task.WhenAll(InitTasks);
+            }
 
             _contextMenuPlugins = GetPluginsForInterface<IContextMenu>();
             foreach (var plugin in AllPlugins)

--- a/Flow.Launcher.Plugin/Interfaces/IPlugin.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPlugin.cs
@@ -30,7 +30,12 @@ namespace Flow.Launcher.Plugin
         /// <param name="context"></param>
         void Init(PluginInitContext context);
 
-        Task IAsyncPlugin.InitAsync(PluginInitContext context) => Task.Run(() => Init(context));
+        async Task IAsyncPlugin.InitAsync(PluginInitContext context)
+        {
+            // Some plugins should not be initialized in task
+            Init(context);
+            await Task.CompletedTask;
+        }
 
         Task<List<Result>> IAsyncPlugin.QueryAsync(Query query, CancellationToken token) => Task.Run(() => Query(query));
     }


### PR DESCRIPTION
# Issue

If using `Task.Run` to initialize my plugin Clipboard+, my plugin will fail to monitor the clipboard. (I do not know why, but my plugin cannot listen to system clipboard event if we do so)

The issue with StartAsSTA is that you registered a hook via the specific thread, but once it is created, the thread is finishing and die, which leaves Windows couldn't fire the event because it cannot find the thread that is registering the event.

So we should not use `Task` to run plugin init event. Instead, we would better to run `InitAsync` in main thread with `foreach`.

# Test

Use `foreach` will affect performance but just a little bit. I use 15 plugins and test with `Stopwatch.DebugAsync`.

With `Task.WhenAll` the plugins are fully initialized in about 1350ms, while with `foreach` the plugins are fully initialized in around 1250ms.

Considering majority of plugins do not need much time to initialize, this solution can serve the purpose.

Here is my plugin for test:
[Clipboard+-2.1.1 - Test InitAsync.zip](https://github.com/user-attachments/files/19053680/Clipboard%2B-2.1.1.-.Test.InitAsync.zip)