### PR TITLE
Use dependency injection instead of navigation parameter

### DIFF
--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml.cs
@@ -1,6 +1,8 @@
-﻿using System;
-using System.Windows.Navigation;
+﻿using System.Windows.Navigation;
+using Flow.Launcher.Core;
 using Flow.Launcher.SettingPages.ViewModels;
+using Flow.Launcher.Infrastructure.UserSettings;
+using CommunityToolkit.Mvvm.DependencyInjection;
 
 namespace Flow.Launcher.SettingPages.Views;
 
@@ -12,8 +14,8 @@ public partial class SettingsPaneAbout
     {
         if (!IsInitialized)
         {
-            if (e.ExtraData is not SettingWindow.PaneData { Settings: { } settings, Updater: { } updater })
-                throw new ArgumentException("Settings are required for SettingsPaneAbout.");
+            var settings = Ioc.Default.GetRequiredService<Settings>();
+            var updater = Ioc.Default.GetRequiredService<Updater>();
             _viewModel = new SettingsPaneAboutViewModel(settings, updater);
             DataContext = _viewModel;
             InitializeComponent();

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using System.Windows.Navigation;
+﻿using System.Windows.Navigation;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Flow.Launcher.Core;
+using Flow.Launcher.Core.Configuration;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.SettingPages.ViewModels;
 
@@ -13,8 +15,9 @@ public partial class SettingsPaneGeneral
     {
         if (!IsInitialized)
         {
-            if (e.ExtraData is not SettingWindow.PaneData { Settings: { } settings, Updater: {} updater, Portable: {} portable })
-                throw new ArgumentException("Settings, Updater and Portable are required for SettingsPaneGeneral.");
+            var settings = Ioc.Default.GetRequiredService<Settings>();
+            var updater = Ioc.Default.GetRequiredService<Updater>();
+            var portable = Ioc.Default.GetRequiredService<Portable>();
             _viewModel = new SettingsPaneGeneralViewModel(settings, updater, portable);
             DataContext = _viewModel;
             InitializeComponent();

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneHotkey.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneHotkey.xaml.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Windows.Navigation;
+﻿using System.Windows.Navigation;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.SettingPages.ViewModels;
+using Flow.Launcher.Infrastructure.UserSettings;
 
 namespace Flow.Launcher.SettingPages.Views;
 
@@ -12,8 +13,7 @@ public partial class SettingsPaneHotkey
     {
         if (!IsInitialized)
         {
-            if (e.ExtraData is not SettingWindow.PaneData { Settings: { } settings })
-                throw new ArgumentException("Settings are required for SettingsPaneHotkey.");
+            var settings = Ioc.Default.GetRequiredService<Settings>();
             _viewModel = new SettingsPaneHotkeyViewModel(settings);
             DataContext = _viewModel;
             InitializeComponent();

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
@@ -1,10 +1,11 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Navigation;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.SettingPages.ViewModels;
 using Flow.Launcher.ViewModel;
+using Flow.Launcher.Infrastructure.UserSettings;
 
 namespace Flow.Launcher.SettingPages.Views;
 
@@ -16,8 +17,7 @@ public partial class SettingsPanePluginStore
     {
         if (!IsInitialized)
         {
-            if (e.ExtraData is not SettingWindow.PaneData { Settings: { } settings })
-                throw new ArgumentException($"Settings are required for {nameof(SettingsPanePluginStore)}.");
+            var settings = Ioc.Default.GetRequiredService<Settings>();
             _viewModel = new SettingsPanePluginStoreViewModel();
             DataContext = _viewModel;
             InitializeComponent();

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using System.Windows.Input;
+﻿using System.Windows.Input;
 using System.Windows.Navigation;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.SettingPages.ViewModels;
+using Flow.Launcher.Infrastructure.UserSettings;
 
 namespace Flow.Launcher.SettingPages.Views;
 
@@ -13,8 +14,7 @@ public partial class SettingsPanePlugins
     {
         if (!IsInitialized)
         {
-            if (e.ExtraData is not SettingWindow.PaneData { Settings: { } settings })
-                throw new ArgumentException("Settings are required for SettingsPaneHotkey.");
+            var settings = Ioc.Default.GetRequiredService<Settings>();
             _viewModel = new SettingsPanePluginsViewModel(settings);
             DataContext = _viewModel;
             InitializeComponent();

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneProxy.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneProxy.xaml.cs
@@ -1,6 +1,8 @@
-﻿using System;
-using System.Windows.Navigation;
+﻿using System.Windows.Navigation;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Flow.Launcher.Core;
 using Flow.Launcher.SettingPages.ViewModels;
+using Flow.Launcher.Infrastructure.UserSettings;
 
 namespace Flow.Launcher.SettingPages.Views;
 
@@ -12,8 +14,8 @@ public partial class SettingsPaneProxy
     {
         if (!IsInitialized)
         {
-            if (e.ExtraData is not SettingWindow.PaneData { Settings: { } settings, Updater: { } updater })
-                throw new ArgumentException($"Settings are required for {nameof(SettingsPaneProxy)}.");
+            var settings = Ioc.Default.GetRequiredService<Settings>();
+            var updater = Ioc.Default.GetRequiredService<Updater>();
             _viewModel = new SettingsPaneProxyViewModel(settings, updater);
             DataContext = _viewModel;
             InitializeComponent();

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media;
+﻿using System.Windows.Controls;
 using System.Windows.Navigation;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.SettingPages.ViewModels;
 using Page = ModernWpf.Controls.Page;
+using Flow.Launcher.Infrastructure.UserSettings;
 
 namespace Flow.Launcher.SettingPages.Views;
 
@@ -16,8 +15,7 @@ public partial class SettingsPaneTheme : Page
     {
         if (!IsInitialized)
         {
-            if (e.ExtraData is not SettingWindow.PaneData { Settings: { } settings })
-                throw new ArgumentException($"Settings are required for {nameof(SettingsPaneTheme)}.");
+            var settings = Ioc.Default.GetRequiredService<Settings>();
             _viewModel = new SettingsPaneThemeViewModel(settings);
             DataContext = _viewModel;
             InitializeComponent();

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -4,8 +4,6 @@ using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Interop;
 using CommunityToolkit.Mvvm.DependencyInjection;
-using Flow.Launcher.Core;
-using Flow.Launcher.Core.Configuration;
 using Flow.Launcher.Helper;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
@@ -18,8 +16,6 @@ namespace Flow.Launcher;
 
 public partial class SettingWindow
 {
-    private readonly Updater _updater;
-    private readonly IPortable _portable;
     private readonly IPublicAPI _api;
     private readonly Settings _settings;
     private readonly SettingWindowViewModel _viewModel;
@@ -30,8 +26,6 @@ public partial class SettingWindow
         _settings = Ioc.Default.GetRequiredService<Settings>();
         DataContext = viewModel;
         _viewModel = viewModel;
-        _updater = Ioc.Default.GetRequiredService<Updater>();
-        _portable = Ioc.Default.GetRequiredService<Portable>();
         _api = Ioc.Default.GetRequiredService<IPublicAPI>();
         InitializePosition();
         InitializeComponent();
@@ -166,10 +160,9 @@ public partial class SettingWindow
 
     private void NavigationView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
     {
-        var paneData = new PaneData(_settings, _updater, _portable);
         if (args.IsSettingsSelected)
         {
-            ContentFrame.Navigate(typeof(SettingsPaneGeneral), paneData);
+            ContentFrame.Navigate(typeof(SettingsPaneGeneral));
         }
         else
         {
@@ -191,7 +184,7 @@ public partial class SettingWindow
                 nameof(About) => typeof(SettingsPaneAbout),
                 _ => typeof(SettingsPaneGeneral)
             };
-            ContentFrame.Navigate(pageType, paneData);
+            ContentFrame.Navigate(pageType);
         }
     }
 
@@ -211,6 +204,4 @@ public partial class SettingWindow
     {
         NavView.SelectedItem ??= NavView.MenuItems[0]; /* Set First Page */
     }
-
-    public record PaneData(Settings Settings, Updater Updater, IPortable Portable);
 }


### PR DESCRIPTION
Follow on with #3310.

We should use dependency injection instead of navigation parameter to get instances.