### PR TITLE
Revert "Bump System.Data.OleDb from 8.0.1 to 9.0.2"

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Flow.Launcher.Plugin.Explorer.csproj
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Flow.Launcher.Plugin.Explorer.csproj
@@ -45,7 +45,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.Data.OleDb" Version="9.0.2" />
+    <!-- Do not upgrade System.Data.OleDb since we are .Net7.0 -->
+    <PackageReference Include="System.Data.OleDb" Version="8.0.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="tlbimp-Microsoft.Search.Interop" Version="1.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Fix ![image](https://github.com/user-attachments/assets/b9ba7c5d-89aa-4457-9bc0-0363429a6a2a)

We can upgrade this when we move to .net9.