### PR TITLE
Use Command Keyword to Search System Command

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Sys/Command.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Command.cs
@@ -6,12 +6,39 @@ namespace Flow.Launcher.Plugin.Sys
     {
         public string Key { get; set; }
 
+        private string name;
         [JsonIgnore]
-        public string Name { get; set; }
+        public string Name
+        {
+            get => name;
+            set
+            {
+                name = value;
+                OnPropertyChanged();
+            }
+        }
 
+        private string description;
         [JsonIgnore]
-        public string Description { get; set; }
+        public string Description
+        {
+            get => description;
+            set
+            {
+                description = value;
+                OnPropertyChanged();
+            }
+        }
 
-        public string Keyword { get; set; }
+        private string keyword;
+        public string Keyword
+        {
+            get => keyword;
+            set
+            {
+                keyword = value;
+                OnPropertyChanged();
+            }
+        }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Sys/Command.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Command.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Flow.Launcher.Plugin.Sys
+{
+    public class Command : BaseModel
+    {
+        public string Key { get; set; }
+
+        [JsonIgnore]
+        public string Name { get; set; }
+
+        [JsonIgnore]
+        public string Description { get; set; }
+
+        public string Keyword { get; set; }
+    }
+}

--- a/Plugins/Flow.Launcher.Plugin.Sys/CommandKeywordSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Sys/CommandKeywordSetting.xaml
@@ -1,0 +1,121 @@
+﻿<Window
+    x:Class="Flow.Launcher.Plugin.Sys.CommandKeywordSettingWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Title="{DynamicResource lowlauncher_plugin_sys_command_keyword_setting_window_title}"
+    Width="550"
+    Background="{DynamicResource PopupBGColor}"
+    Foreground="{DynamicResource PopupTextColor}"
+    ResizeMode="NoResize"
+    SizeToContent="Height"
+    WindowStartupLocation="CenterScreen"
+    mc:Ignorable="d">
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="32" ResizeBorderThickness="{x:Static SystemParameters.WindowResizeBorderThickness}" />
+    </WindowChrome.WindowChrome>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition Height="80" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0">
+            <StackPanel>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Button
+                        Grid.Column="1"
+                        Click="OnCancelButtonClick"
+                        Style="{StaticResource TitleBarCloseButtonStyle}">
+                        <Path
+                            Width="46"
+                            Height="32"
+                            Data="M 18,11 27,20 M 18,20 27,11"
+                            Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                            StrokeThickness="1">
+                            <Path.Style>
+                                <Style TargetType="Path">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                            <Setter Property="Opacity" Value="0.5" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Path.Style>
+                        </Path>
+                    </Button>
+                </Grid>
+            </StackPanel>
+            <StackPanel Margin="26 12 26 0">
+                <StackPanel Margin="0 0 0 12">
+                    <TextBlock
+                        Grid.Column="0"
+                        Margin="0 0 0 0"
+                        FontSize="20"
+                        FontWeight="SemiBold"
+                        Text="{DynamicResource flowlauncher_plugin_sys_custom_command_keyword}"
+                        TextAlignment="Left" />
+                </StackPanel>
+
+                <StackPanel>
+                    <TextBlock
+                        x:Name="CommandKeywordTips"
+                        FontSize="14"
+                        TextAlignment="Left"
+                        TextWrapping="WrapWithOverflow" />
+                </StackPanel>
+
+                <Grid Margin="0 24 0 24">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Grid.Column="0"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
+                        FontSize="14"
+                        Text="{DynamicResource flowlauncher_plugin_sys_command_keyword}" />
+                    <TextBox
+                        x:Name="CommandKeyword"
+                        Grid.Column="1"
+                        Margin="10"
+                        HorizontalAlignment="Stretch" />
+                    <Button
+                        x:Name="btnTestActionKeyword"
+                        Grid.Row="1"
+                        Grid.Column="2"
+                        Margin="0 0 10 0"
+                        Padding="10 5 10 5"
+                        Click="OnResetButtonClick"
+                        Content="{DynamicResource flowlauncher_plugin_sys_reset}" />
+                </Grid>
+            </StackPanel>
+        </StackPanel>
+        <Border
+            Grid.Row="1"
+            Background="{DynamicResource PopupButtonAreaBGColor}"
+            BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
+            BorderThickness="0 1 0 0">
+            <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
+                <Button
+                    MinWidth="140"
+                    Margin="10 0 5 0"
+                    Click="OnCancelButtonClick"
+                    Content="{DynamicResource flowlauncher_plugin_sys_cancel}" />
+                <Button
+                    MinWidth="140"
+                    Margin="5 0 10 0"
+                    Click="OnConfirmButtonClick"
+                    Content="{DynamicResource flowlauncher_plugin_sys_confirm}"
+                    Style="{DynamicResource AccentButtonStyle}" />
+            </StackPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/Plugins/Flow.Launcher.Plugin.Sys/CommandKeywordSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/CommandKeywordSetting.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System.Windows;
+
+namespace Flow.Launcher.Plugin.Sys
+{
+    public partial class CommandKeywordSettingWindow
+    {
+        private readonly Command _oldSearchSource;
+        private readonly PluginInitContext _context;
+
+        public CommandKeywordSettingWindow(PluginInitContext context, Command old)
+        {
+            _context = context;
+            _oldSearchSource = old;
+            InitializeComponent();
+            CommandKeyword.Text = old.Keyword;
+            CommandKeywordTips.Text = string.Format(_context.API.GetTranslation("flowlauncher_plugin_sys_custom_command_keyword_tip"), old.Name);
+        }
+
+        private void OnCancelButtonClick(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        private void OnConfirmButtonClick(object sender, RoutedEventArgs e)
+        {
+            var keyword = CommandKeyword.Text;
+            if (string.IsNullOrEmpty(keyword))
+            {
+                var warning = _context.API.GetTranslation("flowlauncher_plugin_sys_input_command_keyword");
+                _context.API.ShowMsgBox(warning);
+            }
+            else
+            {
+                _oldSearchSource.Keyword = keyword;
+                Close();
+            }
+        }
+
+        private void OnResetButtonClick(object sender, RoutedEventArgs e)
+        {
+            // Key is the default value of this command
+            CommandKeyword.Text = _oldSearchSource.Key;
+        }
+    }
+}

--- a/Plugins/Flow.Launcher.Plugin.Sys/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Languages/en.xaml
@@ -4,8 +4,9 @@
     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <!--  Command List  -->
-    <system:String x:Key="flowlauncher_plugin_sys_command">Command</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_name">Name</system:String>
     <system:String x:Key="flowlauncher_plugin_sys_desc">Description</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_command">Command</system:String>
 
     <system:String x:Key="flowlauncher_plugin_sys_shutdown_computer_cmd">Shutdown</system:String>
     <system:String x:Key="flowlauncher_plugin_sys_restart_computer_cmd">Restart</system:String>
@@ -28,6 +29,8 @@
     <system:String x:Key="flowlauncher_plugin_sys_open_userdata_location_cmd">Flow Launcher UserData Folder</system:String>
     <system:String x:Key="flowlauncher_plugin_sys_toggle_game_mode_cmd">Toggle Game Mode</system:String>
     <system:String x:Key="flowlauncher_plugin_sys_theme_selector_cmd">Set the Flow Launcher Theme</system:String>
+
+    <system:String x:Key="flowlauncher_plugin_sys_edit">Edit</system:String>
 
     <!--  Command Descriptions  -->
     <system:String x:Key="flowlauncher_plugin_sys_shutdown_computer">Shutdown Computer</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Sys/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Languages/en.xaml
@@ -64,6 +64,15 @@
     <system:String x:Key="flowlauncher_plugin_sys_dlgtext_restart_computer_advanced">Are you sure you want to restart the computer with Advanced Boot Options?</system:String>
     <system:String x:Key="flowlauncher_plugin_sys_dlgtext_logoff_computer">Are you sure you want to log off?</system:String>
 
+    <system:String x:Key="flowlauncher_plugin_sys_command_keyword_setting_window_title">Command Keyword Setting</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_custom_command_keyword">Custom Command Keyword</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_custom_command_keyword_tip">Enter a keyword to search for command: {0}. This keyword is used to match your query.</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_command_keyword">Command Keyword</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_reset">Reset</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_confirm">Confirm</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_cancel">Cancel</system:String>
+    <system:String x:Key="flowlauncher_plugin_sys_input_command_keyword">Please enter a non-empty command keyword</system:String>
+
     <system:String x:Key="flowlauncher_plugin_sys_plugin_name">System Commands</system:String>
     <system:String x:Key="flowlauncher_plugin_sys_plugin_description">Provides System related commands. e.g. shutdown, lock, settings etc.</system:String>
 

--- a/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -18,10 +19,6 @@ namespace Flow.Launcher.Plugin.Sys
 {
     public class Main : IPlugin, ISettingProvider, IPluginI18n
     {
-        private PluginInitContext context;
-        private Settings settings;
-        private ThemeSelector themeSelector;
-
         private readonly Dictionary<string, string> KeywordTitleMappings = new()
         {
             {"Shutdown", "flowlauncher_plugin_sys_shutdown_computer_cmd"},
@@ -48,23 +45,28 @@ namespace Flow.Launcher.Plugin.Sys
         };
         private readonly Dictionary<string, string> KeywordDescriptionMappings = new();
 
-        private SettingsViewModel _viewModel;
-
-        // SHTDN_REASON_MAJOR_OTHER indicates a generic shutdown reason that isn't categorized under hardware failure, software updates, or other predefined reasons.
+        // SHTDN_REASON_MAJOR_OTHER indicates a generic shutdown reason that isn't categorized under hardware failure,
+        // software updates, or other predefined reasons.
         // SHTDN_REASON_FLAG_PLANNED marks the shutdown as planned rather than an unexpected shutdown or failure
-        private const SHUTDOWN_REASON REASON = SHUTDOWN_REASON.SHTDN_REASON_MAJOR_OTHER | SHUTDOWN_REASON.SHTDN_REASON_FLAG_PLANNED;
+        private const SHUTDOWN_REASON REASON = SHUTDOWN_REASON.SHTDN_REASON_MAJOR_OTHER |
+            SHUTDOWN_REASON.SHTDN_REASON_FLAG_PLANNED;
+
+        private PluginInitContext _context;
+        private Settings _settings;
+        private ThemeSelector _themeSelector;
+        private SettingsViewModel _viewModel;
 
         public Control CreateSettingPanel()
         {
             UpdateLocalizedNameDescription(false);
-            return new SysSettings(_viewModel);
+            return new SysSettings(_context, _viewModel);
         }
 
         public List<Result> Query(Query query)
         {
             if(query.Search.StartsWith(ThemeSelector.Keyword))
             {
-                return themeSelector.Query(query);
+                return _themeSelector.Query(query);
             }
 
             var commands = Commands();
@@ -99,7 +101,7 @@ namespace Flow.Launcher.Plugin.Sys
                 return "Title Not Found";
             }
 
-            return context.API.GetTranslation(translationKey);
+            return _context.API.GetTranslation(translationKey);
         }
 
         private string GetDescription(string key)
@@ -110,7 +112,7 @@ namespace Flow.Launcher.Plugin.Sys
                 return "Description Not Found";
             }
 
-            return context.API.GetTranslation(translationKey);
+            return _context.API.GetTranslation(translationKey);
         }
 
         [Obsolete]
@@ -122,7 +124,7 @@ namespace Flow.Launcher.Plugin.Sys
                 return "Title Not Found";
             }
 
-            var translatedTitle = context.API.GetTranslation(translationKey);
+            var translatedTitle = _context.API.GetTranslation(translationKey);
 
             if (query == null)
             {
@@ -142,10 +144,10 @@ namespace Flow.Launcher.Plugin.Sys
 
         public void Init(PluginInitContext context)
         {
-            this.context = context;
-            settings = context.API.LoadSettingJsonStorage<Settings>();
-            _viewModel = new SettingsViewModel(settings);
-            themeSelector = new ThemeSelector(context);
+            _context = context;
+            _settings = context.API.LoadSettingJsonStorage<Settings>();
+            _viewModel = new SettingsViewModel(_settings);
+            _themeSelector = new ThemeSelector(context);
             foreach (string key in KeywordTitleMappings.Keys)
             {
                 // Remove _cmd in the last of the strings
@@ -155,9 +157,9 @@ namespace Flow.Launcher.Plugin.Sys
 
         private void UpdateLocalizedNameDescription(bool force)
         {
-            if (string.IsNullOrEmpty(settings.Commands[0].Name) || force)
+            if (string.IsNullOrEmpty(_settings.Commands[0].Name) || force)
             {
-                foreach (var c in settings.Commands)
+                foreach (var c in _settings.Commands)
                 {
                     c.Name = GetTitle(c.Key);
                     c.Description = GetDescription(c.Key);
@@ -214,14 +216,14 @@ namespace Flow.Launcher.Plugin.Sys
                 new Result
                 {
                     Title = "Shutdown",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_shutdown_computer"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_shutdown_computer"),
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\xe7e8"),
                     IcoPath = "Images\\shutdown.png",
                     Action = c =>
                     {
-                        var result = context.API.ShowMsgBox(
-                            context.API.GetTranslation("flowlauncher_plugin_sys_dlgtext_shutdown_computer"),
-                            context.API.GetTranslation("flowlauncher_plugin_sys_shutdown_computer"),
+                        var result = _context.API.ShowMsgBox(
+                            _context.API.GetTranslation("flowlauncher_plugin_sys_dlgtext_shutdown_computer"),
+                            _context.API.GetTranslation("flowlauncher_plugin_sys_shutdown_computer"),
                             MessageBoxButton.YesNo, MessageBoxImage.Warning);
 
                         if (result == MessageBoxResult.Yes)
@@ -236,14 +238,14 @@ namespace Flow.Launcher.Plugin.Sys
                 new Result
                 {
                     Title = "Restart",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_restart_computer"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_restart_computer"),
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\xe777"),
                     IcoPath = "Images\\restart.png",
                     Action = c =>
                     {
-                        var result = context.API.ShowMsgBox(
-                            context.API.GetTranslation("flowlauncher_plugin_sys_dlgtext_restart_computer"),
-                            context.API.GetTranslation("flowlauncher_plugin_sys_restart_computer"),
+                        var result = _context.API.ShowMsgBox(
+                            _context.API.GetTranslation("flowlauncher_plugin_sys_dlgtext_restart_computer"),
+                            _context.API.GetTranslation("flowlauncher_plugin_sys_restart_computer"),
                             MessageBoxButton.YesNo, MessageBoxImage.Warning);
 
                         if (result == MessageBoxResult.Yes)
@@ -258,14 +260,14 @@ namespace Flow.Launcher.Plugin.Sys
                 new Result
                 {
                     Title = "Restart With Advanced Boot Options",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_restart_advanced"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_restart_advanced"),
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\xecc5"),
                     IcoPath = "Images\\restart_advanced.png",
                     Action = c =>
                     {
-                        var result = context.API.ShowMsgBox(
-                            context.API.GetTranslation("flowlauncher_plugin_sys_dlgtext_restart_computer_advanced"),
-                            context.API.GetTranslation("flowlauncher_plugin_sys_restart_computer"),
+                        var result = _context.API.ShowMsgBox(
+                            _context.API.GetTranslation("flowlauncher_plugin_sys_dlgtext_restart_computer_advanced"),
+                            _context.API.GetTranslation("flowlauncher_plugin_sys_restart_computer"),
                             MessageBoxButton.YesNo, MessageBoxImage.Warning);
 
                         if (result == MessageBoxResult.Yes)
@@ -280,14 +282,14 @@ namespace Flow.Launcher.Plugin.Sys
                 new Result
                 {
                     Title = "Log Off/Sign Out",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_log_off"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_log_off"),
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\xe77b"),
                     IcoPath = "Images\\logoff.png",
                     Action = c =>
                     {
-                        var result = context.API.ShowMsgBox(
-                            context.API.GetTranslation("flowlauncher_plugin_sys_dlgtext_logoff_computer"),
-                            context.API.GetTranslation("flowlauncher_plugin_sys_log_off"),
+                        var result = _context.API.ShowMsgBox(
+                            _context.API.GetTranslation("flowlauncher_plugin_sys_dlgtext_logoff_computer"),
+                            _context.API.GetTranslation("flowlauncher_plugin_sys_log_off"),
                             MessageBoxButton.YesNo, MessageBoxImage.Warning);
 
                         if (result == MessageBoxResult.Yes)
@@ -299,7 +301,7 @@ namespace Flow.Launcher.Plugin.Sys
                 new Result
                 {
                     Title = "Lock",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_lock"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_lock"),
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\xe72e"),
                     IcoPath = "Images\\lock.png",
                     Action = c =>
@@ -311,7 +313,7 @@ namespace Flow.Launcher.Plugin.Sys
                 new Result
                 {
                     Title = "Sleep",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_sleep"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_sleep"),
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\xec46"),
                     IcoPath = "Images\\sleep.png",
                     Action = c =>
@@ -323,7 +325,7 @@ namespace Flow.Launcher.Plugin.Sys
                 new Result
                 {
                     Title = "Hibernate",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_hibernate"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_hibernate"),
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\xe945"),
                     IcoPath = "Images\\hibernate.png",
                     Action= c =>
@@ -335,7 +337,7 @@ namespace Flow.Launcher.Plugin.Sys
                  new Result
                 {
                     Title = "Index Option",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_indexoption"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_indexoption"),
                     IcoPath = "Images\\indexoption.png",
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\xe773"),
                     Action = c =>
@@ -347,7 +349,7 @@ namespace Flow.Launcher.Plugin.Sys
                 new Result
                 {
                     Title = "Empty Recycle Bin",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_emptyrecyclebin"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_emptyrecyclebin"),
                     IcoPath = "Images\\recyclebin.png",
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\xe74d"),
                     Action = c =>
@@ -358,7 +360,7 @@ namespace Flow.Launcher.Plugin.Sys
                         var result = PInvoke.SHEmptyRecycleBin(new(), string.Empty, 0);
                         if (result != HRESULT.S_OK && result != HRESULT.E_UNEXPECTED)
                         {
-                            context.API.ShowMsgBox("Failed to empty the recycle bin. This might happen if:\n" +
+                            _context.API.ShowMsgBox("Failed to empty the recycle bin. This might happen if:\n" +
                                             "- A file in the recycle bin is in use\n" +
                                             "- You don't have permission to delete some items\n" +
                                             "Please close any applications that might be using these files and try again.",
@@ -372,7 +374,7 @@ namespace Flow.Launcher.Plugin.Sys
                 new Result
                 {
                     Title = "Open Recycle Bin",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_openrecyclebin"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_openrecyclebin"),
                     IcoPath = "Images\\openrecyclebin.png",
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\xe74d"),
                     CopyText = recycleBinFolder,
@@ -385,7 +387,7 @@ namespace Flow.Launcher.Plugin.Sys
                 new Result
                 {
                     Title = "Exit",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_exit"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_exit"),
                     IcoPath = "Images\\app.png",
                     Action = c =>
                     {
@@ -396,52 +398,52 @@ namespace Flow.Launcher.Plugin.Sys
                 new Result
                 {
                     Title = "Save Settings",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_save_all_settings"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_save_all_settings"),
                     IcoPath = "Images\\app.png",
                     Action = c =>
                     {
-                        context.API.SaveAppAllSettings();
-                        context.API.ShowMsg(context.API.GetTranslation("flowlauncher_plugin_sys_dlgtitle_success"),
-                            context.API.GetTranslation("flowlauncher_plugin_sys_dlgtext_all_settings_saved"));
+                        _context.API.SaveAppAllSettings();
+                        _context.API.ShowMsg(_context.API.GetTranslation("flowlauncher_plugin_sys_dlgtitle_success"),
+                            _context.API.GetTranslation("flowlauncher_plugin_sys_dlgtext_all_settings_saved"));
                         return true;
                     }
                 },
                 new Result
                 {
                     Title = "Restart Flow Launcher",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_restart"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_restart"),
                     IcoPath = "Images\\app.png",
                     Action = c =>
                     {
-                        context.API.RestartApp();
+                        _context.API.RestartApp();
                         return false;
                     }
                 },
                 new Result
                 {
                     Title = "Settings",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_setting"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_setting"),
                     IcoPath = "Images\\app.png",
                     Action = c =>
                     {
-                        context.API.OpenSettingDialog();
+                        _context.API.OpenSettingDialog();
                         return true;
                     }
                 },
                 new Result
                 {
                     Title = "Reload Plugin Data",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_reload_plugin_data"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_reload_plugin_data"),
                     IcoPath = "Images\\app.png",
                     Action = c =>
                     {
                         // Hide the window first then show msg after done because sometimes the reload could take a while, so not to make user think it's frozen. 
-                        context.API.HideMainWindow();
+                        _context.API.HideMainWindow();
 
-                        _ = context.API.ReloadAllPluginData().ContinueWith(_ =>
-                            context.API.ShowMsg(
-                                context.API.GetTranslation("flowlauncher_plugin_sys_dlgtitle_success"),
-                                context.API.GetTranslation(
+                        _ = _context.API.ReloadAllPluginData().ContinueWith(_ =>
+                            _context.API.ShowMsg(
+                                _context.API.GetTranslation("flowlauncher_plugin_sys_dlgtitle_success"),
+                                _context.API.GetTranslation(
                                     "flowlauncher_plugin_sys_dlgtext_all_applicableplugins_reloaded")),
                             System.Threading.Tasks.TaskScheduler.Current);
 
@@ -451,75 +453,75 @@ namespace Flow.Launcher.Plugin.Sys
                 new Result
                 {
                     Title = "Check For Update",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_check_for_update"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_check_for_update"),
                     IcoPath = "Images\\checkupdate.png",
                     Action = c =>
                     {
-                        context.API.HideMainWindow();
-                        context.API.CheckForNewUpdate();
+                        _context.API.HideMainWindow();
+                        _context.API.CheckForNewUpdate();
                         return true;
                     }
                 },
                 new Result
                 {
                     Title = "Open Log Location",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_open_log_location"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_open_log_location"),
                     IcoPath = "Images\\app.png",
                     CopyText = logPath,
                     AutoCompleteText = logPath,
                     Action = c =>
                     {
-                        context.API.OpenDirectory(logPath);
+                        _context.API.OpenDirectory(logPath);
                         return true;
                     }
                 },
                 new Result
                 {
                     Title = "Flow Launcher Tips",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_open_docs_tips"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_open_docs_tips"),
                     IcoPath = "Images\\app.png",
                     CopyText = Constant.Documentation,
                     AutoCompleteText = Constant.Documentation,
                     Action = c =>
                     {
-                        context.API.OpenUrl(Constant.Documentation);
+                        _context.API.OpenUrl(Constant.Documentation);
                         return true;
                     }
                 },
                 new Result
                 {
                     Title = "Flow Launcher UserData Folder",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_open_userdata_location"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_open_userdata_location"),
                     IcoPath = "Images\\app.png",
                     CopyText = userDataPath,
                     AutoCompleteText = userDataPath,
                     Action = c =>
                     {
-                        context.API.OpenDirectory(userDataPath);
+                        _context.API.OpenDirectory(userDataPath);
                         return true;
                     }
                 },
                 new Result
                 {
                     Title = "Toggle Game Mode",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_toggle_game_mode"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_toggle_game_mode"),
                     IcoPath = "Images\\app.png",
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\ue7fc"),
                     Action = c =>
                     {
-                        context.API.ToggleGameMode();
+                        _context.API.ToggleGameMode();
                         return true;
                     }
                 },
                 new Result
                 {
                     Title = "Set Flow Launcher Theme",
-                    SubTitle = context.API.GetTranslation("flowlauncher_plugin_sys_theme_selector"),
+                    SubTitle = _context.API.GetTranslation("flowlauncher_plugin_sys_theme_selector"),
                     IcoPath = "Images\\app.png",
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\ue7fc"),
                     Action = c =>
                     {
-                        context.API.ChangeQuery($"{ThemeSelector.Keyword} ");
+                        _context.API.ChangeQuery($"{ThemeSelector.Keyword} ");
                         return false;
                     }
                 }
@@ -530,12 +532,17 @@ namespace Flow.Launcher.Plugin.Sys
 
         public string GetTranslatedPluginTitle()
         {
-            return context.API.GetTranslation("flowlauncher_plugin_sys_plugin_name");
+            return _context.API.GetTranslation("flowlauncher_plugin_sys_plugin_name");
         }
 
         public string GetTranslatedPluginDescription()
         {
-            return context.API.GetTranslation("flowlauncher_plugin_sys_plugin_description");
+            return _context.API.GetTranslation("flowlauncher_plugin_sys_plugin_description");
+        }
+
+        public void OnCultureInfoChanged(CultureInfo _)
+        {
+            UpdateLocalizedNameDescription(true);
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
@@ -78,26 +78,23 @@ namespace Flow.Launcher.Plugin.Sys
                 c.Title = command.Name;
                 c.SubTitle = command.Description;
 
-                // Firstly, we will search the localized title & subtitle
+                // Match from localized title & localized subtitle & keyword
                 var titleMatch = _context.API.FuzzySearch(query.Search, c.Title);
                 var subTitleMatch = _context.API.FuzzySearch(query.Search, c.SubTitle);
+                var keywordMatch = _context.API.FuzzySearch(query.Search, command.Keyword);
 
+                // Get the largest score from them
                 var score = Math.Max(titleMatch.Score, subTitleMatch.Score);
-                if (score > 0)
+                var finalScore = Math.Max(score, keywordMatch.Score);
+                if (finalScore > 0)
                 {
-                    c.Score = score;
+                    c.Score = finalScore;
 
-                    if (score == titleMatch.Score)
+                    // If title match has the highest score, highlight title
+                    if (finalScore == titleMatch.Score)
+                    {
                         c.TitleHighlightData = titleMatch.MatchData;
-
-                    results.Add(c);
-                }
-
-                // If no match found, we will search the keyword
-                score = _context.API.FuzzySearch(query.Search, command.Keyword).Score;
-                if (score > 0)
-                {
-                    c.Score = score;
+                    }
 
                     results.Add(c);
                 }

--- a/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
@@ -78,7 +78,23 @@ namespace Flow.Launcher.Plugin.Sys
                 c.Title = command.Name;
                 c.SubTitle = command.Description;
 
-                var score = _context.API.FuzzySearch(query.Search, command.Keyword).Score;
+                // Firstly, we will search the localized title & subtitle
+                var titleMatch = _context.API.FuzzySearch(query.Search, c.Title);
+                var subTitleMatch = _context.API.FuzzySearch(query.Search, c.SubTitle);
+
+                var score = Math.Max(titleMatch.Score, subTitleMatch.Score);
+                if (score > 0)
+                {
+                    c.Score = score;
+
+                    if (score == titleMatch.Score)
+                        c.TitleHighlightData = titleMatch.MatchData;
+
+                    results.Add(c);
+                }
+
+                // If no match found, we will search the keyword
+                score = _context.API.FuzzySearch(query.Search, command.Keyword).Score;
                 if (score > 0)
                 {
                     c.Score = score;

--- a/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
@@ -28,8 +28,12 @@ namespace Flow.Launcher.Plugin.Sys
 
         public Control CreateSettingPanel()
         {
-            var results = Commands();
-            return new SysSettings(results);
+            var commands = Commands();
+            foreach (var c in commands)
+            {
+                c.Title = GetDynamicTitle(null, c);
+            }
+            return new SysSettings(commands);
         }
 
         public List<Result> Query(Query query)
@@ -72,6 +76,11 @@ namespace Flow.Launcher.Plugin.Sys
             }
 
             var translatedTitle = context.API.GetTranslation(translationKey);
+
+            if (query == null)
+            {
+                return translatedTitle;
+            }
 
             if (result.Title == translatedTitle)
             {

--- a/Plugins/Flow.Launcher.Plugin.Sys/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Settings.cs
@@ -1,0 +1,127 @@
+﻿using System.Collections.ObjectModel;
+using System.Text.Json.Serialization;
+
+namespace Flow.Launcher.Plugin.Sys;
+
+public class Settings : BaseModel
+{
+    public Settings()
+    {
+        if (Commands.Count > 0)
+        {
+            SelectedCommand = Commands[0];
+        }
+    }
+
+    public ObservableCollection<Command> Commands { get; set; } = new ObservableCollection<Command>
+    {
+        new()
+        {
+            Key = "Shutdown",
+            Keyword = "Shutdown"
+        },
+        new()
+        {
+            Key = "Restart",
+            Keyword = "Restart"
+        },
+        new()
+        {
+            Key = "Restart With Advanced Boot Options",
+            Keyword = "Restart With Advanced Boot Options"
+        },
+        new()
+        {
+            Key = "Log Off/Sign Out",
+            Keyword = "Log Off/Sign Out"
+        },
+        new()
+        {
+            Key = "Lock",
+            Keyword = "Lock"
+        },
+        new()
+        {
+            Key = "Sleep",
+            Keyword = "Sleep"
+        },
+        new()
+        {
+            Key = "Hibernate",
+            Keyword = "Hibernate"
+        },
+        new()
+        {
+            Key = "Index Option",
+            Keyword = "Index Option"
+        },
+        new()
+        {
+            Key = "Empty Recycle Bin",
+            Keyword = "Empty Recycle Bin"
+        },
+        new()
+        {
+            Key = "Open Recycle Bin",
+            Keyword = "Open Recycle Bin"
+        },
+        new()
+        {
+            Key = "Exit",
+            Keyword = "Exit"
+        },
+        new()
+        {
+            Key = "Save Settings",
+            Keyword = "Save Settings"
+        },
+        new()
+        {
+            Key = "Restart Flow Launcher",
+            Keyword = "Restart Flow Launcher"
+        },
+        new()
+        {
+            Key = "Settings",
+            Keyword = "Settings"
+        },
+        new()
+        {
+            Key = "Reload Plugin Data",
+            Keyword = "Reload Plugin Data"
+        },
+        new()
+        {
+            Key = "Check For Update",
+            Keyword = "Check For Update"
+        },
+        new()
+        {
+            Key = "Open Log Location",
+            Keyword = "Open Log Location"
+        },
+        new()
+        {
+            Key = "Flow Launcher Tips",
+            Keyword = "Flow Launcher Tips"
+        },
+        new()
+        {
+            Key = "Flow Launcher UserData Folder",
+            Keyword = "Flow Launcher UserData Folder"
+        },
+        new()
+        {
+            Key = "Toggle Game Mode",
+            Keyword = "Toggle Game Mode"
+        },
+        new()
+        {
+            Key = "Set Flow Launcher Theme",
+            Keyword = "Set Flow Launcher Theme"
+        }
+    };
+
+    [JsonIgnore]
+    public Command SelectedCommand { get; set; }
+}

--- a/Plugins/Flow.Launcher.Plugin.Sys/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/SettingsViewModel.cs
@@ -1,0 +1,12 @@
+﻿namespace Flow.Launcher.Plugin.Sys
+{
+    public class SettingsViewModel
+    {
+        public SettingsViewModel(Settings settings)
+        {
+            Settings = settings;
+        }
+
+        public Settings Settings { get; }
+    }
+}

--- a/Plugins/Flow.Launcher.Plugin.Sys/SysSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Sys/SysSettings.xaml
@@ -4,36 +4,66 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="clr-namespace:Flow.Launcher.Plugin.Sys"
+    d:DataContext="{d:DesignInstance vm:SettingsViewModel}"
     d:DesignHeight="300"
     d:DesignWidth="300"
     mc:Ignorable="d">
-    <Grid Margin="70,18,18,18">
+    <Grid Margin="70 18 18 18">
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
         <ListView
             x:Name="lbxCommands"
             Grid.Row="0"
             Margin="0"
             BorderBrush="DarkGray"
             BorderThickness="1"
+            ItemsSource="{Binding Settings.Commands}"
+            MouseDoubleClick="MouseDoubleClickItem"
+            SelectedItem="{Binding Settings.SelectedCommand}"
             SizeChanged="ListView_SizeChanged"
             Style="{StaticResource {x:Static GridView.GridViewStyleKey}}">
             <ListView.View>
                 <GridView>
-                    <GridViewColumn Width="150" Header="{DynamicResource flowlauncher_plugin_sys_command}">
+                    <GridViewColumn Width="150" Header="{DynamicResource flowlauncher_plugin_sys_name}">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding Title}" TextTrimming="CharacterEllipsis" />
+                                <TextBlock Text="{Binding Name}" TextTrimming="CharacterEllipsis" />
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
+
                     <GridViewColumn Width="379" Header="{DynamicResource flowlauncher_plugin_sys_desc}">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding SubTitle}" TextTrimming="CharacterEllipsis" />
+                                <TextBlock Text="{Binding Description}" TextTrimming="CharacterEllipsis" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+
+                    <GridViewColumn Width="150" Header="{DynamicResource flowlauncher_plugin_sys_command}">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Keyword}" TextTrimming="CharacterEllipsis" />
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
                 </GridView>
             </ListView.View>
         </ListView>
+
+        <StackPanel
+            Grid.Row="1"
+            HorizontalAlignment="Right"
+            Orientation="Horizontal">
+            <Button
+                Width="100"
+                Margin="10"
+                Click="OnEditCommandKeywordClick"
+                Content="{DynamicResource flowlauncher_plugin_sys_edit}" />
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/Plugins/Flow.Launcher.Plugin.Sys/SysSettings.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/SysSettings.xaml.cs
@@ -5,11 +5,13 @@ namespace Flow.Launcher.Plugin.Sys
 {
     public partial class SysSettings : UserControl
     {
+        private readonly PluginInitContext _context;
         private readonly Settings _settings;
 
-        public SysSettings(SettingsViewModel viewModel)
+        public SysSettings(PluginInitContext context, SettingsViewModel viewModel)
         {
             InitializeComponent();
+            _context = context;
             _settings = viewModel.Settings;
             DataContext = viewModel;
         }
@@ -36,24 +38,16 @@ namespace Flow.Launcher.Plugin.Sys
 
         public void OnEditCommandKeywordClick(object sender, RoutedEventArgs e)
         {
-            /*var webSearch = new SearchSourceSettingWindow
-                (
-                    _settings.SearchSources, _context, _settings.SelectedSearchSource
-                );
-
-            webSearch.ShowDialog();*/
+            var commandKeyword = new CommandKeywordSettingWindow(_context, _settings.SelectedCommand);
+            commandKeyword.ShowDialog();
         }
 
         private void MouseDoubleClickItem(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             if (((FrameworkElement)e.OriginalSource).DataContext is Command && _settings.SelectedCommand != null)
             {
-                /*var webSearch = new SearchSourceSettingWindow
-                (
-                    _settings.SearchSources, _context, _settings.SelectedSearchSource
-                );
-
-                webSearch.ShowDialog();*/
+                var commandKeyword = new CommandKeywordSettingWindow(_context, _settings.SelectedCommand);
+                commandKeyword.ShowDialog();
             }
         }
     }

--- a/Plugins/Flow.Launcher.Plugin.Sys/SysSettings.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/SysSettings.xaml.cs
@@ -1,28 +1,28 @@
-﻿using System.Collections.Generic;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 
 namespace Flow.Launcher.Plugin.Sys
 {
     public partial class SysSettings : UserControl
     {
-        public SysSettings(List<Result> Results)
+        private readonly Settings _settings;
+
+        public SysSettings(SettingsViewModel viewModel)
         {
             InitializeComponent();
-
-            foreach (var Result in Results)
-            {
-                lbxCommands.Items.Add(Result);
-            }
+            _settings = viewModel.Settings;
+            DataContext = viewModel;
         }
+
         private void ListView_SizeChanged(object sender, SizeChangedEventArgs e)
         {
             ListView listView = sender as ListView;
             GridView gView = listView.View as GridView;
 
             var workingWidth = listView.ActualWidth - SystemParameters.VerticalScrollBarWidth; // take into account vertical scrollbar
-            var col1 = 0.3;
-            var col2 = 0.7;
+            var col1 = 0.2;
+            var col2 = 0.6;
+            var col3 = 0.2;
 
             if (workingWidth <= 0)
             {
@@ -31,6 +31,30 @@ namespace Flow.Launcher.Plugin.Sys
 
             gView.Columns[0].Width = workingWidth * col1;
             gView.Columns[1].Width = workingWidth * col2;
+            gView.Columns[2].Width = workingWidth * col3;
+        }
+
+        public void OnEditCommandKeywordClick(object sender, RoutedEventArgs e)
+        {
+            /*var webSearch = new SearchSourceSettingWindow
+                (
+                    _settings.SearchSources, _context, _settings.SelectedSearchSource
+                );
+
+            webSearch.ShowDialog();*/
+        }
+
+        private void MouseDoubleClickItem(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (((FrameworkElement)e.OriginalSource).DataContext is Command && _settings.SelectedCommand != null)
+            {
+                /*var webSearch = new SearchSourceSettingWindow
+                (
+                    _settings.SearchSources, _context, _settings.SelectedSearchSource
+                );
+
+                webSearch.ShowDialog();*/
+            }
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Sys/ThemeSelector.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/ThemeSelector.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Core.Resource;
-using Flow.Launcher.Infrastructure.UserSettings;
+using FLSettings = Flow.Launcher.Infrastructure.UserSettings.Settings;
 
 namespace Flow.Launcher.Plugin.Sys
 {
@@ -10,7 +10,7 @@ namespace Flow.Launcher.Plugin.Sys
     {
         public const string Keyword = "fltheme";
 
-        private readonly Settings _settings;
+        private readonly FLSettings _settings;
         private readonly Theme _theme;
         private readonly PluginInitContext _context;
 
@@ -43,7 +43,7 @@ namespace Flow.Launcher.Plugin.Sys
         {
             _context = context;
             _theme = Ioc.Default.GetRequiredService<Theme>();
-            _settings = Ioc.Default.GetRequiredService<Settings>();
+            _settings = Ioc.Default.GetRequiredService<FLSettings>();
         }
 
         public List<Result> Query(Query query)

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsViewModel.cs
@@ -1,21 +1,12 @@
-﻿using Flow.Launcher.Infrastructure.Storage;
-
-namespace Flow.Launcher.Plugin.WebSearch
+﻿namespace Flow.Launcher.Plugin.WebSearch
 {
     public class SettingsViewModel
     {
-        private readonly PluginJsonStorage<Settings> _storage;
-
         public SettingsViewModel(Settings settings)
         {
             Settings = settings;
         }
 
         public Settings Settings { get; }
-
-        public void Save()
-        {
-            _storage.Save();
-        }
     }
 }


### PR DESCRIPTION
# Use Command Keyword to Search System Command

Previously, FL uses the English title & translated title & subtitle to search the commands. If English title is matched, the result title will be in English which I think can cause confusion for users.

This PR Introduces command keyword to replace the original function of searching with English title. (Users can still search with translated title & subtitle) And users can change this command keyword.

By default, the command keywords are the same as the English title. And users can set whatever they like for faster query.

# Demo

https://github.com/user-attachments/assets/4ae1ee9d-5f97-47bb-a1a7-8d4adf048bf3

# Test

* Change command keyword & Search them.
* Name & Description column are now translated.
* Sys plugin can correctly save & load settings.

Close #3343