### PR TITLE
Fix custom query hotkey settings issue

### DIFF
--- a/Flow.Launcher/CustomQueryHotkeySetting.xaml
+++ b/Flow.Launcher/CustomQueryHotkeySetting.xaml
@@ -104,7 +104,7 @@
                         VerticalAlignment="Center"
                         HorizontalContentAlignment="Left"
                         DefaultHotkey=""
-                        Type="None" />
+                        Type="CustomQueryHotkey" />
                     <TextBlock
                         Grid.Row="1"
                         Grid.Column="0"

--- a/Flow.Launcher/CustomQueryHotkeySetting.xaml
+++ b/Flow.Launcher/CustomQueryHotkeySetting.xaml
@@ -58,9 +58,9 @@
                     </Button>
                 </Grid>
             </StackPanel>
-            <StackPanel Margin="26,0,26,0">
+            <StackPanel Margin="26 0 26 0">
                 <TextBlock
-                    Margin="0,0,0,12"
+                    Margin="0 0 0 12"
                     FontSize="20"
                     FontWeight="SemiBold"
                     Text="{DynamicResource customeQueryHotkeyTitle}"
@@ -72,10 +72,10 @@
                     TextWrapping="WrapWithOverflow" />
                 <Image
                     Width="478"
-                    Margin="0,20,0,0"
+                    Margin="0 20 0 0"
                     Source="/Images/illustration_01.png" />
 
-                <Grid Width="478" Margin="0,20,0,0">
+                <Grid Width="478" Margin="0 20 0 0">
                     <Grid.RowDefinitions>
                         <RowDefinition />
                         <RowDefinition />
@@ -99,11 +99,12 @@
                         Grid.Row="0"
                         Grid.Column="1"
                         Grid.ColumnSpan="2"
-                        Margin="10,0,10,0"
+                        Margin="10 0 10 0"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         HorizontalContentAlignment="Left"
-                        DefaultHotkey="" />
+                        DefaultHotkey=""
+                        Type="None" />
                     <TextBlock
                         Grid.Row="1"
                         Grid.Column="0"
@@ -123,8 +124,8 @@
                         x:Name="btnTestActionKeyword"
                         Grid.Row="1"
                         Grid.Column="2"
-                        Margin="0,0,10,0"
-                        Padding="10,5,10,5"
+                        Margin="0 0 10 0"
+                        Padding="10 5 10 5"
                         Click="BtnTestActionKeyword_OnClick"
                         Content="{DynamicResource preview}" />
                 </Grid>
@@ -132,21 +133,21 @@
         </StackPanel>
         <Border
             Grid.Row="1"
-            Margin="0,14,0,0"
+            Margin="0 14 0 0"
             Background="{DynamicResource PopupButtonAreaBGColor}"
             BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
-            BorderThickness="0,1,0,0">
+            BorderThickness="0 1 0 0">
             <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                 <Button
                     x:Name="btnCancel"
                     MinWidth="140"
-                    Margin="10,0,5,0"
+                    Margin="10 0 5 0"
                     Click="BtnCancel_OnClick"
                     Content="{DynamicResource cancel}" />
                 <Button
                     x:Name="btnAdd"
                     MinWidth="140"
-                    Margin="5,0,10,0"
+                    Margin="5 0 10 0"
                     Click="btnAdd_OnClick"
                     Style="{StaticResource AccentButtonStyle}">
                     <TextBlock x:Name="lblAdd" Text="{DynamicResource done}" />

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -84,7 +84,7 @@ namespace Flow.Launcher
             nameof(Type),
             typeof(HotkeyType),
             typeof(HotkeyControl),
-            new FrameworkPropertyMetadata(HotkeyType.None, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnHotkeyChanged)
+            new FrameworkPropertyMetadata(HotkeyType.CustomQueryHotkey, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnHotkeyChanged)
         );
 
         public HotkeyType Type
@@ -95,8 +95,8 @@ namespace Flow.Launcher
 
         public enum HotkeyType
         {
-            // Custom hotkeys
-            None,  // Used for getting hotkey from dialog result
+            // Custom query hotkeys
+            CustomQueryHotkey,
             // Settings hotkeys
             Hotkey,
             PreviewHotkey,
@@ -125,8 +125,8 @@ namespace Flow.Launcher
             {
                 return Type switch
                 {
-                    // Custom hotkeys
-                    HotkeyType.None => hotkey,
+                    // Custom query hotkeys
+                    HotkeyType.CustomQueryHotkey => hotkey,
                     // Settings hotkeys
                     HotkeyType.Hotkey => _settings.Hotkey,
                     HotkeyType.PreviewHotkey => _settings.PreviewHotkey,
@@ -149,8 +149,10 @@ namespace Flow.Launcher
             {
                 switch (Type)
                 {
-                    // Custom hotkeys
-                    case HotkeyType.None:
+                    // Custom query hotkeys
+                    case HotkeyType.CustomQueryHotkey:
+                        // We just need to store it in a local field
+                        // because we will save to settings in other place
                         hotkey = value;
                         break;
                     // Settings hotkeys

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -84,7 +84,7 @@ namespace Flow.Launcher
             nameof(Type),
             typeof(HotkeyType),
             typeof(HotkeyControl),
-            new FrameworkPropertyMetadata(HotkeyType.Hotkey, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnHotkeyChanged)
+            new FrameworkPropertyMetadata(HotkeyType.None, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnHotkeyChanged)
         );
 
         public HotkeyType Type
@@ -95,6 +95,9 @@ namespace Flow.Launcher
 
         public enum HotkeyType
         {
+            // Custom hotkeys
+            None,  // Used for getting hotkey from dialog result
+            // Settings hotkeys
             Hotkey,
             PreviewHotkey,
             OpenContextMenuHotkey,
@@ -115,12 +118,16 @@ namespace Flow.Launcher
         // and it will not construct settings instances twice
         private static readonly Settings _settings = Ioc.Default.GetRequiredService<Settings>();
 
+        private string hotkey = string.Empty;
         public string Hotkey
         {
             get
             {
                 return Type switch
                 {
+                    // Custom hotkeys
+                    HotkeyType.None => hotkey,
+                    // Settings hotkeys
                     HotkeyType.Hotkey => _settings.Hotkey,
                     HotkeyType.PreviewHotkey => _settings.PreviewHotkey,
                     HotkeyType.OpenContextMenuHotkey => _settings.OpenContextMenuHotkey,
@@ -135,13 +142,18 @@ namespace Flow.Launcher
                     HotkeyType.SelectPrevItemHotkey2 => _settings.SelectPrevItemHotkey2,
                     HotkeyType.SelectNextItemHotkey => _settings.SelectNextItemHotkey,
                     HotkeyType.SelectNextItemHotkey2 => _settings.SelectNextItemHotkey2,
-                    _ => string.Empty
+                    _ => throw new System.NotImplementedException("Hotkey type not setted")
                 };
             }
             set
             {
                 switch (Type)
                 {
+                    // Custom hotkeys
+                    case HotkeyType.None:
+                        hotkey = value;
+                        break;
+                    // Settings hotkeys
                     case HotkeyType.Hotkey:
                         _settings.Hotkey = value;
                         break;
@@ -185,7 +197,7 @@ namespace Flow.Launcher
                         _settings.SelectNextItemHotkey2 = value;
                         break;
                     default:
-                        return;
+                        throw new System.NotImplementedException("Hotkey type not setted");
                 }
 
                 // After setting the hotkey, we need to refresh the interface

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -84,7 +84,7 @@ namespace Flow.Launcher
             nameof(Type),
             typeof(HotkeyType),
             typeof(HotkeyControl),
-            new FrameworkPropertyMetadata(HotkeyType.CustomQueryHotkey, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnHotkeyChanged)
+            new FrameworkPropertyMetadata(HotkeyType.None, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnHotkeyChanged)
         );
 
         public HotkeyType Type
@@ -95,6 +95,7 @@ namespace Flow.Launcher
 
         public enum HotkeyType
         {
+            None,
             // Custom query hotkeys
             CustomQueryHotkey,
             // Settings hotkeys

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -142,7 +142,7 @@ namespace Flow.Launcher
                     HotkeyType.SelectPrevItemHotkey2 => _settings.SelectPrevItemHotkey2,
                     HotkeyType.SelectNextItemHotkey => _settings.SelectNextItemHotkey,
                     HotkeyType.SelectNextItemHotkey2 => _settings.SelectNextItemHotkey2,
-                    _ => throw new System.NotImplementedException("Hotkey type not setted")
+                    _ => throw new System.NotImplementedException("Hotkey type not set")
                 };
             }
             set
@@ -197,7 +197,7 @@ namespace Flow.Launcher
                         _settings.SelectNextItemHotkey2 = value;
                         break;
                     default:
-                        throw new System.NotImplementedException("Hotkey type not setted");
+                        throw new System.NotImplementedException("Hotkey type not set");
                 }
 
                 // After setting the hotkey, we need to refresh the interface


### PR DESCRIPTION
# Add new `enum` type to handle logic for custom query hotkey setting dialog

As you can see, the new version of `HotkeyControl` uses `Type` to specific the `Hotkey` getter and setter.

And previously, the default value of `Type` is `Hotkey` so the `HotkeyControl` in `CustomQueryHotkeySettings` will fallback to `case HotkeyType.Hotkey:`, resulting the change of the search hotkey.

So we need to add a new `enum` type so that `HotkeyControl` will cache the hotkey value and return it as result which is needed for `CustomQueryHotkeySettings` (it uses )

Follow on with #3310.

# Test

* Set / Update / Delete custom query hotkey.