### PR TITLE
Fix Plugin Manager Issue

### DIFF
--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -131,6 +131,7 @@ namespace Flow.Launcher
                 Ioc.Default.GetRequiredService<Internationalization>().ChangeLanguage(_settings.Language);
 
                 PluginManager.LoadPlugins(_settings.PluginSettings);
+                Ioc.Default.GetRequiredService<MainViewModel>().RegisterResultsUpdatedEvent();
 
                 Http.Proxy = _settings.Proxy;
 

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -127,11 +127,14 @@ namespace Flow.Launcher
 
                 AbstractPluginEnvironment.PreStartPluginExecutablePathUpdate(_settings);
 
+                PluginManager.LoadPlugins(_settings.PluginSettings);
+
+                // Register ResultsUpdated event after all plugins are loaded
+                Ioc.Default.GetRequiredService<MainViewModel>().RegisterResultsUpdatedEvent();
+
+                // Change language after all plugins are initialized
                 // TODO: Clean InternationalizationManager.Instance and InternationalizationManager.Instance.GetTranslation in future
                 Ioc.Default.GetRequiredService<Internationalization>().ChangeLanguage(_settings.Language);
-
-                PluginManager.LoadPlugins(_settings.PluginSettings);
-                Ioc.Default.GetRequiredService<MainViewModel>().RegisterResultsUpdatedEvent();
 
                 Http.Proxy = _settings.Proxy;
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -168,7 +168,6 @@ namespace Flow.Launcher.ViewModel
             };
 
             RegisterViewUpdate();
-            RegisterResultsUpdatedEvent();
             _ = RegisterClockAndDateUpdateAsync();
         }
 
@@ -213,7 +212,7 @@ namespace Flow.Launcher.ViewModel
             }
         }
 
-        private void RegisterResultsUpdatedEvent()
+        public void RegisterResultsUpdatedEvent()
         {
             foreach (var pair in PluginManager.GetPluginsForInterface<IResultUpdated>())
             {


### PR DESCRIPTION
When we call other functions that need `AllPlugins`, we should put them after `PluginManager.LoadPlugins(_settings.PluginSettings);`.

* Since FL introduces dependency injection #3175, the constructor of `MainViewModel` is brought forward because `PublicAPIInstance` needs its instance, so we cannot put `RegisterResultsUpdatedEvent()` in its constructor.
* Since `Ioc.Default.GetRequiredService<Internationalization>().ChangeLanguage(_settings.Language);` needs to check plugins with `IPluginI18n` interface, it should be put after `Ioc.Default.GetRequiredService<MainViewModel>().RegisterResultsUpdatedEvent();` 