### PR TITLE
Enable acrylic effect on first launch

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -98,6 +98,9 @@ namespace Flow.Launcher
             {
                 _settings.FirstLaunch = false;
                 App.API.SaveAppAllSettings();
+                /* Set Backdrop Type to Acrylic for Windows 11 when First Launch. Default is None. */
+                if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 22000))
+                    _settings.BackdropType = BackdropTypes.Acrylic;
                 var WelcomeWindow = new WelcomeWindow();
                 WelcomeWindow.Show();
             }


### PR DESCRIPTION
## What's the PR
- Enable acrylic effect on first launch if running on Windows 11
- Default backdrop is none.
- Change the backdrop setting to Acrylic on first launch if the conditions are met.
- The first impression improves when the program is launched for the first time 😉