### PR TITLE
Fix cursor doesn't move to the end on initial launch

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -143,7 +143,9 @@ namespace Flow.Launcher
 
             // Since the default main window visibility is visible, so we need set focus during startup
             QueryTextBox.Focus();
-
+            // Set the initial state of the QueryTextBoxCursorMovedToEnd property
+            // Without this part, when shown for the first time, switching the context menu does not move the cursor to the end.
+            _viewModel.QueryTextCursorMovedToEnd = false;
             _viewModel.PropertyChanged += (o, e) =>
             {
                 switch (e.PropertyName)


### PR DESCRIPTION
## What's the PR ##
- Fix https://github.com/Flow-Launcher/Flow.Launcher/issues/3373

## What's the Issue
- In the initial launch state, when navigating back from the context menu to the search results, the cursor is incorrectly positioned at the beginning.
- After Hide(), the cursor moves to the end without any issues.

## Cause of the issue and analysis
- QueryTextCursorMovedToEnd is triggered whenever the value changes, but it seems it wasn't triggered initially because there was no default value or it was already True. When the window is hidden for the first time, a default value of false is added, which allowed it to function correctly afterward.
 
## Solution
- A default value(false) has now been added during OnLoaded.