### PR TITLE
Fix Language Change Issue

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -205,9 +205,6 @@ namespace Flow.Launcher.Core.Plugin
                 }
             }
 
-            InternationalizationManager.Instance.AddPluginLanguageDirectories(GetPluginsForInterface<IPluginI18n>());
-            InternationalizationManager.Instance.ChangeLanguage(Ioc.Default.GetRequiredService<Settings>().Language);
-
             if (failedPlugins.Any())
             {
                 var failed = string.Join(",", failedPlugins.Select(x => x.Metadata.Name));

--- a/Flow.Launcher.Core/Resource/Internationalization.cs
+++ b/Flow.Launcher.Core/Resource/Internationalization.cs
@@ -144,6 +144,21 @@ namespace Flow.Launcher.Core.Resource
             _settings.Language = isSystem ? Constant.SystemLanguageCode : language.LanguageCode;
         }
 
+        private Language GetLanguageByLanguageCode(string languageCode)
+        {
+            var lowercase = languageCode.ToLower();
+            var language = AvailableLanguages.GetAvailableLanguages().FirstOrDefault(o => o.LanguageCode.ToLower() == lowercase);
+            if (language == null)
+            {
+                Log.Error($"|Internationalization.GetLanguageByLanguageCode|Language code can't be found <{languageCode}>");
+                return AvailableLanguages.English;
+            }
+            else
+            {
+                return language;
+            }
+        }
+
         private async Task ChangeLanguageAsync(Language language)
         {
             // Remove old language files and load language
@@ -160,21 +175,6 @@ namespace Flow.Launcher.Core.Resource
 
             // Raise event for plugins after culture is set
             await Task.Run(UpdatePluginMetadataTranslations);
-        }
-
-        private static Language GetLanguageByLanguageCode(string languageCode)
-        {
-            var lowercase = languageCode.ToLower();
-            var language = AvailableLanguages.GetAvailableLanguages().FirstOrDefault(o => o.LanguageCode.ToLower() == lowercase);
-            if (language == null)
-            {
-                Log.Error($"|Internationalization.GetLanguageByLanguageCode|Language code can't be found <{languageCode}>");
-                return AvailableLanguages.English;
-            }
-            else
-            {
-                return language;
-            }
         }
 
         public bool PromptShouldUsePinyin(string languageCodeToSet)

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -132,13 +132,14 @@ namespace Flow.Launcher
                 // Register ResultsUpdated event after all plugins are loaded
                 Ioc.Default.GetRequiredService<MainViewModel>().RegisterResultsUpdatedEvent();
 
-                // Change language after all plugins are initialized
-                // TODO: Clean InternationalizationManager.Instance and InternationalizationManager.Instance.GetTranslation in future
-                Ioc.Default.GetRequiredService<Internationalization>().ChangeLanguage(_settings.Language);
-
                 Http.Proxy = _settings.Proxy;
 
                 await PluginManager.InitializePluginsAsync();
+
+                // Change language after all plugins are initialized because we need to update plugin title based on their api
+                // TODO: Clean InternationalizationManager.Instance and InternationalizationManager.Instance.GetTranslation in future
+                await Ioc.Default.GetRequiredService<Internationalization>().InitializeLanguageAsync();
+
                 await imageLoadertask;
 
                 var window = new MainWindow();


### PR DESCRIPTION
Follow on with #3365.

# Improve Language Initialization

Originally, we use `ChangeLanguage` to initialize language & change language, which I think is a little bit unclear.

Now I add `InitializeLanguage` for initializing language and I remove `ChangeLanguage` in `PluginManager` because we only need to call it once.

# Fix Language Initialization Issue

This function should be called after plugins are initialized because we will call `GetTranslatedTitle` function to update plugin metadata and many plugins use `Context.API` to get its translated titles and descriptions, so we would better to call `InitAsync` before calling this function.