### PR TITLE
Fix Freezing with GPU

### DIFF
--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -165,9 +165,32 @@ namespace Flow.Launcher
                 API.SaveAppAllSettings();
                 Log.Info(
                     "|App.OnStartup|End Flow Launcher startup ----------------------------------------------------  ");
+                Microsoft.Win32.SystemEvents.PowerModeChanged += SystemEvents_PowerModeChanged;
+                Microsoft.Win32.SystemEvents.SessionEnding += SystemEvents_SessionEnding;
+                Microsoft.Win32.SystemEvents.SessionSwitch += SystemEvents_SessionSwitch;
             });
         }
-
+        private void SystemEvents_PowerModeChanged(object sender, Microsoft.Win32.PowerModeChangedEventArgs e)
+        {
+            if (e.Mode == Microsoft.Win32.PowerModes.Resume)
+            {
+                var mainViewModel = Ioc.Default.GetRequiredService<MainViewModel>();
+                mainViewModel.SystemWakeUpShow();
+            }
+        }
+        private void SystemEvents_SessionEnding(object sender, Microsoft.Win32.SessionEndingEventArgs e)
+        {
+            var mainViewModel = Ioc.Default.GetRequiredService<MainViewModel>();
+            mainViewModel.SystemWakeUpShow();
+        }
+        private void SystemEvents_SessionSwitch(object sender, Microsoft.Win32.SessionSwitchEventArgs e)
+        {
+            if (e.Reason == Microsoft.Win32.SessionSwitchReason.SessionUnlock)
+            {
+                var mainViewModel = Ioc.Default.GetRequiredService<MainViewModel>();
+                mainViewModel.SystemWakeUpShow();
+            }
+        }
 #pragma warning restore VSTHRD100 // Avoid async void methods
 
         private void AutoStartup()

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -175,11 +175,6 @@ namespace Flow.Launcher
                             {
                                 if (_viewModel.MainWindowVisibilityStatus)
                                 {
-                                    if (_settings.UseSound)
-                                    {
-                                        SoundPlay();
-                                    }
-
                                     UpdatePosition(false);
                                     _viewModel.ResetPreview();
                                     Activate();
@@ -269,7 +264,6 @@ namespace Flow.Launcher
             Environment.Exit(0);
         }
         
-        // Win32 API 함수 정의
         [DllImport("wtsapi32.dll", SetLastError = true)]
         private static extern bool WTSRegisterSessionNotification(IntPtr hWnd, int dwFlags);
 
@@ -469,26 +463,24 @@ namespace Flow.Launcher
 
                 handled = true;
             }
-            // Windows 잠금(Win+L) 이벤트 처리
+            // Windows (Win+L) Event
             else if (msg == WM_WTSSESSION_CHANGE)
             {
                 int reason = wParam.ToInt32();
                 if (reason == WTS_SESSION_LOCK)
                 {
-                    // Windows 잠금 발생 시 메시지 박스 표시
                     Application.Current.Dispatcher.Invoke(() =>
                     {
-                        _viewModel.Show();
+                        _viewModel.SystemWakeUpShow();
                     });
 
                     handled = true;
                 }
                 else if (reason == WTS_SESSION_UNLOCK)
                 {
-                    // Windows 잠금 해제 시 메시지 박스 표시 (선택적)
                     Application.Current.Dispatcher.Invoke(() =>
                     {
-                        _viewModel.Show();
+                        _viewModel.SystemWakeUpShow();
                     });
 
                     handled = true;
@@ -515,7 +507,7 @@ namespace Flow.Launcher
             }
         }
 
-        private void SoundPlay()
+        public void SoundPlay()
         {
             if (_settings.WMPInstalled)
             {

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -36,9 +36,9 @@ public partial class SettingWindow
         RefreshMaximizeRestoreButton();
         // Fix (workaround) for the window freezes after lock screen (Win+L) or sleep
         // https://stackoverflow.com/questions/4951058/software-rendering-mode-wpf
-        HwndSource hwndSource = PresentationSource.FromVisual(this) as HwndSource;
-        HwndTarget hwndTarget = hwndSource.CompositionTarget;
-        hwndTarget.RenderMode = RenderMode.SoftwareOnly;  // Must use software only render mode here
+        //HwndSource hwndSource = PresentationSource.FromVisual(this) as HwndSource;
+        //HwndTarget hwndTarget = hwndSource.CompositionTarget;
+        //hwndTarget.RenderMode = RenderMode.SoftwareOnly;  // Must use software only render mode here
 
         InitializePosition();
     }

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1376,7 +1376,7 @@ namespace Flow.Launcher.ViewModel
                 {
                     if (Application.Current.MainWindow is MainWindow mainWindow)
                     {
-                        Win32Helper.DWMSetCloakForWindow(mainWindow, false);
+                        Win32Helper.DWMSetCloakForWindow(mainWindow, true);
                         mainWindow.ClockPanel.Visibility = Visibility.Visible;
                         SearchIconVisibility = Visibility.Visible;
                         

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1392,12 +1392,10 @@ namespace Flow.Launcher.ViewModel
                         mainWindow.Show();
                         mainWindow.Activate();
                         mainWindow.Focus();
-                
-                        // Win32 메서드로 강제 활성화
+                        
                         var hwnd = new WindowInteropHelper(mainWindow).Handle;
                         Win32Helper.SetForegroundWindow(hwnd);
-                
-                        // 잠시 후 Topmost 해제
+                        
                         Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
                         {
                             mainWindow.Topmost = false;

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1352,12 +1352,39 @@ namespace Flow.Launcher.ViewModel
             }
         }
 
+        public void SystemWakeUpShow()
+        {
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                if (Application.Current.MainWindow is MainWindow mainWindow)
+                {
+                    // 📌 Remove DWM Cloak (Make the window visible normally)
+                    Win32Helper.DWMSetCloakForWindow(mainWindow, false);
+
+                    // 📌 Restore UI elements
+                    mainWindow.ClockPanel.Visibility = Visibility.Visible;
+                    //mainWindow.SearchIcon.Visibility = Visibility.Visible;
+                    SearchIconVisibility = Visibility.Visible;
+                }
+
+                // Update WPF properties
+                MainWindowOpacity = 0.01;
+                MainWindowVisibility = Visibility.Visible;
+                MainWindowVisibilityStatus = true;
+                VisibilityChanged?.Invoke(this, new VisibilityChangedEventArgs { IsVisible = true });
+                Hide();
+            });
+        }
         public void Show()
         {
             Application.Current.Dispatcher.Invoke(() =>
             {
                 if (Application.Current.MainWindow is MainWindow mainWindow)
                 {
+                    if (Settings.UseSound)
+                    {
+                        mainWindow.SoundPlay();
+                    }
                     // 📌 Remove DWM Cloak (Make the window visible normally)
                     Win32Helper.DWMSetCloakForWindow(mainWindow, false);
 


### PR DESCRIPTION
## What's PR
- Fixed a freezing issue after sleep when the GPU is active
- Activate the GPU

## Reproduce
- Open FLOW's settings window, then press WIN+L to switch to the lock screen. 
-  After logging back in, try navigating to a different menu in the settings window to check if it freezes.

## How to Fix
- When the first window is opened during a freeze, the settings window unfreezes.
- Handled specific events to trigger showing the main window when they occur.

## Issues and Idea
- When sound is enabled, a sound plays and a brief flicker is visible.
- Consider implementing a custom show method that skips sound and uses opacity to create a transparent effect.

## Test Cases
- [x] The settings window should not freeze after re-entering from WIN+L.
- [x] The settings window should not freeze after resuming from sleep