### PR TITLE
Fix Clock/Search Icon show logic

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -761,7 +761,7 @@ namespace Flow.Launcher
             _viewModel.ProgressBarVisibility = Visibility.Hidden;
         }
 
-        public void WindowAnimation()
+        private void WindowAnimation()
         {
             _isArrowKeyPressed = true;
 

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Media;
 using System.Threading.Tasks;
@@ -76,7 +75,7 @@ namespace Flow.Launcher
             DataContext = _viewModel;
 
             InitializeComponent();
-            UpdatePosition(true);
+            UpdatePosition();
 
             InitSoundEffects();
             DataObject.AddPastingHandler(QueryTextBox, QueryTextBox_OnPaste);
@@ -112,7 +111,7 @@ namespace Flow.Launcher
             }
 
             // Hide window if need
-            UpdatePosition(true);
+            UpdatePosition();
             if (_settings.HideOnStartup)
             {
                 _viewModel.Hide();
@@ -139,7 +138,7 @@ namespace Flow.Launcher
             InitProgressbarAnimation();
 
             // Force update position
-            UpdatePosition(true);
+            UpdatePosition();
 
             // Refresh frame
             await Ioc.Default.GetRequiredService<Theme>().RefreshFrameAsync();
@@ -167,7 +166,7 @@ namespace Flow.Launcher
                                         SoundPlay();
                                     }
 
-                                    UpdatePosition(false);
+                                    UpdatePosition();
                                     _viewModel.ResetPreview();
                                     Activate();
                                     QueryTextBox.Focus();
@@ -269,7 +268,6 @@ namespace Flow.Launcher
 
         private void OnLocationChanged(object sender, EventArgs e)
         {
-
             if (_settings.SearchWindowScreen == SearchWindowScreens.RememberLastLaunchLocation)
             {
                 _settings.WindowLeft = Left;
@@ -281,9 +279,11 @@ namespace Flow.Launcher
         {
             _settings.WindowLeft = Left;
             _settings.WindowTop = Top;
+
             ClockPanel.Opacity = 0;
             SearchIcon.Opacity = 0;
-            //This condition stops extra hide call when animator is on,
+
+            // This condition stops extra hide call when animator is on,
             // which causes the toggling to occasional hide instead of show.
             if (_viewModel.MainWindowVisibilityStatus)
             {
@@ -291,7 +291,6 @@ namespace Flow.Launcher
                 // This also stops the mainwindow from flickering occasionally after Settings window is opened
                 // and always after Settings window is closed.
                 if (_settings.UseAnimation)
- 
                     await Task.Delay(100);
 
                 if (_settings.HideWhenDeactivated && !_viewModel.ExternalPreviewVisible)
@@ -589,13 +588,8 @@ namespace Flow.Launcher
 
         #region Window Position
 
-        private void UpdatePosition(bool force)
+        private void UpdatePosition()
         {
-            if (!force)
-            {
-                return;
-            }
-
             // Initialize call twice to work around multi-display alignment issue- https://github.com/Flow-Launcher/Flow.Launcher/issues/2910
             InitializePosition();
             InitializePosition();
@@ -770,20 +764,16 @@ namespace Flow.Launcher
         public void WindowAnimation()
         {
             _isArrowKeyPressed = true;
-            UpdatePosition(false);
-            if(_settings.UseAnimation)
-            {
-                    ClockPanel.Opacity = 0;
-                    SearchIcon.Opacity = 0;
-            }
-            else
-            {
-                ClockPanel.Opacity = 1;
-                SearchIcon.Opacity = 1;
-            }
+
+            UpdatePosition();
+
+            var opacity = _settings.UseAnimation ? 0.0 : 1.0;
+            ClockPanel.Opacity = opacity;
+            SearchIcon.Opacity = opacity;
+
             var clocksb = new Storyboard();
             var iconsb = new Storyboard();
-            CircleEase easing = new CircleEase { EasingMode = EasingMode.EaseInOut };
+            var easing = new CircleEase { EasingMode = EasingMode.EaseInOut };
 
             var animationLength = _settings.AnimationSpeed switch
             {
@@ -811,7 +801,7 @@ namespace Flow.Launcher
                 FillBehavior = FillBehavior.HoldEnd
             };
 
-            double TargetIconOpacity = GetOpacityFromStyle(SearchIcon.Style, 1.0);
+            var TargetIconOpacity = GetOpacityFromStyle(SearchIcon.Style, 1.0);
 
             var IconOpacity = new DoubleAnimation
             {
@@ -822,7 +812,7 @@ namespace Flow.Launcher
                 FillBehavior = FillBehavior.HoldEnd
             };
             
-            double rightMargin = GetThicknessFromStyle(ClockPanel.Style, new Thickness(0, 0, DefaultRightMargin, 0)).Right;
+            var rightMargin = GetThicknessFromStyle(ClockPanel.Style, new Thickness(0, 0, DefaultRightMargin, 0)).Right;
 
             var thicknessAnimation = new ThicknessAnimation
             {

--- a/Flow.Launcher/Resources/Dark.xaml
+++ b/Flow.Launcher/Resources/Dark.xaml
@@ -115,6 +115,8 @@
     <SolidColorBrush x:Key="InfoBarWarningIcon" Color="#FCE100" />
     <SolidColorBrush x:Key="InfoBarWarningBG" Color="#433519" />
     <SolidColorBrush x:Key="InfoBarBD" Color="#19000000" />
+    
+    <SolidColorBrush x:Key="MouseOverWindowCloseButtonForegroundBrush" Color="#ffffff" />
 
     <SolidColorBrush x:Key="ButtonOutBorder" Color="Transparent" />
     <SolidColorBrush x:Key="ButtonInsideBorder" Color="#3f3f3f" />

--- a/Flow.Launcher/Resources/Light.xaml
+++ b/Flow.Launcher/Resources/Light.xaml
@@ -107,6 +107,7 @@
     <SolidColorBrush x:Key="InfoBarWarningBG" Color="#FFF4CE" />
     <SolidColorBrush x:Key="InfoBarBD" Color="#0F000000" />
 
+    <SolidColorBrush x:Key="MouseOverWindowCloseButtonForegroundBrush" Color="#ffffff" />
 
     <SolidColorBrush x:Key="ButtonOutBorder" Color="#e5e5e5" />
     <SolidColorBrush x:Key="ButtonInsideBorder" Color="#d3d3d3" />

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -56,6 +56,7 @@
                     Width="16"
                     Height="16"
                     Margin="10 4 4 4"
+                    RenderOptions.BitmapScalingMode="HighQuality"
                     Source="/Images/app.png" />
                 <TextBlock
                     Grid.Row="0"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -18,6 +18,8 @@
     Loaded="OnLoaded"
     MouseDown="window_MouseDown"
     ResizeMode="CanResize"
+    SnapsToDevicePixels="True"
+    UseLayoutRounding="True"
     StateChanged="Window_StateChanged"
     Top="{Binding SettingWindowTop, Mode=TwoWay}"
     WindowStartupLocation="Manual"

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1473,7 +1473,6 @@ namespace Flow.Launcher.ViewModel
                     {
                         Application.Current.Dispatcher.BeginInvoke(() => 
                             mainWindow.WindowAnimation());
-                        Debug.WriteLine("Call Animation");
                     }
                 }
 
@@ -1540,10 +1539,6 @@ namespace Flow.Launcher.ViewModel
             if (Application.Current.MainWindow is MainWindow mainWindow)
             {
                 // 📌 Set Opacity of icon and clock to 0 and apply Visibility.Hidden
-                Application.Current.Dispatcher.Invoke(() =>
-                {
-         
-                }, DispatcherPriority.Render);
                 if(Settings.UseAnimation)
                 {
                     mainWindow.ClockPanel.Opacity = 0;
@@ -1555,7 +1550,6 @@ namespace Flow.Launcher.ViewModel
                     mainWindow.SearchIcon.Opacity = 1;   
                 }
                 mainWindow.ClockPanel.Visibility = Visibility.Hidden;
-                //mainWindow.SearchIcon.Visibility = Visibility.Hidden;
                 SearchIconVisibility = Visibility.Hidden;
 
                 // Force UI update

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1478,10 +1478,6 @@ namespace Flow.Launcher.ViewModel
 
                     // 📌 Restore UI elements
                     //mainWindow.SearchIcon.Visibility = Visibility.Visible;
-                    if (Settings.UseAnimation)
-                    {
-                        mainWindow.WindowAnimation();
-                    }
                 }
             }, DispatcherPriority.Render);
 


### PR DESCRIPTION
## What's the PR
### Problem
Currently, there are the following issues in the dev branch:

![image](https://github.com/user-attachments/assets/8f34a443-5527-449e-961e-de6a980d5836)

- When show is called while in a mode where the query remains, the clock and search icon are displayed.
- When typing a query in a mode where the query remains, the animation no longer works.
- The QuerySuggestionText overlaps with the clock.
- The search icon overlaps with SearchIcon.

### Fixes
![image](https://github.com/user-attachments/assets/18946eee-87e1-4a8f-83fc-841dd8e7a22a)
- The clock is no longer shown when show is called while in a mode where the query remains.
- If the query-remaining mode is in an action keyword active state, the search icon is not shown when show is called.
- The _isAnimating variable has been removed. It was used in the old animation system to prevent storing window coordinates while the window was moving. Since the new animation no longer moves the window, this variable is no longer needed.

## Test Cases
- [x] The clock should not be displayed when in a query mode where the query remains.
- [x] The search icon should not be displayed when the query remains and an action keyword is active.
- [x] The clock should be displayed when the query text length is zero.
- [x] Each icon should behave according to whether animation is enabled or not.

### ETC
With this change, modes where the query remains will no longer show the clock by default. I considered various approaches—like showing the clock while adjusting the length of QuerySuggestionText to fit the clock area—but ultimately, I think this is the right solution.