### PR TITLE
New API Function ValidateDirectory and ValidateDataDirectory & Cleanup Helper.cs in Flow.Launcher.Infrastructure project

### DIFF
--- a/Flow.Launcher.Core/Updater.cs
+++ b/Flow.Launcher.Core/Updater.cs
@@ -17,6 +17,7 @@ using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
 using System.Text.Json.Serialization;
 using System.Threading;
+using System.Text.Json;
 
 namespace Flow.Launcher.Core
 {
@@ -51,7 +52,7 @@ namespace Flow.Launcher.Core
                 var newReleaseVersion = Version.Parse(newUpdateInfo.FutureReleaseEntry.Version.ToString());
                 var currentVersion = Version.Parse(Constant.Version);
 
-                Log.Info($"|Updater.UpdateApp|Future Release <{newUpdateInfo.FutureReleaseEntry.Formatted()}>");
+                Log.Info($"|Updater.UpdateApp|Future Release <{Formatted(newUpdateInfo.FutureReleaseEntry)}>");
 
                 if (newReleaseVersion <= currentVersion)
                 {
@@ -150,6 +151,16 @@ namespace Flow.Launcher.Core
             var tips = string.Format(translator.GetTranslation("newVersionTips"), version);
 
             return tips;
+        }
+
+        private static string Formatted<T>(T t)
+        {
+            var formatted = JsonSerializer.Serialize(t, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+
+            return formatted;
         }
     }
 }

--- a/Flow.Launcher.Infrastructure/Helper.cs
+++ b/Flow.Launcher.Infrastructure/Helper.cs
@@ -2,18 +2,11 @@
 
 using System;
 using System.IO;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Flow.Launcher.Infrastructure
 {
     public static class Helper
     {
-        static Helper()
-        {
-            jsonFormattedSerializerOptions.Converters.Add(new JsonStringEnumConverter());
-        }
-
         /// <summary>
         /// http://www.yinwang.org/blog-cn/2015/11/21/programming-philosophy
         /// </summary>
@@ -70,21 +63,6 @@ namespace Flow.Launcher.Infrastructure
             {
                 Directory.CreateDirectory(path);
             }
-        }
-
-        private static readonly JsonSerializerOptions jsonFormattedSerializerOptions = new JsonSerializerOptions
-        {
-            WriteIndented = true
-        };
-
-        public static string Formatted<T>(this T t)
-        {
-            var formatted = JsonSerializer.Serialize(t, new JsonSerializerOptions
-            {
-                WriteIndented = true
-            });
-
-            return formatted;
         }
     }
 }

--- a/Flow.Launcher.Infrastructure/Helper.cs
+++ b/Flow.Launcher.Infrastructure/Helper.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 
 using System;
-using System.IO;
 
 namespace Flow.Launcher.Infrastructure
 {
@@ -27,41 +26,6 @@ namespace Flow.Launcher.Infrastructure
             if (obj == null)
             {
                 throw new NullReferenceException();
-            }
-        }
-
-        public static void ValidateDataDirectory(string bundledDataDirectory, string dataDirectory)
-        {
-            if (!Directory.Exists(dataDirectory))
-            {
-                Directory.CreateDirectory(dataDirectory);
-            }
-
-            foreach (var bundledDataPath in Directory.GetFiles(bundledDataDirectory))
-            {
-                var data = Path.GetFileName(bundledDataPath);
-                var dataPath = Path.Combine(dataDirectory, data.NonNull());
-                if (!File.Exists(dataPath))
-                {
-                    File.Copy(bundledDataPath, dataPath);
-                }
-                else
-                {
-                    var time1 = new FileInfo(bundledDataPath).LastWriteTimeUtc;
-                    var time2 = new FileInfo(dataPath).LastWriteTimeUtc;
-                    if (time1 != time2)
-                    {
-                        File.Copy(bundledDataPath, dataPath, true);
-                    }
-                }
-            }
-        }
-
-        public static void ValidateDirectory(string path)
-        {
-            if (!Directory.Exists(path))
-            {
-                Directory.CreateDirectory(path);
             }
         }
     }

--- a/Flow.Launcher.Infrastructure/Storage/BinaryStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/BinaryStorage.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.UserSettings;
+using Flow.Launcher.Plugin.SharedCommands;
 using MemoryPack;
 
 namespace Flow.Launcher.Infrastructure.Storage
@@ -21,7 +22,7 @@ namespace Flow.Launcher.Infrastructure.Storage
         public BinaryStorage(string filename, string directoryPath = null)
         {
             directoryPath ??= DataLocation.CacheDirectory;
-            Helper.ValidateDirectory(directoryPath);
+            FilesFolders.ValidateDirectory(directoryPath);
 
             FilePath = Path.Combine(directoryPath, $"{filename}{FileSuffix}");
         }

--- a/Flow.Launcher.Infrastructure/Storage/FlowLauncherJsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/FlowLauncherJsonStorage.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Flow.Launcher.Infrastructure.UserSettings;
+using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Infrastructure.Storage
 {
@@ -8,7 +9,7 @@ namespace Flow.Launcher.Infrastructure.Storage
         public FlowLauncherJsonStorage()
         {
             var directoryPath = Path.Combine(DataLocation.DataDirectory(), DirectoryName);
-            Helper.ValidateDirectory(directoryPath);
+            FilesFolders.ValidateDirectory(directoryPath);
 
             var filename = typeof(T).Name;
             FilePath = Path.Combine(directoryPath, $"{filename}{FileSuffix}");

--- a/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Flow.Launcher.Infrastructure.Logger;
+using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Infrastructure.Storage
 {
@@ -37,7 +38,7 @@ namespace Flow.Launcher.Infrastructure.Storage
             FilePath = filePath;
             DirectoryPath = Path.GetDirectoryName(filePath) ?? throw new ArgumentException("Invalid file path");
 
-            Helper.ValidateDirectory(DirectoryPath);
+            FilesFolders.ValidateDirectory(DirectoryPath);
         }
 
         public async Task<T> LoadAsync()

--- a/Flow.Launcher.Infrastructure/Storage/PluginJsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/PluginJsonStorage.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Flow.Launcher.Infrastructure.UserSettings;
+using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Infrastructure.Storage
 {
@@ -14,7 +15,7 @@ namespace Flow.Launcher.Infrastructure.Storage
             var dataType = typeof(T);
             AssemblyName = dataType.Assembly.GetName().Name;
             DirectoryPath = Path.Combine(DataLocation.PluginSettingsDirectory, AssemblyName);
-            Helper.ValidateDirectory(DirectoryPath);
+            FilesFolders.ValidateDirectory(DirectoryPath);
 
             FilePath = Path.Combine(DirectoryPath, $"{dataType.Name}{FileSuffix}");
         }

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -318,5 +318,51 @@ namespace Flow.Launcher.Plugin.SharedCommands
         {
             return path.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
         }
+
+        /// <summary>
+        /// Validates a directory, creating it if it doesn't exist
+        /// </summary>
+        /// <param name="path"></param>
+        public static void ValidateDirectory(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+        }
+
+        /// <summary>
+        /// Validates a data directory, synchronizing it by ensuring all files from a bundled source directory exist in it.
+        /// If files are missing or outdated, they are copied from the bundled directory to the data directory.
+        /// </summary>
+        /// <param name="bundledDataDirectory"></param>
+        /// <param name="dataDirectory"></param>
+        public static void ValidateDataDirectory(string bundledDataDirectory, string dataDirectory)
+        {
+            if (!Directory.Exists(dataDirectory))
+            {
+                Directory.CreateDirectory(dataDirectory);
+            }
+
+            foreach (var bundledDataPath in Directory.GetFiles(bundledDataDirectory))
+            {
+                var data = Path.GetFileName(bundledDataPath);
+                if (data == null) continue;
+                var dataPath = Path.Combine(dataDirectory, data);
+                if (!File.Exists(dataPath))
+                {
+                    File.Copy(bundledDataPath, dataPath);
+                }
+                else
+                {
+                    var time1 = new FileInfo(bundledDataPath).LastWriteTimeUtc;
+                    var time2 = new FileInfo(dataPath).LastWriteTimeUtc;
+                    if (time1 != time2)
+                    {
+                        File.Copy(bundledDataPath, dataPath, true);
+                    }
+                }
+            }
+        }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Program/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Main.cs
@@ -6,13 +6,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Controls;
-using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin.Program.Programs;
 using Flow.Launcher.Plugin.Program.Views;
 using Flow.Launcher.Plugin.Program.Views.Models;
+using Flow.Launcher.Plugin.SharedCommands;
 using Microsoft.Extensions.Caching.Memory;
 using Path = System.IO.Path;
 using Stopwatch = Flow.Launcher.Infrastructure.Stopwatch;
@@ -191,7 +191,7 @@ namespace Flow.Launcher.Plugin.Program
 
             await Stopwatch.NormalAsync("|Flow.Launcher.Plugin.Program.Main|Preload programs cost", async () =>
             {
-                Helper.ValidateDirectory(Context.CurrentPluginMetadata.PluginCacheDirectoryPath);
+                FilesFolders.ValidateDirectory(Context.CurrentPluginMetadata.PluginCacheDirectoryPath);
 
                 static void MoveFile(string sourcePath, string destinationPath)
                 {

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Controls;
-using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Plugin.WebSearch
@@ -180,7 +179,7 @@ namespace Flow.Launcher.Plugin.WebSearch
 
                 // Default images directory is in the WebSearch's application folder  
                 DefaultImagesDirectory = Path.Combine(pluginDirectory, Images);
-                Helper.ValidateDataDirectory(bundledImagesDirectory, DefaultImagesDirectory);
+                FilesFolders.ValidateDataDirectory(bundledImagesDirectory, DefaultImagesDirectory);
 
                 // Custom images directory is in the WebSearch's data location folder
                 CustomImagesDirectory = Path.Combine(_context.CurrentPluginMetadata.PluginSettingsDirectoryPath, "CustomIcons");


### PR DESCRIPTION
# Move format function location

Move `Flow.Launcher.Infrastructure.Format` function to `Updater.cs` since this function is only used by `Updater.cs`.

# Move `ValidateDirectory` functions location

Move `ValidateDataDirectory()` and `ValidateDirectory()` function in `Flow.Launcher.Infrastructure` project to `FilesFolders.cs` since they are functions related to directory and `Program` and `WebSearch` plugin use them so we would better to put them in `Flow.Launcher.Plugin` project for all plugin usage.