### PR TITLE
Fix environment exit & Wait image cache save before restarting & Add settings saving lock & Do not crash when caught exception saving

### DIFF
--- a/Flow.Launcher.Core/Configuration/Portable.cs
+++ b/Flow.Launcher.Core/Configuration/Portable.cs
@@ -159,7 +159,7 @@ namespace Flow.Launcher.Core.Configuration
                 {
                     FilesFolders.OpenPath(Constant.RootDirectory, (s) => API.ShowMsgBox(s));
 
-                    Application.Current.Shutdown();
+                    Environment.Exit(0);
                 }
             }
             // Otherwise, if the portable data folder is marked for deletion,

--- a/Flow.Launcher.Core/Configuration/Portable.cs
+++ b/Flow.Launcher.Core/Configuration/Portable.cs
@@ -22,7 +22,7 @@ namespace Flow.Launcher.Core.Configuration
         /// As at Squirrel.Windows version 1.5.2, UpdateManager needs to be disposed after finish
         /// </summary>
         /// <returns></returns>
-        private UpdateManager NewUpdateManager()
+        private static UpdateManager NewUpdateManager()
         {
             var applicationFolderName = Constant.ApplicationDirectory
                                             .Split(new[] { Path.DirectorySeparatorChar }, StringSplitOptions.None)
@@ -81,20 +81,16 @@ namespace Flow.Launcher.Core.Configuration
 
         public void RemoveShortcuts()
         {
-            using (var portabilityUpdater = NewUpdateManager())
-            {
-                portabilityUpdater.RemoveShortcutsForExecutable(Constant.ApplicationFileName, ShortcutLocation.StartMenu);
-                portabilityUpdater.RemoveShortcutsForExecutable(Constant.ApplicationFileName, ShortcutLocation.Desktop);
-                portabilityUpdater.RemoveShortcutsForExecutable(Constant.ApplicationFileName, ShortcutLocation.Startup);
-            }
+            using var portabilityUpdater = NewUpdateManager();
+            portabilityUpdater.RemoveShortcutsForExecutable(Constant.ApplicationFileName, ShortcutLocation.StartMenu);
+            portabilityUpdater.RemoveShortcutsForExecutable(Constant.ApplicationFileName, ShortcutLocation.Desktop);
+            portabilityUpdater.RemoveShortcutsForExecutable(Constant.ApplicationFileName, ShortcutLocation.Startup);
         }
 
         public void RemoveUninstallerEntry()
         {
-            using (var portabilityUpdater = NewUpdateManager())
-            {
-                portabilityUpdater.RemoveUninstallerRegistryEntry();
-            }
+            using var portabilityUpdater = NewUpdateManager();
+            portabilityUpdater.RemoveUninstallerRegistryEntry();
         }
 
         public void MoveUserDataFolder(string fromLocation, string toLocation)
@@ -110,12 +106,10 @@ namespace Flow.Launcher.Core.Configuration
 
         public void CreateShortcuts()
         {
-            using (var portabilityUpdater = NewUpdateManager())
-            {
-                portabilityUpdater.CreateShortcutsForExecutable(Constant.ApplicationFileName, ShortcutLocation.StartMenu, false);
-                portabilityUpdater.CreateShortcutsForExecutable(Constant.ApplicationFileName, ShortcutLocation.Desktop, false);
-                portabilityUpdater.CreateShortcutsForExecutable(Constant.ApplicationFileName, ShortcutLocation.Startup, false);
-            }
+            using var portabilityUpdater = NewUpdateManager();
+            portabilityUpdater.CreateShortcutsForExecutable(Constant.ApplicationFileName, ShortcutLocation.StartMenu, false);
+            portabilityUpdater.CreateShortcutsForExecutable(Constant.ApplicationFileName, ShortcutLocation.Desktop, false);
+            portabilityUpdater.CreateShortcutsForExecutable(Constant.ApplicationFileName, ShortcutLocation.Startup, false);
         }
 
         public void CreateUninstallerEntry()
@@ -129,18 +123,14 @@ namespace Flow.Launcher.Core.Configuration
                 subKey2.SetValue("DisplayIcon", Path.Combine(Constant.ApplicationDirectory, "app.ico"), RegistryValueKind.String);
             }
 
-            using (var portabilityUpdater = NewUpdateManager())
-            {
-                _ = portabilityUpdater.CreateUninstallerRegistryEntry();
-            }
+            using var portabilityUpdater = NewUpdateManager();
+            _ = portabilityUpdater.CreateUninstallerRegistryEntry();
         }
 
-        internal void IndicateDeletion(string filePathTodelete)
+        private static void IndicateDeletion(string filePathTodelete)
         {
             var deleteFilePath = Path.Combine(filePathTodelete, DataLocation.DeletionIndicatorFile);
-            using (var _ = File.CreateText(deleteFilePath))
-            {
-            }
+            using var _ = File.CreateText(deleteFilePath);
         }
 
         ///<summary>

--- a/Flow.Launcher.Core/Configuration/Portable.cs
+++ b/Flow.Launcher.Core/Configuration/Portable.cs
@@ -169,7 +169,7 @@ namespace Flow.Launcher.Core.Configuration
                 {
                     FilesFolders.OpenPath(Constant.RootDirectory, (s) => API.ShowMsgBox(s));
 
-                    Environment.Exit(0);
+                    Application.Current.Shutdown();
                 }
             }
             // Otherwise, if the portable data folder is marked for deletion,

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -23,6 +23,8 @@ namespace Flow.Launcher.Core.Plugin
         protected ConcurrentDictionary<string, object?> Settings { get; set; } = null!;
         public required IPublicAPI API { get; init; }
 
+        private static readonly string ClassName = nameof(JsonRPCPluginSettings);
+
         private JsonStorage<ConcurrentDictionary<string, object?>> _storage = null!;
 
         private static readonly Thickness SettingPanelMargin = (Thickness)Application.Current.FindResource("SettingPanelMargin");
@@ -122,12 +124,26 @@ namespace Flow.Launcher.Core.Plugin
 
         public async Task SaveAsync()
         {
-            await _storage.SaveAsync();
+            try
+            {
+                await _storage.SaveAsync();
+            }
+            catch (System.Exception e)
+            {
+                API.LogException(ClassName, $"Failed to save plugin settings to path: {SettingPath}", e);
+            }
         }
 
         public void Save()
         {
-            _storage.Save();
+            try
+            {
+                _storage.Save();
+            }
+            catch (System.Exception e)
+            {
+                API.LogException(ClassName, $"Failed to save plugin settings to path: {SettingPath}", e);
+            }
         }
         
         public bool NeedCreateSettingPanel()

--- a/Flow.Launcher.Core/Updater.cs
+++ b/Flow.Launcher.Core/Updater.cs
@@ -4,10 +4,11 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using JetBrains.Annotations;
-using Squirrel;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Plugin.SharedCommands;
 using Flow.Launcher.Infrastructure;
@@ -15,8 +16,8 @@ using Flow.Launcher.Infrastructure.Http;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
-using System.Text.Json.Serialization;
-using System.Threading;
+using JetBrains.Annotations;
+using Squirrel;
 
 namespace Flow.Launcher.Core
 {
@@ -70,7 +71,7 @@ namespace Flow.Launcher.Core
 
                 if (DataLocation.PortableDataLocationInUse())
                 {
-                    var targetDestination = updateManager.RootAppDirectory + $"\\app-{newReleaseVersion.ToString()}\\{DataLocation.PortableFolderName}";
+                    var targetDestination = updateManager.RootAppDirectory + $"\\app-{newReleaseVersion}\\{DataLocation.PortableFolderName}";
                     FilesFolders.CopyAll(DataLocation.PortableDataPath, targetDestination, (s) => _api.ShowMsgBox(s));
                     if (!FilesFolders.VerifyBothFolderFilesEqual(DataLocation.PortableDataPath, targetDestination, (s) => _api.ShowMsgBox(s)))
                         _api.ShowMsgBox(string.Format(_api.GetTranslation("update_flowlauncher_fail_moving_portable_user_profile_data"),
@@ -122,7 +123,7 @@ namespace Flow.Launcher.Core
         }
 
         // https://github.com/Squirrel/Squirrel.Windows/blob/master/src/Squirrel/UpdateManager.Factory.cs
-        private async Task<UpdateManager> GitHubUpdateManagerAsync(string repository)
+        private static async Task<UpdateManager> GitHubUpdateManagerAsync(string repository)
         {
             var uri = new Uri(repository);
             var api = $"https://api.github.com/repos{uri.AbsolutePath}/releases";
@@ -144,9 +145,9 @@ namespace Flow.Launcher.Core
             return manager;
         }
 
-        public string NewVersionTips(string version)
+        private static string NewVersionTips(string version)
         {
-            var translator = InternationalizationManager.Instance;
+            var translator = Ioc.Default.GetRequiredService<Internationalization>();
             var tips = string.Format(translator.GetTranslation("newVersionTips"), version);
 
             return tips;

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -71,6 +71,10 @@ namespace Flow.Launcher.Infrastructure.Image
                     .Select(x => x.Key)
                     .ToList());
             }
+            catch (System.Exception e)
+            {
+                Log.Exception($"|ImageLoader.SaveAsync|Failed to save image cache to file", e);
+            }
             finally
             {
                 storageLock.Release();

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -61,7 +61,7 @@ namespace Flow.Launcher.Infrastructure.Image
             });
         }
 
-        public static async Task Save()
+        public static async Task SaveAsync()
         {
             await storageLock.WaitAsync();
 
@@ -75,6 +75,12 @@ namespace Flow.Launcher.Infrastructure.Image
             {
                 storageLock.Release();
             }
+        }
+
+        public static async Task WaitSaveAsync()
+        {
+            await storageLock.WaitAsync();
+            storageLock.Release();
         }
 
         private static async Task<List<(string, bool)>> LoadStorageToConcurrentDictionaryAsync()

--- a/Flow.Launcher.Infrastructure/Storage/FlowLauncherJsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/FlowLauncherJsonStorage.cs
@@ -1,10 +1,19 @@
 ﻿using System.IO;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Infrastructure.UserSettings;
+using Flow.Launcher.Plugin;
 
 namespace Flow.Launcher.Infrastructure.Storage
 {
     public class FlowLauncherJsonStorage<T> : JsonStorage<T> where T : new()
     {
+        private static readonly string ClassName = "FlowLauncherJsonStorage";
+
+        // We should not initialize API in static constructor because it will create another API instance
+        private static IPublicAPI api = null;
+        private static IPublicAPI API => api ??= Ioc.Default.GetRequiredService<IPublicAPI>();
+
         public FlowLauncherJsonStorage()
         {
             var directoryPath = Path.Combine(DataLocation.DataDirectory(), DirectoryName);
@@ -12,6 +21,30 @@ namespace Flow.Launcher.Infrastructure.Storage
 
             var filename = typeof(T).Name;
             FilePath = Path.Combine(directoryPath, $"{filename}{FileSuffix}");
+        }
+
+        public new void Save()
+        {
+            try
+            {
+                base.Save();
+            }
+            catch (System.Exception e)
+            {
+                API.LogException(ClassName, $"Failed to save FL settings to path: {FilePath}", e);
+            }
+        }
+
+        public new async Task SaveAsync()
+        {
+            try
+            {
+                await base.SaveAsync();
+            }
+            catch (System.Exception e)
+            {
+                API.LogException(ClassName, $"Failed to save FL settings to path: {FilePath}", e);
+            }
         }
     }
 }

--- a/Flow.Launcher.Infrastructure/Storage/FlowLauncherJsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/FlowLauncherJsonStorage.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
+using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Infrastructure.Storage
 {

--- a/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
@@ -180,24 +180,20 @@ namespace Flow.Launcher.Infrastructure.Storage
 
         public void Save()
         {
-            throw new NotImplementedException("Save error");
-
-            /*string serialized = JsonSerializer.Serialize(Data,
+            string serialized = JsonSerializer.Serialize(Data,
                 new JsonSerializerOptions { WriteIndented = true });
 
             File.WriteAllText(TempFilePath, serialized);
 
-            AtomicWriteSetting();*/
+            AtomicWriteSetting();
         }
 
         public async Task SaveAsync()
         {
-            throw new NotImplementedException("SaveAsync error");
-
-            /*await using var tempOutput = File.OpenWrite(TempFilePath);
+            await using var tempOutput = File.OpenWrite(TempFilePath);
             await JsonSerializer.SerializeAsync(tempOutput, Data,
                 new JsonSerializerOptions { WriteIndented = true });
-            AtomicWriteSetting();*/
+            AtomicWriteSetting();
         }
 
         private void AtomicWriteSetting()

--- a/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
@@ -180,20 +180,24 @@ namespace Flow.Launcher.Infrastructure.Storage
 
         public void Save()
         {
-            string serialized = JsonSerializer.Serialize(Data,
+            throw new NotImplementedException("Save error");
+
+            /*string serialized = JsonSerializer.Serialize(Data,
                 new JsonSerializerOptions { WriteIndented = true });
 
             File.WriteAllText(TempFilePath, serialized);
 
-            AtomicWriteSetting();
+            AtomicWriteSetting();*/
         }
 
         public async Task SaveAsync()
         {
-            await using var tempOutput = File.OpenWrite(TempFilePath);
+            throw new NotImplementedException("SaveAsync error");
+
+            /*await using var tempOutput = File.OpenWrite(TempFilePath);
             await JsonSerializer.SerializeAsync(tempOutput, Data,
                 new JsonSerializerOptions { WriteIndented = true });
-            AtomicWriteSetting();
+            AtomicWriteSetting();*/
         }
 
         private void AtomicWriteSetting()

--- a/Flow.Launcher.Infrastructure/Storage/PluginJsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/PluginJsonStorage.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
+using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Infrastructure.Storage
 {

--- a/Flow.Launcher.Infrastructure/Storage/PluginJsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/PluginJsonStorage.cs
@@ -1,5 +1,8 @@
 ﻿using System.IO;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Infrastructure.UserSettings;
+using Flow.Launcher.Plugin;
 
 namespace Flow.Launcher.Infrastructure.Storage
 {
@@ -7,6 +10,12 @@ namespace Flow.Launcher.Infrastructure.Storage
     {
         // Use assembly name to check which plugin is using this storage
         public readonly string AssemblyName;
+
+        private static readonly string ClassName = "PluginJsonStorage";
+
+        // We should not initialize API in static constructor because it will create another API instance
+        private static IPublicAPI api = null;
+        private static IPublicAPI API => api ??= Ioc.Default.GetRequiredService<IPublicAPI>();
 
         public PluginJsonStorage()
         {
@@ -22,6 +31,30 @@ namespace Flow.Launcher.Infrastructure.Storage
         public PluginJsonStorage(T data) : this()
         {
             Data = data;
+        }
+
+        public new void Save()
+        {
+            try
+            {
+                base.Save();
+            }
+            catch (System.Exception e)
+            {
+                API.LogException(ClassName, $"Failed to save plugin settings to path: {FilePath}", e);
+            }
+        }
+
+        public new async Task SaveAsync()
+        {
+            try
+            {
+                await base.SaveAsync();
+            }
+            catch (System.Exception e)
+            {
+                API.LogException(ClassName, $"Failed to save plugin settings to path: {FilePath}", e);
+            }
         }
     }
 }

--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -492,7 +492,7 @@ namespace Flow.Launcher.Infrastructure
         #region Notification
         public static bool IsNotificationSupport()
         {
-            // Noticification only supported Windows 10 19041+
+            // Notification only supported Windows 10 19041+
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
                 Environment.OSVersion.Version.Build >= 19041;
         }

--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -490,6 +490,7 @@ namespace Flow.Launcher.Infrastructure
         #endregion
 
         #region Notification
+
         public static bool IsNotificationSupport()
         {
             // Notification only supported Windows 10 19041+

--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -488,5 +488,16 @@ namespace Flow.Launcher.Infrastructure
         }
 
         #endregion
+
+        #region Noticification
+
+        public static bool IsNotificationSupport()
+        {
+            // Noticification only supported Windows 10 19041+
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                Environment.OSVersion.Version.Build >= 19041;
+        }
+
+        #endregion
     }
 }

--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -489,8 +489,7 @@ namespace Flow.Launcher.Infrastructure
 
         #endregion
 
-        #region Noticification
-
+        #region Notification
         public static bool IsNotificationSupport()
         {
             // Noticification only supported Windows 10 19041+

--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -491,9 +491,9 @@ namespace Flow.Launcher.Infrastructure
 
         #region Notification
 
-        public static bool IsNotificationSupport()
+        public static bool IsNotificationSupported()
         {
-            // Notification only supported Windows 10 19041+
+            // Notifications only supported on Windows 10 19041+
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
                 Environment.OSVersion.Version.Build >= 19041;
         }

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -304,6 +304,14 @@ namespace Flow.Launcher
                     return;
                 }
 
+                // If we call Environment.Exit(0), the application dispose will be called before _mainWindow.Close()
+                // Accessing _mainWindow?.Dispatcher will cause the application stuck
+                // So here we need to check it and just return so that we will not acees _mainWindow?.Dispatcher
+                if (!_mainWindow.CanClose)
+                {
+                    return;
+                }
+
                 _disposed = true;
             }
 

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -32,6 +32,13 @@ namespace Flow.Launcher
 {
     public partial class MainWindow : IDisposable
     {
+        #region Public Property
+
+        // Window Event: Close Event
+        public bool CanClose { get; set; } = false;
+
+        #endregion
+
         #region Private Fields
 
         // Dependency Injection
@@ -45,8 +52,6 @@ namespace Flow.Launcher
         private readonly ContextMenu _contextMenu = new();
         private readonly MainViewModel _viewModel;
 
-        // Window Event: Close Event
-        private bool _canClose = false;
         // Window Event: Key Event
         private bool _isArrowKeyPressed = false;
 
@@ -279,7 +284,7 @@ namespace Flow.Launcher
 
         private async void OnClosing(object sender, CancelEventArgs e)
         {
-            if (!_canClose)
+            if (!CanClose)
             {
                 _notifyIcon.Visible = false;
                 App.API.SaveAppAllSettings();
@@ -287,7 +292,7 @@ namespace Flow.Launcher
                 await PluginManager.DisposePluginsAsync();
                 Notification.Uninstall();
                 // After plugins are all disposed, we can close the main window
-                _canClose = true;
+                CanClose = true;
                 // Use this instead of Close() to avoid InvalidOperationException when calling Close() in OnClosing event
                 Application.Current.Shutdown();
             }

--- a/Flow.Launcher/Notification.cs
+++ b/Flow.Launcher/Notification.cs
@@ -9,7 +9,7 @@ namespace Flow.Launcher
 {
     internal static class Notification
     {
-        internal static bool legacy = !Win32Helper.IsNotificationSupport();
+        internal static bool legacy = !Win32Helper.IsNotificationSupported();
 
         internal static void Uninstall()
         {

--- a/Flow.Launcher/Notification.cs
+++ b/Flow.Launcher/Notification.cs
@@ -9,8 +9,8 @@ namespace Flow.Launcher
 {
     internal static class Notification
     {
-        internal static bool legacy = Environment.OSVersion.Version.Build < 19041;
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "<Pending>")]
+        internal static bool legacy = !Win32Helper.IsNotificationSupport();
+
         internal static void Uninstall()
         {
             if (!legacy)
@@ -25,7 +25,6 @@ namespace Flow.Launcher
             });
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "<Pending>")]
         private static void ShowInternal(string title, string subTitle, string iconPath = null)
         {
             // Handle notification for win7/8/early win10

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -57,16 +57,18 @@ namespace Flow.Launcher
             _mainVM.ChangeQueryText(query, requery);
         }
 
+#pragma warning disable VSTHRD100 // Avoid async void methods
+
         public async void RestartApp()
         {
             _mainVM.Hide();
 
-            // we must manually save
+            // We must manually save
             // UpdateManager.RestartApp() will call Environment.Exit(0)
             // which will cause ungraceful exit
             SaveAppAllSettings();
 
-            // wait for all image caches to be saved
+            // Wait for all image caches to be saved before restarting
             await ImageLoader.WaitSaveAsync();
 
             // Restart requires Squirrel's Update.exe to be present in the parent folder, 
@@ -74,6 +76,8 @@ namespace Flow.Launcher
             // the project may not restart or just terminates. This is expected.
             UpdateManager.RestartApp(Constant.ApplicationFileName);
         }
+
+#pragma warning restore VSTHRD100 // Avoid async void methods
 
         public void ShowMainWindow() => _mainVM.Show();
 

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -37,6 +37,8 @@ namespace Flow.Launcher
         private readonly Internationalization _translater;
         private readonly MainViewModel _mainVM;
 
+        private readonly object _saveSettingsLock = new();
+
         #region Constructor
 
         public PublicAPIInstance(Settings settings, Internationalization translater, MainViewModel mainVM)
@@ -92,9 +94,12 @@ namespace Flow.Launcher
 
         public void SaveAppAllSettings()
         {
-            PluginManager.Save();
-            _mainVM.Save();
-            _settings.Save();
+            lock (_saveSettingsLock)
+            {
+                _settings.Save();
+                PluginManager.Save();
+                _mainVM.Save();
+            }
             _ = ImageLoader.SaveAsync();
         }
 

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -57,7 +57,7 @@ namespace Flow.Launcher
             _mainVM.ChangeQueryText(query, requery);
         }
 
-        public void RestartApp()
+        public async void RestartApp()
         {
             _mainVM.Hide();
 
@@ -65,6 +65,9 @@ namespace Flow.Launcher
             // UpdateManager.RestartApp() will call Environment.Exit(0)
             // which will cause ungraceful exit
             SaveAppAllSettings();
+
+            // wait for all image caches to be saved
+            await ImageLoader.WaitSaveAsync();
 
             // Restart requires Squirrel's Update.exe to be present in the parent folder, 
             // it is only published from the project's release pipeline. When debugging without it,
@@ -88,7 +91,7 @@ namespace Flow.Launcher
             PluginManager.Save();
             _mainVM.Save();
             _settings.Save();
-            _ = ImageLoader.Save();
+            _ = ImageLoader.SaveAsync();
         }
 
         public Task ReloadAllPluginData() => PluginManager.ReloadDataAsync();


### PR DESCRIPTION
# Fix `Environment.Exit(0)` issue

Since #3367 has introduced `Application.Current.Shutdown` for app dispose, using `Environment.Exit(0)` will cause issue.

```
// If we call Environment.Exit(0), the application dispose will be called before _mainWindow.Close()
// Accessing _mainWindow?.Dispatcher will cause the application stuck
// So here we need to check it and just return so that we will not acees _mainWindow?.Dispatcher
```

# Wait image cache save

Before restarting app, we should wait `ImageLoader.SaveAsync`.

# Add settings save lock

Make multiple thread safe.

# Do not crash when caught exception in saving

Use try when calling `JsonStorage` and `BinaryStorage` save.

# Test

- [x] Install original dev version and install one plugin. When application is exited for restarting, it will stuck. Using installer in this PR, the issue is fixed.