### PR TITLE
New API Function Theme Load & Get & Change

### DIFF
--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -81,11 +81,6 @@ namespace Flow.Launcher.Core.Resource
 
         #region Theme Resources
 
-        public string GetCurrentTheme()
-        {
-            return _settings.Theme;
-        }
-
         private void MakeSureThemeDirectoriesExist()
         {
             foreach (var dir in _themeDirectories.Where(dir => !Directory.Exists(dir)))
@@ -127,7 +122,7 @@ namespace Flow.Launcher.Core.Resource
             try
             {
                 // Load a ResourceDictionary for the specified theme.
-                var themeName = GetCurrentTheme();
+                var themeName = _settings.Theme;
                 var dict = GetThemeResourceDictionary(themeName);
                 
                 // Apply font settings to the theme resource.
@@ -330,7 +325,7 @@ namespace Flow.Launcher.Core.Resource
 
         private ResourceDictionary GetCurrentResourceDictionary()
         {
-            return GetResourceDictionary(GetCurrentTheme());
+            return GetResourceDictionary(_settings.Theme);
         }
 
         private ThemeData GetThemeDataFromPath(string path)
@@ -383,9 +378,15 @@ namespace Flow.Launcher.Core.Resource
 
         #endregion
 
-        #region Load & Change
+        #region Get & Change Theme
 
-        public List<ThemeData> LoadAvailableThemes()
+        public ThemeData GetCurrentTheme()
+        {
+            var themes = GetAvailableThemes();
+            return themes.FirstOrDefault(t => t.FileNameWithoutExtension == _settings.Theme) ?? themes.FirstOrDefault();
+        }
+
+        public List<ThemeData> GetAvailableThemes()
         {
             List<ThemeData> themes = new List<ThemeData>();
             foreach (var themeDirectory in _themeDirectories)
@@ -403,7 +404,7 @@ namespace Flow.Launcher.Core.Resource
         public bool ChangeTheme(string theme = null)
         {
             if (string.IsNullOrEmpty(theme))
-                theme = GetCurrentTheme();
+                theme = _settings.Theme;
 
             string path = GetThemePath(theme);
             try
@@ -591,7 +592,7 @@ namespace Flow.Launcher.Core.Resource
                 {
                     AutoDropShadow(useDropShadowEffect);
                 }
-                SetBlurForWindow(GetCurrentTheme(), backdropType);
+                SetBlurForWindow(_settings.Theme, backdropType);
 
                 if (!BlurEnabled)
                 {
@@ -610,7 +611,7 @@ namespace Flow.Launcher.Core.Resource
                 // Get the actual backdrop type and drop shadow effect settings
                 var (backdropType, _) = GetActualValue();
 
-                SetBlurForWindow(GetCurrentTheme(), backdropType);
+                SetBlurForWindow(_settings.Theme, backdropType);
             }, DispatcherPriority.Render);
         }
 
@@ -896,12 +897,6 @@ namespace Flow.Launcher.Core.Resource
 
             return resource is bool b && b;
         }
-
-        #endregion
-
-        #region Classes
-
-        public record ThemeData(string FileNameWithoutExtension, string Name, bool? IsDark = null, bool? HasBlur = null);
 
         #endregion
     }

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -344,5 +344,24 @@ namespace Flow.Launcher.Plugin
         /// Stop the loading bar in main window
         /// </summary>
         public void StopLoadingBar();
+
+        /// <summary>
+        /// Get all available themes
+        /// </summary>
+        /// <returns></returns>
+        public List<ThemeData> GetAvailableThemes();
+
+        /// <summary>
+        /// Get the current theme
+        /// </summary>
+        /// <returns></returns>
+        public ThemeData GetCurrentTheme();
+
+        /// <summary>
+        /// Set the current theme
+        /// </summary>
+        /// <param name="theme"></param>
+        /// <returns></returns>
+        public void SetCurrentTheme(ThemeData theme);
     }
 }

--- a/Flow.Launcher.Plugin/ThemeData.cs
+++ b/Flow.Launcher.Plugin/ThemeData.cs
@@ -1,0 +1,71 @@
+﻿namespace Flow.Launcher.Plugin;
+
+/// <summary>
+/// Theme data model
+/// </summary>
+public class ThemeData
+{
+    /// <summary>
+    /// Theme file name without extension
+    /// </summary>
+    public string FileNameWithoutExtension { get; private init; }
+
+    /// <summary>
+    /// Theme name
+    /// </summary>
+    public string Name { get; private init; }
+
+    /// <summary>
+    /// Theme file path
+    /// </summary>
+    public bool? IsDark { get; private init; }
+
+    /// <summary>
+    /// Theme file path
+    /// </summary>
+    public bool? HasBlur { get; private init; }
+
+    /// <summary>
+    /// Theme data constructor
+    /// </summary>
+    public ThemeData(string fileNameWithoutExtension, string name, bool? isDark = null, bool? hasBlur = null)
+    {
+        FileNameWithoutExtension = fileNameWithoutExtension;
+        Name = name;
+        IsDark = isDark;
+        HasBlur = hasBlur;
+    }
+
+    /// <inheritdoc />
+    public static bool operator ==(ThemeData left, ThemeData right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <inheritdoc />
+    public static bool operator !=(ThemeData left, ThemeData right)
+    {
+        return !(left == right);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object obj)
+    {
+        if (obj is not ThemeData other)
+            return false;
+        return FileNameWithoutExtension == other.FileNameWithoutExtension &&
+            Name == other.Name;
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        return Name?.GetHashCode() ?? 0;
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return Name;
+    }
+}

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -37,6 +37,9 @@ namespace Flow.Launcher
         private readonly Internationalization _translater;
         private readonly MainViewModel _mainVM;
 
+        private Theme _theme;
+        private Theme Theme => _theme ??= Ioc.Default.GetRequiredService<Theme>();
+
         private readonly object _saveSettingsLock = new();
 
         #region Constructor
@@ -353,6 +356,16 @@ namespace Flow.Launcher
             MessageBoxEx.Show(messageBoxText, caption, button, icon, defaultResult);
 
         public Task ShowProgressBoxAsync(string caption, Func<Action<double>, Task> reportProgressAsync, Action cancelProgress = null) => ProgressBoxEx.ShowAsync(caption, reportProgressAsync, cancelProgress);
+
+        public List<ThemeData> GetAvailableThemes() => Theme.GetAvailableThemes();
+
+        public ThemeData GetCurrentTheme() => Theme.GetCurrentTheme();
+
+        public void SetCurrentTheme(ThemeData theme)
+        {
+            Theme.ChangeTheme(theme.FileNameWithoutExtension);
+            _ = _theme.RefreshFrameAsync();
+        }
 
         #endregion
 

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
@@ -28,25 +28,23 @@ public partial class SettingsPaneThemeViewModel : BaseModel
     public static string LinkHowToCreateTheme => @"https://www.flowlauncher.com/theme-builder/";
     public static string LinkThemeGallery => "https://github.com/Flow-Launcher/Flow.Launcher/discussions/1438";
 
-    private List<Theme.ThemeData> _themes;
-    public List<Theme.ThemeData> Themes => _themes ??= _theme.LoadAvailableThemes();
+    private List<ThemeData> _themes;
+    public List<ThemeData> Themes => _themes ??= App.API.GetAvailableThemes();
 
-    private Theme.ThemeData _selectedTheme;
-    public Theme.ThemeData SelectedTheme
+    private ThemeData _selectedTheme;
+    public ThemeData SelectedTheme
     {
-        get => _selectedTheme ??= Themes.Find(v => v.FileNameWithoutExtension == _theme.GetCurrentTheme());
+        get => _selectedTheme ??= Themes.Find(v => v == App.API.GetCurrentTheme());
         set
         {
             _selectedTheme = value;
-            _theme.ChangeTheme(value.FileNameWithoutExtension);
+            App.API.SetCurrentTheme(value);
 
             // Update UI state
             OnPropertyChanged(nameof(BackdropType));
             OnPropertyChanged(nameof(IsBackdropEnabled));
             OnPropertyChanged(nameof(IsDropShadowEnabled));
             OnPropertyChanged(nameof(DropShadowEffect));
-
-            _ = _theme.RefreshFrameAsync();
         }
     }
 

--- a/Plugins/Flow.Launcher.Plugin.Sys/ThemeSelector.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/ThemeSelector.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using CommunityToolkit.Mvvm.DependencyInjection;
-using Flow.Launcher.Core.Resource;
 
 namespace Flow.Launcher.Plugin.Sys
 {
@@ -11,32 +9,6 @@ namespace Flow.Launcher.Plugin.Sys
 
         private readonly PluginInitContext _context;
 
-        // Do not initialize it in the constructor, because it will cause null reference in
-        // var dicts = Application.Current.Resources.MergedDictionaries; line of Theme
-        private Theme theme = null;
-        private Theme Theme => theme ??= Ioc.Default.GetRequiredService<Theme>();
-
-        #region Theme Selection
-
-        // Theme select codes simplified from SettingsPaneThemeViewModel.cs
-
-        private Theme.ThemeData _selectedTheme;
-        public Theme.ThemeData SelectedTheme
-        {
-            get => _selectedTheme ??= Themes.Find(v => v.FileNameWithoutExtension == Theme.GetCurrentTheme());
-            set
-            {
-                _selectedTheme = value;
-                Theme.ChangeTheme(value.FileNameWithoutExtension);
-
-                _ = Theme.RefreshFrameAsync();
-            }
-        }
-
-        private List<Theme.ThemeData> Themes => Theme.LoadAvailableThemes();
-
-        #endregion
-
         public ThemeSelector(PluginInitContext context)
         {
             _context = context;
@@ -44,28 +16,31 @@ namespace Flow.Launcher.Plugin.Sys
 
         public List<Result> Query(Query query)
         {
+            var themes = _context.API.GetAvailableThemes();
+            var selectedTheme = _context.API.GetCurrentTheme();
+
             var search = query.SecondToEndSearch;
             if (string.IsNullOrWhiteSpace(search))
             {
-                return Themes.Select(CreateThemeResult)
+                return themes.Select(x => CreateThemeResult(x, selectedTheme))
                     .OrderBy(x => x.Title)
                     .ToList();
             }
 
-            return Themes.Select(theme => (theme, matchResult: _context.API.FuzzySearch(search, theme.Name)))
+            return themes.Select(theme => (theme, matchResult: _context.API.FuzzySearch(search, theme.Name)))
                 .Where(x => x.matchResult.IsSearchPrecisionScoreMet())
-                .Select(x => CreateThemeResult(x.theme, x.matchResult.Score, x.matchResult.MatchData))
+                .Select(x => CreateThemeResult(x.theme, selectedTheme, x.matchResult.Score, x.matchResult.MatchData))
                 .OrderBy(x => x.Title)
                 .ToList();
         }
 
-        private Result CreateThemeResult(Theme.ThemeData theme) => CreateThemeResult(theme, 0, null);
+        private Result CreateThemeResult(ThemeData theme, ThemeData selectedTheme) => CreateThemeResult(theme, selectedTheme, 0, null);
 
-        private Result CreateThemeResult(Theme.ThemeData theme, int score, IList<int> highlightData)
+        private Result CreateThemeResult(ThemeData theme, ThemeData selectedTheme, int score, IList<int> highlightData)
         {
-            string themeName = theme.Name;
+            var themeName = theme.FileNameWithoutExtension;
             string title;
-            if (theme == SelectedTheme)
+            if (theme == selectedTheme)
             {
                 title = $"{theme.Name} ★";
                 // Set current theme to the top
@@ -101,7 +76,7 @@ namespace Flow.Launcher.Plugin.Sys
                 Score = score,
                 Action = c =>
                 {
-                    SelectedTheme = theme;
+                    _context.API.SetCurrentTheme(theme);
                     _context.API.ReQuery();
                     return false;
                 }


### PR DESCRIPTION
# New API Functions Theme Load & Get & Change

Add new api functions to support plugin get available themes, get current theme and set current theme.

Improve `SettingsPaneThemePage` and `Sys` plugin with those api functions.

```
/// <summary>
/// Get all available themes
/// </summary>
/// <returns></returns>
public List<ThemeData> GetAvailableThemes();

/// <summary>
/// Get the current theme
/// </summary>
/// <returns></returns>
public ThemeData GetCurrentTheme();

/// <summary>
/// Set the current theme
/// </summary>
/// <param name="theme"></param>
/// <returns></returns>
public void SetCurrentTheme(ThemeData theme);
```

# Test

* SettingsPaneThemePage and Sys plugin can get current theme and set current theme.