### PR TITLE
Initialize HotKeyMapper after window is loaded & Wait image cache saved before closing main window

### DIFF
--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -5,12 +5,10 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Documents;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.Storage;
-using static Flow.Launcher.Infrastructure.Http.Http;
 
 namespace Flow.Launcher.Infrastructure.Image
 {
@@ -27,7 +25,6 @@ namespace Flow.Launcher.Infrastructure.Image
         public static ImageSource LoadingImage { get; } = new BitmapImage(new Uri(Constant.LoadingImgIcon));
         public const int SmallIconSize = 64;
         public const int FullIconSize = 256;
-
 
         private static readonly string[] ImageExtensions = { ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".ico" };
 
@@ -183,7 +180,7 @@ namespace Flow.Launcher.Infrastructure.Image
         private static async Task<BitmapImage> LoadRemoteImageAsync(bool loadFullImage, Uri uriResult)
         {
             // Download image from url
-            await using var resp = await GetStreamAsync(uriResult);
+            await using var resp = await Http.Http.GetStreamAsync(uriResult);
             await using var buffer = new MemoryStream();
             await resp.CopyToAsync(buffer);
             buffer.Seek(0, SeekOrigin.Begin);

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -179,8 +179,6 @@ namespace Flow.Launcher
                 Current.MainWindow = _mainWindow;
                 Current.MainWindow.Title = Constant.FlowLauncher;
 
-                HotKeyMapper.Initialize();
-
                 // main windows needs initialized before theme change because of blur settings
                 Ioc.Default.GetRequiredService<Theme>().ChangeTheme();
 

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -175,7 +175,7 @@ namespace Flow.Launcher
             // Without this part, when shown for the first time, switching the context menu does not move the cursor to the end.
             _viewModel.QueryTextCursorMovedToEnd = false;
             
-            // Initialize hotkey mapper after window shown or hiden the first it is loaded
+            // Initialize hotkey mapper after window is loaded
             HotKeyMapper.Initialize();
 
             // View model property changed event

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Threading;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Core.Resource;
+using Flow.Launcher.Helper;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Infrastructure.Image;

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -18,6 +18,7 @@ using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Core.Resource;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Hotkey;
+using Flow.Launcher.Infrastructure.Image;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin.SharedCommands;
 using Flow.Launcher.ViewModel;
@@ -292,6 +293,7 @@ namespace Flow.Launcher
                 _notifyIcon.Visible = false;
                 App.API.SaveAppAllSettings();
                 e.Cancel = true;
+                await ImageLoader.WaitSaveAsync();
                 await PluginManager.DisposePluginsAsync();
                 Notification.Uninstall();
                 // After plugins are all disposed, we can close the main window

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -173,6 +173,9 @@ namespace Flow.Launcher
             // Without this part, when shown for the first time, switching the context menu does not move the cursor to the end.
             _viewModel.QueryTextCursorMovedToEnd = false;
             
+            // Initialize hotkey mapper after window shown or hiden the first it is loaded
+            HotKeyMapper.Initialize();
+
             // View model property changed event
             _viewModel.PropertyChanged += (o, e) =>
             {


### PR DESCRIPTION
# Initialize `HotKeyMapper` after window is loaded

Initialize hotkey after main window is loaded because when main window is loading, it will change main window visibility state which can possibly cause conflict when hotkey operation like toggling main window visibility.

# Wait image cache saved before closing main window

When we close FL, we should wait cache saved before closing app.