### PR TITLE
Add Tag column in websearch

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/en.xaml
@@ -13,6 +13,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Edit</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Add</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Enabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_tag">Tag</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirm</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSource.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSource.cs
@@ -31,6 +31,8 @@ namespace Flow.Launcher.Plugin.WebSearch
         }
 
         public string Url { get; set; }
+        
+        public string Tag { get; set; }
 
         [JsonIgnore]
         public bool Status => Enabled;
@@ -45,6 +47,7 @@ namespace Flow.Launcher.Plugin.WebSearch
                 Url = Url,
                 Icon = Icon,
                 CustomIcon = CustomIcon,
+                Tag = Tag,
                 Enabled = Enabled
             };
             return webSearch;

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
@@ -101,6 +101,7 @@
                                     <RowDefinition />
                                     <RowDefinition />
                                     <RowDefinition />
+                                    <RowDefinition />
                                 </Grid.RowDefinitions>
                                 <TextBlock
                                     Grid.Row="0"
@@ -175,13 +176,28 @@
                                 <TextBlock
                                     Grid.Row="4"
                                     Grid.Column="0"
+                                    Margin="10,15,15,10"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    FontSize="14"
+                                    Text="{DynamicResource flowlauncher_plugin_websearch_tag}" />
+                                <TextBox
+                                    Grid.Row="4"
+                                    Grid.Column="1"
+                                    Margin="10,10,10,0"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Center"
+                                    Text="{Binding SearchSource.Tag}" />
+                                <TextBlock
+                                    Grid.Row="5"
+                                    Grid.Column="0"
                                     Margin="10,10,15,15"
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
                                     FontSize="14"
                                     Text="{DynamicResource flowlauncher_plugin_websearch_enabled_label}" />
                                 <CheckBox
-                                    Grid.Row="4"
+                                    Grid.Row="5"
                                     Grid.Column="1"
                                     Margin="10,10,10,15"
                                     VerticalAlignment="Center"

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
@@ -96,6 +96,10 @@
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
+                    <GridViewColumn 
+                        Width="130"
+                        DisplayMemberBinding="{Binding Tag}"
+                        Header="{DynamicResource flowlauncher_plugin_websearch_tag}" />
                 </GridView>
             </ListView.View>
         </ListView>


### PR DESCRIPTION
## What's the PR
![image](https://github.com/user-attachments/assets/d2bc1d08-46ec-4f85-af94-e087d8962071)
- Add Tag column in websearch listbox
- Resolve  https://github.com/Flow-Launcher/Flow.Launcher/discussions/3423
- By default, items with tags are prioritized and displayed at the top when the page is opened.

## Detail
- On first launch, there is no value as before, and the feature does not exist yet.
- The keyword was added purely for grouping similar items together.
- If there are many web search entries, knowing just the tag keyword could allow users to view multiple web search options, and in the future, a feature could be added to auto-fill by pressing Enter. (In that case, it would be convenient to use even without remembering all the individual web search keywords.) Therefore, I believe this current state is acceptable.

##  Memo
- Honestly, I'm not sure if it's really necessary or not 😇
- I went ahead and built it, so I'm uploading it for now.