### PR TITLE
Set max result lower limit to 1

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -524,7 +524,7 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
             }
         }
 
-        public int MaxResultLowerLimit => 100;
+        public int MaxResultLowerLimit => 1;
         public int MaxResultUpperLimit => 100000;
 
         public int MaxResult


### PR DESCRIPTION
I think it is okay to set max result lower limit to 1.

Fix #3341 