### PR TITLE
Disabled space input in websearch and explorer

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml
@@ -80,6 +80,7 @@
                         Width="135"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
+                        DataObject.Pasting="TextBox_Pasting"
                         PreviewKeyDown="TxtCurrentActionKeyword_OnKeyDown"
                         Text="{Binding ActionKeyword}" />
                 </StackPanel>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Input;
@@ -93,7 +94,27 @@ namespace Flow.Launcher.Plugin.Explorer.Views
                 OnDoneButtonClick(sender, e);
                 e.Handled = true;
             }
+            if (e.Key == Key.Space)
+            {
+                e.Handled = true;
+            }
         }
+        private void TextBox_Pasting(object sender, DataObjectPastingEventArgs e)
+        {
+            if (e.DataObject.GetDataPresent(DataFormats.Text))
+            {
+                string text = e.DataObject.GetData(DataFormats.Text) as string;
+                if (!string.IsNullOrEmpty(text) && text.Any(char.IsWhiteSpace))
+                {
+                    e.CancelCommand();
+                }
+            }
+            else
+            {
+                e.CancelCommand();
+            }
+        }
+
         public event PropertyChangedEventHandler PropertyChanged;
         protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
@@ -56,13 +56,13 @@
                     </Button>
                 </Grid>
             </StackPanel>
-            <StackPanel Margin="26,12,26,0">
+            <StackPanel Margin="26 12 26 0">
                 <Grid>
                     <StackPanel>
-                        <StackPanel Grid.Row="0" Margin="0,0,0,12">
+                        <StackPanel Grid.Row="0" Margin="0 0 0 12">
                             <TextBlock
                                 Grid.Column="0"
-                                Margin="0,0,0,0"
+                                Margin="0 0 0 0"
                                 FontSize="20"
                                 FontWeight="SemiBold"
                                 Text="{DynamicResource flowlauncher_plugin_websearch_window_title}"
@@ -75,7 +75,7 @@
                                 TextAlignment="Left"
                                 TextWrapping="WrapWithOverflow" />
                             <TextBox
-                                Margin="0,12,0,12"
+                                Margin="0 12 0 12"
                                 FontSize="14"
                                 FontWeight="SemiBold"
                                 IsReadOnly="True"
@@ -83,7 +83,7 @@
                                 TextAlignment="Center"
                                 TextWrapping="WrapWithOverflow" />
                             <TextBlock
-                                Margin="0,0,0,14"
+                                Margin="0 0 0 14"
                                 FontSize="14"
                                 Text="{DynamicResource flowlauncher_plugin_websearch_guide_3}"
                                 TextAlignment="Left"
@@ -105,7 +105,7 @@
                                 <TextBlock
                                     Grid.Row="0"
                                     Grid.Column="0"
-                                    Margin="10,10,15,10"
+                                    Margin="10 10 15 10"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Center"
                                     FontSize="14"
@@ -120,7 +120,7 @@
                                 <TextBlock
                                     Grid.Row="1"
                                     Grid.Column="0"
-                                    Margin="10,10,15,10"
+                                    Margin="10 10 15 10"
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
                                     FontSize="14"
@@ -131,7 +131,7 @@
                                     Orientation="Horizontal">
                                     <Button
                                         Height="35"
-                                        Margin="10,0,0,0"
+                                        Margin="10 0 0 0"
                                         VerticalAlignment="Center"
                                         Click="OnSelectIconClick"
                                         Content="{DynamicResource flowlauncher_plugin_websearch_select_icon}" />
@@ -139,13 +139,13 @@
                                         Name="imgPreviewIcon"
                                         Width="24"
                                         Height="24"
-                                        Margin="14,0,0,0"
+                                        Margin="14 0 0 0"
                                         VerticalAlignment="Center" />
                                 </StackPanel>
                                 <TextBlock
                                     Grid.Row="2"
                                     Grid.Column="0"
-                                    Margin="10,10,15,10"
+                                    Margin="10 10 15 10"
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
                                     FontSize="14"
@@ -160,7 +160,7 @@
                                 <TextBlock
                                     Grid.Row="3"
                                     Grid.Column="0"
-                                    Margin="10,10,15,10"
+                                    Margin="10 10 15 10"
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
                                     FontSize="14"
@@ -168,14 +168,16 @@
                                 <TextBox
                                     Grid.Row="3"
                                     Grid.Column="1"
-                                    Margin="10,0,10,0"
+                                    Margin="10 0 10 0"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Center"
+                                    DataObject.Pasting="TextBox_Pasting"
+                                    PreviewKeyDown="TextBox_PreviewKeyDown"
                                     Text="{Binding SearchSource.ActionKeyword}" />
                                 <TextBlock
                                     Grid.Row="4"
                                     Grid.Column="0"
-                                    Margin="10,10,15,15"
+                                    Margin="10 10 15 15"
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
                                     FontSize="14"
@@ -183,7 +185,7 @@
                                 <CheckBox
                                     Grid.Row="4"
                                     Grid.Column="1"
-                                    Margin="10,10,10,15"
+                                    Margin="10 10 10 15"
                                     VerticalAlignment="Center"
                                     IsChecked="{Binding SearchSource.Enabled}" />
                             </Grid>
@@ -196,16 +198,16 @@
             Grid.Row="1"
             Background="{DynamicResource PopupButtonAreaBGColor}"
             BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
-            BorderThickness="0,1,0,0">
+            BorderThickness="0 1 0 0">
             <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                 <Button
                     MinWidth="140"
-                    Margin="10,0,5,0"
+                    Margin="10 0 5 0"
                     Click="OnCancelButtonClick"
                     Content="{DynamicResource flowlauncher_plugin_websearch_cancel}" />
                 <Button
                     MinWidth="140"
-                    Margin="5,0,10,0"
+                    Margin="5 0 10 0"
                     Click="OnConfirmButtonClick"
                     Content="{DynamicResource flowlauncher_plugin_websearch_confirm}"
                     Style="{DynamicResource AccentButtonStyle}" />

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
+using System.Windows.Input;
 using Microsoft.Win32;
 
 namespace Flow.Launcher.Plugin.WebSearch
@@ -141,6 +143,30 @@ namespace Flow.Launcher.Plugin.WebSearch
                     
                     imgPreviewIcon.Source = await _viewModel.LoadPreviewIconAsync(selectedNewIconImageFullPath);
                 }
+            }
+        }
+
+        //Block Space Input
+        private void TextBox_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Space)
+            {
+                e.Handled = true;
+            }
+        }
+        private void TextBox_Pasting(object sender, DataObjectPastingEventArgs e)
+        {
+            if (e.DataObject.GetDataPresent(DataFormats.Text))
+            {
+                string text = e.DataObject.GetData(DataFormats.Text) as string;
+                if (!string.IsNullOrEmpty(text) && text.Any(char.IsWhiteSpace))
+                {
+                    e.CancelCommand();
+                }
+            }
+            else
+            {
+                e.CancelCommand();
             }
         }
     }


### PR DESCRIPTION
## What's the PR
- Although multiple action keywords can now be registered using spaces, this feature does not apply to plugins that do not internally support multiple action keywords.

- To prevent user confusion or unintended attempts, code has been added to block whitespace input (including space, tab, and pasted whitespace) in the action keyword registration TextBox for such plugins.

- This is handled at the UI input level to avoid complex internal processing and in case multi-keyword support is implemented in the future.