### PR TITLE
Fix explorer settings panel margin

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -598,7 +598,7 @@
                     <ComboBox
                         Grid.Row="2"
                         Grid.Column="1"
-                        Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
+                        Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                         VerticalAlignment="Center"
                         ItemsSource="{Binding Settings.SortOptions, Mode=OneWay}"
                         SelectedItem="{Binding Settings.SortOption}"
@@ -623,7 +623,7 @@
                         Grid.Row="3"
                         Grid.Column="1"
                         Width="{StaticResource SettingPanelPathTextBoxWidth}"
-                        Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
+                        Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                         HorizontalAlignment="Left"
                         Text="{Binding EverythingInstalledPath}" />
 


### PR DESCRIPTION
For the elements in `Gird.Column="1"`, we should use `SettingPanelItemLeftTopBottomMargin`.