### PR TITLE
Fix storage save directory issue

### DIFF
--- a/Flow.Launcher.Infrastructure/Storage/BinaryStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/BinaryStorage.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.UserSettings;
@@ -38,6 +39,16 @@ namespace Flow.Launcher.Infrastructure.Storage
             FilesFolders.ValidateDirectory(DirectoryPath);
 
             FilePath = Path.Combine(DirectoryPath, $"{filename}{FileSuffix}");
+        }
+
+        // Let the old Program plugin get this constructor
+        [Obsolete("This constructor is obsolete. Use BinaryStorage(string filename) instead.")]
+        public BinaryStorage(string filename, string directoryPath = null!)
+        {
+            directoryPath ??= DataLocation.CacheDirectory;
+            FilesFolders.ValidateDirectory(directoryPath);
+
+            FilePath = Path.Combine(directoryPath, $"{filename}{FileSuffix}");
         }
 
         public async ValueTask<T> TryLoadAsync(T defaultData)

--- a/Flow.Launcher.Infrastructure/Storage/BinaryStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/BinaryStorage.cs
@@ -82,7 +82,9 @@ namespace Flow.Launcher.Infrastructure.Storage
 
         public void Save()
         {
-            FilesFolders.ValidateDirectory(DirectoryPath); // User may delete the directory, so we need to check it
+            // User may delete the directory, so we need to check it
+            FilesFolders.ValidateDirectory(DirectoryPath);
+
             var serialized = MemoryPackSerializer.Serialize(Data);
             File.WriteAllBytes(FilePath, serialized);
         }
@@ -103,7 +105,9 @@ namespace Flow.Launcher.Infrastructure.Storage
         // so we need to pass it to SaveAsync
         public async ValueTask SaveAsync(T data)
         {
-            FilesFolders.ValidateDirectory(DirectoryPath); // User may delete the directory, so we need to check it
+            // User may delete the directory, so we need to check it
+            FilesFolders.ValidateDirectory(DirectoryPath);
+
             await using var stream = new FileStream(FilePath, FileMode.Create);
             await MemoryPackSerializer.SerializeAsync(stream, data);
         }

--- a/Flow.Launcher.Infrastructure/Storage/BinaryStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/BinaryStorage.cs
@@ -82,8 +82,8 @@ namespace Flow.Launcher.Infrastructure.Storage
 
         public void Save()
         {
+            FilesFolders.ValidateDirectory(DirectoryPath); // User may delete the directory, so we need to check it
             var serialized = MemoryPackSerializer.Serialize(Data);
-
             File.WriteAllBytes(FilePath, serialized);
         }
 
@@ -103,6 +103,7 @@ namespace Flow.Launcher.Infrastructure.Storage
         // so we need to pass it to SaveAsync
         public async ValueTask SaveAsync(T data)
         {
+            FilesFolders.ValidateDirectory(DirectoryPath); // User may delete the directory, so we need to check it
             await using var stream = new FileStream(FilePath, FileMode.Create);
             await MemoryPackSerializer.SerializeAsync(stream, data);
         }

--- a/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
@@ -183,7 +183,10 @@ namespace Flow.Launcher.Infrastructure.Storage
 
         public void Save()
         {
-            string serialized = JsonSerializer.Serialize(Data,
+            // User may delete the directory, so we need to check it
+            FilesFolders.ValidateDirectory(DirectoryPath);
+
+            var serialized = JsonSerializer.Serialize(Data,
                 new JsonSerializerOptions { WriteIndented = true });
 
             File.WriteAllText(TempFilePath, serialized);
@@ -193,6 +196,9 @@ namespace Flow.Launcher.Infrastructure.Storage
 
         public async Task SaveAsync()
         {
+            // User may delete the directory, so we need to check it
+            FilesFolders.ValidateDirectory(DirectoryPath);
+
             await using var tempOutput = File.OpenWrite(TempFilePath);
             await JsonSerializer.SerializeAsync(tempOutput, Data,
                 new JsonSerializerOptions { WriteIndented = true });


### PR DESCRIPTION
Check directory before saving storage to fix `System.IO.DirectoryNotFoundException: Could not find a part of the path`.
Add old constructor for old `Program` plugin.

Fix #3451.