### PR TITLE
Improve FL Exiting & Exception Handler

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -37,7 +37,7 @@ namespace Flow.Launcher.Core.Plugin
 
         private static PluginsSettings Settings;
         private static List<PluginMetadata> _metadatas;
-        private static List<string> _modifiedPlugins = new();
+        private static readonly List<string> _modifiedPlugins = new();
 
         /// <summary>
         /// Directories that will hold Flow Launcher plugin directory
@@ -299,7 +299,7 @@ namespace Flow.Launcher.Core.Plugin
                 {
                     Title = $"{metadata.Name}: Failed to respond!",
                     SubTitle = "Select this result for more info",
-                    IcoPath = Flow.Launcher.Infrastructure.Constant.ErrorIcon,
+                    IcoPath = Constant.ErrorIcon,
                     PluginDirectory = metadata.PluginDirectory,
                     ActionKeywordAssigned = query.ActionKeyword,
                     PluginID = metadata.ID,
@@ -376,8 +376,8 @@ namespace Flow.Launcher.Core.Plugin
         {
             // this method is only checking for action keywords (defined as not '*') registration
             // hence the actionKeyword != Query.GlobalPluginWildcardSign logic
-            return actionKeyword != Query.GlobalPluginWildcardSign
-                   && NonGlobalPlugins.ContainsKey(actionKeyword);
+            return actionKeyword != Query.GlobalPluginWildcardSign 
+                && NonGlobalPlugins.ContainsKey(actionKeyword);
         }
 
         /// <summary>

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -61,16 +61,16 @@ namespace Flow.Launcher.Core.Plugin
         /// </summary>
         public static void Save()
         {
-            foreach (var plugin in AllPlugins)
+            foreach (var pluginPair in AllPlugins)
             {
-                var savable = plugin.Plugin as ISavable;
+                var savable = pluginPair.Plugin as ISavable;
                 try
                 {
                     savable?.Save();
                 }
                 catch (Exception e)
                 {
-                    throw new FlowPluginException(plugin.Metadata, e);
+                    API.LogException(ClassName, $"Failed to save plugin {pluginPair.Metadata.Name}", e);
                 }
             }
 
@@ -102,7 +102,7 @@ namespace Flow.Launcher.Core.Plugin
             }
             catch (Exception e)
             {
-                throw new FlowPluginException(pluginPair.Metadata, e);
+                API.LogException(ClassName, $"Failed to dispose plugin {pluginPair.Metadata.Name}", e);
             }
         }
 

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -88,14 +88,21 @@ namespace Flow.Launcher.Core.Plugin
 
         private static async Task DisposePluginAsync(PluginPair pluginPair)
         {
-            switch (pluginPair.Plugin)
+            try
             {
-                case IDisposable disposable:
-                    disposable.Dispose();
-                    break;
-                case IAsyncDisposable asyncDisposable:
-                    await asyncDisposable.DisposeAsync();
-                    break;
+                switch (pluginPair.Plugin)
+                {
+                    case IDisposable disposable:
+                        disposable.Dispose();
+                        break;
+                    case IAsyncDisposable asyncDisposable:
+                        await asyncDisposable.DisposeAsync();
+                        break;
+                }
+            }
+            catch (Exception e)
+            {
+                throw new FlowPluginException(pluginPair.Metadata, e);
             }
         }
 

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -64,7 +64,14 @@ namespace Flow.Launcher.Core.Plugin
             foreach (var plugin in AllPlugins)
             {
                 var savable = plugin.Plugin as ISavable;
-                savable?.Save();
+                try
+                {
+                    savable?.Save();
+                }
+                catch (Exception e)
+                {
+                    throw new FlowPluginException(plugin.Metadata, e);
+                }
             }
 
             API.SavePluginSettings();

--- a/Flow.Launcher.Core/Resource/Internationalization.cs
+++ b/Flow.Launcher.Core/Resource/Internationalization.cs
@@ -22,8 +22,8 @@ namespace Flow.Launcher.Core.Resource
         private const string DefaultFile = "en.xaml";
         private const string Extension = ".xaml";
         private readonly Settings _settings;
-        private readonly List<string> _languageDirectories = new List<string>();
-        private readonly List<ResourceDictionary> _oldResources = new List<ResourceDictionary>();
+        private readonly List<string> _languageDirectories = new();
+        private readonly List<ResourceDictionary> _oldResources = new();
         private readonly string SystemLanguageCode;
 
         public Internationalization(Settings settings)
@@ -144,7 +144,7 @@ namespace Flow.Launcher.Core.Resource
             _settings.Language = isSystem ? Constant.SystemLanguageCode : language.LanguageCode;
         }
 
-        private Language GetLanguageByLanguageCode(string languageCode)
+        private static Language GetLanguageByLanguageCode(string languageCode)
         {
             var lowercase = languageCode.ToLower();
             var language = AvailableLanguages.GetAvailableLanguages().FirstOrDefault(o => o.LanguageCode.ToLower() == lowercase);
@@ -239,7 +239,7 @@ namespace Flow.Launcher.Core.Resource
             return list;
         }
 
-        public string GetTranslation(string key)
+        public static string GetTranslation(string key)
         {
             var translation = Application.Current.TryFindResource(key);
             if (translation is string)
@@ -257,8 +257,7 @@ namespace Flow.Launcher.Core.Resource
         {
             foreach (var p in PluginManager.GetPluginsForInterface<IPluginI18n>())
             {
-                var pluginI18N = p.Plugin as IPluginI18n;
-                if (pluginI18N == null) return;
+                if (p.Plugin is not IPluginI18n pluginI18N) return;
                 try
                 {
                     p.Metadata.Name = pluginI18N.GetTranslatedPluginTitle();
@@ -272,11 +271,11 @@ namespace Flow.Launcher.Core.Resource
             }
         }
 
-        public string LanguageFile(string folder, string language)
+        private static string LanguageFile(string folder, string language)
         {
             if (Directory.Exists(folder))
             {
-                string path = Path.Combine(folder, language);
+                var path = Path.Combine(folder, language);
                 if (File.Exists(path))
                 {
                     return path;
@@ -284,7 +283,7 @@ namespace Flow.Launcher.Core.Resource
                 else
                 {
                     Log.Error($"|Internationalization.LanguageFile|Language path can't be found <{path}>");
-                    string english = Path.Combine(folder, DefaultFile);
+                    var english = Path.Combine(folder, DefaultFile);
                     if (File.Exists(english))
                     {
                         return english;

--- a/Flow.Launcher.Infrastructure/Storage/BinaryStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/BinaryStorage.cs
@@ -45,10 +45,10 @@ namespace Flow.Launcher.Infrastructure.Storage
         [Obsolete("This constructor is obsolete. Use BinaryStorage(string filename) instead.")]
         public BinaryStorage(string filename, string directoryPath = null!)
         {
-            directoryPath ??= DataLocation.CacheDirectory;
-            FilesFolders.ValidateDirectory(directoryPath);
+            DirectoryPath = directoryPath ?? DataLocation.CacheDirectory;
+            FilesFolders.ValidateDirectory(DirectoryPath);
 
-            FilePath = Path.Combine(directoryPath, $"{filename}{FileSuffix}");
+            FilePath = Path.Combine(DirectoryPath, $"{filename}{FileSuffix}");
         }
 
         public async ValueTask<T> TryLoadAsync(T defaultData)

--- a/Flow.Launcher.Infrastructure/Storage/FlowLauncherJsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/FlowLauncherJsonStorage.cs
@@ -17,11 +17,11 @@ namespace Flow.Launcher.Infrastructure.Storage
 
         public FlowLauncherJsonStorage()
         {
-            var directoryPath = Path.Combine(DataLocation.DataDirectory(), DirectoryName);
-            FilesFolders.ValidateDirectory(directoryPath);
+            DirectoryPath = Path.Combine(DataLocation.DataDirectory(), DirectoryName);
+            FilesFolders.ValidateDirectory(DirectoryPath);
 
             var filename = typeof(T).Name;
-            FilePath = Path.Combine(directoryPath, $"{filename}{FileSuffix}");
+            FilePath = Path.Combine(DirectoryPath, $"{filename}{FileSuffix}");
         }
 
         public new void Save()

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -264,12 +264,12 @@ namespace Flow.Launcher.Plugin.SharedCommands
             var index = path.LastIndexOf('\\');
             if (index > 0 && index < (path.Length - 1))
             {
-                string previousDirectoryPath = path.Substring(0, index + 1);
-                return locationExists(previousDirectoryPath) ? previousDirectoryPath : "";
+                string previousDirectoryPath = path[..(index + 1)];
+                return locationExists(previousDirectoryPath) ? previousDirectoryPath : string.Empty;
             }
             else
             {
-                return "";
+                return string.Empty;
             }
         }
 
@@ -285,7 +285,7 @@ namespace Flow.Launcher.Plugin.SharedCommands
                 // not full path, get previous level directory string
                 var indexOfSeparator = path.LastIndexOf('\\');
 
-                return path.Substring(0, indexOfSeparator + 1);
+                return path[..(indexOfSeparator + 1)];
             }
 
             return path;

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -153,6 +153,7 @@ namespace Flow.Launcher
 
                 RegisterAppDomainExceptions();
                 RegisterDispatcherUnhandledException();
+                RegisterTaskSchedulerUnhandledException();
 
                 var imageLoadertask = ImageLoader.InitializeAsync();
 
@@ -282,6 +283,15 @@ namespace Flow.Launcher
         private static void RegisterAppDomainExceptions()
         {
             AppDomain.CurrentDomain.UnhandledException += ErrorReporting.UnhandledExceptionHandle;
+        }
+
+        /// <summary>
+        /// let exception throw as normal is better for Debug
+        /// </summary>
+        [Conditional("RELEASE")]
+        private static void RegisterTaskSchedulerUnhandledException()
+        {
+            TaskScheduler.UnobservedTaskException += ErrorReporting.TaskSchedulerUnobservedTaskException;
         }
 
         #endregion

--- a/Flow.Launcher/Helper/ErrorReporting.cs
+++ b/Flow.Launcher/Helper/ErrorReporting.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Threading;
-using NLog;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Exception;
+using NLog;
 
 namespace Flow.Launcher.Helper;
 
@@ -34,7 +35,7 @@ public static class ErrorReporting
     public static void TaskSchedulerUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
     {
         //handle unobserved task exceptions
-        Report(e.Exception);
+        Application.Current.Dispatcher.Invoke(() => Report(e.Exception));
         //prevent application exist, so the user can copy prompted error info
         e.SetObserved();
     }

--- a/Flow.Launcher/Helper/ErrorReporting.cs
+++ b/Flow.Launcher/Helper/ErrorReporting.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using System.Windows.Threading;
 using NLog;
 using Flow.Launcher.Infrastructure;
@@ -28,6 +29,14 @@ public static class ErrorReporting
         Report(e.Exception);
         //prevent application exist, so the user can copy prompted error info
         e.Handled = true;
+    }
+
+    public static void TaskSchedulerUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+    {
+        //handle unobserved task exceptions
+        Report(e.Exception);
+        //prevent application exist, so the user can copy prompted error info
+        e.SetObserved();
     }
 
     public static string RuntimeInfo()

--- a/Flow.Launcher/Helper/ErrorReporting.cs
+++ b/Flow.Launcher/Helper/ErrorReporting.cs
@@ -36,8 +36,7 @@ public static class ErrorReporting
     {
         //handle unobserved task exceptions
         Application.Current.Dispatcher.Invoke(() => Report(e.Exception));
-        //prevent application exist, so the user can copy prompted error info
-        e.SetObserved();
+        //prevent application exit, so the user can copy the prompted error info
     }
 
     public static string RuntimeInfo()

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -291,15 +291,15 @@ namespace Flow.Launcher
         {
             if (!CanClose)
             {
+                CanClose = true;
                 _notifyIcon.Visible = false;
                 App.API.SaveAppAllSettings();
                 e.Cancel = true;
                 await ImageLoader.WaitSaveAsync();
                 await PluginManager.DisposePluginsAsync();
                 Notification.Uninstall();
-                // After plugins are all disposed, we can close the main window
-                CanClose = true;
-                // Use this instead of Close() to avoid InvalidOperationException when calling Close() in OnClosing event
+                // After plugins are all disposed, we shutdown application to close app
+                // We use this instead of Close() to avoid InvalidOperationException when calling Close() in OnClosing event
                 Application.Current.Shutdown();
             }
         }

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -38,20 +38,23 @@ namespace Flow.Launcher
     public class PublicAPIInstance : IPublicAPI, IRemovable
     {
         private readonly Settings _settings;
-        private readonly Internationalization _translater;
         private readonly MainViewModel _mainVM;
 
+        // Must use getter to access Application.Current.Resources.MergedDictionaries so earlier
         private Theme _theme;
         private Theme Theme => _theme ??= Ioc.Default.GetRequiredService<Theme>();
+
+        // Must use getter to avoid circular dependency
+        private Updater _updater;
+        private Updater Updater => _updater ??= Ioc.Default.GetRequiredService<Updater>();
 
         private readonly object _saveSettingsLock = new();
 
         #region Constructor
 
-        public PublicAPIInstance(Settings settings, Internationalization translater, MainViewModel mainVM)
+        public PublicAPIInstance(Settings settings, MainViewModel mainVM)
         {
             _settings = settings;
-            _translater = translater;
             _mainVM = mainVM;
             GlobalHotkey.hookedKeyboardCallback = KListener_hookedKeyboardCallback;
             WebRequest.RegisterPrefix("data", new DataWebRequestFactory());
@@ -100,8 +103,7 @@ namespace Flow.Launcher
             remove => _mainVM.VisibilityChanged -= value;
         }
 
-        // Must use Ioc.Default.GetRequiredService<Updater>() to avoid circular dependency
-        public void CheckForNewUpdate() => _ = Ioc.Default.GetRequiredService<Updater>().UpdateAppAsync(false);
+        public void CheckForNewUpdate() => _ = Updater.UpdateAppAsync(false);
 
         public void SaveAppAllSettings()
         {
@@ -178,7 +180,7 @@ namespace Flow.Launcher
 
         public void StopLoadingBar() => _mainVM.ProgressBarVisibility = Visibility.Collapsed;
 
-        public string GetTranslation(string key) => _translater.GetTranslation(key);
+        public string GetTranslation(string key) => Internationalization.GetTranslation(key);
 
         public List<PluginPair> GetAllPlugins() => PluginManager.AllPlugins.ToList();
 


### PR DESCRIPTION
# Use try-catch to call plugin Save & Dispose method so that Application can exit normally even plugins have exceptions

Tested. When plugin throw exception during saving & disposing, the application can exit normally.

# Fix storage DirectoryPath issue

Make `DirectoryPath` is not null. Follow on with #3452.

# Support TaskScheduler.UnobservedTaskException handler

Fix #3453.