### PR TITLE
Fix possible win32 exception

### DIFF
--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -376,7 +376,8 @@ namespace Flow.Launcher.Infrastructure
             if (!IsForegroundWindow(hwnd))
             {
                 var result = PInvoke.SetForegroundWindow(hwnd);
-                if (!result) throw new Win32Exception(Marshal.GetLastWin32Error());
+                // If we cannot set the foreground window, we can use the foreground window and switch the layout
+                if (!result) hwnd = PInvoke.GetForegroundWindow();
             }
 
             // Get the current foreground window thread ID


### PR DESCRIPTION
# Fix possible win32 exception for keyboard switch

```

Please open new issue in https://github.com/Flow-Launcher/Flow.Launcher/issues
1. Upload log file: C:\Users\11602\AppData\Roaming\FlowLauncher\Logs\1.19.5\2025-04-13.txt
2. Copy below exception message

Flow Launcher version: 1.19.5
OS Version: 26100.3775
IntPtr Length: 8
x64: True

Python Path: C:\Users\11602\AppData\Roaming\FlowLauncher\Environments\Python\PythonEmbeddable-v3.11.4\pythonw.exe
Node Path: C:\Program Files\nodejs\node.exe

Date: 04/13/2025 20:27:38
Exception:
System.ComponentModel.Win32Exception (0x80004005): The operation completed successfully.
   at Flow.Launcher.Infrastructure.Win32Helper.SwitchToEnglishKeyboardLayout(Boolean backupPrevious) in C:\projects\flow-launcher\Flow.Launcher.Infrastructure\Win32Helper.cs:line 379
   at Flow.Launcher.ViewModel.MainViewModel.Show() in C:\projects\flow-launcher\Flow.Launcher\ViewModel\MainViewModel.cs:line 1527
   at Flow.Launcher.ViewModel.MainViewModel.ToggleFlowLauncher() in C:\projects\flow-launcher\Flow.Launcher\ViewModel\MainViewModel.cs:line 1468
   at Flow.Launcher.Helper.HotKeyMapper.OnToggleHotkey(Object sender, HotkeyEventArgs args) in C:\projects\flow-launcher\Flow.Launcher\Helper\HotKeyMapper.cs:line 32
   at NHotkey.HotkeyManagerBase.HandleHotkeyMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled, Hotkey& hotkey)
   at NHotkey.Wpf.HotkeyManager.HandleMessage(IntPtr hwnd, Int32 msg, IntPtr wparam, IntPtr lparam, Boolean& handled)
   at System.Windows.Interop.HwndSource.PublicHooksFilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```

Fix #3428.