### PR TITLE
Fix Content Dialog owner & Fix Win32Exception

### DIFF
--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -365,20 +365,9 @@ namespace Flow.Launcher.Infrastructure
             // No installed English layout found
             if (enHKL == HKL.Null) return;
 
-            // When application is exiting, the Application.Current will be null
-            if (Application.Current == null) return;
-
-            // Get the FL main window
-            var hwnd = GetWindowHandle(Application.Current.MainWindow, true);
+            // Get the foreground window
+            var hwnd = PInvoke.GetForegroundWindow();
             if (hwnd == HWND.Null) return;
-
-            // Check if the FL main window is the current foreground window
-            if (!IsForegroundWindow(hwnd))
-            {
-                var result = PInvoke.SetForegroundWindow(hwnd);
-                // If we cannot set the foreground window, we can use the foreground window and switch the layout
-                if (!result) hwnd = PInvoke.GetForegroundWindow();
-            }
 
             // Get the current foreground window thread ID
             var threadId = PInvoke.GetWindowThreadProcessId(hwnd);

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -8,6 +6,8 @@ using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Helper;
 using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Infrastructure.UserSettings;
+
+#nullable enable
 
 namespace Flow.Launcher
 {
@@ -242,9 +242,10 @@ namespace Flow.Launcher
                 HotKeyMapper.RemoveHotkey(Hotkey);
             }
 
-            var dialog = new HotkeyControlDialog(Hotkey, DefaultHotkey, WindowTitle);
-
-            dialog.Owner = Window.GetWindow(this);
+            var dialog = new HotkeyControlDialog(Hotkey, DefaultHotkey, WindowTitle)
+            {
+                Owner = Window.GetWindow(this)
+            };
 
             await dialog.ShowAsync();
             switch (dialog.ResultType)

--- a/Flow.Launcher/HotkeyControl.xaml.cs
+++ b/Flow.Launcher/HotkeyControl.xaml.cs
@@ -243,6 +243,9 @@ namespace Flow.Launcher
             }
 
             var dialog = new HotkeyControlDialog(Hotkey, DefaultHotkey, WindowTitle);
+
+            dialog.Owner = Window.GetWindow(this);
+
             await dialog.ShowAsync();
             switch (dialog.ResultType)
             {

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginsViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginsViewModel.cs
@@ -5,7 +5,6 @@ using System.Windows.Controls;
 using System.Windows;
 using CommunityToolkit.Mvvm.Input;
 using Flow.Launcher.Core.Plugin;
-using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.ViewModel;
@@ -116,6 +115,7 @@ public partial class SettingsPanePluginsViewModel : BaseModel
     {
         var helpDialog = new ContentDialog()
         {
+            Owner = Application.Current.MainWindow,
             Content = new StackPanel
             {
                 Children =
@@ -146,7 +146,6 @@ public partial class SettingsPanePluginsViewModel : BaseModel
                     }
                 }
             },
-
             PrimaryButtonText = (string)Application.Current.Resources["commonOK"],
             CornerRadius = new CornerRadius(8),
             Style = (Style)Application.Current.Resources["ContentDialog"]


### PR DESCRIPTION
## What's the PR
- Fix the following error: an exception occurs when the Content Dialog in ModernWpf has no Owner set.
```
05:49:12 Exception: System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Could not find an owner window for this ContentDialog.) ---> System.InvalidOperationException: Could not find an owner window for this ContentDialog. at ModernWpf.Controls.ContentDialog.ShowAsync() at Flow.Launcher.HotkeyControl.OpenHotkeyDialogAsync() in C:\DEV\Flow Launcher\Flow.Launcher\HotkeyControl.xaml.cs:line 246 --- End of inner exception stack trac
```

- Fix the Win32Exception
```
System.ComponentModel.Win32Exception (0x80004005): 작업을 완료했습니다.
   at Flow.Launcher.Infrastructure.Win32Helper.SwitchToEnglishKeyboardLayout(Boolean backupPrevious) in C:\DEV\Flow Launcher\Flow.Launcher.Infrastructure\Win32Helper.cs:line 382
   at Flow.Launcher.ViewModel.MainViewModel.Show() in C:\DEV\Flow Launcher\Flow.Launcher\ViewModel\MainViewModel.cs:line 1548
   at Flow.Launcher.ViewModel.MainViewModel.ToggleFlowLauncher() in C:\DEV\Flow Launcher\Flow.Launcher\ViewModel\MainViewModel.cs:line 1468
   at Flow.Launcher.MainWindow.<InitializeNotifyIcon>b__33_0(Object o, RoutedEventArgs e) in C:\DEV\Flow Launcher\Flow.Launcher\MainWindow.xaml.cs:line 616
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.Controls.MenuItem.InvokeClickAfterRender(Object arg)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler) 
```

## Steps to Reproduce
- In a dev build where this PR is not applied, try to change the hotkey. (The first click does nothing, and the dialog appears on the second click.)
- Close the entire settings window.
- Try to change the hotkey again.
- Observe the error.

## Verification
- Try changing the hotkey. (The dialog should appear on the first click.)
- Close the entire settings window.
- Try changing the hotkey again.
