### PR TITLE
Fix Possible Window Popup During Startup & Fix Store Plugin List Refresh Issue

### DIFF
--- a/Flow.Launcher.Core/ExternalPlugins/CommunityPluginSource.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/CommunityPluginSource.cs
@@ -16,11 +16,11 @@ namespace Flow.Launcher.Core.ExternalPlugins
 {
     public record CommunityPluginSource(string ManifestFileUrl)
     {
+        private static readonly string ClassName = nameof(CommunityPluginSource);
+
         // We should not initialize API in static constructor because it will create another API instance
         private static IPublicAPI api = null;
         private static IPublicAPI API => api ??= Ioc.Default.GetRequiredService<IPublicAPI>();
-
-        private static readonly string ClassName = nameof(CommunityPluginSource);
 
         private string latestEtag = "";
 
@@ -70,7 +70,7 @@ namespace Flow.Launcher.Core.ExternalPlugins
                 else
                 {
                     API.LogWarn(ClassName, $"Failed to load resource {ManifestFileUrl} with response {response.StatusCode}");
-                    return plugins;
+                    return null;
                 }
             }
             catch (Exception e)
@@ -83,7 +83,7 @@ namespace Flow.Launcher.Core.ExternalPlugins
                 {
                     API.LogException(ClassName, "Error Occurred", e);
                 }
-                return plugins;
+                return null;
             }
         }
     }

--- a/Flow.Launcher.Core/ExternalPlugins/CommunityPluginStore.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/CommunityPluginStore.cs
@@ -40,10 +40,14 @@ namespace Flow.Launcher.Core.ExternalPlugins
                 var completedTask = await Task.WhenAny(tasks);
                 if (completedTask.IsCompletedSuccessfully)
                 {
-                    // one of the requests completed successfully; keep its results
-                    // and cancel the remaining http requests.
-                    pluginResults = await completedTask;
-                    cts.Cancel();
+                    var result = await completedTask;
+                    if (result != null)
+                    {
+                        // one of the requests completed successfully; keep its results
+                        // and cancel the remaining http requests.
+                        pluginResults = result;
+                        cts.Cancel();
+                    }
                 }
                 tasks.Remove(completedTask);
             }

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -202,18 +202,11 @@ namespace Flow.Launcher
         {
             // we try to enable auto-startup on first launch, or reenable if it was removed
             // but the user still has the setting set
-            if (_settings.StartFlowLauncherOnSystemStartup && !Helper.AutoStartup.IsEnabled)
+            if (_settings.StartFlowLauncherOnSystemStartup)
             {
                 try
                 {
-                    if (_settings.UseLogonTaskForStartup)
-                    {
-                        Helper.AutoStartup.EnableViaLogonTask();
-                    }
-                    else
-                    {
-                        Helper.AutoStartup.EnableViaRegistry();
-                    }
+                    Helper.AutoStartup.CheckIsEnabled(_settings.UseLogonTaskForStartup);
                 }
                 catch (Exception e)
                 {

--- a/Flow.Launcher/Helper/AutoStartup.cs
+++ b/Flow.Launcher/Helper/AutoStartup.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Security.Principal;
 using Flow.Launcher.Infrastructure;
-using Flow.Launcher.Infrastructure.Logger;
 using Microsoft.Win32;
 using Microsoft.Win32.TaskScheduler;
 

--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -5,7 +5,6 @@ using NHotkey;
 using NHotkey.Wpf;
 using Flow.Launcher.ViewModel;
 using ChefKeys;
-using Flow.Launcher.Infrastructure.Logger;
 using CommunityToolkit.Mvvm.DependencyInjection;
 
 namespace Flow.Launcher.Helper;

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneGeneralViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneGeneralViewModel.cs
@@ -48,11 +48,11 @@ public partial class SettingsPaneGeneralViewModel : BaseModel
                 {
                     if (UseLogonTaskForStartup)
                     {
-                        AutoStartup.EnableViaLogonTask();
+                        AutoStartup.ChangeToViaLogonTask();
                     }
                     else
                     {
-                        AutoStartup.EnableViaRegistry();
+                        AutoStartup.ChangeToViaRegistry();
                     }
                 }
                 else


### PR DESCRIPTION
# Fix Possible Window Popup During Startup

If FL enabled both logon task and registry,  `Hide Flow Launcher on startup` will not work since the later one will trigger main window show event. So we need to check both because if both of them are enabled.

Follow on with #3218.

# Fix Store Plugin List Refresh Issue

Use null as flag to return value so that we can handle plugin source issue.

Follow on with #3460.