### PR TITLE
Rename ‘Search Window Position’ to ‘Search Window Location’

### DIFF
--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -58,7 +58,7 @@
     <system:String x:Key="setAutoStartFailed">Error setting launch on startup</system:String>
     <system:String x:Key="hideFlowLauncherWhenLoseFocus">Hide Flow Launcher when focus is lost</system:String>
     <system:String x:Key="dontPromptUpdateMsg">Do not show new version notifications</system:String>
-    <system:String x:Key="SearchWindowPosition">Search Window Position</system:String>
+    <system:String x:Key="SearchWindowPosition">Search Window Location</system:String>
     <system:String x:Key="SearchWindowScreenRememberLastLaunchLocation">Remember Last Position</system:String>
     <system:String x:Key="SearchWindowScreenCursor">Monitor with Mouse Cursor</system:String>
     <system:String x:Key="SearchWindowScreenFocus">Monitor with Focused Window</system:String>

--- a/Flow.Launcher/Resources/Light.xaml
+++ b/Flow.Launcher/Resources/Light.xaml
@@ -22,7 +22,7 @@
 
     <SolidColorBrush x:Key="BasicSystemAccentColor" Color="{m:DynamicColor SystemAccentColor}" />
 
-    <SolidColorBrush x:Key="Color00B" Color="#CEFAFAFA" />
+    <SolidColorBrush x:Key="Color00B" Color="#FAFAFA" />
     <SolidColorBrush x:Key="Color01B" Color="#f3f3f3" />
     <SolidColorBrush x:Key="Color02B" Color="#ffffff" />
     <SolidColorBrush x:Key="Color03B" Color="#e5e5e5" />


### PR DESCRIPTION
## What's the PR
![image](https://github.com/user-attachments/assets/4455cd85-6335-4e4f-bc41-b62c71b1a32d)
- Rename ‘Search Window Position’ to ‘Search Window Location’
- Requested from @deefrawley 
- Only the option title has been changed; all other areas still use “Position.”