### PR TITLE
Remember selected position

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -1125,6 +1125,13 @@ namespace Flow.Launcher
         {
             var textBox = (TextBox)sender;
             _viewModel.QueryText = textBox.Text;
+    
+            // Reset Index when query null
+            if (string.IsNullOrEmpty(textBox.Text))
+            {
+                _viewModel.Results.ResetSelectedIndex();
+            }
+    
             _viewModel.Query(_settings.SearchQueryResultsWithDelay);
         }
 


### PR DESCRIPTION
# Improve SelectedIndex Retention on Query Updates and Context Menu Return

## Summary

This PR improves the behavior of `SelectedIndex` to prevent it from resetting to 0 in the following scenarios:

- When loading occurs during a query search and completes
- When returning from an opened context menu

By avoiding unnecessary index resets, the user experience becomes more consistent and intuitive.

---

## Details

### Main Changes

- **Retain SelectedIndex on context menu return:**  
  Previously, returning from a context menu caused the query to be re-applied, which reset the index to 0.  
  A new logic now updates the `QueryText` without refreshing the result list, preventing index reset in this case.

- **Handle null QueryText:**  
  When `QueryText` becomes `null`, the stored index is now properly cleared.

- **Changed behavior for users with "retain query" mode enabled:**  
  Previously, the index would reset even if the query remained the same.  
  Now, the index is preserved as long as the query is not cleared.  
  This is considered more intuitive, so no setting toggle was added.

---

## Additional Fixes

- **Prevent simultaneous display of context menu and result list during loading:**  
  A bug was discovered where opening the context menu before loading completed could result in both the context menu and results being shown at the same time.  
  The update logic now checks for open context menus and skips result updates if one is active.

---

## Test Cases

- On initial launch, typing a query should place the index at 0.
- There should never be a case where no result is selected (i.e., index must always be valid).
- Opening and closing the context menu should not reset the selection.
- Loading during search should no longer reset the index on completion.

During testing, there were a few instances where no index was selected, so further testing is needed.