### PR TITLE
Fix clock not displaying in certain situations

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -138,8 +138,12 @@ namespace Flow.Launcher
             else
             {
                 _viewModel.Show();
+                if (_settings.UseAnimation)
+                {
+                    WindowAnimation();
+                }
             }
-
+            
             // Show notify icon when flowlauncher is hidden
             InitializeNotifyIcon();
 

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -138,6 +138,9 @@ namespace Flow.Launcher
             else
             {
                 _viewModel.Show();
+                // When HideOnStartup is off and UseAnimation is on,
+                // there was a bug where the clock would not appear at all on the initial launch
+                // So we need to forcibly trigger animation here to ensure the clock visible
                 if (_settings.UseAnimation)
                 {
                     WindowAnimation();

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -889,10 +889,10 @@ namespace Flow.Launcher
                 FillBehavior = FillBehavior.HoldEnd
             };
 
-            Storyboard.SetTargetProperty(ClockOpacity, new PropertyPath(OpacityProperty));
             Storyboard.SetTarget(ClockOpacity, ClockPanel);
+            Storyboard.SetTargetProperty(ClockOpacity, new PropertyPath(OpacityProperty));
 
-            Storyboard.SetTargetName(thicknessAnimation, "ClockPanel");
+            Storyboard.SetTarget(thicknessAnimation, ClockPanel);
             Storyboard.SetTargetProperty(thicknessAnimation, new PropertyPath(MarginProperty));
 
             Storyboard.SetTarget(IconMotion, SearchIcon);

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -140,7 +140,7 @@ namespace Flow.Launcher
                 _viewModel.Show();
                 // When HideOnStartup is off and UseAnimation is on,
                 // there was a bug where the clock would not appear at all on the initial launch
-                // So we need to forcibly trigger animation here to ensure the clock visible
+                // So we need to forcibly trigger animation here to ensure the clock is visible
                 if (_settings.UseAnimation)
                 {
                     WindowAnimation();


### PR DESCRIPTION
### 🛠 Fix clock not displaying on first launch (when animation is enabled)

- When `HideOnStartup = off` and `Animation = on`, there was a bug where the clock would **not appear at all on the initial launch**.
- After the first launch, the clock behaves normally.
- This PR addresses the issue by **forcibly triggering the animation on `OnLoaded`**, ensuring the clock becomes visible on the first load.

### ⚠️ Notes

- Even after this fix, **the animation might appear to be missing** due to rendering timing.  
  If you slow down the animation duration, you’ll notice it’s actually running.
- Adjusting the position of the animation trigger within `OnLoaded` can make the animation look better.  
  However, doing so caused a **slight delay in visibility when animation was disabled**.
- While a more refined fix is possible, it would **increase complexity**.  
  Since the clock **does show up correctly**, and this is the key UX issue, no further changes were made.

### 💡 UX Consideration

- The lack of visible animation on the first load is likely due to **rendering timing** and is not perceived as unnatural by most users.
- If users ask, just say:  
  _"The animation was too fast because your PC is so fast."_ 😄
