### PR TITLE
Fix NumberBox Placeholder text color

### DIFF
--- a/Flow.Launcher/Resources/CustomControlTemplate.xaml
+++ b/Flow.Launcher/Resources/CustomControlTemplate.xaml
@@ -2802,7 +2802,6 @@
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
                             <Setter TargetName="HeaderContentPresenter" Property="Foreground" Value="{DynamicResource TextControlHeaderForegroundDisabled}" />
-                            <Setter Property="Background" Value="{DynamicResource CustomNumberBoxBGDisabled}" />
                             <Setter TargetName="BorderElementInline" Property="Background" Value="{DynamicResource TextControlBackgroundDisabled}" />
                             <Setter TargetName="BorderElement" Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushDisabled}" />
                             <Setter TargetName="BorderElement" Property="BorderThickness" Value="0 0 0 0" />

--- a/Flow.Launcher/Resources/Dark.xaml
+++ b/Flow.Launcher/Resources/Dark.xaml
@@ -107,6 +107,7 @@
     <Color x:Key="NumberBoxColor24">#f5f5f5</Color>
     <Color x:Key="NumberBoxColor25">#464646</Color>
     <Color x:Key="NumberBoxColor26">#ffffff</Color>
+    <SolidColorBrush x:Key="NumberBoxPlaceHolder" Color="#464646" />
     <Color x:Key="HoverStoreGrid">#272727</Color>
 
     <!--  Resources for HotkeyControl  -->


### PR DESCRIPTION
## What's the PR
- Remove background setter for disabled state and add placeholder color for NumberBox

Before
![image](https://github.com/user-attachments/assets/b8d5ec01-f2c0-4b74-8ca4-893ab35f3052)

After
![image](https://github.com/user-attachments/assets/385ede80-f668-48b7-9dcf-d66d018e9831)

### Comment
I clearly remember working on it and even testing it, but in the current dev build, the style is missing in dark mode. I also removed another unused style that wasn’t in the color list at all—though I’m pretty sure I worked on that too. I tried checking if I did it in another PR, but couldn’t find anything. Either aliens have tampered with my memory, or early-onset dementia is setting in. If I end up in a nursing home someday, please consider donating a portion of your funds in my memory.