### PR TITLE
Let more controls follow setting window font & Add Use Logon Task option in welcome page 5

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -215,7 +215,7 @@ namespace Flow.Launcher.Core.Plugin
                             TextWrapping = TextWrapping.WrapWithOverflow
                         };
 
-                        desc.SetResourceReference(TextBlock.StyleProperty, "SettingPanelTextBlockDescriptionStyle"); // for theme change
+                        desc.SetResourceReference(FrameworkElement.StyleProperty, "SettingPanelTextBlockDescriptionStyle"); // for theme change
                     }
 
                     // Add the name and description to the panel
@@ -251,6 +251,8 @@ namespace Flow.Launcher.Core.Plugin
                                 ToolTip = attributes.Description
                             };
 
+                            textBox.SetResourceReference(Control.FontFamilyProperty, "SettingWindowFont"); // for theme change
+
                             textBox.TextChanged += (_, _) =>
                             {
                                 Settings[attributes.Name] = textBox.Text;
@@ -273,12 +275,14 @@ namespace Flow.Launcher.Core.Plugin
                                 ToolTip = attributes.Description
                             };
 
+                            textBox.SetResourceReference(Control.FontFamilyProperty, "SettingWindowFont"); // for theme change
+
                             textBox.TextChanged += (_, _) =>
                             {
                                 Settings[attributes.Name] = textBox.Text;
                             };
 
-                            var Btn = new Button()
+                            var btn = new Button()
                             {
                                 HorizontalAlignment = HorizontalAlignment.Left,
                                 VerticalAlignment = VerticalAlignment.Center,
@@ -286,7 +290,9 @@ namespace Flow.Launcher.Core.Plugin
                                 Content = API.GetTranslation("select")
                             };
 
-                            Btn.Click += (_, _) =>
+                            btn.SetResourceReference(Control.FontFamilyProperty, "SettingWindowFont"); // for theme change
+
+                            btn.Click += (_, _) =>
                             {
                                 using System.Windows.Forms.CommonDialog dialog = type switch
                                 {
@@ -320,7 +326,7 @@ namespace Flow.Launcher.Core.Plugin
 
                             // Create a stack panel to wrap the button and text box
                             stackPanel.Children.Add(textBox);
-                            stackPanel.Children.Add(Btn);
+                            stackPanel.Children.Add(btn);
 
                             contentControl = stackPanel;
 
@@ -339,6 +345,8 @@ namespace Flow.Launcher.Core.Plugin
                                 Text = Settings[attributes.Name] as string ?? string.Empty,
                                 ToolTip = attributes.Description
                             };
+
+                            textBox.SetResourceReference(Control.FontFamilyProperty, "SettingWindowFont"); // for theme change
 
                             textBox.TextChanged += (sender, _) =>
                             {
@@ -362,6 +370,8 @@ namespace Flow.Launcher.Core.Plugin
                                 ToolTip = attributes.Description,
                             };
 
+                            passwordBox.SetResourceReference(Control.FontFamilyProperty, "SettingWindowFont"); // for theme change
+
                             passwordBox.PasswordChanged += (sender, _) =>
                             {
                                 Settings[attributes.Name] = ((PasswordBox)sender).Password;
@@ -382,6 +392,8 @@ namespace Flow.Launcher.Core.Plugin
                                 Margin = SettingPanelItemLeftTopBottomMargin,
                                 ToolTip = attributes.Description
                             };
+
+                            comboBox.SetResourceReference(Control.FontFamilyProperty, "SettingWindowFont"); // for theme change
 
                             comboBox.SelectionChanged += (sender, _) =>
                             {
@@ -408,6 +420,8 @@ namespace Flow.Launcher.Core.Plugin
                                 Content = attributes.Label,
                                 ToolTip = attributes.Description
                             };
+
+                            checkBox.SetResourceReference(Control.FontFamilyProperty, "SettingWindowFont"); // for theme change
 
                             checkBox.Click += (sender, _) =>
                             {
@@ -451,7 +465,7 @@ namespace Flow.Launcher.Core.Plugin
                         {
                             var sep = new Separator();
 
-                            sep.SetResourceReference(Separator.StyleProperty, "SettingPanelSeparatorStyle");
+                            sep.SetResourceReference(FrameworkElement.StyleProperty, "SettingPanelSeparatorStyle");
 
                             contentControl = sep;
 

--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -2,6 +2,7 @@
 using System.Collections.ObjectModel;
 using System.Text.Json.Serialization;
 using System.Windows;
+using System.Windows.Media;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Infrastructure.Logger;
@@ -113,6 +114,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
                 {
                     _settingWindowFont = value;
                     OnPropertyChanged();
+                    Application.Current.Resources["SettingWindowFont"] = new FontFamily(value);
                 }
             }
         }

--- a/Flow.Launcher/ActionKeywords.xaml
+++ b/Flow.Launcher/ActionKeywords.xaml
@@ -5,6 +5,7 @@
     Title="{DynamicResource actionKeywordsTitle}"
     Width="450"
     Background="{DynamicResource PopuBGColor}"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Foreground="{DynamicResource PopupTextColor}"
     Icon="Images\app.png"
     Loaded="ActionKeyword_OnLoaded"
@@ -53,11 +54,11 @@
                         </Button>
                     </Grid>
                 </StackPanel>
-                <StackPanel Margin="26,12,26,0">
-                    <StackPanel Grid.Row="0" Margin="0,0,0,12">
+                <StackPanel Margin="26 12 26 0">
+                    <StackPanel Grid.Row="0" Margin="0 0 0 12">
                         <TextBlock
                             Grid.Column="0"
-                            Margin="0,0,0,0"
+                            Margin="0 0 0 0"
                             FontSize="20"
                             FontWeight="SemiBold"
                             Text="{DynamicResource actionKeywordsTitle}"
@@ -71,7 +72,7 @@
                             TextWrapping="WrapWithOverflow" />
                     </StackPanel>
 
-                    <StackPanel Margin="0,18,0,0" Orientation="Horizontal">
+                    <StackPanel Margin="0 18 0 0" Orientation="Horizontal">
                         <TextBlock
                             Grid.Row="0"
                             Grid.Column="1"
@@ -83,14 +84,14 @@
                             x:Name="tbOldActionKeyword"
                             Grid.Row="0"
                             Grid.Column="1"
-                            Margin="14,10,10,10"
+                            Margin="14 10 10 10"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             FontSize="14"
                             FontWeight="SemiBold"
                             Foreground="{DynamicResource Color05B}" />
                     </StackPanel>
-                    <StackPanel Margin="0,0,0,10" Orientation="Horizontal">
+                    <StackPanel Margin="0 0 0 10" Orientation="Horizontal">
                         <TextBlock
                             Grid.Row="1"
                             Grid.Column="1"
@@ -101,7 +102,7 @@
                         <TextBox
                             x:Name="tbAction"
                             Width="105"
-                            Margin="10,10,15,10"
+                            Margin="10 10 15 10"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center" />
                     </StackPanel>
@@ -112,21 +113,23 @@
             Grid.Row="1"
             Background="{DynamicResource PopupButtonAreaBGColor}"
             BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
-            BorderThickness="0,1,0,0">
+            BorderThickness="0 1 0 0">
             <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                 <Button
                     x:Name="btnCancel"
                     Width="145"
                     Height="30"
-                    Margin="10,0,5,0"
+                    Margin="10 0 5 0"
                     Click="BtnCancel_OnClick"
-                    Content="{DynamicResource cancel}" />
+                    Content="{DynamicResource cancel}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     x:Name="btnDone"
                     Width="145"
                     Height="30"
-                    Margin="5,0,10,0"
+                    Margin="5 0 10 0"
                     Click="btnDone_OnClick"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     Style="{StaticResource AccentButtonStyle}">
                     <TextBlock x:Name="lblAdd" Text="{DynamicResource done}" />
                 </Button>

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -198,6 +198,10 @@ namespace Flow.Launcher
 
 #pragma warning restore VSTHRD100 // Avoid async void methods
 
+        /// <summary>
+        /// check startup only for Release
+        /// </summary>
+        [Conditional("RELEASE")]
         private void AutoStartup()
         {
             // we try to enable auto-startup on first launch, or reenable if it was removed

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Media;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Core;
 using Flow.Launcher.Core.Configuration;
@@ -149,7 +150,7 @@ namespace Flow.Launcher
                 Ioc.Default.GetRequiredService<Portable>().PreStartCleanUpAfterPortabilityUpdate();
 
                 API.LogInfo(ClassName, "Begin Flow Launcher startup ----------------------------------------------------");
-                API.LogInfo(ClassName, "Runtime info:{ErrorReporting.RuntimeInfo()}");
+                API.LogInfo(ClassName, $"Runtime info:{ErrorReporting.RuntimeInfo()}");
 
                 RegisterAppDomainExceptions();
                 RegisterDispatcherUnhandledException();
@@ -169,19 +170,18 @@ namespace Flow.Launcher
                 await PluginManager.InitializePluginsAsync();
 
                 // Change language after all plugins are initialized because we need to update plugin title based on their api
-                // TODO: Clean InternationalizationManager.Instance and InternationalizationManager.Instance.GetTranslation in future
                 await Ioc.Default.GetRequiredService<Internationalization>().InitializeLanguageAsync();
-
                 await imageLoadertask;
 
-                _mainWindow = new MainWindow();
+                // Update dynamic resources base on settings
+                Current.Resources["SettingWindowFont"] = new FontFamily(_settings.SettingWindowFont);
 
-                API.LogInfo(ClassName, "Dependencies Info:{ErrorReporting.DependenciesInfo()}");
+                _mainWindow = new MainWindow();
 
                 Current.MainWindow = _mainWindow;
                 Current.MainWindow.Title = Constant.FlowLauncher;
 
-                // main windows needs initialized before theme change because of blur settings
+                // Main windows needs initialized before theme change because of blur settings
                 Ioc.Default.GetRequiredService<Theme>().ChangeTheme();
 
                 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);

--- a/Flow.Launcher/CustomQueryHotkeySetting.xaml
+++ b/Flow.Launcher/CustomQueryHotkeySetting.xaml
@@ -8,7 +8,7 @@
     Width="530"
     Background="{DynamicResource PopuBGColor}"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
-    FontFamily="{Binding Settings.SettingWindowFont, Mode=TwoWay}"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Foreground="{DynamicResource PopupTextColor}"
     Icon="Images\app.png"
     MouseDown="window_MouseDown"
@@ -120,7 +120,8 @@
                         Grid.Column="1"
                         Margin="10"
                         HorizontalAlignment="Stretch"
-                        VerticalAlignment="Center" />
+                        VerticalAlignment="Center"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
                     <Button
                         x:Name="btnTestActionKeyword"
                         Grid.Row="1"
@@ -128,7 +129,8 @@
                         Margin="0 0 10 0"
                         Padding="10 5 10 5"
                         Click="BtnTestActionKeyword_OnClick"
-                        Content="{DynamicResource preview}" />
+                        Content="{DynamicResource preview}"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
                 </Grid>
             </StackPanel>
         </StackPanel>
@@ -144,12 +146,14 @@
                     MinWidth="140"
                     Margin="10 0 5 0"
                     Click="BtnCancel_OnClick"
-                    Content="{DynamicResource cancel}" />
+                    Content="{DynamicResource cancel}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     x:Name="btnAdd"
                     MinWidth="140"
                     Margin="5 0 10 0"
                     Click="btnAdd_OnClick"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     Style="{StaticResource AccentButtonStyle}">
                     <TextBlock x:Name="lblAdd" Text="{DynamicResource done}" />
                 </Button>

--- a/Flow.Launcher/CustomQueryHotkeySetting.xaml.cs
+++ b/Flow.Launcher/CustomQueryHotkeySetting.xaml.cs
@@ -10,14 +10,14 @@ namespace Flow.Launcher
 {
     public partial class CustomQueryHotkeySetting : Window
     {
-        public Settings Settings { get; }
+        private readonly Settings _settings;
 
         private bool update;
         private CustomPluginHotkey updateCustomHotkey;
 
         public CustomQueryHotkeySetting(Settings settings)
         {
-            Settings = settings;
+            _settings = settings;
             InitializeComponent();
         }
 
@@ -30,13 +30,13 @@ namespace Flow.Launcher
         {
             if (!update)
             {
-                Settings.CustomPluginHotkeys ??= new ObservableCollection<CustomPluginHotkey>();
+                _settings.CustomPluginHotkeys ??= new ObservableCollection<CustomPluginHotkey>();
 
                 var pluginHotkey = new CustomPluginHotkey
                 {
                     Hotkey = HotkeyControl.CurrentHotkey.ToString(), ActionKeyword = tbAction.Text
                 };
-                Settings.CustomPluginHotkeys.Add(pluginHotkey);
+                _settings.CustomPluginHotkeys.Add(pluginHotkey);
 
                 HotKeyMapper.SetCustomQueryHotkey(pluginHotkey);
             }
@@ -55,7 +55,7 @@ namespace Flow.Launcher
 
         public void UpdateItem(CustomPluginHotkey item)
         {
-            updateCustomHotkey = Settings.CustomPluginHotkeys.FirstOrDefault(o =>
+            updateCustomHotkey = _settings.CustomPluginHotkeys.FirstOrDefault(o =>
                 o.ActionKeyword == item.ActionKeyword && o.Hotkey == item.Hotkey);
             if (updateCustomHotkey == null)
             {

--- a/Flow.Launcher/CustomShortcutSetting.xaml
+++ b/Flow.Launcher/CustomShortcutSetting.xaml
@@ -7,7 +7,7 @@
     Width="530"
     Background="{DynamicResource PopuBGColor}"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
-    FontFamily="{Binding Settings.SettingWindowFont, Mode=TwoWay}"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Foreground="{DynamicResource PopupTextColor}"
     Icon="Images\app.png"
     ResizeMode="NoResize"
@@ -109,6 +109,7 @@
                             Width="180"
                             Margin="10"
                             HorizontalAlignment="Left"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             Text="{Binding Key}" />
                         <TextBlock
                             Grid.Row="1"
@@ -129,12 +130,14 @@
                                 Padding="10 5 10 5"
                                 Click="BtnTestShortcut_OnClick"
                                 Content="{DynamicResource preview}"
-                                DockPanel.Dock="Right" />
+                                DockPanel.Dock="Right"
+                                FontFamily="{DynamicResource SettingWindowFont}" />
                             <TextBox
                                 x:Name="tbExpand"
                                 Margin="10 0 10 0"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Center"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 Text="{Binding Value}" />
                         </DockPanel>
                     </Grid>
@@ -153,12 +156,14 @@
                     MinWidth="140"
                     Margin="10 0 5 0"
                     Click="BtnCancel_OnClick"
-                    Content="{DynamicResource cancel}" />
+                    Content="{DynamicResource cancel}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     x:Name="btnAdd"
                     MinWidth="140"
                     Margin="5 0 10 0"
                     Click="BtnAdd_OnClick"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     Style="{StaticResource AccentButtonStyle}">
                     <TextBlock x:Name="lblAdd" Text="{DynamicResource done}" />
                 </Button>

--- a/Flow.Launcher/CustomShortcutSetting.xaml.cs
+++ b/Flow.Launcher/CustomShortcutSetting.xaml.cs
@@ -1,15 +1,11 @@
 ﻿using System.Windows;
 using System.Windows.Input;
-using CommunityToolkit.Mvvm.DependencyInjection;
-using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.SettingPages.ViewModels;
 
 namespace Flow.Launcher
 {
     public partial class CustomShortcutSetting : Window
     {
-        public Settings Settings { get; } = Ioc.Default.GetRequiredService<Settings>();
-
         private readonly SettingsPaneHotkeyViewModel _hotkeyVm;
         public string Key { get; set; } = string.Empty;
         public string Value { get; set; } = string.Empty;

--- a/Flow.Launcher/HotkeyControl.xaml
+++ b/Flow.Launcher/HotkeyControl.xaml
@@ -7,15 +7,15 @@
     mc:Ignorable="d">
     <Button
         Width="Auto"
+        Click="GetNewHotkey"
         FontSize="13"
         FontWeight="Bold"
-        Foreground="{DynamicResource Color01B}"
-        Click="GetNewHotkey">
+        Foreground="{DynamicResource Color01B}">
         <Button.Template>
             <ControlTemplate TargetType="Button">
                 <Border
                     x:Name="ButtonBorder"
-                    Padding="5,0,5,0"
+                    Padding="5 0 5 0"
                     Background="{DynamicResource ButtonBackgroundColor}"
                     BorderBrush="{DynamicResource ButtonInsideBorder}"
                     BorderThickness="1"
@@ -28,26 +28,21 @@
                             <Condition Property="IsMouseOver" Value="True" />
                             <Condition Property="IsPressed" Value="True" />
                         </MultiTrigger.Conditions>
-                        <Setter TargetName="ButtonBorder" Property="Background"
-                                Value="{DynamicResource ButtonMousePressed}" />
-                        <Setter TargetName="ButtonBorder" Property="BorderBrush"
-                                Value="{DynamicResource ButtonMousePressedInsideBorder}" />
+                        <Setter TargetName="ButtonBorder" Property="Background" Value="{DynamicResource ButtonMousePressed}" />
+                        <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="{DynamicResource ButtonMousePressedInsideBorder}" />
                     </MultiTrigger>
                     <MultiTrigger>
                         <MultiTrigger.Conditions>
                             <Condition Property="IsMouseOver" Value="True" />
                         </MultiTrigger.Conditions>
-                        <Setter TargetName="ButtonBorder" Property="Background"
-                                Value="{DynamicResource ButtonMouseOver}" />
+                        <Setter TargetName="ButtonBorder" Property="Background" Value="{DynamicResource ButtonMouseOver}" />
                     </MultiTrigger>
                     <MultiTrigger>
                         <MultiTrigger.Conditions>
                             <Condition Property="IsPressed" Value="True" />
                         </MultiTrigger.Conditions>
-                        <Setter TargetName="ButtonBorder" Property="Background"
-                                Value="{DynamicResource ButtonMousePressed}" />
-                        <Setter TargetName="ButtonBorder" Property="BorderBrush"
-                                Value="{DynamicResource CustomContextHover}" />
+                        <Setter TargetName="ButtonBorder" Property="Background" Value="{DynamicResource ButtonMousePressed}" />
+                        <Setter TargetName="ButtonBorder" Property="BorderBrush" Value="{DynamicResource CustomContextHover}" />
                     </MultiTrigger>
                 </ControlTemplate.Triggers>
             </ControlTemplate>
@@ -62,12 +57,12 @@
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <Border
-                            Margin="2,5,2,5"
-                            Padding="10,5,10,5"
+                            Margin="2 5 2 5"
+                            Padding="10 5 10 5"
                             Background="{DynamicResource AccentButtonBackground}"
                             BorderThickness="1"
                             CornerRadius="5">
-                            <TextBlock Text="{Binding}" />
+                            <TextBlock FontFamily="{DynamicResource SettingWindowFont}" Text="{Binding}" />
                         </Border>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/Flow.Launcher/HotkeyControlDialog.xaml
+++ b/Flow.Launcher/HotkeyControlDialog.xaml
@@ -5,7 +5,7 @@
     xmlns:ui="http://schemas.modernwpf.com/2019"
     Background="{DynamicResource PopuBGColor}"
     BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
-    BorderThickness="0,1,0,0"
+    BorderThickness="0 1 0 0"
     CornerRadius="8"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
     Foreground="{DynamicResource PopupTextColor}"
@@ -24,14 +24,14 @@
         </Grid.RowDefinitions>
 
         <!--  Window title and the keys in the hotkey  -->
-        <Grid Grid.Row="0" Margin="26,12,26,0">
+        <Grid Grid.Row="0" Margin="26 12 26 0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <StackPanel>
                 <TextBlock
-                    Margin="0,0,0,0"
+                    Margin="0 0 0 0"
                     FontSize="20"
                     FontWeight="SemiBold"
                     Text="{Binding WindowTitle}"
@@ -42,8 +42,8 @@
                 Grid.Row="1"
                 Width="450"
                 Height="100"
-                Margin="0,100,0,0"
-                Padding="26,12,26,0">
+                Margin="0 100 0 0"
+                Padding="26 12 26 0">
                 <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                     <ItemsControl ItemsSource="{Binding KeysToDisplay}">
                         <ItemsControl.ItemsPanel>
@@ -56,12 +56,12 @@
                                 <Border
                                     MinWidth="50"
                                     MinHeight="50"
-                                    Margin="5,0,5,0"
+                                    Margin="5 0 5 0"
                                     Padding="8"
                                     Background="{DynamicResource AccentButtonBackground}"
                                     CornerRadius="6">
                                     <TextBlock
-                                        Margin="5,0,5,0"
+                                        Margin="5 0 5 0"
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
                                         FontSize="18"
@@ -82,9 +82,9 @@
             <Border
                 x:Name="Alert"
                 Width="420"
-                Padding="0, 10"
-                VerticalAlignment="Center"
+                Padding="0 10"
                 HorizontalAlignment="Center"
+                VerticalAlignment="Center"
                 Background="{DynamicResource InfoBarWarningBG}"
                 BorderBrush="{DynamicResource InfoBarBD}"
                 BorderThickness="1"
@@ -97,21 +97,21 @@
                     </Grid.ColumnDefinitions>
                     <ui:FontIcon
                         Grid.Column="0"
-                        Margin="20,0,14,0"
+                        Margin="20 0 14 0"
                         VerticalAlignment="Center"
                         FontSize="15"
                         Foreground="{DynamicResource InfoBarWarningIcon}"
                         Glyph="&#xf167;" />
                     <TextBlock
-                        Grid.Column="1"
                         x:Name="tbMsg"
-                        Margin="0,0,0,2"
-                        Padding="0,0,8,0"
+                        Grid.Column="1"
+                        Margin="0 0 0 2"
+                        Padding="0 0 8 0"
                         HorizontalAlignment="Left"
                         FontSize="13"
                         FontWeight="SemiBold"
-                        TextWrapping="Wrap"
-                        Foreground="{DynamicResource Color05B}" />
+                        Foreground="{DynamicResource Color05B}"
+                        TextWrapping="Wrap" />
                 </Grid>
             </Border>
 
@@ -122,7 +122,7 @@
             Grid.Row="2"
             Background="{DynamicResource PopupButtonAreaBGColor}"
             BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
-            BorderThickness="0,1,0,0"
+            BorderThickness="0 1 0 0"
             CornerRadius="0 0 8 8">
             <StackPanel
                 Margin="10"
@@ -132,37 +132,42 @@
                     x:Name="OverwriteBtn"
                     Height="30"
                     MinWidth="100"
-                    Margin="0,0,4,0"
+                    Margin="0 0 4 0"
                     Click="Overwrite"
                     Content="{DynamicResource commonOverwrite}"
-                    Visibility="Collapsed"
-                    Style="{StaticResource AccentButtonStyle}" />
+                    FontFamily="{DynamicResource SettingWindowFont}"
+                    Style="{StaticResource AccentButtonStyle}"
+                    Visibility="Collapsed" />
                 <Button
                     x:Name="SaveBtn"
                     Height="30"
                     MinWidth="100"
-                    Margin="0,0,4,0"
+                    Margin="0 0 4 0"
                     Click="Save"
                     Content="{DynamicResource commonSave}"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     Style="{StaticResource AccentButtonStyle}" />
                 <Button
                     Height="30"
                     MinWidth="100"
-                    Margin="4,0,4,0"
+                    Margin="4 0 4 0"
                     Click="Reset"
-                    Content="{DynamicResource commonReset}" />
+                    Content="{DynamicResource commonReset}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     Height="30"
                     MinWidth="100"
-                    Margin="4,0,4,0"
+                    Margin="4 0 4 0"
                     Click="Delete"
-                    Content="{DynamicResource commonDelete}" />
+                    Content="{DynamicResource commonDelete}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     Height="30"
                     MinWidth="100"
-                    Margin="4,0,0,0"
+                    Margin="4 0 0 0"
                     Click="Cancel"
-                    Content="{DynamicResource commonCancel}" />
+                    Content="{DynamicResource commonCancel}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
             </StackPanel>
         </Border>
     </Grid>

--- a/Flow.Launcher/Resources/Controls/HotkeyDisplay.xaml
+++ b/Flow.Launcher/Resources/Controls/HotkeyDisplay.xaml
@@ -23,12 +23,12 @@
                         <Border.Style>
                             <Style TargetType="{x:Type Border}">
                                 <Setter Property="Background" Value="{DynamicResource Color12B}" />
-                                <Setter Property="Padding" Value="5,0,5,0" />
+                                <Setter Property="Padding" Value="5 0 5 0" />
                                 <Setter Property="BorderThickness" Value="1" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding Type, RelativeSource={RelativeSource AncestorType=local:HotkeyDisplay}}" Value="Small">
                                         <Setter Property="Background" Value="Transparent" />
-                                        <Setter Property="Padding" Value="0,0,0,0" />
+                                        <Setter Property="Padding" Value="0 0 0 0" />
                                         <Setter Property="BorderThickness" Value="0" />
                                     </DataTrigger>
                                 </Style.Triggers>
@@ -51,14 +51,14 @@
                                 <Border.Style>
                                     <Style TargetType="{x:Type Border}">
                                         <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}" />
-                                        <Setter Property="Padding" Value="10,5,10,5" />
-                                        <Setter Property="Margin" Value="2,5,2,5" />
+                                        <Setter Property="Padding" Value="10 5 10 5" />
+                                        <Setter Property="Margin" Value="2 5 2 5" />
                                         <Setter Property="BorderThickness" Value="1" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding Type, RelativeSource={RelativeSource AncestorType=local:HotkeyDisplay}}" Value="Small">
                                                 <Setter Property="Background" Value="{DynamicResource AccentButtonBackground}" />
-                                                <Setter Property="Padding" Value="10,5,10,5" />
-                                                <Setter Property="Margin" Value="2,0,2,0" />
+                                                <Setter Property="Padding" Value="10 5 10 5" />
+                                                <Setter Property="Margin" Value="2 0 2 0" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>

--- a/Flow.Launcher/Resources/Controls/HotkeyDisplay.xaml
+++ b/Flow.Launcher/Resources/Controls/HotkeyDisplay.xaml
@@ -63,7 +63,10 @@
                                         </Style.Triggers>
                                     </Style>
                                 </Border.Style>
-                                <TextBlock Foreground="{DynamicResource AccentButtonForegroundPointerOver}" Text="{Binding}" />
+                                <TextBlock
+                                    FontFamily="{DynamicResource SettingWindowFont}"
+                                    Foreground="{DynamicResource AccentButtonForegroundPointerOver}"
+                                    Text="{Binding}" />
                             </Border>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>

--- a/Flow.Launcher/Resources/Controls/HotkeyDisplay.xaml.cs
+++ b/Flow.Launcher/Resources/Controls/HotkeyDisplay.xaml.cs
@@ -42,11 +42,9 @@ namespace Flow.Launcher.Resources.Controls
 
         private static void keyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            var control = d as UserControl;
-            if (null == control) return; // This should not be possible
+            if (d is not UserControl) return; // This should not be possible
 
-            var newValue = e.NewValue as string;
-            if (null == newValue) return;
+            if (e.NewValue is not string newValue) return;
 
             if (d is not HotkeyDisplay hotkeyDisplay)
                 return;

--- a/Flow.Launcher/Resources/Controls/InstalledPluginDisplayKeyword.xaml
+++ b/Flow.Launcher/Resources/Controls/InstalledPluginDisplayKeyword.xaml
@@ -43,6 +43,7 @@
                 Content="{Binding ActionKeywordsText}"
                 Cursor="Hand"
                 DockPanel.Dock="Right"
+                FontFamily="{DynamicResource SettingWindowFont}"
                 FontWeight="Bold"
                 ToolTip="{DynamicResource actionKeywordsTooltip}" />
         </DockPanel>

--- a/Flow.Launcher/Resources/Pages/WelcomePage1.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage1.xaml
@@ -127,7 +127,7 @@
                             Style="{DynamicResource StyleImageFadeIn}" />
                         <TextBlock
                             Canvas.Left="205"
-                            Margin="12,0,0,0"
+                            Margin="12 0 0 0"
                             VerticalAlignment="Center"
                             FontSize="30"
                             Foreground="White"
@@ -151,30 +151,30 @@
                     Style="{DynamicResource WizardMove}" />
 
 
-                <StackPanel Width="550" Margin="24,20,24,20">
-                    <StackPanel Margin="0,0,24,0">
+                <StackPanel Width="550" Margin="24 20 24 20">
+                    <StackPanel Margin="0 0 24 0">
                         <TextBlock
                             FontSize="20"
                             FontWeight="SemiBold"
                             Text="{DynamicResource Welcome_Page1_Title}" />
                         <TextBlock
-                            Margin="0,10,24,0"
+                            Margin="0 10 24 0"
                             FontSize="14"
                             Text="{DynamicResource Welcome_Page1_Text01}"
                             TextWrapping="WrapWithOverflow" />
                         <TextBlock
-                            Margin="0,10,24,0"
+                            Margin="0 10 24 0"
                             FontSize="14"
                             Text="{DynamicResource Welcome_Page1_Text02}"
                             TextWrapping="WrapWithOverflow" />
                         <TextBlock
-                            Margin="0,30,0,0"
+                            Margin="0 30 0 0"
                             FontSize="14"
                             FontWeight="SemiBold"
                             Text="{DynamicResource language}" />
                         <ComboBox
                             Width="200"
-                            Margin="0,10,0,0"
+                            Margin="0 10 0 0"
                             DisplayMemberPath="Display"
                             ItemsSource="{Binding Languages}"
                             SelectedValue="{Binding CustomLanguage, Mode=TwoWay}"

--- a/Flow.Launcher/Resources/Pages/WelcomePage1.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage1.xaml.cs
@@ -10,17 +10,19 @@ namespace Flow.Launcher.Resources.Pages
     public partial class WelcomePage1
     {
         public Settings Settings { get; private set; }
+        private WelcomeViewModel _viewModel;
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             if (!IsInitialized)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
+                _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
                 InitializeComponent();
             }
             // Sometimes the navigation is not triggered by button click,
             // so we need to reset the page number
-            Ioc.Default.GetRequiredService<WelcomeViewModel>().PageNum = 1;
+            _viewModel.PageNum = 1;
             base.OnNavigatedTo(e);
         }
 

--- a/Flow.Launcher/Resources/Pages/WelcomePage1.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage1.xaml.cs
@@ -1,28 +1,32 @@
 ﻿using System.Collections.Generic;
 using System.Windows.Navigation;
-using Flow.Launcher.Infrastructure.UserSettings;
-using Flow.Launcher.Core.Resource;
 using CommunityToolkit.Mvvm.DependencyInjection;
+using Flow.Launcher.Core.Resource;
+using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.ViewModel;
 
 namespace Flow.Launcher.Resources.Pages
 {
     public partial class WelcomePage1
     {
+        public Settings Settings { get; private set; }
+
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            Settings = Ioc.Default.GetRequiredService<Settings>();
+            if (!IsInitialized)
+            {
+                Settings = Ioc.Default.GetRequiredService<Settings>();
+                InitializeComponent();
+            }
             // Sometimes the navigation is not triggered by button click,
             // so we need to reset the page number
             Ioc.Default.GetRequiredService<WelcomeViewModel>().PageNum = 1;
-            InitializeComponent();
+            base.OnNavigatedTo(e);
         }
 
         private readonly Internationalization _translater = Ioc.Default.GetRequiredService<Internationalization>();
 
         public List<Language> Languages => _translater.LoadAvailableLanguages();
-
-        public Settings Settings { get; set; }
 
         public string CustomLanguage
         {

--- a/Flow.Launcher/Resources/Pages/WelcomePage2.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage2.xaml
@@ -56,7 +56,7 @@
                     Margin="0"
                     Background="{Binding PreviewBackground}">
                     <StackPanel
-                        Margin="0,80,0,0"
+                        Margin="0 80 0 0"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
                         Orientation="Horizontal">
@@ -89,29 +89,29 @@
                 </StackPanel>
             </Border>
 
-            <StackPanel Grid.Row="1" Margin="24,20,24,20">
+            <StackPanel Grid.Row="1" Margin="24 20 24 20">
                 <StackPanel>
                     <TextBlock
                         FontSize="20"
                         FontWeight="SemiBold"
                         Text="{DynamicResource Welcome_Page2_Title}" />
                     <TextBlock
-                        Margin="0,10,0,0"
+                        Margin="0 10 0 0"
                         FontSize="14"
                         Text="{DynamicResource Welcome_Page2_Text01}"
                         TextWrapping="WrapWithOverflow" />
                     <TextBlock
-                        Margin="0,10,0,0"
+                        Margin="0 10 0 0"
                         FontSize="14"
                         Text="{DynamicResource Welcome_Page2_Text02}"
                         TextWrapping="WrapWithOverflow" />
                     <TextBlock
-                        Margin="0,30,0,0"
+                        Margin="0 30 0 0"
                         FontSize="14"
                         FontWeight="SemiBold"
                         Text="{DynamicResource flowlauncherHotkey}" />
                     <flowlauncher:HotkeyControl
-                        Margin="0,8,0,0"
+                        Margin="0 8 0 0"
                         ChangeHotkey="{Binding SetTogglingHotkeyCommand}"
                         DefaultHotkey="Alt+Space"
                         Type="Hotkey"

--- a/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
@@ -1,25 +1,29 @@
-﻿using Flow.Launcher.Helper;
-using Flow.Launcher.Infrastructure.Hotkey;
-using Flow.Launcher.Infrastructure.UserSettings;
+﻿using System.Windows.Media;
 using System.Windows.Navigation;
 using CommunityToolkit.Mvvm.Input;
-using Flow.Launcher.ViewModel;
-using System.Windows.Media;
 using CommunityToolkit.Mvvm.DependencyInjection;
+using Flow.Launcher.Helper;
+using Flow.Launcher.Infrastructure.Hotkey;
+using Flow.Launcher.Infrastructure.UserSettings;
+using Flow.Launcher.ViewModel;
 
 namespace Flow.Launcher.Resources.Pages
 {
     public partial class WelcomePage2
     {
-        public Settings Settings { get; set; }
+        public Settings Settings { get; private set; }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            Settings = Ioc.Default.GetRequiredService<Settings>();
+            if (!IsInitialized)
+            {
+                Settings = Ioc.Default.GetRequiredService<Settings>();
+                InitializeComponent();
+            }
             // Sometimes the navigation is not triggered by button click,
             // so we need to reset the page number
             Ioc.Default.GetRequiredService<WelcomeViewModel>().PageNum = 2;
-            InitializeComponent();
+            base.OnNavigatedTo(e);
         }
 
         [RelayCommand]

--- a/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
@@ -12,17 +12,19 @@ namespace Flow.Launcher.Resources.Pages
     public partial class WelcomePage2
     {
         public Settings Settings { get; private set; }
+        private WelcomeViewModel _viewModel;
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             if (!IsInitialized)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
+                _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
                 InitializeComponent();
             }
             // Sometimes the navigation is not triggered by button click,
             // so we need to reset the page number
-            Ioc.Default.GetRequiredService<WelcomeViewModel>().PageNum = 2;
+            _viewModel.PageNum = 2;
             base.OnNavigatedTo(e);
         }
 

--- a/Flow.Launcher/Resources/Pages/WelcomePage3.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage3.xaml
@@ -13,15 +13,15 @@
     <Page.Resources>
         <Style x:Key="KbdLine" TargetType="Border">
             <Setter Property="CornerRadius" Value="8" />
-            <Setter Property="Margin" Value="0,3,0,3" />
+            <Setter Property="Margin" Value="0 3 0 3" />
             <Setter Property="Background" Value="{DynamicResource Color01B}" />
         </Style>
         <Style x:Key="Kbd" TargetType="Border">
             <Setter Property="CornerRadius" Value="4" />
-            <Setter Property="Padding" Value="12,4,12,4" />
+            <Setter Property="Padding" Value="12 4 12 4" />
             <Setter Property="Background" Value="{DynamicResource Color00B}" />
             <Setter Property="BorderBrush" Value="{DynamicResource Color18B}" />
-            <Setter Property="BorderThickness" Value="1,1,1,2" />
+            <Setter Property="BorderThickness" Value="1 1 1 2" />
         </Style>
         <Style x:Key="KbdText" TargetType="TextBlock">
             <Setter Property="TextAlignment" Value="Center" />
@@ -36,17 +36,17 @@
         </Grid.RowDefinitions>
         <TextBlock
             Grid.Row="0"
-            Margin="24,20,24,14"
+            Margin="24 20 24 14"
             FontSize="20"
             FontWeight="SemiBold"
             Text="{DynamicResource Welcome_Page3_Title}" />
         <ScrollViewer
             Grid.Row="1"
             Height="478"
-            Margin="0,0,0,0"
+            Margin="0 0 0 0"
             HorizontalAlignment="Stretch"
             FontSize="13">
-            <StackPanel Margin="24,0,24,0">
+            <StackPanel Margin="24 0 24 0">
                 <Border
                     BorderBrush="{DynamicResource Color03B}"
                     BorderThickness="0"
@@ -54,7 +54,7 @@
                     <StackPanel>
                         <cc:Card
                             Title="{DynamicResource HotkeyUpDownDesc}"
-                            BorderThickness="0,0,0,0"
+                            BorderThickness="0 0 0 0"
                             Type="Inside">
                             <StackPanel Orientation="Horizontal">
                                 <cc:HotkeyDisplay Keys="←+→" Type="Small" />
@@ -62,7 +62,7 @@
                         </cc:Card>
                         <cc:Card
                             Title="{DynamicResource HotkeyLeftRightDesc}"
-                            BorderThickness="0,0,0,0"
+                            BorderThickness="0 0 0 0"
                             Type="Inside">
                             <StackPanel Orientation="Horizontal">
                                 <cc:HotkeyDisplay Keys="↑+↓" Type="Small" />
@@ -70,7 +70,7 @@
                         </cc:Card>
                         <cc:Card
                             Title="{DynamicResource HotkeyESCDesc}"
-                            BorderThickness="0,0,0,0"
+                            BorderThickness="0 0 0 0"
                             Type="Inside">
                             <StackPanel Orientation="Horizontal">
                                 <cc:HotkeyDisplay Keys="ESC" Type="Small" />
@@ -78,13 +78,13 @@
                         </cc:Card>
                         <cc:Card
                             Title="{DynamicResource HotkeyRunDesc}"
-                            BorderThickness="0,0,0,0"
+                            BorderThickness="0 0 0 0"
                             Type="Inside">
                             <cc:HotkeyDisplay Keys="ENTER" Type="Small" />
                         </cc:Card>
                         <cc:Card
                             Title="{DynamicResource HotkeyShiftEnterDesc}"
-                            BorderThickness="0,0,0,0"
+                            BorderThickness="0 0 0 0"
                             Type="Inside">
                             <StackPanel Orientation="Horizontal">
                                 <cc:HotkeyDisplay Keys="SHIFT+ENTER" Type="Small" />
@@ -92,7 +92,7 @@
                         </cc:Card>
                         <cc:Card
                             Title="{DynamicResource HotkeyCtrlEnterDesc}"
-                            BorderThickness="0,0,0,0"
+                            BorderThickness="0 0 0 0"
                             Type="Inside">
                             <StackPanel Orientation="Horizontal">
                                 <cc:HotkeyDisplay Keys="CTRL+ENTER" Type="Small" />
@@ -100,7 +100,7 @@
                         </cc:Card>
                         <cc:Card
                             Title="{DynamicResource HotkeyCtrlShiftEnterDesc}"
-                            BorderThickness="0,0,0,0"
+                            BorderThickness="0 0 0 0"
                             Type="Inside">
                             <StackPanel Orientation="Horizontal">
                                 <cc:HotkeyDisplay Keys="CTRL+SHIFT+ENTER" Type="Small" />

--- a/Flow.Launcher/Resources/Pages/WelcomePage3.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage3.xaml.cs
@@ -7,15 +7,19 @@ namespace Flow.Launcher.Resources.Pages
 {
     public partial class WelcomePage3
     {
+        public Settings Settings { get; private set; }
+
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            Settings = Ioc.Default.GetRequiredService<Settings>();
+            if (!IsInitialized)
+            {
+                Settings = Ioc.Default.GetRequiredService<Settings>();
+                InitializeComponent();
+            }
             // Sometimes the navigation is not triggered by button click,
             // so we need to reset the page number
             Ioc.Default.GetRequiredService<WelcomeViewModel>().PageNum = 3;
-            InitializeComponent();
+            base.OnNavigatedTo(e);
         }
-
-        public Settings Settings { get; set; }
     }
 }

--- a/Flow.Launcher/Resources/Pages/WelcomePage3.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage3.xaml.cs
@@ -8,17 +8,19 @@ namespace Flow.Launcher.Resources.Pages
     public partial class WelcomePage3
     {
         public Settings Settings { get; private set; }
+        private WelcomeViewModel _viewModel;
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             if (!IsInitialized)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
+                _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
                 InitializeComponent();
             }
             // Sometimes the navigation is not triggered by button click,
             // so we need to reset the page number
-            Ioc.Default.GetRequiredService<WelcomeViewModel>().PageNum = 3;
+            _viewModel.PageNum = 3;
             base.OnNavigatedTo(e);
         }
     }

--- a/Flow.Launcher/Resources/Pages/WelcomePage4.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage4.xaml
@@ -4,8 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Flow.Launcher.Resources.Pages"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="http://schemas.modernwpf.com/2019"
     Title="WelcomePage4"
     d:DesignHeight="450"
     d:DesignWidth="800"
@@ -36,8 +36,8 @@
         </Style>
         <Style x:Key="RecommendQuery" TargetType="Border">
             <Setter Property="CornerRadius" Value="8" />
-            <Setter Property="Padding" Value="20,7,12,7" />
-            <Setter Property="Margin" Value="4,4,4,4" />
+            <Setter Property="Padding" Value="20 7 12 7" />
+            <Setter Property="Margin" Value="4 4 4 4" />
             <Setter Property="Background" Value="{DynamicResource Color01B}" />
         </Style>
         <Style x:Key="QueryText" TargetType="TextBlock">
@@ -50,7 +50,7 @@
             <Setter Property="TextAlignment" Value="Left" />
             <Setter Property="TextAlignment" Value="Left" />
             <Setter Property="FontSize" Value="13" />
-            <Setter Property="Margin" Value="0,4,0,0" />
+            <Setter Property="Margin" Value="0 4 0 0" />
             <Setter Property="Foreground" Value="{DynamicResource Color04B}" />
         </Style>
     </Page.Resources>
@@ -81,26 +81,26 @@
                             Canvas.Left="0"
                             Width="450"
                             Height="280"
-                            Margin="0,0,0,0"
+                            Margin="0 0 0 0"
                             Source="../../images/page_img01.png"
                             Style="{DynamicResource StyleImageFadeIn}" />
                     </Canvas>
                 </StackPanel>
             </Border>
 
-            <StackPanel Grid.Row="1" Margin="24,20,24,20">
+            <StackPanel Grid.Row="1" Margin="24 20 24 20">
                 <StackPanel>
                     <TextBlock
                         FontSize="20"
                         FontWeight="SemiBold"
                         Text="{DynamicResource Welcome_Page4_Title}" />
                     <TextBlock
-                        Margin="0,10,0,10"
+                        Margin="0 10 0 10"
                         FontSize="14"
                         Text="{DynamicResource Welcome_Page4_Text01}"
                         TextWrapping="WrapWithOverflow" />
                     <UniformGrid
-                        Margin="0,14,0,0"
+                        Margin="0 14 0 0"
                         Columns="2"
                         Rows="2">
                         <Border Style="{DynamicResource RecommendQuery}">

--- a/Flow.Launcher/Resources/Pages/WelcomePage4.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage4.xaml.cs
@@ -1,21 +1,25 @@
-﻿using CommunityToolkit.Mvvm.DependencyInjection;
+﻿using System.Windows.Navigation;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.ViewModel;
-using System.Windows.Navigation;
 
 namespace Flow.Launcher.Resources.Pages
 {
     public partial class WelcomePage4
     {
+        public Settings Settings { get; private set; }
+
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            Settings = Ioc.Default.GetRequiredService<Settings>();
+            if (!IsInitialized)
+            {
+                Settings = Ioc.Default.GetRequiredService<Settings>();
+                InitializeComponent();
+            }
             // Sometimes the navigation is not triggered by button click,
             // so we need to reset the page number
             Ioc.Default.GetRequiredService<WelcomeViewModel>().PageNum = 4;
-            InitializeComponent();
+            base.OnNavigatedTo(e);
         }
-
-        public Settings Settings { get; set; }
     }
 }

--- a/Flow.Launcher/Resources/Pages/WelcomePage4.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage4.xaml.cs
@@ -8,17 +8,19 @@ namespace Flow.Launcher.Resources.Pages
     public partial class WelcomePage4
     {
         public Settings Settings { get; private set; }
+        private WelcomeViewModel _viewModel;
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             if (!IsInitialized)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
+                _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
                 InitializeComponent();
             }
             // Sometimes the navigation is not triggered by button click,
             // so we need to reset the page number
-            Ioc.Default.GetRequiredService<WelcomeViewModel>().PageNum = 4;
+            _viewModel.PageNum = 4;
             base.OnNavigatedTo(e);
         }
     }

--- a/Flow.Launcher/Resources/Pages/WelcomePage5.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage5.xaml
@@ -80,51 +80,43 @@
             </Border>
 
             <StackPanel Grid.Row="1" Margin="24 20 24 20">
-                <StackPanel>
-                    <TextBlock
-                        FontSize="20"
-                        FontWeight="SemiBold"
-                        Text="{DynamicResource Welcome_Page5_Title}" />
-                    <TextBlock
-                        Margin="0 10 0 0"
-                        FontSize="14"
-                        Text="{DynamicResource Welcome_Page5_Text01}"
-                        TextWrapping="WrapWithOverflow" />
-                    <StackPanel Margin="0 30 0 0" Orientation="Horizontal">
-                        <CheckBox
-                            Checked="OnAutoStartupChecked"
-                            Content="{DynamicResource startFlowLauncherOnSystemStartup}"
-                            IsChecked="{Binding Settings.StartFlowLauncherOnSystemStartup}"
-                            Style="{DynamicResource DefaultCheckBoxStyle}"
-                            Unchecked="OnAutoStartupUncheck" />
-                    </StackPanel>
-                    <StackPanel Margin="0 30 0 0" Orientation="Horizontal">
-                        <CheckBox
-                            Checked="OnUseLogonTaskChecked"
-                            Content="{DynamicResource useLogonTaskForStartup}"
-                            IsChecked="{Binding Settings.UseLogonTaskForStartup}"
-                            Style="{DynamicResource DefaultCheckBoxStyle}"
-                            ToolTip="{DynamicResource useLogonTaskForStartupTooltip}"
-                            Unchecked="OnUseLogonTaskUncheck" />
-                    </StackPanel>
-                    <StackPanel Margin="0 0 0 0" Orientation="Horizontal">
-                        <CheckBox
-                            Checked="OnHideOnStartupChecked"
-                            Content="{DynamicResource hideOnStartup}"
-                            IsChecked="{Binding Settings.HideOnStartup}"
-                            Style="{DynamicResource DefaultCheckBoxStyle}"
-                            Unchecked="OnHideOnStartupUnchecked" />
-                    </StackPanel>
-                    <Button
-                        Width="150"
-                        Height="40"
-                        Margin="0 60 0 0"
-                        HorizontalAlignment="Right"
-                        Click="BtnCancel_OnClick"
-                        Content="{DynamicResource done}"
-                        Style="{DynamicResource AccentButtonStyle}" />
-                </StackPanel>
-
+                <TextBlock
+                    FontSize="20"
+                    FontWeight="SemiBold"
+                    Text="{DynamicResource Welcome_Page5_Title}" />
+                <TextBlock
+                    Margin="0 10 0 0"
+                    FontSize="14"
+                    Text="{DynamicResource Welcome_Page5_Text01}"
+                    TextWrapping="WrapWithOverflow" />
+                <CheckBox
+                    Margin="0 30 0 0"
+                    Checked="OnAutoStartupChecked"
+                    Content="{DynamicResource startFlowLauncherOnSystemStartup}"
+                    IsChecked="{Binding Settings.StartFlowLauncherOnSystemStartup}"
+                    Style="{DynamicResource DefaultCheckBoxStyle}"
+                    Unchecked="OnAutoStartupUncheck" />
+                <CheckBox
+                    Checked="OnUseLogonTaskChecked"
+                    Content="{DynamicResource useLogonTaskForStartup}"
+                    IsChecked="{Binding Settings.UseLogonTaskForStartup}"
+                    Style="{DynamicResource DefaultCheckBoxStyle}"
+                    ToolTip="{DynamicResource useLogonTaskForStartupTooltip}"
+                    Unchecked="OnUseLogonTaskUncheck" />
+                <CheckBox
+                    Checked="OnHideOnStartupChecked"
+                    Content="{DynamicResource hideOnStartup}"
+                    IsChecked="{Binding Settings.HideOnStartup}"
+                    Style="{DynamicResource DefaultCheckBoxStyle}"
+                    Unchecked="OnHideOnStartupUnchecked" />
+                <Button
+                    Width="150"
+                    Height="40"
+                    Margin="0 30 0 0"
+                    HorizontalAlignment="Right"
+                    Click="BtnCancel_OnClick"
+                    Content="{DynamicResource done}"
+                    Style="{DynamicResource AccentButtonStyle}" />
             </StackPanel>
         </Grid>
     </ScrollViewer>

--- a/Flow.Launcher/Resources/Pages/WelcomePage5.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage5.xaml
@@ -79,18 +79,18 @@
                 </StackPanel>
             </Border>
 
-            <StackPanel Grid.Row="1" Margin="24,20,24,20">
+            <StackPanel Grid.Row="1" Margin="24 20 24 20">
                 <StackPanel>
                     <TextBlock
                         FontSize="20"
                         FontWeight="SemiBold"
                         Text="{DynamicResource Welcome_Page5_Title}" />
                     <TextBlock
-                        Margin="0,10,0,0"
+                        Margin="0 10 0 0"
                         FontSize="14"
                         Text="{DynamicResource Welcome_Page5_Text01}"
                         TextWrapping="WrapWithOverflow" />
-                    <StackPanel Margin="0,30,0,0" Orientation="Horizontal">
+                    <StackPanel Margin="0 30 0 0" Orientation="Horizontal">
                         <CheckBox
                             Checked="OnAutoStartupChecked"
                             Content="{DynamicResource startFlowLauncherOnSystemStartup}"
@@ -98,7 +98,7 @@
                             Style="{DynamicResource DefaultCheckBoxStyle}"
                             Unchecked="OnAutoStartupUncheck" />
                     </StackPanel>
-                    <StackPanel Margin="0,0,0,0" Orientation="Horizontal">
+                    <StackPanel Margin="0 0 0 0" Orientation="Horizontal">
                         <CheckBox
                             Checked="OnHideOnStartupChecked"
                             Content="{DynamicResource hideOnStartup}"
@@ -109,7 +109,7 @@
                     <Button
                         Width="150"
                         Height="40"
-                        Margin="0,60,0,0"
+                        Margin="0 60 0 0"
                         HorizontalAlignment="Right"
                         Click="BtnCancel_OnClick"
                         Content="{DynamicResource done}"

--- a/Flow.Launcher/Resources/Pages/WelcomePage5.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage5.xaml
@@ -98,6 +98,15 @@
                             Style="{DynamicResource DefaultCheckBoxStyle}"
                             Unchecked="OnAutoStartupUncheck" />
                     </StackPanel>
+                    <StackPanel Margin="0 30 0 0" Orientation="Horizontal">
+                        <CheckBox
+                            Checked="OnUseLogonTaskChecked"
+                            Content="{DynamicResource useLogonTaskForStartup}"
+                            IsChecked="{Binding Settings.UseLogonTaskForStartup}"
+                            Style="{DynamicResource DefaultCheckBoxStyle}"
+                            ToolTip="{DynamicResource useLogonTaskForStartupTooltip}"
+                            Unchecked="OnUseLogonTaskUncheck" />
+                    </StackPanel>
                     <StackPanel Margin="0 0 0 0" Orientation="Horizontal">
                         <CheckBox
                             Checked="OnHideOnStartupChecked"

--- a/Flow.Launcher/Resources/Pages/WelcomePage5.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage5.xaml.cs
@@ -1,26 +1,31 @@
 ﻿using System.Windows;
 using System.Windows.Navigation;
-using Flow.Launcher.Infrastructure.UserSettings;
-using Microsoft.Win32;
-using Flow.Launcher.Infrastructure;
 using CommunityToolkit.Mvvm.DependencyInjection;
+using Flow.Launcher.Infrastructure;
+using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.ViewModel;
+using Microsoft.Win32;
 
 namespace Flow.Launcher.Resources.Pages
 {
     public partial class WelcomePage5
     {
+        public Settings Settings { get; private set; }
+
         private const string StartupPath = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run";
-        public Settings Settings { get; set; }
         public bool HideOnStartup { get; set; }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            Settings = Ioc.Default.GetRequiredService<Settings>();
+            if (!IsInitialized)
+            {
+                Settings = Ioc.Default.GetRequiredService<Settings>();
+                InitializeComponent();
+            }
             // Sometimes the navigation is not triggered by button click,
             // so we need to reset the page number
             Ioc.Default.GetRequiredService<WelcomeViewModel>().PageNum = 5;
-            InitializeComponent();
+            base.OnNavigatedTo(e);
         }
 
         private void OnAutoStartupChecked(object sender, RoutedEventArgs e)
@@ -59,6 +64,5 @@ namespace Flow.Launcher.Resources.Pages
             var window = Window.GetWindow(this);
             window.Close();
         }
-
     }
 }

--- a/Flow.Launcher/Resources/SettingWindowStyle.xaml
+++ b/Flow.Launcher/Resources/SettingWindowStyle.xaml
@@ -8,6 +8,9 @@
     <converters:TextConverter x:Key="TextConverter" />
     <core:TranslationConverter x:Key="TranslationConverter" />
 
+    <!--  Setting Window Font  -->
+    <FontFamily x:Key="SettingWindowFont">Segoe UI</FontFamily>
+
     <!--  Icon for Theme Type Label  -->
     <Geometry x:Key="circle_half_stroke_solid">F1 M512,512z M0,0z M448,256C448,150,362,64,256,64L256,448C362,448,448,362,448,256z M0,256A256,256,0,1,1,512,256A256,256,0,1,1,0,256z</Geometry>
     <Style x:Key="StoreItemFocusVisualStyleKey">
@@ -371,10 +374,14 @@
                             <Grid Margin="20 0 0 0">
                                 <StackPanel>
                                     <TextBlock
-                                        Margin="0 20 0 4"
+                                        Margin="0 20 0 0"
+                                        FontFamily="{DynamicResource SettingWindowFont}"
                                         FontWeight="Bold"
                                         Text="{DynamicResource searchplugin_Noresult_Title}" />
-                                    <TextBlock Text="{DynamicResource searchplugin_Noresult_Subtitle}" />
+                                    <TextBlock
+                                        Margin="0 4 0 0"
+                                        FontFamily="{DynamicResource SettingWindowFont}"
+                                        Text="{DynamicResource searchplugin_Noresult_Subtitle}" />
                                 </StackPanel>
                             </Grid>
                         </ControlTemplate>

--- a/Flow.Launcher/SelectBrowserWindow.xaml
+++ b/Flow.Launcher/SelectBrowserWindow.xaml
@@ -10,7 +10,7 @@
     Width="550"
     Background="{DynamicResource PopuBGColor}"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
-    FontFamily="{Binding Settings.SettingWindowFont, Mode=TwoWay}"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Foreground="{DynamicResource PopupTextColor}"
     ResizeMode="NoResize"
     SizeToContent="Height"
@@ -88,6 +88,7 @@
                         Margin="14 0 0 0"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         ItemsSource="{Binding CustomBrowsers}"
                         SelectedIndex="{Binding SelectedCustomBrowserIndex}">
                         <ComboBox.ItemTemplate>
@@ -99,11 +100,13 @@
                     <Button
                         Margin="10 0 0 0"
                         Click="btnAdd_Click"
-                        Content="{DynamicResource add}" />
+                        Content="{DynamicResource add}"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
                     <Button
                         Margin="10 0 0 0"
                         Click="btnDelete_Click"
                         Content="{DynamicResource delete}"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsEnabled="{Binding CustomBrowser.Editable}" />
 
                 </StackPanel>
@@ -143,6 +146,7 @@
                             Margin="10 5 0 0"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Center"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             IsEnabled="{Binding Editable}"
                             Text="{Binding Name}" />
                         <TextBlock
@@ -168,6 +172,9 @@
                                 DockPanel.Dock="Right">
                                 <Button.Style>
                                     <Style BasedOn="{StaticResource DefaultButtonStyle}" TargetType="{x:Type Button}">
+                                        <Style.Setters>
+                                            <Setter Property="FontFamily" Value="{DynamicResource SettingWindowFont}" />
+                                        </Style.Setters>
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding ElementName=PathTextBox, UpdateSourceTrigger=PropertyChanged, Path=IsEnabled}" Value="False">
                                                 <Setter Property="IsEnabled" Value="False" />
@@ -181,6 +188,7 @@
                                 Margin="10 10 5 0"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Center"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsEnabled="{Binding Editable}"
                                 Text="{Binding Path}" />
                         </DockPanel>
@@ -192,8 +200,14 @@
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             Orientation="Horizontal">
-                            <RadioButton Content="{DynamicResource defaultBrowser_newTab}" IsChecked="{Binding OpenInTab}" />
-                            <RadioButton Content="{DynamicResource defaultBrowser_newWindow}" IsChecked="{Binding OpenInNewWindow, Mode=OneTime}" />
+                            <RadioButton
+                                Content="{DynamicResource defaultBrowser_newTab}"
+                                FontFamily="{DynamicResource SettingWindowFont}"
+                                IsChecked="{Binding OpenInTab}" />
+                            <RadioButton
+                                Content="{DynamicResource defaultBrowser_newWindow}"
+                                FontFamily="{DynamicResource SettingWindowFont}"
+                                IsChecked="{Binding OpenInNewWindow, Mode=OneTime}" />
                         </StackPanel>
                         <TextBlock
                             Grid.Row="3"
@@ -214,6 +228,7 @@
                                 x:Name="fileArgTextBox"
                                 Width="180"
                                 Margin="10 0 0 0"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 Text="{Binding PrivateArg}" />
                             <CheckBox
                                 Margin="12 0 0 0"
@@ -245,13 +260,15 @@
                     Width="145"
                     Margin="0 0 5 0"
                     Click="btnCancel_Click"
-                    Content="{DynamicResource cancel}" />
+                    Content="{DynamicResource cancel}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     x:Name="btnDone"
                     Width="145"
                     Margin="5 0 0 0"
                     Click="btnDone_Click"
                     Content="{DynamicResource done}"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     ForceCursor="True"
                     Style="{DynamicResource AccentButtonStyle}" />
             </StackPanel>

--- a/Flow.Launcher/SelectBrowserWindow.xaml.cs
+++ b/Flow.Launcher/SelectBrowserWindow.xaml.cs
@@ -10,7 +10,7 @@ namespace Flow.Launcher
     [INotifyPropertyChanged]
     public partial class SelectBrowserWindow : Window
     {
-        public Settings Settings { get; }
+        private readonly Settings _settings;
 
         private int selectedCustomBrowserIndex;
 
@@ -27,9 +27,9 @@ namespace Flow.Launcher
         public CustomBrowserViewModel CustomBrowser => CustomBrowsers[SelectedCustomBrowserIndex];
         public SelectBrowserWindow(Settings settings)
         {
-            Settings = settings;
-            CustomBrowsers = new ObservableCollection<CustomBrowserViewModel>(Settings.CustomBrowserList.Select(x => x.Copy()));
-            SelectedCustomBrowserIndex = Settings.CustomBrowserIndex;
+            _settings = settings;
+            CustomBrowsers = new ObservableCollection<CustomBrowserViewModel>(_settings.CustomBrowserList.Select(x => x.Copy()));
+            SelectedCustomBrowserIndex = _settings.CustomBrowserIndex;
             InitializeComponent();
         }
 
@@ -40,8 +40,8 @@ namespace Flow.Launcher
 
         private void btnDone_Click(object sender, RoutedEventArgs e)
         {
-            Settings.CustomBrowserList = CustomBrowsers.ToList();
-            Settings.CustomBrowserIndex = SelectedCustomBrowserIndex;
+            _settings.CustomBrowserList = CustomBrowsers.ToList();
+            _settings.CustomBrowserIndex = SelectedCustomBrowserIndex;
             Close();
         }
 

--- a/Flow.Launcher/SelectFileManagerWindow.xaml
+++ b/Flow.Launcher/SelectFileManagerWindow.xaml
@@ -10,7 +10,7 @@
     Width="600"
     Background="{DynamicResource PopuBGColor}"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
-    FontFamily="{Binding Settings.SettingWindowFont, Mode=TwoWay}"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Foreground="{DynamicResource PopupTextColor}"
     ResizeMode="NoResize"
     SizeToContent="Height"
@@ -90,6 +90,7 @@
                             Margin="14 0 0 0"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             ItemsSource="{Binding CustomExplorers}"
                             SelectedIndex="{Binding SelectedCustomExplorerIndex}">
                             <ComboBox.ItemTemplate>
@@ -101,11 +102,13 @@
                         <Button
                             Margin="10 0 0 0"
                             Click="btnAdd_Click"
-                            Content="{DynamicResource add}" />
+                            Content="{DynamicResource add}"
+                            FontFamily="{DynamicResource SettingWindowFont}" />
                         <Button
                             Margin="10 0 0 0"
                             Click="btnDelete_Click"
                             Content="{DynamicResource delete}"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             IsEnabled="{Binding CustomExplorer.Editable}" />
 
                     </StackPanel>
@@ -145,6 +148,7 @@
                                 Margin="10 5 15 0"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Center"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsEnabled="{Binding Editable}"
                                 Text="{Binding Name}" />
                             <TextBlock
@@ -166,6 +170,9 @@
                                     DockPanel.Dock="Right">
                                     <Button.Style>
                                         <Style BasedOn="{StaticResource DefaultButtonStyle}" TargetType="{x:Type Button}">
+                                            <Style.Setters>
+                                                <Setter Property="FontFamily" Value="{DynamicResource SettingWindowFont}" />
+                                            </Style.Setters>
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding ElementName=ProfileTextBox, UpdateSourceTrigger=PropertyChanged, Path=IsEnabled}" Value="False">
                                                     <Setter Property="IsEnabled" Value="False" />
@@ -179,6 +186,7 @@
                                     Margin="10 10 10 0"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Center"
+                                    FontFamily="{DynamicResource SettingWindowFont}"
                                     IsEnabled="{Binding Editable}"
                                     Text="{Binding Path}" />
                             </DockPanel>
@@ -199,6 +207,7 @@
                                 Margin="10 10 15 0"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Center"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsEnabled="{Binding Editable}"
                                 Text="{Binding DirectoryArgument}" />
                             <TextBlock
@@ -218,6 +227,7 @@
                                 Margin="10 10 15 20"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Center"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsEnabled="{Binding Editable}"
                                 Text="{Binding FileArgument}" />
                         </Grid>
@@ -237,7 +247,8 @@
                     Width="145"
                     Margin="0 0 5 0"
                     Click="btnCancel_Click"
-                    Content="{DynamicResource cancel}" />
+                    Content="{DynamicResource cancel}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     x:Name="btnDone"
                     Width="145"
@@ -247,6 +258,9 @@
                     ForceCursor="True">
                     <Button.Style>
                         <Style BasedOn="{StaticResource AccentButtonStyle}" TargetType="{x:Type Button}">
+                            <Style.Setters>
+                                <Setter Property="FontFamily" Value="{DynamicResource SettingWindowFont}" />
+                            </Style.Setters>
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding Text.Length, ElementName=ProfileTextBox, UpdateSourceTrigger=PropertyChanged}" Value="0">
                                     <Setter Property="IsEnabled" Value="False" />

--- a/Flow.Launcher/SelectFileManagerWindow.xaml.cs
+++ b/Flow.Launcher/SelectFileManagerWindow.xaml.cs
@@ -12,7 +12,7 @@ namespace Flow.Launcher
     [INotifyPropertyChanged]
     public partial class SelectFileManagerWindow : Window
     {
-        public Settings Settings { get; }
+        private readonly Settings _settings;
 
         private int selectedCustomExplorerIndex;
 
@@ -29,9 +29,9 @@ namespace Flow.Launcher
         public CustomExplorerViewModel CustomExplorer => CustomExplorers[SelectedCustomExplorerIndex];
         public SelectFileManagerWindow(Settings settings)
         {
-            Settings = settings;
-            CustomExplorers = new ObservableCollection<CustomExplorerViewModel>(Settings.CustomExplorerList.Select(x => x.Copy()));
-            SelectedCustomExplorerIndex = Settings.CustomExplorerIndex;
+            _settings = settings;
+            CustomExplorers = new ObservableCollection<CustomExplorerViewModel>(_settings.CustomExplorerList.Select(x => x.Copy()));
+            SelectedCustomExplorerIndex = _settings.CustomExplorerIndex;
             InitializeComponent();
         }
 
@@ -42,8 +42,8 @@ namespace Flow.Launcher
 
         private void btnDone_Click(object sender, RoutedEventArgs e)
         {
-            Settings.CustomExplorerList = CustomExplorers.ToList();
-            Settings.CustomExplorerIndex = SelectedCustomExplorerIndex;
+            _settings.CustomExplorerList = CustomExplorers.ToList();
+            _settings.CustomExplorerIndex = SelectedCustomExplorerIndex;
             Close();
         }
 

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneGeneralViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneGeneralViewModel.cs
@@ -79,7 +79,7 @@ public partial class SettingsPaneGeneralViewModel : BaseModel
             {
                 try
                 {
-                    if (UseLogonTaskForStartup)
+                    if (value)
                     {
                         AutoStartup.ChangeToViaLogonTask();
                     }

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneGeneralViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneGeneralViewModel.cs
@@ -17,6 +17,7 @@ namespace Flow.Launcher.SettingPages.ViewModels;
 public partial class SettingsPaneGeneralViewModel : BaseModel
 {
     public Settings Settings { get; }
+
     private readonly Updater _updater;
     private readonly IPortable _portable;
     private readonly Internationalization _translater;

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
-using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.ViewModel;
 

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneProxyViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneProxyViewModel.cs
@@ -1,4 +1,6 @@
 ﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using Flow.Launcher.Core;
 using Flow.Launcher.Infrastructure.UserSettings;
@@ -19,39 +21,32 @@ public partial class SettingsPaneProxyViewModel : BaseModel
     }
 
     [RelayCommand]
-    private void OnTestProxyClicked()
+    private async Task OnTestProxyClickedAsync()
     {
-        var message = TestProxy();
+        var message = await TestProxyAsync();
         App.API.ShowMsgBox(App.API.GetTranslation(message));
     }
 
-    private string TestProxy()
+    private async Task<string> TestProxyAsync()
     {
         if (string.IsNullOrEmpty(Settings.Proxy.Server)) return "serverCantBeEmpty";
         if (Settings.Proxy.Port <= 0) return "portCantBeEmpty";
 
-        HttpWebRequest request = (HttpWebRequest)WebRequest.Create(_updater.GitHubRepository);
+        var handler = new HttpClientHandler
+        {
+            Proxy = new WebProxy(Settings.Proxy.Server, Settings.Proxy.Port)
+        };
 
-        if (string.IsNullOrEmpty(Settings.Proxy.UserName) || string.IsNullOrEmpty(Settings.Proxy.Password))
+        if (!string.IsNullOrEmpty(Settings.Proxy.UserName) && !string.IsNullOrEmpty(Settings.Proxy.Password))
         {
-            request.Proxy = new WebProxy(Settings.Proxy.Server, Settings.Proxy.Port);
-        }
-        else
-        {
-            request.Proxy = new WebProxy(Settings.Proxy.Server, Settings.Proxy.Port)
-            {
-                Credentials = new NetworkCredential(Settings.Proxy.UserName, Settings.Proxy.Password)
-            };
+            handler.Proxy.Credentials = new NetworkCredential(Settings.Proxy.UserName, Settings.Proxy.Password);
         }
 
+        using var client = new HttpClient(handler);
         try
         {
-            var response = (HttpWebResponse)request.GetResponse();
-            return response.StatusCode switch
-            {
-                HttpStatusCode.OK => "proxyIsCorrect",
-                _ => "proxyConnectFailed"
-            };
+            var response = await client.GetAsync(_updater.GitHubRepository);
+            return response.IsSuccessStatusCode ? "proxyIsCorrect" : "proxyConnectFailed";
         }
         catch
         {

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneProxyViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneProxyViewModel.cs
@@ -8,13 +8,14 @@ namespace Flow.Launcher.SettingPages.ViewModels;
 
 public partial class SettingsPaneProxyViewModel : BaseModel
 {
-    private readonly Updater _updater;
     public Settings Settings { get; }
+
+    private readonly Updater _updater;
 
     public SettingsPaneProxyViewModel(Settings settings, Updater updater)
     {
-        _updater = updater;
         Settings = settings;
+        _updater = updater;
     }
 
     [RelayCommand]

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
@@ -22,10 +22,11 @@ namespace Flow.Launcher.SettingPages.ViewModels;
 
 public partial class SettingsPaneThemeViewModel : BaseModel
 {
+    public Settings Settings { get; }
+    private readonly Theme _theme;
+
     private readonly string DefaultFont = Win32Helper.GetSystemDefaultFont();
     public string BackdropSubText => !Win32Helper.IsBackdropSupported() ? App.API.GetTranslation("BackdropTypeDisabledToolTip") : ""; 
-    public Settings Settings { get; }
-    private readonly Theme _theme = Ioc.Default.GetRequiredService<Theme>();
 
     public static string LinkHowToCreateTheme => @"https://www.flowlauncher.com/theme-builder/";
     public static string LinkThemeGallery => "https://github.com/Flow-Launcher/Flow.Launcher/discussions/1438";
@@ -289,59 +290,14 @@ public partial class SettingsPaneThemeViewModel : BaseModel
         set => Settings.UseDate = value;
     }
 
+    public FontFamily ClockPanelFont { get; }
+
     public Brush PreviewBackground
     {
         get => WallpaperPathRetrieval.GetWallpaperBrush();
     }
 
-    public ResultsViewModel PreviewResults
-    {
-        get
-        {
-            var results = new List<Result>
-            {
-                new()
-                {
-                    Title = App.API.GetTranslation("SampleTitleExplorer"),
-                    SubTitle = App.API.GetTranslation("SampleSubTitleExplorer"),
-                    IcoPath = Path.Combine(
-                        Constant.ProgramDirectory,
-                        @"Plugins\Flow.Launcher.Plugin.Explorer\Images\explorer.png"
-                    )
-                },
-                new()
-                {
-                    Title = App.API.GetTranslation("SampleTitleWebSearch"),
-                    SubTitle = App.API.GetTranslation("SampleSubTitleWebSearch"),
-                    IcoPath = Path.Combine(
-                        Constant.ProgramDirectory,
-                        @"Plugins\Flow.Launcher.Plugin.WebSearch\Images\web_search.png"
-                    )
-                },
-                new()
-                {
-                    Title = App.API.GetTranslation("SampleTitleProgram"),
-                    SubTitle = App.API.GetTranslation("SampleSubTitleProgram"),
-                    IcoPath = Path.Combine(
-                        Constant.ProgramDirectory,
-                        @"Plugins\Flow.Launcher.Plugin.Program\Images\program.png"
-                    )
-                },
-                new()
-                {
-                    Title = App.API.GetTranslation("SampleTitleProcessKiller"),
-                    SubTitle = App.API.GetTranslation("SampleSubTitleProcessKiller"),
-                    IcoPath = Path.Combine(
-                        Constant.ProgramDirectory,
-                        @"Plugins\Flow.Launcher.Plugin.ProcessKiller\Images\app.png"
-                    )
-                }
-            };
-            var vm = new ResultsViewModel(Settings);
-            vm.AddResults(results, "PREVIEW");
-            return vm;
-        }
-    }
+    public ResultsViewModel PreviewResults { get; }
 
     public FontFamily SelectedQueryBoxFont
     {
@@ -482,6 +438,50 @@ public partial class SettingsPaneThemeViewModel : BaseModel
     public SettingsPaneThemeViewModel(Settings settings)
     {
         Settings = settings;
+        _theme = Ioc.Default.GetRequiredService<Theme>();
+        ClockPanelFont = new FontFamily(DefaultFont);
+        var results = new List<Result>
+            {
+                new()
+                {
+                    Title = App.API.GetTranslation("SampleTitleExplorer"),
+                    SubTitle = App.API.GetTranslation("SampleSubTitleExplorer"),
+                    IcoPath = Path.Combine(
+                        Constant.ProgramDirectory,
+                        @"Plugins\Flow.Launcher.Plugin.Explorer\Images\explorer.png"
+                    )
+                },
+                new()
+                {
+                    Title = App.API.GetTranslation("SampleTitleWebSearch"),
+                    SubTitle = App.API.GetTranslation("SampleSubTitleWebSearch"),
+                    IcoPath = Path.Combine(
+                        Constant.ProgramDirectory,
+                        @"Plugins\Flow.Launcher.Plugin.WebSearch\Images\web_search.png"
+                    )
+                },
+                new()
+                {
+                    Title = App.API.GetTranslation("SampleTitleProgram"),
+                    SubTitle = App.API.GetTranslation("SampleSubTitleProgram"),
+                    IcoPath = Path.Combine(
+                        Constant.ProgramDirectory,
+                        @"Plugins\Flow.Launcher.Plugin.Program\Images\program.png"
+                    )
+                },
+                new()
+                {
+                    Title = App.API.GetTranslation("SampleTitleProcessKiller"),
+                    SubTitle = App.API.GetTranslation("SampleSubTitleProcessKiller"),
+                    IcoPath = Path.Combine(
+                        Constant.ProgramDirectory,
+                        @"Plugins\Flow.Launcher.Plugin.ProcessKiller\Images\app.png"
+                    )
+                }
+            };
+        var vm = new ResultsViewModel(Settings);
+        vm.AddResults(results, "PREVIEW");
+        PreviewResults = vm;
     }
 
     [RelayCommand]

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -39,8 +39,12 @@
                     <Button
                         Margin="0 0 10 0"
                         Command="{Binding UpdateAppCommand}"
-                        Content="{DynamicResource checkUpdates}" />
-                    <Button Padding="0" Style="{StaticResource AccentButtonStyle}">
+                        Content="{DynamicResource checkUpdates}"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
+                    <Button
+                        Padding="0"
+                        FontFamily="{DynamicResource SettingWindowFont}"
+                        Style="{StaticResource AccentButtonStyle}">
                         <Hyperlink
                             NavigateUri="{Binding SponsorPage}"
                             RequestNavigate="OnRequestNavigate"
@@ -58,14 +62,16 @@
                 <cc:HyperLink Text="{DynamicResource releaseNotes}" Uri="{Binding ReleaseNotes}" />
             </cc:Card>
 
-
             <cc:Card
                 Title="{DynamicResource userdatapath}"
                 Margin="0 14 0 0"
                 Icon="&#xEC25;;"
                 Sub="{DynamicResource userdatapathToolTip}">
                 <StackPanel Orientation="Horizontal">
-                    <Button Command="{Binding OpenParentOfSettingsFolderCommand}" Content="{DynamicResource userdatapathButton}" />
+                    <Button
+                        Command="{Binding OpenParentOfSettingsFolderCommand}"
+                        Content="{DynamicResource userdatapathButton}"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
                 </StackPanel>
             </cc:Card>
 
@@ -98,30 +104,41 @@
                     <Button
                         Margin="0 0 12 0"
                         Command="{Binding AskClearCacheFolderConfirmationCommand}"
-                        Content="{Binding CacheFolderSize, Mode=OneWay}" />
+                        Content="{Binding CacheFolderSize, Mode=OneWay}"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
                     <Button
                         Margin="0 0 12 0"
                         Command="{Binding AskClearLogFolderConfirmationCommand}"
-                        Content="{Binding LogFolderSize, Mode=OneWay}" />
+                        Content="{Binding LogFolderSize, Mode=OneWay}"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
                     <Button
                         Content="&#xec7a;"
                         FontFamily="/Resources/#Segoe Fluent Icons"
                         FontSize="20">
                         <ui:FlyoutService.Flyout>
                             <ui:MenuFlyout>
-                                <MenuItem Command="{Binding OpenWelcomeWindowCommand}" Header="{DynamicResource welcomewindow}">
+                                <MenuItem
+                                    Command="{Binding OpenWelcomeWindowCommand}"
+                                    FontFamily="{DynamicResource SettingWindowFont}"
+                                    Header="{DynamicResource welcomewindow}">
                                     <MenuItem.Icon>
                                         <ui:FontIcon Glyph="&#xe939;" />
                                     </MenuItem.Icon>
                                 </MenuItem>
 
-                                <MenuItem Command="{Binding OpenSettingsFolderCommand}" Header="{DynamicResource settingfolder}">
+                                <MenuItem
+                                    Command="{Binding OpenSettingsFolderCommand}"
+                                    FontFamily="{DynamicResource SettingWindowFont}"
+                                    Header="{DynamicResource settingfolder}">
                                     <MenuItem.Icon>
                                         <ui:FontIcon Glyph="&#xe8b7;" />
                                     </MenuItem.Icon>
                                 </MenuItem>
 
-                                <MenuItem Command="{Binding OpenLogsFolderCommand}" Header="{DynamicResource logfolder}">
+                                <MenuItem
+                                    Command="{Binding OpenLogsFolderCommand}"
+                                    FontFamily="{DynamicResource SettingWindowFont}"
+                                    Header="{DynamicResource logfolder}">
                                     <MenuItem.Icon>
                                         <ui:FontIcon Glyph="&#xe8b7;" />
                                     </MenuItem.Icon>
@@ -143,6 +160,7 @@
                         Type="Inside">
                         <ComboBox
                             DisplayMemberPath="Display"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             ItemsSource="{Binding LogLevels}"
                             SelectedValue="{Binding LogLevel}"
                             SelectedValuePath="Value" />
@@ -152,12 +170,16 @@
                         Icon="&#xf259;"
                         Type="Inside">
                         <StackPanel Orientation="Horizontal">
-                            <Button Command="{Binding ResetSettingWindowFontCommand}" Content="Reset" />
+                            <Button
+                                Command="{Binding ResetSettingWindowFontCommand}"
+                                Content="Reset"
+                                FontFamily="{DynamicResource SettingWindowFont}" />
                             <ComboBox
                                 Margin="12 8 0 8"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Top"
                                 DisplayMemberPath="Source"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 ItemsSource="{Binding Source={StaticResource SortedFonts}}"
                                 SelectedValue="{Binding SettingWindowFont, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                 SelectedValuePath="Source" />

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
@@ -39,6 +39,7 @@
                 Icon="&#xe8fc;">
                 <cc:ExCard.SideContent>
                     <ui:ToggleSwitch
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsOn="{Binding StartFlowLauncherOnSystemStartup}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}" />
@@ -48,6 +49,7 @@
                     Sub="{DynamicResource useLogonTaskForStartupTooltip}"
                     Type="InsideFit">
                     <ui:ToggleSwitch
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsOn="{Binding UseLogonTaskForStartup}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}" />
@@ -58,6 +60,7 @@
                 Icon="&#xed1a;"
                 Sub="{DynamicResource hideOnStartupToolTip}">
                 <ui:ToggleSwitch
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsOn="{Binding Settings.HideOnStartup}"
                     OffContent="{DynamicResource disable}"
                     OnContent="{DynamicResource enable}" />
@@ -65,6 +68,7 @@
 
             <cc:Card Title="{DynamicResource hideFlowLauncherWhenLoseFocus}" Margin="0 14 0 0">
                 <ui:ToggleSwitch
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsOn="{Binding Settings.HideWhenDeactivated}"
                     OffContent="{DynamicResource disable}"
                     OnContent="{DynamicResource enable}" />
@@ -72,6 +76,7 @@
 
             <cc:Card Title="{DynamicResource hideNotifyIcon}" Sub="{DynamicResource hideNotifyIconToolTip}">
                 <ui:ToggleSwitch
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsOn="{Binding Settings.HideNotifyIcon}"
                     OffContent="{DynamicResource disable}"
                     OnContent="{DynamicResource enable}" />
@@ -84,6 +89,7 @@
                             MinWidth="220"
                             VerticalAlignment="Center"
                             DisplayMemberPath="Display"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             FontSize="14"
                             ItemsSource="{Binding SearchWindowScreens}"
                             SelectedValue="{Binding Settings.SearchWindowScreen}"
@@ -92,6 +98,7 @@
                             MinWidth="160"
                             Margin="18 0 0 0"
                             VerticalAlignment="Center"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             FontSize="14"
                             ItemsSource="{Binding ScreenNumbers}"
                             SelectedValue="{Binding Settings.CustomScreenNumber}"
@@ -110,6 +117,7 @@
                             MinWidth="160"
                             VerticalAlignment="Center"
                             DisplayMemberPath="Display"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             FontSize="14"
                             ItemsSource="{Binding SearchWindowAligns}"
                             SelectedValue="{Binding Settings.SearchWindowAlign}"
@@ -145,6 +153,7 @@
                 Icon="&#xe7fc;"
                 Sub="{DynamicResource ignoreHotkeysOnFullscreenToolTip}">
                 <ui:ToggleSwitch
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsOn="{Binding Settings.IgnoreHotkeysOnFullscreen}"
                     OffContent="{DynamicResource disable}"
                     OnContent="{DynamicResource enable}" />
@@ -156,6 +165,7 @@
                 Icon="&#xe8a1;"
                 Sub="{Binding AlwaysPreviewToolTip}">
                 <ui:ToggleSwitch
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsOn="{Binding Settings.AlwaysPreview}"
                     OffContent="{DynamicResource disable}"
                     OnContent="{DynamicResource enable}"
@@ -167,6 +177,7 @@
                 Margin="0 14 0 0"
                 Icon="&#xecc5;">
                 <ui:ToggleSwitch
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsOn="{Binding AutoUpdates}"
                     OffContent="{DynamicResource disable}"
                     OnContent="{DynamicResource enable}" />
@@ -177,6 +188,7 @@
                 Icon="&#xe88e;"
                 Sub="{DynamicResource portableModeToolTIp}">
                 <ui:ToggleSwitch
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsOn="{Binding PortableMode}"
                     OffContent="{DynamicResource disable}"
                     OnContent="{DynamicResource enable}" />
@@ -187,6 +199,7 @@
                     <ComboBox
                         MaxWidth="200"
                         DisplayMemberPath="Display"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         ItemsSource="{Binding SearchPrecisionScores}"
                         SelectedValue="{Binding Settings.QuerySearchPrecision}"
                         SelectedValuePath="Value" />
@@ -196,6 +209,7 @@
                     <ComboBox
                         MinWidth="210"
                         DisplayMemberPath="Display"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         ItemsSource="{Binding LastQueryModes}"
                         SelectedValue="{Binding Settings.LastQueryMode}"
                         SelectedValuePath="Value" />
@@ -209,6 +223,7 @@
                 Sub="{DynamicResource searchDelayToolTip}">
                 <cc:ExCard.SideContent>
                     <ui:ToggleSwitch
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsOn="{Binding Settings.SearchQueryResultsWithDelay}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}" />
@@ -221,6 +236,7 @@
                         <ui:NumberBox
                             Width="120"
                             Margin="0 0 0 0"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             Maximum="1000"
                             Minimum="0"
                             SmallChange="10"
@@ -241,7 +257,8 @@
                     MaxWidth="250"
                     Margin="10 0 0 0"
                     Command="{Binding SelectFileManagerCommand}"
-                    Content="{Binding Settings.CustomExplorer.Name}" />
+                    Content="{Binding Settings.CustomExplorer.Name}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
             </cc:Card>
 
             <cc:Card
@@ -253,7 +270,8 @@
                     MaxWidth="250"
                     Margin="10 0 0 0"
                     Command="{Binding SelectBrowserCommand}"
-                    Content="{Binding Settings.CustomBrowser.Name}" />
+                    Content="{Binding Settings.CustomBrowser.Name}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
             </cc:Card>
 
             <cc:Card Title="{DynamicResource pythonFilePath}" Margin="0 14 0 0">
@@ -261,12 +279,14 @@
                     <TextBox
                         Width="300"
                         Height="34"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         Text="{Binding Settings.PluginSettings.PythonExecutablePath, TargetNullValue='None'}" />
                     <Button
                         Height="34"
                         Margin="10 0 0 0"
                         Command="{Binding SelectPythonCommand}"
-                        Content="{DynamicResource select}" />
+                        Content="{DynamicResource select}"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
                 </StackPanel>
             </cc:Card>
 
@@ -275,12 +295,14 @@
                     <TextBox
                         Width="300"
                         Height="34"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         Text="{Binding Settings.PluginSettings.NodeExecutablePath, TargetNullValue='None'}" />
                     <Button
                         Height="34"
                         Margin="10 0 0 0"
                         Command="{Binding SelectNodeCommand}"
-                        Content="{DynamicResource select}" />
+                        Content="{DynamicResource select}"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
                 </StackPanel>
             </cc:Card>
 
@@ -290,6 +312,7 @@
                 Icon="&#xe8d3;"
                 Sub="{DynamicResource typingStartEnTooltip}">
                 <ui:ToggleSwitch
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsOn="{Binding Settings.AlwaysStartEn}"
                     OffContent="{DynamicResource disable}"
                     OnContent="{DynamicResource enable}" />
@@ -300,6 +323,7 @@
                 Icon="&#xe98a;"
                 Sub="{DynamicResource ShouldUsePinyinToolTip}">
                 <ui:ToggleSwitch
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsOn="{Binding Settings.ShouldUsePinyin}"
                     OffContent="{DynamicResource disable}"
                     OnContent="{DynamicResource enable}"
@@ -314,10 +338,12 @@
                     MaxWidth="200"
                     Margin="10 0 0 0"
                     DisplayMemberPath="Display"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     ItemsSource="{Binding Languages}"
                     SelectedValue="{Binding Language}"
                     SelectedValuePath="LanguageCode" />
             </cc:Card>
+
             <Border Visibility="{Binding KoreanIMERegistryKeyExists, Converter={StaticResource BoolToVisibilityConverter}}">
                 <cc:InfoBar
                     Title="{DynamicResource KoreanImeTitle}"
@@ -336,6 +362,7 @@
                     Icon="&#xe88b;"
                     Sub="{DynamicResource KoreanImeRegistryTooltip}">
                     <ui:ToggleSwitch
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsOn="{Binding LegacyKoreanIMEEnabled}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}" />
@@ -344,7 +371,10 @@
                     Title="{DynamicResource KoreanImeOpenLink}"
                     Icon="&#xF210;"
                     Sub="{DynamicResource KoreanImeOpenLinkToolTip}">
-                    <Button Command="{Binding OpenImeSettingsCommand}" Content="{DynamicResource KoreanImeOpenLinkButton}" />
+                    <Button
+                        Command="{Binding OpenImeSettingsCommand}"
+                        Content="{DynamicResource KoreanImeOpenLinkButton}"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
                 </cc:Card>
             </cc:CardGroup>
         </VirtualizingStackPanel>

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneHotkey.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneHotkey.xaml
@@ -54,6 +54,7 @@
                 <cc:Card Title="{DynamicResource openResultModifiers}" Sub="{DynamicResource openResultModifiersToolTip}">
                     <ComboBox
                         Width="120"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         FontSize="14"
                         ItemsSource="{Binding OpenResultModifiersList}"
                         SelectedValue="{Binding Settings.OpenResultModifiers}" />
@@ -61,6 +62,7 @@
 
                 <cc:Card Title="{DynamicResource showOpenResultHotkey}" Sub="{DynamicResource showOpenResultHotkeyToolTip}">
                     <ui:ToggleSwitch
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsOn="{Binding Settings.ShowOpenResultHotkey}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}" />
@@ -204,7 +206,6 @@
                 </StackPanel>
             </cc:ExCard>
 
-
             <cc:ExCard
                 Title="{DynamicResource autoCompleteHotkey}"
                 Margin="0 14 0 0"
@@ -313,17 +314,20 @@
                                 MinWidth="100"
                                 Margin="10"
                                 Command="{Binding CustomHotkeyDeleteCommand}"
-                                Content="{DynamicResource delete}" />
+                                Content="{DynamicResource delete}"
+                                FontFamily="{DynamicResource SettingWindowFont}" />
                             <Button
                                 MinWidth="100"
                                 Margin="10"
                                 Command="{Binding CustomHotkeyEditCommand}"
-                                Content="{DynamicResource edit}" />
+                                Content="{DynamicResource edit}"
+                                FontFamily="{DynamicResource SettingWindowFont}" />
                             <Button
                                 MinWidth="100"
                                 Margin="10 10 0 10"
                                 Command="{Binding CustomHotkeyAddCommand}"
-                                Content="{DynamicResource add}" />
+                                Content="{DynamicResource add}"
+                                FontFamily="{DynamicResource SettingWindowFont}" />
                         </StackPanel>
                     </StackPanel>
                 </StackPanel>
@@ -377,17 +381,20 @@
                                 MinWidth="100"
                                 Margin="10"
                                 Command="{Binding CustomShortcutDeleteCommand}"
-                                Content="{DynamicResource delete}" />
+                                Content="{DynamicResource delete}"
+                                FontFamily="{DynamicResource SettingWindowFont}" />
                             <Button
                                 MinWidth="100"
                                 Margin="10"
                                 Command="{Binding CustomShortcutEditCommand}"
-                                Content="{DynamicResource edit}" />
+                                Content="{DynamicResource edit}"
+                                FontFamily="{DynamicResource SettingWindowFont}" />
                             <Button
                                 MinWidth="100"
                                 Margin="10 10 0 10"
                                 Command="{Binding CustomShortcutAddCommand}"
-                                Content="{DynamicResource add}" />
+                                Content="{DynamicResource add}"
+                                FontFamily="{DynamicResource SettingWindowFont}" />
                         </StackPanel>
                     </StackPanel>
                 </StackPanel>
@@ -434,8 +441,6 @@
                     </StackPanel>
                 </StackPanel>
             </cc:ExCard>
-
-
         </StackPanel>
     </ScrollViewer>
 </ui:Page>

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml
@@ -37,9 +37,9 @@
         <Border
             Grid.Row="0"
             Grid.Column="0"
-            Padding="5,18,0,0">
+            Padding="5 18 0 0">
             <TextBlock
-                Margin="0,5"
+                Margin="0 5"
                 FontSize="30"
                 Style="{StaticResource PageTitle}"
                 Text="{DynamicResource pluginStore}"
@@ -49,16 +49,17 @@
         <DockPanel
             Grid.Row="0"
             Grid.Column="1"
-            Margin="5,24,0,0">
+            Margin="5 24 0 0">
 
             <TextBox
                 Name="PluginStoreFilterTextbox"
                 Width="150"
                 Height="34"
-                Margin="0,0,26,0"
+                Margin="0 0 26 0"
                 HorizontalAlignment="Right"
                 ContextMenu="{StaticResource TextBoxContextMenu}"
                 DockPanel.Dock="Right"
+                FontFamily="{DynamicResource SettingWindowFont}"
                 FontSize="14"
                 Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
                 TextAlignment="Left"
@@ -75,8 +76,9 @@
                                 Stretch="None">
                                 <VisualBrush.Visual>
                                     <Label
-                                        Padding="10,0,0,0"
+                                        Padding="10 0 0 0"
                                         Content="{DynamicResource searchplugin}"
+                                        FontFamily="{DynamicResource SettingWindowFont}"
                                         Foreground="{DynamicResource CustomContextDisabled}" />
                                 </VisualBrush.Visual>
                             </VisualBrush>
@@ -97,13 +99,14 @@
             </TextBox>
             <Button
                 Height="34"
-                Margin="0,5,10,5"
-                Padding="12,4"
+                Margin="0 5 10 5"
+                Padding="12 4"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 Command="{Binding RefreshExternalPluginsCommand}"
                 Content="{DynamicResource refresh}"
                 DockPanel.Dock="Right"
+                FontFamily="{DynamicResource SettingWindowFont}"
                 FontSize="13" />
         </DockPanel>
         <ListView
@@ -111,8 +114,9 @@
             Grid.Row="1"
             Grid.Column="0"
             Grid.ColumnSpan="2"
-            Margin="4,0,0,0"
-            Padding="0,0,18,0"
+            Margin="4 0 0 0"
+            Padding="0 0 18 0"
+            FontFamily="{DynamicResource SettingWindowFont}"
             FontSize="14"
             ItemContainerStyle="{StaticResource StoreList}"
             ItemsSource="{Binding Source={StaticResource PluginStoreCollectionView}}"
@@ -125,7 +129,7 @@
                 <ItemsPanelTemplate>
                     <wpftk:VirtualizingWrapPanel
                         x:Name="ItemWrapPanel"
-                        Margin="0,0,0,10"
+                        Margin="0 0 0 10"
                         ItemSize="216,184"
                         MouseWheelDelta="48"
                         ScrollLineDelta="16"
@@ -143,7 +147,7 @@
                                         <Grid>
                                             <StackPanel Orientation="Vertical">
                                                 <TextBlock
-                                                    Margin="2,0,0,10"
+                                                    Margin="2 0 0 10"
                                                     VerticalAlignment="Top"
                                                     FontSize="16"
                                                     FontWeight="Bold"
@@ -231,11 +235,12 @@
                                     <VirtualizingStackPanel
                                         Grid.Row="0"
                                         Grid.Column="0"
-                                        Margin="5,0,0,0"
+                                        Margin="5 0 0 0"
                                         Orientation="Horizontal">
                                         <TextBlock
-                                            Margin="0,0,5,0"
+                                            Margin="0 0 5 0"
                                             VerticalAlignment="Center"
+                                            FontFamily="{DynamicResource SettingWindowFont}"
                                             FontSize="14"
                                             FontWeight="Bold"
                                             Foreground="{DynamicResource Color05B}"
@@ -244,6 +249,7 @@
                                             ToolTip="{Binding Name}" />
                                         <TextBlock
                                             VerticalAlignment="Center"
+                                            FontFamily="{DynamicResource SettingWindowFont}"
                                             FontSize="12"
                                             Foreground="{DynamicResource Color05B}"
                                             Text="{Binding Version}"
@@ -253,7 +259,8 @@
                                     <TextBlock
                                         Grid.Row="1"
                                         Grid.Column="0"
-                                        Margin="5,4,0,0"
+                                        Margin="5 4 0 0"
+                                        FontFamily="{DynamicResource SettingWindowFont}"
                                         TextWrapping="Wrap">
                                         <Hyperlink
                                             Foreground="{DynamicResource Color04B}"
@@ -267,38 +274,41 @@
                                         Grid.Row="0"
                                         Grid.RowSpan="2"
                                         Grid.Column="1"
-                                        Margin="20,0,0,0"
+                                        Margin="20 0 0 0"
                                         HorizontalAlignment="Right"
                                         Orientation="Horizontal">
                                         <Button
                                             MinHeight="42"
-                                            Margin="5,0"
-                                            Padding="15,5"
+                                            Margin="5 0"
+                                            Padding="15 5"
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Center"
                                             Command="{Binding ShowCommandQueryCommand}"
                                             CommandParameter="install"
                                             Content="{DynamicResource installbtn}"
+                                            FontFamily="{DynamicResource SettingWindowFont}"
                                             Visibility="{Binding LabelInstalled, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter='!'}" />
                                         <Button
                                             MinHeight="42"
-                                            Margin="5,0"
-                                            Padding="15,5"
+                                            Margin="5 0"
+                                            Padding="15 5"
                                             HorizontalAlignment="Right"
                                             VerticalAlignment="Center"
                                             Command="{Binding ShowCommandQueryCommand}"
                                             CommandParameter="uninstall"
                                             Content="{DynamicResource uninstallbtn}"
+                                            FontFamily="{DynamicResource SettingWindowFont}"
                                             Visibility="{Binding LabelInstalled, Converter={StaticResource BoolToVisibilityConverter}}" />
                                         <Button
                                             MinHeight="42"
-                                            Margin="5,0"
-                                            Padding="15,5"
+                                            Margin="5 0"
+                                            Padding="15 5"
                                             HorizontalAlignment="Right"
                                             VerticalAlignment="Center"
                                             Command="{Binding ShowCommandQueryCommand}"
                                             CommandParameter="update"
                                             Content="{DynamicResource updatebtn}"
+                                            FontFamily="{DynamicResource SettingWindowFont}"
                                             Style="{DynamicResource AccentButtonStyle}"
                                             Visibility="{Binding LabelUpdate, Converter={StaticResource BoolToVisibilityConverter}}" />
                                     </VirtualizingStackPanel>
@@ -311,15 +321,15 @@
                                     <Image
                                         Width="32"
                                         Height="32"
-                                        Margin="18,24,0,0"
+                                        Margin="18 24 0 0"
                                         HorizontalAlignment="Left"
                                         RenderOptions.BitmapScalingMode="Fant"
                                         Source="{Binding IcoPath, IsAsync=True}" />
                                     <Border
                                         x:Name="LabelUpdate"
                                         Height="12"
-                                        Margin="10,24,0,0"
-                                        Padding="6,2"
+                                        Margin="10 24 0 0"
+                                        Padding="6 2"
                                         HorizontalAlignment="Left"
                                         VerticalAlignment="Top"
                                         Background="#45BD59"
@@ -328,7 +338,8 @@
                                         Visibility="{Binding LabelUpdate, Converter={StaticResource BoolToVisibilityConverter}}" />
                                 </StackPanel>
                                 <TextBlock
-                                    Margin="18,10,18,0"
+                                    Margin="18 10 18 0"
+                                    FontFamily="{DynamicResource SettingWindowFont}"
                                     FontWeight="SemiBold"
                                     Foreground="{DynamicResource Color05B}"
                                     Text="{Binding Name}"
@@ -336,16 +347,15 @@
                                     ToolTip="{Binding Version}" />
                                 <TextBlock
                                     Height="60"
-                                    Margin="18,6,18,0"
-                                    Padding="0,0,0,10"
+                                    Margin="18 6 18 0"
+                                    Padding="0 0 0 10"
+                                    FontFamily="{DynamicResource SettingWindowFont}"
                                     FontSize="12"
                                     Foreground="{DynamicResource Color04B}"
                                     Text="{Binding Description, Mode=OneWay}"
                                     TextTrimming="WordEllipsis"
                                     TextWrapping="Wrap" />
-
                             </StackPanel>
-
                         </Grid>
                     </Button>
                 </DataTemplate>

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml
@@ -49,6 +49,7 @@
                     HorizontalContentAlignment="Left"
                     Background="{DynamicResource Color00B}"
                     DisplayMemberPath="Display"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     ItemsSource="{Binding DisplayModes}"
                     SelectedValue="{Binding SelectedDisplayMode, Mode=TwoWay}"
                     SelectedValuePath="Value" />
@@ -75,6 +76,7 @@
                     ToolTipService.Placement="Top">
                     <TextBox.Style>
                         <Style BasedOn="{StaticResource DefaultTextBoxStyle}" TargetType="TextBox">
+                            <Setter Property="FontFamily" Value="{DynamicResource SettingWindowFont}" />
                             <Style.Resources>
                                 <VisualBrush
                                     x:Key="CueBannerBrush"
@@ -85,6 +87,7 @@
                                         <Label
                                             Padding="10 0 0 0"
                                             Content="{DynamicResource searchplugin}"
+                                            FontFamily="{DynamicResource SettingWindowFont}"
                                             Foreground="{DynamicResource CustomContextDisabled}" />
                                     </VisualBrush.Visual>
                                 </VisualBrush>
@@ -113,6 +116,7 @@
             <ListBox
                 Margin="5 0 7 10"
                 Background="{DynamicResource Color01B}"
+                FontFamily="{DynamicResource SettingWindowFont}"
                 FontSize="14"
                 ItemContainerStyle="{StaticResource PluginList}"
                 ItemsSource="{Binding FilteredPluginViewModels}"

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneProxy.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneProxy.xaml
@@ -2,11 +2,11 @@
     x:Class="Flow.Launcher.SettingPages.Views.SettingsPaneProxy"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:cc="clr-namespace:Flow.Launcher.Resources.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
     xmlns:ui="http://schemas.modernwpf.com/2019"
-    xmlns:cc="clr-namespace:Flow.Launcher.Resources.Controls"
     xmlns:viewModels="clr-namespace:Flow.Launcher.SettingPages.ViewModels"
     Title="Proxy"
     d:DataContext="{d:DesignInstance viewModels:SettingsPaneProxyViewModel}"
@@ -18,8 +18,8 @@
     </Page.Resources>
     <ScrollViewer
         Padding="5 0 24 0"
-        FontSize="14"
         CanContentScroll="True"
+        FontSize="14"
         VirtualizingStackPanel.IsVirtualizing="True"
         VirtualizingStackPanel.ScrollUnit="Pixel">
 
@@ -34,6 +34,7 @@
             <cc:CardGroup>
                 <cc:Card Title="{DynamicResource enableProxy}">
                     <ui:ToggleSwitch
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsOn="{Binding Settings.Proxy.Enabled}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}" />
@@ -42,6 +43,7 @@
                 <cc:Card Title="{DynamicResource server}">
                     <TextBox
                         Width="300"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsEnabled="{Binding Settings.Proxy.Enabled}"
                         Text="{Binding Settings.Proxy.Server}" />
                 </cc:Card>
@@ -49,6 +51,7 @@
                 <cc:Card Title="{DynamicResource port}">
                     <TextBox
                         Width="100"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsEnabled="{Binding Settings.Proxy.Enabled}"
                         Text="{Binding Settings.Proxy.Port, TargetNullValue={x:Static sys:String.Empty}}" />
                 </cc:Card>
@@ -56,6 +59,7 @@
                 <cc:Card Title="{DynamicResource userName}">
                     <TextBox
                         Width="200"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsEnabled="{Binding Settings.Proxy.Enabled}"
                         Text="{Binding Settings.Proxy.UserName}" />
                 </cc:Card>
@@ -63,6 +67,7 @@
                 <cc:Card Title="{DynamicResource password}">
                     <TextBox
                         Width="200"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsEnabled="{Binding Settings.Proxy.Enabled}"
                         Text="{Binding Settings.Proxy.Password}" />
                 </cc:Card>
@@ -71,9 +76,10 @@
             <cc:Card Title="{DynamicResource testProxy}" Margin="0 8 0 0">
                 <Button
                     Width="150"
+                    Command="{Binding TestProxyClickedCommand}"
                     Content="{DynamicResource testProxy}"
-                    IsEnabled="{Binding Settings.Proxy.Enabled}"
-                    Command="{Binding TestProxyClickedCommand}"/>
+                    FontFamily="{DynamicResource SettingWindowFont}"
+                    IsEnabled="{Binding Settings.Proxy.Enabled}" />
             </cc:Card>
         </StackPanel>
     </ScrollViewer>

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml
@@ -100,6 +100,7 @@
                                 VerticalAlignment="Center"
                                 ui:ControlHelper.Header="{DynamicResource SearchBarHeight}"
                                 AutoToolTipPlacement="TopLeft"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsMoveToPointEnabled="True"
                                 IsSnapToTickEnabled="True"
                                 Maximum="60"
@@ -116,6 +117,7 @@
                                 VerticalAlignment="Center"
                                 ui:ControlHelper.Header="{DynamicResource queryBoxFont}"
                                 AutoToolTipPlacement="TopLeft"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsMoveToPointEnabled="True"
                                 IsSnapToTickEnabled="True"
                                 Maximum="{Binding ElementName=WindowHeightValue, Path=Value, UpdateSourceTrigger=PropertyChanged}"
@@ -127,6 +129,7 @@
                                 Margin="12 4 12 0"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Top"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsSynchronizedWithCurrentItem="False"
                                 ItemsSource="{Binding Source={StaticResource SortedFonts}}"
                                 SelectedItem="{Binding SelectedQueryBoxFont}" />
@@ -135,6 +138,7 @@
                                 Margin="12 8 12 8"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Top"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 ItemsSource="{Binding SelectedQueryBoxFont.FamilyTypefaces}"
                                 SelectedItem="{Binding SelectedQueryBoxFontFaces}">
                                 <ComboBox.ItemTemplate>
@@ -159,6 +163,7 @@
                                 VerticalAlignment="Stretch"
                                 ui:ControlHelper.Header="{DynamicResource ItemHeight}"
                                 AutoToolTipPlacement="TopLeft"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsMoveToPointEnabled="True"
                                 IsSnapToTickEnabled="True"
                                 Maximum="100"
@@ -175,6 +180,7 @@
                                 VerticalAlignment="Center"
                                 ui:ControlHelper.Header="{DynamicResource resultItemFont}"
                                 AutoToolTipPlacement="TopLeft"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsMoveToPointEnabled="True"
                                 IsSnapToTickEnabled="True"
                                 Maximum="80"
@@ -186,6 +192,7 @@
                                 Margin="12 4 12 0"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Top"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsSynchronizedWithCurrentItem="False"
                                 ItemsSource="{Binding Source={StaticResource SortedFonts}}"
                                 SelectedItem="{Binding SelectedResultFont}" />
@@ -194,6 +201,7 @@
                                 Margin="12 4 12 8"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Top"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 ItemsSource="{Binding SelectedResultFont.FamilyTypefaces}"
                                 SelectedItem="{Binding SelectedResultFontFaces}">
                                 <ComboBox.ItemTemplate>
@@ -218,6 +226,7 @@
                                 VerticalAlignment="Center"
                                 ui:ControlHelper.Header="{DynamicResource resultSubItemFont}"
                                 AutoToolTipPlacement="TopLeft"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsMoveToPointEnabled="True"
                                 IsSnapToTickEnabled="True"
                                 Maximum="80"
@@ -229,6 +238,7 @@
                                 Margin="12 4 12 0"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Top"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsSynchronizedWithCurrentItem="False"
                                 ItemsSource="{Binding Source={StaticResource SortedFonts}}"
                                 SelectedItem="{Binding SelectedResultSubFont}" />
@@ -237,6 +247,7 @@
                                 Margin="12 4 12 8"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Top"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 ItemsSource="{Binding SelectedResultSubFont.FamilyTypefaces}"
                                 SelectedItem="{Binding SelectedResultSubFontFaces}">
                                 <ComboBox.ItemTemplate>
@@ -260,12 +271,14 @@
                                 HorizontalAlignment="Stretch"
                                 Command="{Binding ImportCommand}"
                                 Content="{DynamicResource ImportThemeSize}"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 ToolTip="{DynamicResource ImportThemeSizeToolTip}" />
                             <Button
                                 Margin="12 4 12 12"
                                 HorizontalAlignment="Stretch"
                                 Command="{Binding ResetCommand}"
                                 Content="{DynamicResource resetCustomize}"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 ToolTip="{DynamicResource resetCustomizeToolTip}" />
                         </StackPanel>
                     </ScrollViewer>
@@ -331,7 +344,6 @@
                                                 IsReadOnly="True"
                                                 Style="{DynamicResource QueryBoxStyle}"
                                                 Text="{DynamicResource hiThere}" />
-
                                         </Border>
                                         <StackPanel
                                             x:Name="ClockPanel"
@@ -340,11 +352,13 @@
                                             Visibility="Visible">
                                             <TextBlock
                                                 x:Name="ClockBox"
+                                                FontFamily="{Binding ClockPanelFont, Mode=OneTime}"
                                                 Style="{DynamicResource ClockBox}"
                                                 Text="{Binding ClockText}"
                                                 Visibility="{Binding UseClock, Converter={StaticResource BoolToVisibilityConverter}}" />
                                             <TextBlock
                                                 x:Name="DateBox"
+                                                FontFamily="{Binding ClockPanelFont, Mode=OneTime}"
                                                 Style="{DynamicResource DateBox}"
                                                 Text="{Binding DateText}"
                                                 Visibility="{Binding UseDate, Converter={StaticResource BoolToVisibilityConverter}}" />
@@ -446,6 +460,7 @@
                                         Margin="0 0 0 0"
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
+                                        FontFamily="{DynamicResource SettingWindowFont}"
                                         Text="{Binding Name}"
                                         TextWrapping="Wrap" />
                                     <ui:PathIcon
@@ -492,6 +507,7 @@
                         MinWidth="160"
                         VerticalAlignment="Center"
                         DisplayMemberPath="Display"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         FontSize="14"
                         IsEnabled="{Binding IsBackdropEnabled}"
                         ItemsSource="{Binding BackdropTypesList}"
@@ -526,6 +542,7 @@
                 <cc:ExCard.SideContent>
                     <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                         <ui:ToggleSwitch
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             IsOn="{Binding KeepMaxResults}"
                             OffContent="{DynamicResource disable}"
                             OnContent="{DynamicResource enable}" />
@@ -537,6 +554,7 @@
                     Type="InsideFit">
                     <ComboBox
                         Width="100"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         ItemsSource="{Binding MaxResultsRange}"
                         SelectedItem="{Binding Settings.MaxResultsToShow}" />
                 </cc:Card>
@@ -555,10 +573,12 @@
                             MinWidth="180"
                             Margin="10 0 18 0"
                             VerticalAlignment="Center"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             FontSize="14"
                             ItemsSource="{Binding TimeFormatList}"
                             SelectedItem="{Binding TimeFormat}" />
                         <ui:ToggleSwitch
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             IsOn="{Binding UseClock}"
                             OffContent="{DynamicResource disable}"
                             OnContent="{DynamicResource enable}" />
@@ -576,10 +596,12 @@
                             MinWidth="180"
                             Margin="10 0 18 0"
                             VerticalAlignment="Center"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             FontSize="14"
                             ItemsSource="{Binding DateFormatList}"
                             SelectedItem="{Binding DateFormat}" />
                         <ui:ToggleSwitch
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             IsOn="{Binding UseDate}"
                             OffContent="{DynamicResource disable}"
                             OnContent="{DynamicResource enable}" />
@@ -595,6 +617,7 @@
                 Sub="{DynamicResource ShowPlaceholderTip}">
                 <cc:ExCard.SideContent>
                     <ui:ToggleSwitch
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsOn="{Binding ShowPlaceholder}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}" />
@@ -605,6 +628,7 @@
                     Type="InsideFit">
                     <TextBox
                         MinWidth="150"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         Text="{Binding PlaceholderText}"
                         TextWrapping="NoWrap" />
                 </cc:Card>
@@ -618,6 +642,7 @@
                 Sub="{DynamicResource AnimationTip}">
                 <cc:ExCard.SideContent>
                     <ui:ToggleSwitch
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsOn="{Binding UseAnimation}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}" />
@@ -631,6 +656,7 @@
                             MinWidth="160"
                             VerticalAlignment="Center"
                             DisplayMemberPath="Display"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             FontSize="14"
                             ItemsSource="{Binding AnimationSpeeds}"
                             SelectedValue="{Binding Settings.AnimationSpeed}"
@@ -655,6 +681,7 @@
                 Sub="{DynamicResource SoundEffectTip}">
                 <cc:ExCard.SideContent>
                     <ui:ToggleSwitch
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsOn="{Binding UseSound}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}" />
@@ -672,6 +699,7 @@
                         <Slider
                             Width="250"
                             VerticalAlignment="Center"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             IsMoveToPointEnabled="True"
                             IsSnapToTickEnabled="True"
                             Maximum="100"
@@ -723,6 +751,7 @@
                 Icon="&#xf6b8;"
                 Sub="{DynamicResource useGlyphUIEffect}">
                 <ui:ToggleSwitch
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsOn="{Binding UseGlyphIcons}"
                     OffContent="{DynamicResource disable}"
                     OnContent="{DynamicResource enable}" />
@@ -736,12 +765,14 @@
                 Sub="{DynamicResource showBadgesToolTip}">
                 <cc:ExCard.SideContent>
                     <ui:ToggleSwitch
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsOn="{Binding Settings.ShowBadges}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}" />
                 </cc:ExCard.SideContent>
                 <cc:Card Title="{DynamicResource showBadgesGlobalOnly}" Type="InsideFit">
                     <ui:ToggleSwitch
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsOn="{Binding Settings.ShowBadgesGlobalOnly}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}" />
@@ -756,6 +787,7 @@
                 <ComboBox
                     MinWidth="180"
                     DisplayMemberPath="Display"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     FontSize="14"
                     ItemsSource="{Binding ColorSchemes}"
                     SelectedValue="{Binding ColorScheme, Mode=TwoWay}"
@@ -770,7 +802,8 @@
                 <Button
                     MinWidth="180"
                     Command="{Binding OpenThemesFolderCommand}"
-                    Content="{DynamicResource OpenThemeFolder}" />
+                    Content="{DynamicResource OpenThemeFolder}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
             </cc:Card>
 
             <!--  How to create theme link  -->

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -13,7 +13,7 @@
     MinHeight="600"
     d:DataContext="{d:DesignInstance vm:SettingWindowViewModel}"
     Closed="OnClosed"
-    FontFamily="{Binding Settings.SettingWindowFont, Mode=TwoWay}"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Icon="Images\app.ico"
     Left="{Binding SettingWindowLeft, Mode=TwoWay}"
     Loaded="OnLoaded"
@@ -213,13 +213,19 @@
                     </ui:NavigationView.PaneCustomContent>
                     <ui:NavigationView.MenuItems>
 
-                        <ui:NavigationViewItem x:Name="General" Content="{DynamicResource general}">
+                        <ui:NavigationViewItem
+                            x:Name="General"
+                            Content="{DynamicResource general}"
+                            FontFamily="{DynamicResource SettingWindowFont}">
                             <ui:NavigationViewItem.Icon>
                                 <ui:BitmapIcon ShowAsMonochrome="False" UriSource="/Images/settings.png" />
                             </ui:NavigationViewItem.Icon>
                         </ui:NavigationViewItem>
 
-                        <ui:NavigationViewItem x:Name="Plugins" Content="{DynamicResource plugins}">
+                        <ui:NavigationViewItem
+                            x:Name="Plugins"
+                            Content="{DynamicResource plugins}"
+                            FontFamily="{DynamicResource SettingWindowFont}">
                             <ui:NavigationViewItem.Icon>
                                 <ui:BitmapIcon ShowAsMonochrome="False" UriSource="/Images/plugins.png" />
                             </ui:NavigationViewItem.Icon>
@@ -228,31 +234,44 @@
                         <ui:NavigationViewItem
                             x:Name="PluginStore"
                             Content="{DynamicResource pluginStore}"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             Tag="PluginStore">
                             <ui:NavigationViewItem.Icon>
                                 <ui:BitmapIcon ShowAsMonochrome="False" UriSource="/Images/store.png" />
                             </ui:NavigationViewItem.Icon>
                         </ui:NavigationViewItem>
 
-                        <ui:NavigationViewItem x:Name="Theme" Content="{DynamicResource appearance}">
+                        <ui:NavigationViewItem
+                            x:Name="Theme"
+                            Content="{DynamicResource appearance}"
+                            FontFamily="{DynamicResource SettingWindowFont}">
                             <ui:NavigationViewItem.Icon>
                                 <ui:BitmapIcon ShowAsMonochrome="False" UriSource="/Images/theme.png" />
                             </ui:NavigationViewItem.Icon>
                         </ui:NavigationViewItem>
 
-                        <ui:NavigationViewItem x:Name="Hotkey" Content="{DynamicResource hotkeys}">
+                        <ui:NavigationViewItem
+                            x:Name="Hotkey"
+                            Content="{DynamicResource hotkeys}"
+                            FontFamily="{DynamicResource SettingWindowFont}">
                             <ui:NavigationViewItem.Icon>
                                 <ui:BitmapIcon ShowAsMonochrome="False" UriSource="/Images/keyboard.png" />
                             </ui:NavigationViewItem.Icon>
                         </ui:NavigationViewItem>
 
-                        <ui:NavigationViewItem x:Name="Proxy" Content="{DynamicResource proxy}">
+                        <ui:NavigationViewItem
+                            x:Name="Proxy"
+                            Content="{DynamicResource proxy}"
+                            FontFamily="{DynamicResource SettingWindowFont}">
                             <ui:NavigationViewItem.Icon>
                                 <ui:BitmapIcon ShowAsMonochrome="False" UriSource="/Images/proxy.png" />
                             </ui:NavigationViewItem.Icon>
                         </ui:NavigationViewItem>
 
-                        <ui:NavigationViewItem x:Name="About" Content="{DynamicResource about}">
+                        <ui:NavigationViewItem
+                            x:Name="About"
+                            Content="{DynamicResource about}"
+                            FontFamily="{DynamicResource SettingWindowFont}">
                             <ui:NavigationViewItem.Icon>
                                 <ui:BitmapIcon ShowAsMonochrome="False" UriSource="/Images/info.png" />
                             </ui:NavigationViewItem.Icon>
@@ -265,8 +284,5 @@
                 </ui:NavigationView>
             </Grid>
         </Border>
-
-
-
     </Grid>
 </Window>

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -5,11 +5,11 @@ namespace Flow.Launcher.ViewModel;
 
 public partial class SettingWindowViewModel : BaseModel
 {
-    public Settings Settings { get; }
+    private readonly Settings _settings;
 
     public SettingWindowViewModel(Settings settings)
     {
-        Settings = settings;
+        _settings = settings;
     }
 
     /// <summary>
@@ -17,30 +17,30 @@ public partial class SettingWindowViewModel : BaseModel
     /// </summary>
     public void Save()
     {
-        Settings.Save();
+        _settings.Save();
     }
 
     public double SettingWindowWidth
     {
-        get => Settings.SettingWindowWidth;
-        set => Settings.SettingWindowWidth = value;
+        get => _settings.SettingWindowWidth;
+        set => _settings.SettingWindowWidth = value;
     }
 
     public double SettingWindowHeight
     {
-        get => Settings.SettingWindowHeight;
-        set => Settings.SettingWindowHeight = value;
+        get => _settings.SettingWindowHeight;
+        set => _settings.SettingWindowHeight = value;
     }
 
     public double? SettingWindowTop
     {
-        get => Settings.SettingWindowTop;
-        set => Settings.SettingWindowTop = value;
+        get => _settings.SettingWindowTop;
+        set => _settings.SettingWindowTop = value;
     }
 
     public double? SettingWindowLeft
     {
-        get => Settings.SettingWindowLeft;
-        set => Settings.SettingWindowLeft = value;
+        get => _settings.SettingWindowLeft;
+        set => _settings.SettingWindowLeft = value;
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/CustomBrowserSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/CustomBrowserSetting.xaml
@@ -9,6 +9,7 @@
     Title="{DynamicResource flowlauncher_plugin_browserbookmark_bookmarkDataSetting}"
     Width="550"
     Background="{DynamicResource PopuBGColor}"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Foreground="{DynamicResource PopupTextColor}"
     KeyDown="WindowKeyDown"
     ResizeMode="NoResize"
@@ -60,17 +61,17 @@
                     </Button>
                 </Grid>
             </StackPanel>
-            <StackPanel Margin="26,0,26,0">
-                <StackPanel Margin="0,0,0,12">
+            <StackPanel Margin="26 0 26 0">
+                <StackPanel Margin="0 0 0 12">
                     <TextBlock
-                        Margin="0,0,0,0"
+                        Margin="0 0 0 0"
                         FontSize="20"
                         FontWeight="SemiBold"
                         Text="{DynamicResource flowlauncher_plugin_browserbookmark_bookmarkDataSetting}"
                         TextAlignment="Left" />
                 </StackPanel>
 
-                <StackPanel Margin="0,0,0,20" Orientation="Horizontal">
+                <StackPanel Margin="0 0 0 20" Orientation="Horizontal">
                     <Grid Width="474" HorizontalAlignment="Stretch">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
@@ -86,23 +87,23 @@
                             Grid.Row="0"
                             Grid.Column="0"
                             Grid.ColumnSpan="2"
-                            Margin="5,0,0,20">
+                            Margin="5 0 0 20">
                             <TextBlock
-                                Margin="0,0,0,4"
+                                Margin="0 0 0 4"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
                                 FontSize="14"
                                 Text="{DynamicResource flowlauncher_plugin_browserbookmark_guideMessage01}"
                                 TextWrapping="WrapWithOverflow" />
                             <TextBlock
-                                Margin="0,4,0,4"
+                                Margin="0 4 0 4"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
                                 FontSize="14"
                                 Text="{DynamicResource flowlauncher_plugin_browserbookmark_guideMessage02}"
                                 TextWrapping="WrapWithOverflow" />
                             <TextBlock
-                                Margin="0,4,0,0"
+                                Margin="0 4 0 0"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
                                 FontSize="14"
@@ -112,7 +113,7 @@
                         <TextBlock
                             Grid.Row="1"
                             Grid.Column="0"
-                            Margin="5,0,20,0"
+                            Margin="5 0 20 0"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             FontSize="14"
@@ -122,14 +123,15 @@
                             Grid.Column="1"
                             Width="120"
                             Height="34"
-                            Margin="5,0,10,0"
+                            Margin="5 0 10 0"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             Text="{Binding Name}" />
                         <TextBlock
                             Grid.Row="2"
                             Grid.Column="0"
-                            Margin="5,10,20,0"
+                            Margin="5 10 20 0"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             FontSize="14"
@@ -139,15 +141,16 @@
                             Grid.Column="1"
                             Width="120"
                             Height="34"
-                            Margin="5,10,10,0"
+                            Margin="5 10 10 0"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             ItemsSource="{Binding Source={ui:EnumBindingSource {x:Type local:BrowserType}}}"
                             SelectedItem="{Binding BrowserType}" />
                         <TextBlock
                             Grid.Row="3"
                             Grid.Column="0"
-                            Margin="5,10,20,0"
+                            Margin="5 10 20 0"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             FontSize="14"
@@ -159,17 +162,19 @@
                             <Button
                                 Height="34"
                                 MinWidth="100"
-                                Margin="5,10,0,0"
+                                Margin="5 10 0 0"
                                 VerticalContentAlignment="Stretch"
                                 Click="OnSelectPathClick"
                                 Content="{DynamicResource flowlauncher_plugin_browserbookmark_browseBrowserBookmark}"
-                                DockPanel.Dock="Right" />
+                                DockPanel.Dock="Right"
+                                FontFamily="{DynamicResource SettingWindowFont}" />
                             <TextBox
                                 Name="PathTextBox"
                                 Height="34"
-                                Margin="5,10,0,0"
+                                Margin="5 10 0 0"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Center"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 Text="{Binding DataDirectoryPath}" />
                         </DockPanel>
                     </Grid>
@@ -180,19 +185,21 @@
             Grid.Row="1"
             Background="{DynamicResource PopupButtonAreaBGColor}"
             BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
-            BorderThickness="0,1,0,0">
+            BorderThickness="0 1 0 0">
             <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                 <Button
                     x:Name="btnCancel"
                     MinWidth="145"
-                    Margin="0,0,5,0"
+                    Margin="0 0 5 0"
                     Click="CancelEditCustomBrowser"
-                    Content="{DynamicResource cancel}" />
+                    Content="{DynamicResource cancel}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     Name="btnConfirm"
                     MinWidth="145"
-                    Margin="5,0,0,0"
+                    Margin="5 0 0 0"
                     Click="ConfirmEditCustomBrowser"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     Style="{StaticResource AccentButtonStyle}">
                     <TextBlock x:Name="lblAdd" Text="{DynamicResource done}" />
                 </Button>

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/SettingsControl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Views/SettingsControl.xaml
@@ -24,19 +24,23 @@
             <CheckBox
                 Margin="{StaticResource SettingPanelItemRightMargin}"
                 Content="Chrome"
+                FontFamily="{DynamicResource SettingWindowFont}"
                 IsChecked="{Binding LoadChromeBookmark}" />
             <CheckBox
                 Margin="{StaticResource SettingPanelItemRightMargin}"
                 Content="Edge"
+                FontFamily="{DynamicResource SettingWindowFont}"
                 IsChecked="{Binding LoadEdgeBookmark}" />
             <CheckBox
                 Margin="{StaticResource SettingPanelItemRightMargin}"
                 Content="Firefox"
+                FontFamily="{DynamicResource SettingWindowFont}"
                 IsChecked="{Binding LoadFirefoxBookmark}" />
             <Button
                 Margin="{StaticResource SettingPanelItemRightMargin}"
                 Click="Others_Click"
-                Content="{DynamicResource flowlauncher_plugin_browserbookmark_others}" />
+                Content="{DynamicResource flowlauncher_plugin_browserbookmark_others}"
+                FontFamily="{DynamicResource SettingWindowFont}" />
         </StackPanel>
         <StackPanel
             Name="CustomBrowsersList"
@@ -67,7 +71,8 @@
                 <Button
                     Width="100"
                     Click="NewCustomBrowser"
-                    Content="{DynamicResource flowlauncher_plugin_browserbookmark_addBrowserBookmark}" />
+                    Content="{DynamicResource flowlauncher_plugin_browserbookmark_addBrowserBookmark}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     Width="100"
                     Margin="{StaticResource SettingPanelItemLeftMargin}"
@@ -75,7 +80,10 @@
                     Content="{DynamicResource flowlauncher_plugin_browserbookmark_editBrowserBookmark}">
                     <Button.Style>
                         <Style BasedOn="{StaticResource DefaultButtonStyle}" TargetType="Button">
-                            <Setter Property="IsEnabled" Value="true" />
+                            <Style.Setters>
+                                <Setter Property="IsEnabled" Value="true" />
+                                <Setter Property="FontFamily" Value="{DynamicResource SettingWindowFont}" />
+                            </Style.Setters>
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding ElementName=CustomBrowsers, Path=SelectedItems.Count}" Value="0">
                                     <Setter Property="IsEnabled" Value="false" />
@@ -88,7 +96,8 @@
                     Width="100"
                     Margin="{StaticResource SettingPanelItemLeftMargin}"
                     Click="DeleteCustomBrowser"
-                    Content="{DynamicResource flowlauncher_plugin_browserbookmark_removeBrowserBookmark}" />
+                    Content="{DynamicResource flowlauncher_plugin_browserbookmark_removeBrowserBookmark}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Views/CalculatorSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Views/CalculatorSettings.xaml
@@ -42,6 +42,7 @@
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
             HorizontalAlignment="Left"
             VerticalAlignment="Center"
+            FontFamily="{DynamicResource SettingWindowFont}"
             ItemsSource="{Binding Source={ui:EnumBindingSource {x:Type calculator:DecimalSeparator}}}"
             SelectedItem="{Binding Settings.DecimalSeparator}">
             <ComboBox.ItemTemplate>
@@ -65,6 +66,7 @@
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
             HorizontalAlignment="Left"
             VerticalAlignment="Center"
+            FontFamily="{DynamicResource SettingWindowFont}"
             ItemsSource="{Binding MaxDecimalPlacesRange}"
             SelectedItem="{Binding Settings.MaxDecimalPlaces}" />
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml
@@ -10,6 +10,7 @@
     Height="255"
     Background="{DynamicResource PopuBGColor}"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Foreground="{DynamicResource PopupTextColor}"
     ResizeMode="NoResize"
     SizeToContent="Width"
@@ -57,20 +58,20 @@
                     </Button>
                 </Grid>
             </StackPanel>
-            <StackPanel Margin="26,0,26,0">
-                <StackPanel Margin="0,0,0,12">
+            <StackPanel Margin="26 0 26 0">
+                <StackPanel Margin="0 0 0 12">
                     <TextBlock
-                        Margin="0,0,0,0"
+                        Margin="0 0 0 0"
                         FontSize="20"
                         FontWeight="SemiBold"
                         Text="{DynamicResource plugin_explorer_manageactionkeywords_header}"
                         TextAlignment="Left" />
                 </StackPanel>
 
-                <StackPanel Margin="0,10,0,0" Orientation="Horizontal">
+                <StackPanel Margin="0 10 0 0" Orientation="Horizontal">
                     <TextBlock
                         MinWidth="150"
-                        Margin="0,10,15,10"
+                        Margin="0 10 15 10"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         FontSize="14"
@@ -81,13 +82,14 @@
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         DataObject.Pasting="TextBox_Pasting"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         PreviewKeyDown="TxtCurrentActionKeyword_OnKeyDown"
                         Text="{Binding ActionKeyword}" />
                 </StackPanel>
-                <StackPanel Margin="0,10,0,15" Orientation="Horizontal">
+                <StackPanel Margin="0 10 0 15" Orientation="Horizontal">
                     <TextBlock
                         MinWidth="150"
-                        Margin="0,0,18,0"
+                        Margin="0 0 18 0"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         FontSize="14"
@@ -96,6 +98,7 @@
                         Name="ChkActionKeywordEnabled"
                         Width="auto"
                         VerticalAlignment="Center"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsChecked="{Binding KeywordEnabled, Mode=TwoWay}"
                         ToolTip="{DynamicResource plugin_explorer_actionkeyword_enabled_tooltip}" />
                 </StackPanel>
@@ -105,21 +108,23 @@
             Grid.Row="1"
             Background="{DynamicResource PopupButtonAreaBGColor}"
             BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
-            BorderThickness="0,1,0,0">
+            BorderThickness="0 1 0 0">
             <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                 <Button
                     x:Name="btnCancel"
                     Width="145"
                     Height="30"
-                    Margin="0,0,5,0"
+                    Margin="0 0 5 0"
                     Click="BtnCancel_OnClick"
-                    Content="{DynamicResource cancel}" />
+                    Content="{DynamicResource cancel}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     Name="DownButton"
                     Width="145"
                     Height="30"
-                    Margin="5,0,0,0"
+                    Margin="5 0 0 0"
                     Click="OnDoneButtonClick"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     Style="{StaticResource AccentButtonStyle}">
                     <TextBlock x:Name="lblAdd" Text="{DynamicResource plugin_explorer_actionkeyword_done}" />
                 </Button>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -174,6 +174,7 @@
             Margin="-25 -10 0 0"
             Background="{DynamicResource Color00B}"
             BorderThickness="0"
+            FontFamily="{DynamicResource SettingWindowFont}"
             SelectedIndex="0"
             TabStripPlacement="Top">
             <TabControl.ItemsPanel>
@@ -211,6 +212,7 @@
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         HorizontalAlignment="Left"
                         Content="{DynamicResource plugin_explorer_use_location_as_working_dir}"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsChecked="{Binding Settings.UseLocationAsWorkingDir}" />
 
                     <CheckBox
@@ -220,6 +222,7 @@
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         HorizontalAlignment="Left"
                         Content="{DynamicResource plugin_explorer_default_open_in_file_manager}"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsChecked="{Binding Settings.DefaultOpenFolderInFileManager}" />
 
                     <TextBlock
@@ -239,6 +242,7 @@
                             Width="{StaticResource SettingPanelPathTextBoxWidth}"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             Text="{Binding FileEditorPath}"
                             TextWrapping="NoWrap" />
                         <Button
@@ -246,7 +250,8 @@
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             Command="{Binding OpenFileEditorPathCommand}"
-                            Content="{DynamicResource select}" />
+                            Content="{DynamicResource select}"
+                            FontFamily="{DynamicResource SettingWindowFont}" />
                     </StackPanel>
 
                     <TextBlock
@@ -266,6 +271,7 @@
                             Width="{StaticResource SettingPanelPathTextBoxWidth}"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             Text="{Binding FolderEditorPath}"
                             TextWrapping="NoWrap" />
                         <Button
@@ -273,7 +279,8 @@
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             Command="{Binding OpenFolderEditorPathCommand}"
-                            Content="{DynamicResource select}" />
+                            Content="{DynamicResource select}"
+                            FontFamily="{DynamicResource SettingWindowFont}" />
                     </StackPanel>
 
                     <TextBlock
@@ -293,6 +300,7 @@
                             Width="{StaticResource SettingPanelPathTextBoxWidth}"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             Text="{Binding ShellPath}"
                             TextWrapping="NoWrap" />
                         <Button
@@ -300,7 +308,8 @@
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             Command="{Binding OpenShellPathCommand}"
-                            Content="{DynamicResource select}" />
+                            Content="{DynamicResource select}"
+                            FontFamily="{DynamicResource SettingWindowFont}" />
                     </StackPanel>
 
                     <TextBlock
@@ -317,6 +326,7 @@
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         DisplayMemberPath="Description"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         ItemsSource="{Binding IndexSearchEngines}"
                         SelectedItem="{Binding SelectedIndexSearchEngine}" />
 
@@ -334,6 +344,7 @@
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         DisplayMemberPath="Description"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         ItemsSource="{Binding ContentIndexSearchEngines}"
                         SelectedItem="{Binding SelectedContentSearchEngine}" />
 
@@ -351,6 +362,7 @@
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         DisplayMemberPath="Description"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         ItemsSource="{Binding PathEnumerationEngines}"
                         SelectedItem="{Binding SelectedPathEnumerationEngine}" />
 
@@ -367,6 +379,7 @@
                         MinWidth="{StaticResource SettingPanelTextBoxMinWidth}"
                         Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                         HorizontalAlignment="Left"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         Text="{Binding ExcludedFileTypes}"
                         ToolTip="{DynamicResource plugin_explorer_Excluded_File_Types_Tooltip}" />
 
@@ -384,6 +397,7 @@
                         Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         MaxLength="6"
                         PreviewTextInput="AllowOnlyNumericInput"
                         Text="{Binding MaxResult}"
@@ -395,7 +409,8 @@
                         Grid.ColumnSpan="2"
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         Click="btnOpenIndexingOptions_Click"
-                        Content="{DynamicResource plugin_explorer_Open_Window_Index_Option}" />
+                        Content="{DynamicResource plugin_explorer_Open_Window_Index_Option}"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
                 </Grid>
             </TabItem>
             <TabItem
@@ -421,6 +436,7 @@
                         Grid.ColumnSpan="2"
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         Content="{DynamicResource plugin_explorer_native_context_menu_display_context_menu}"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsChecked="{Binding ShowWindowsContextMenu}" />
 
                     <TextBlock
@@ -440,6 +456,7 @@
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         HorizontalAlignment="Stretch"
                         AcceptsReturn="True"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         Text="{Binding WindowsContextMenuIncludedItems}"
                         TextWrapping="Wrap" />
 
@@ -460,6 +477,7 @@
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         HorizontalAlignment="Stretch"
                         AcceptsReturn="True"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         Text="{Binding WindowsContextMenuExcludedItems}"
                         TextWrapping="Wrap" />
                 </Grid>
@@ -496,14 +514,17 @@
                             <CheckBox
                                 Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                                 Content="{DynamicResource plugin_explorer_previewpanel_display_file_size_checkbox}"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsChecked="{Binding ShowFileSizeInPreviewPanel}" />
                             <CheckBox
                                 Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                                 Content="{DynamicResource plugin_explorer_previewpanel_display_file_creation_checkbox}"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsChecked="{Binding ShowCreatedDateInPreviewPanel}" />
                             <CheckBox
                                 Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                                 Content="{DynamicResource plugin_explorer_previewpanel_display_file_modification_checkbox}"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsChecked="{Binding ShowModifiedDateInPreviewPanel}" />
                         </WrapPanel>
                     </DockPanel>
@@ -530,6 +551,7 @@
                             <StackPanel Margin="{StaticResource SettingPanelItemTopBottomMargin}" Orientation="Horizontal">
                                 <ComboBox
                                     Margin="{StaticResource SettingPanelItemLeftMargin}"
+                                    FontFamily="{DynamicResource SettingWindowFont}"
                                     ItemsSource="{Binding DateFormatList}"
                                     SelectedItem="{Binding PreviewPanelDateFormat}" />
                                 <TextBlock
@@ -541,6 +563,7 @@
                             <StackPanel Margin="{StaticResource SettingPanelItemTopBottomMargin}" Orientation="Horizontal">
                                 <ComboBox
                                     Margin="{StaticResource SettingPanelItemLeftMargin}"
+                                    FontFamily="{DynamicResource SettingWindowFont}"
                                     ItemsSource="{Binding TimeFormatList}"
                                     SelectedItem="{Binding PreviewPanelTimeFormat}" />
                                 <TextBlock
@@ -577,6 +600,7 @@
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         HorizontalAlignment="Left"
                         Content="{DynamicResource flowlauncher_plugin_everything_search_fullpath}"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsChecked="{Binding Settings.EverythingSearchFullPath}" />
 
                     <CheckBox
@@ -586,6 +610,7 @@
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         HorizontalAlignment="Left"
                         Content="{DynamicResource flowlauncher_plugin_everything_enable_run_count}"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsChecked="{Binding Settings.EverythingEnableRunCount}" />
 
                     <TextBlock
@@ -600,6 +625,7 @@
                         Grid.Column="1"
                         Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                         VerticalAlignment="Center"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         ItemsSource="{Binding Settings.SortOptions, Mode=OneWay}"
                         SelectedItem="{Binding Settings.SortOption}"
                         SelectionChanged="EverythingSortOptionChanged">
@@ -625,6 +651,7 @@
                         Width="{StaticResource SettingPanelPathTextBoxWidth}"
                         Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                         HorizontalAlignment="Left"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         Text="{Binding EverythingInstalledPath}" />
 
                     <TextBlock
@@ -679,7 +706,8 @@
                         <Button
                             MinWidth="100"
                             Command="{Binding EditActionKeywordCommand}"
-                            Content="{DynamicResource plugin_explorer_edit}" />
+                            Content="{DynamicResource plugin_explorer_edit}"
+                            FontFamily="{DynamicResource SettingWindowFont}" />
                     </StackPanel>
                 </Grid>
             </TabItem>
@@ -729,19 +757,22 @@
                             MinWidth="100"
                             Command="{Binding RemoveLinkCommand}"
                             CommandParameter="QuickAccessLink"
-                            Content="{DynamicResource plugin_explorer_delete}" />
+                            Content="{DynamicResource plugin_explorer_delete}"
+                            FontFamily="{DynamicResource SettingWindowFont}" />
                         <Button
                             MinWidth="100"
                             Margin="{StaticResource SettingPanelItemLeftMargin}"
                             Command="{Binding EditLinkCommand}"
                             CommandParameter="QuickAccessLink"
-                            Content="{DynamicResource plugin_explorer_edit}" />
+                            Content="{DynamicResource plugin_explorer_edit}"
+                            FontFamily="{DynamicResource SettingWindowFont}" />
                         <Button
                             MinWidth="100"
                             Margin="{StaticResource SettingPanelItemLeftMargin}"
                             Command="{Binding AddLinkCommand}"
                             CommandParameter="QuickAccessLink"
-                            Content="{DynamicResource plugin_explorer_add}" />
+                            Content="{DynamicResource plugin_explorer_add}"
+                            FontFamily="{DynamicResource SettingWindowFont}" />
                     </StackPanel>
                 </Grid>
             </TabItem>
@@ -789,19 +820,22 @@
                             MinWidth="100"
                             Command="{Binding RemoveLinkCommand}"
                             CommandParameter="IndexSearchExcludedPaths"
-                            Content="{DynamicResource plugin_explorer_delete}" />
+                            Content="{DynamicResource plugin_explorer_delete}"
+                            FontFamily="{DynamicResource SettingWindowFont}" />
                         <Button
                             MinWidth="100"
                             Margin="{StaticResource SettingPanelItemLeftMargin}"
                             Command="{Binding EditLinkCommand}"
                             CommandParameter="IndexSearchExcludedPaths"
-                            Content="{DynamicResource plugin_explorer_edit}" />
+                            Content="{DynamicResource plugin_explorer_edit}"
+                            FontFamily="{DynamicResource SettingWindowFont}" />
                         <Button
                             MinWidth="100"
                             Margin="{StaticResource SettingPanelItemLeftMargin}"
                             Command="{Binding AddLinkCommand}"
                             CommandParameter="IndexSearchExcludedPaths"
-                            Content="{DynamicResource plugin_explorer_add}" />
+                            Content="{DynamicResource plugin_explorer_add}"
+                            FontFamily="{DynamicResource SettingWindowFont}" />
                     </StackPanel>
                 </Grid>
             </TabItem>

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/Views/PluginsManagerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/Views/PluginsManagerSettings.xaml
@@ -17,11 +17,13 @@
             Grid.Row="0"
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
             Content="{DynamicResource plugin_pluginsmanager_plugin_settings_unknown_source}"
+            FontFamily="{DynamicResource SettingWindowFont}"
             IsChecked="{Binding WarnFromUnknownSource}" />
         <CheckBox
             Grid.Row="1"
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
             Content="{DynamicResource plugin_pluginsmanager_plugin_settings_auto_restart}"
+            FontFamily="{DynamicResource SettingWindowFont}"
             IsChecked="{Binding AutoRestartAfterChanging}" />
     </Grid>
 </UserControl>

--- a/Plugins/Flow.Launcher.Plugin.ProcessKiller/Views/SettingsControl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.ProcessKiller/Views/SettingsControl.xaml
@@ -18,11 +18,13 @@
             Grid.Row="0"
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
             Content="{DynamicResource flowlauncher_plugin_processkiller_show_window_title}"
+            FontFamily="{DynamicResource SettingWindowFont}"
             IsChecked="{Binding ShowWindowTitle}" />
         <CheckBox
             Grid.Row="1"
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
             Content="{DynamicResource flowlauncher_plugin_processkiller_put_visible_window_process_top}"
+            FontFamily="{DynamicResource SettingWindowFont}"
             IsChecked="{Binding PutVisibleWindowProcessesTop}" />
     </Grid>
 </UserControl>

--- a/Plugins/Flow.Launcher.Plugin.Program/AddProgramSource.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/AddProgramSource.xaml
@@ -5,21 +5,22 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="clr-namespace:Flow.Launcher.Plugin.Program.ViewModels"
-    mc:Ignorable="d"
     Title="{DynamicResource flowlauncher_plugin_program_directory}"
-    d:DataContext="{d:DesignInstance vm:AddProgramSourceViewModel}"
     Width="Auto"
     Height="276"
+    d:DataContext="{d:DesignInstance vm:AddProgramSourceViewModel}"
     Background="{DynamicResource PopuBGColor}"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Foreground="{DynamicResource PopupTextColor}"
     ResizeMode="NoResize"
     SizeToContent="Width"
-    WindowStartupLocation="CenterScreen">
+    WindowStartupLocation="CenterScreen"
+    mc:Ignorable="d">
     <WindowChrome.WindowChrome>
         <WindowChrome CaptionHeight="32" ResizeBorderThickness="{x:Static SystemParameters.WindowResizeBorderThickness}" />
     </WindowChrome.WindowChrome>
     <Window.Resources>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
@@ -59,11 +60,11 @@
                     </Button>
                 </Grid>
             </StackPanel>
-            <StackPanel Margin="26,0,26,0">
-                <StackPanel Grid.Row="0" Margin="0,0,0,12">
+            <StackPanel Margin="26 0 26 0">
+                <StackPanel Grid.Row="0" Margin="0 0 0 12">
                     <TextBlock
                         Grid.Column="0"
-                        Margin="0,0,0,0"
+                        Margin="0 0 0 0"
                         FontSize="20"
                         FontWeight="SemiBold"
                         Text="{DynamicResource flowlauncher_plugin_program_edit_program_source_title}"
@@ -77,7 +78,7 @@
                         TextWrapping="WrapWithOverflow" />
                 </StackPanel>
 
-                <StackPanel Margin="0,10,10,0" Orientation="Horizontal">
+                <StackPanel Margin="0 10 10 0" Orientation="Horizontal">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition />
@@ -104,16 +105,18 @@
                                 HorizontalAlignment="Stretch"
                                 Click="BrowseButton_Click"
                                 Content="{DynamicResource flowlauncher_plugin_program_browse}"
-                                Visibility="{Binding IsCustomSource, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                DockPanel.Dock="Right" />
+                                DockPanel.Dock="Right"
+                                FontFamily="{DynamicResource SettingWindowFont}"
+                                Visibility="{Binding IsCustomSource, Converter={StaticResource BooleanToVisibilityConverter}}" />
                             <TextBox
                                 Name="Directory"
                                 Width="350"
                                 Margin="10"
-                                Text="{Binding Location, Mode=TwoWay}"
-                                IsReadOnly="{Binding IsNotCustomSource}"
                                 HorizontalAlignment="Stretch"
-                                VerticalAlignment="Center" />
+                                VerticalAlignment="Center"
+                                FontFamily="{DynamicResource SettingWindowFont}"
+                                IsReadOnly="{Binding IsNotCustomSource}"
+                                Text="{Binding Location, Mode=TwoWay}" />
                         </DockPanel>
                         <TextBlock
                             Grid.Row="1"
@@ -127,32 +130,35 @@
                             x:Name="Chkbox"
                             Grid.Row="1"
                             Grid.Column="1"
-                            Margin="10,0"
-                            IsChecked="{Binding Enabled, Mode=TwoWay}"
-                            VerticalAlignment="Center" />
+                            Margin="10 0"
+                            VerticalAlignment="Center"
+                            FontFamily="{DynamicResource SettingWindowFont}"
+                            IsChecked="{Binding Enabled, Mode=TwoWay}" />
                     </Grid>
                 </StackPanel>
             </StackPanel>
         </StackPanel>
         <Border
             Grid.Row="1"
-            Margin="0,14,0,0"
+            Margin="0 14 0 0"
             Background="{DynamicResource PopupButtonAreaBGColor}"
             BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
-            BorderThickness="0,1,0,0">
+            BorderThickness="0 1 0 0">
             <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                 <Button
                     x:Name="btnCancel"
                     MinWidth="140"
-                    Margin="10,0,5,0"
+                    Margin="10 0 5 0"
                     Click="BtnCancel_OnClick"
-                    Content="{DynamicResource cancel}" />
+                    Content="{DynamicResource cancel}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     x:Name="btnAdd"
                     MinWidth="140"
-                    Margin="5,0,10,0"
+                    Margin="5 0 10 0"
                     Click="BtnAdd_OnClick"
                     Content="{Binding AddBtnText}"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     Style="{DynamicResource AccentButtonStyle}" />
             </StackPanel>
         </Border>

--- a/Plugins/Flow.Launcher.Plugin.Program/ProgramSuffixes.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/ProgramSuffixes.xaml
@@ -9,6 +9,7 @@
     Width="600"
     Background="{DynamicResource PopuBGColor}"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Foreground="{DynamicResource PopupTextColor}"
     ResizeMode="NoResize"
     SizeToContent="Height"
@@ -46,8 +47,8 @@
             <Setter Property="BorderBrush" Value="{DynamicResource Color03B}" />
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="CornerRadius" Value="5" />
-            <Setter Property="Margin" Value="0,5,0,0" />
-            <Setter Property="Padding" Value="15,15,15,15" />
+            <Setter Property="Margin" Value="0 5 0 0" />
+            <Setter Property="Padding" Value="15 15 15 15" />
             <Setter Property="SnapsToDevicePixels" Value="True" />
             <Setter Property="Visibility" Value="Collapsed" />
             <Style.Triggers>
@@ -65,8 +66,8 @@
             <Setter Property="BorderBrush" Value="{DynamicResource Color03B}" />
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="CornerRadius" Value="5" />
-            <Setter Property="Margin" Value="0,5,0,0" />
-            <Setter Property="Padding" Value="15,15,15,15" />
+            <Setter Property="Margin" Value="0 5 0 0" />
+            <Setter Property="Padding" Value="15 15 15 15" />
             <Setter Property="SnapsToDevicePixels" Value="True" />
             <Setter Property="Visibility" Value="Collapsed" />
             <Style.Triggers>
@@ -120,20 +121,18 @@
                     </Button>
                 </Grid>
             </StackPanel>
-            <StackPanel Margin="26,12,26,0">
-
-                <StackPanel Margin="0,0,0,12">
-
+            <StackPanel Margin="26 12 26 0">
+                <StackPanel Margin="0 0 0 12">
                     <TextBlock
                         Grid.Column="0"
-                        Margin="0,0,0,0"
+                        Margin="0 0 0 0"
                         FontSize="20"
                         FontWeight="SemiBold"
                         Text="{DynamicResource flowlauncher_plugin_program_suffixes}"
                         TextAlignment="Left" />
                 </StackPanel>
                 <TextBlock
-                    Margin="0,0,0,10"
+                    Margin="0 0 0 10"
                     FontSize="14"
                     Text="{DynamicResource flowlauncher_plugin_program_only_index_tip}"
                     TextWrapping="Wrap" />
@@ -151,82 +150,90 @@
                         TextWrapping="Wrap" />
                 </Border>
 
-                <Grid Margin="0,20,0,12">
+                <Grid Margin="0 20 0 12">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="250" />
                         <ColumnDefinition Width="250" />
                     </Grid.ColumnDefinitions>
 
-                    <StackPanel Grid.Column="0" Margin="0,0,0,0">
+                    <StackPanel Grid.Column="0" Margin="0 0 0 0">
                         <TextBlock
-                            Margin="0,0,0,8"
+                            Margin="0 0 0 8"
                             FontSize="16"
                             FontWeight="SemiBold"
                             Text="{DynamicResource flowlauncher_plugin_program_suffixes_executable_types}" />
                         <CheckBox
                             Name="apprefMS"
-                            Margin="10,0,0,0"
+                            Margin="10 0 0 0"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             IsChecked="{Binding SuffixesStatus[appref-ms]}">
                             appref-ms
                         </CheckBox>
                         <CheckBox
                             Name="exe"
-                            Margin="10,0,0,0"
+                            Margin="10 0 0 0"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             IsChecked="{Binding SuffixesStatus[exe]}">
                             exe
                         </CheckBox>
                         <CheckBox
                             Name="lnk"
-                            Margin="10,0,0,0"
+                            Margin="10 0 0 0"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             IsChecked="{Binding SuffixesStatus[lnk]}">
                             lnk
                         </CheckBox>
                         <CheckBox
                             Name="CustomFiles"
-                            Margin="10,0,0,0"
+                            Margin="10 0 0 0"
                             Content="{DynamicResource flowlauncher_plugin_program_suffixes_custom_file_types}"
+                            FontFamily="{DynamicResource SettingWindowFont}"
                             IsChecked="{Binding UseCustomSuffixes}" />
                         <TextBox
                             x:Name="tbSuffixes"
-                            Margin="10,4,0,10"
+                            Margin="10 4 0 10"
                             Style="{StaticResource CustomFileTypeTextBox}" />
                     </StackPanel>
 
                     <Border
                         Grid.Column="1"
-                        Margin="20,0,0,10"
-                        Padding="20,0,0,0"
+                        Margin="20 0 0 10"
+                        Padding="20 0 0 0"
                         BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
-                        BorderThickness="1,0,0,0">
+                        BorderThickness="1 0 0 0">
                         <StackPanel>
                             <TextBlock
-                                Margin="0,0,0,8"
+                                Margin="0 0 0 8"
                                 FontSize="16"
                                 FontWeight="SemiBold"
                                 Text="{DynamicResource flowlauncher_plugin_program_suffixes_URL_types}" />
                             <CheckBox
                                 Name="steam"
-                                Margin="10,0,0,0"
+                                Margin="10 0 0 0"
                                 Content="{DynamicResource flowlauncher_plugin_program_suffixes_URL_steam}"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsChecked="{Binding ProtocolsStatus[steam]}" />
                             <CheckBox
                                 Name="epic"
-                                Margin="10,0,0,0"
+                                Margin="10 0 0 0"
                                 Content="{DynamicResource flowlauncher_plugin_program_suffixes_URL_epic}"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsChecked="{Binding ProtocolsStatus[epic]}" />
                             <CheckBox
                                 Name="http"
-                                Margin="10,0,0,0"
+                                Margin="10 0 0 0"
                                 Content="{DynamicResource flowlauncher_plugin_program_suffixes_URL_http}"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsChecked="{Binding ProtocolsStatus[http]}" />
                             <CheckBox
                                 Name="CustomProtocol"
-                                Margin="10,0,0,0"
+                                Margin="10 0 0 0"
                                 Content="{DynamicResource flowlauncher_plugin_program_suffixes_custom_urls}"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 IsChecked="{Binding UseCustomProtocols}" />
                             <TextBox
                                 x:Name="tbProtocols"
-                                Margin="10,4,0,0"
+                                Margin="10 4 0 0"
                                 Style="{StaticResource CustomURLTypeTextBox}" />
                         </StackPanel>
                     </Border>
@@ -237,30 +244,32 @@
             Grid.Row="1"
             Background="{DynamicResource PopupButtonAreaBGColor}"
             BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
-            BorderThickness="0,1,0,0">
+            BorderThickness="0 1 0 0">
             <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                 <Button
                     x:Name="btnReset"
                     Height="30"
                     MinWidth="140"
-                    Margin="0,0,5,0"
+                    Margin="0 0 5 0"
                     Click="BtnReset_OnClick"
-                    Content="{DynamicResource flowlauncher_plugin_program_reset}" />
+                    Content="{DynamicResource flowlauncher_plugin_program_reset}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     x:Name="btnCancel"
                     Height="30"
                     MinWidth="140"
-                    Margin="5,0,5,0"
+                    Margin="5 0 5 0"
                     Click="BtnCancel_OnClick"
-                    Content="{DynamicResource cancel}" />
-
+                    Content="{DynamicResource cancel}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     Height="30"
                     MinWidth="140"
-                    Margin="5,0,0,0"
+                    Margin="5 0 0 0"
                     HorizontalAlignment="Right"
                     Click="BtnAdd_OnClick"
                     Content="{DynamicResource flowlauncher_plugin_program_update}"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     Style="{DynamicResource AccentButtonStyle}" />
             </StackPanel>
         </Border>

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
@@ -32,6 +32,7 @@
                     Name="UWPEnabled"
                     Margin="{StaticResource SettingPanelItemRightMargin}"
                     Content="{DynamicResource flowlauncher_plugin_program_index_uwp}"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsChecked="{Binding EnableUWP}"
                     ToolTip="{DynamicResource flowlauncher_plugin_program_index_uwp_tooltip}"
                     Visibility="{Binding ShowUWPCheckbox, Converter={StaticResource BooleanToVisibilityConverter}}" />
@@ -39,17 +40,20 @@
                     Name="StartMenuEnabled"
                     Margin="{StaticResource SettingPanelItemRightMargin}"
                     Content="{DynamicResource flowlauncher_plugin_program_index_start}"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsChecked="{Binding EnableStartMenuSource}"
                     ToolTip="{DynamicResource flowlauncher_plugin_program_index_start_tooltip}" />
                 <CheckBox
                     Name="RegistryEnabled"
                     Margin="{StaticResource SettingPanelItemRightMargin}"
                     Content="{DynamicResource flowlauncher_plugin_program_index_registry}"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsChecked="{Binding EnableRegistrySource}"
                     ToolTip="{DynamicResource flowlauncher_plugin_program_index_registry_tooltip}" />
                 <CheckBox
                     Name="PATHEnabled"
                     Content="{DynamicResource flowlauncher_plugin_program_index_PATH}"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsChecked="{Binding EnablePATHSource}"
                     ToolTip="{DynamicResource flowlauncher_plugin_program_index_PATH_tooltip}" />
             </WrapPanel>
@@ -72,20 +76,24 @@
                     <CheckBox
                         Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
                         Content="{DynamicResource flowlauncher_plugin_program_enable_hidelnkpath}"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsChecked="{Binding HideAppsPath}"
                         ToolTip="{DynamicResource flowlauncher_plugin_program_enable_hidelnkpath_tooltip}" />
                     <CheckBox
                         Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
                         Content="{DynamicResource flowlauncher_plugin_program_enable_hideuninstallers}"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsChecked="{Binding HideUninstallers}"
                         ToolTip="{DynamicResource flowlauncher_plugin_program_enable_hideuninstallers_tooltip}" />
                     <CheckBox
                         Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
                         Content="{DynamicResource flowlauncher_plugin_program_enable_description}"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsChecked="{Binding EnableDescription}"
                         ToolTip="{DynamicResource flowlauncher_plugin_program_enable_description_tooltip}" />
                     <CheckBox
                         Content="{DynamicResource flowlauncher_plugin_program_enable_hideduplicatedwindowsapp}"
+                        FontFamily="{DynamicResource SettingWindowFont}"
                         IsChecked="{Binding HideDuplicatedWindowsApp}"
                         ToolTip="{DynamicResource flowlauncher_plugin_program_enable_hideduplicatedwindowsapp_tooltip}" />
                 </WrapPanel>
@@ -101,21 +109,24 @@
                     Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
                     HorizontalAlignment="Right"
                     Click="btnLoadAllProgramSource_OnClick"
-                    Content="{DynamicResource flowlauncher_plugin_program_all_programs}" />
+                    Content="{DynamicResource flowlauncher_plugin_program_all_programs}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     x:Name="btnProgramSuffixes"
                     MinWidth="120"
                     Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
                     HorizontalAlignment="Right"
                     Click="BtnProgramSuffixes_OnClick"
-                    Content="{DynamicResource flowlauncher_plugin_program_suffixes}" />
+                    Content="{DynamicResource flowlauncher_plugin_program_suffixes}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     x:Name="btnReindex"
                     MinWidth="120"
                     Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
                     HorizontalAlignment="Right"
                     Click="btnReindex_Click"
-                    Content="{DynamicResource flowlauncher_plugin_program_reindex}" />
+                    Content="{DynamicResource flowlauncher_plugin_program_reindex}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <StackPanel
                     x:Name="indexingPanel"
                     HorizontalAlignment="Left"
@@ -196,19 +207,22 @@
                     MinWidth="100"
                     Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                     Click="btnProgramSourceStatus_OnClick"
-                    Content="{DynamicResource flowlauncher_plugin_program_disable}" />
+                    Content="{DynamicResource flowlauncher_plugin_program_disable}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     x:Name="btnEditProgramSource"
                     MinWidth="100"
                     Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                     Click="btnEditProgramSource_OnClick"
-                    Content="{DynamicResource flowlauncher_plugin_program_edit}" />
+                    Content="{DynamicResource flowlauncher_plugin_program_edit}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     x:Name="btnAddProgramSource"
                     MinWidth="100"
                     Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                     Click="btnAddProgramSource_OnClick"
-                    Content="{DynamicResource flowlauncher_plugin_program_add}" />
+                    Content="{DynamicResource flowlauncher_plugin_program_add}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
             </StackPanel>
         </DockPanel>
     </Grid>

--- a/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Shell/ShellSetting.xaml
@@ -23,36 +23,42 @@
             Grid.Row="0"
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
             HorizontalAlignment="Left"
-            Content="{DynamicResource flowlauncher_plugin_cmd_relace_winr}" />
+            Content="{DynamicResource flowlauncher_plugin_cmd_relace_winr}"
+            FontFamily="{DynamicResource SettingWindowFont}" />
         <CheckBox
             x:Name="CloseShellAfterPress"
             Grid.Row="1"
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
             HorizontalAlignment="Left"
-            Content="{DynamicResource flowlauncher_plugin_cmd_close_cmd_after_press}" />
+            Content="{DynamicResource flowlauncher_plugin_cmd_close_cmd_after_press}"
+            FontFamily="{DynamicResource SettingWindowFont}" />
         <CheckBox
             x:Name="LeaveShellOpen"
             Grid.Row="2"
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
             HorizontalAlignment="Left"
-            Content="{DynamicResource flowlauncher_plugin_cmd_leave_cmd_open}" />
+            Content="{DynamicResource flowlauncher_plugin_cmd_leave_cmd_open}"
+            FontFamily="{DynamicResource SettingWindowFont}" />
         <CheckBox
             x:Name="AlwaysRunAsAdministrator"
             Grid.Row="3"
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
             HorizontalAlignment="Left"
-            Content="{DynamicResource flowlauncher_plugin_cmd_always_run_as_administrator}" />
+            Content="{DynamicResource flowlauncher_plugin_cmd_always_run_as_administrator}"
+            FontFamily="{DynamicResource SettingWindowFont}" />
         <CheckBox
             x:Name="UseWindowsTerminal"
             Grid.Row="4"
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
             HorizontalAlignment="Left"
-            Content="{DynamicResource flowlauncher_plugin_cmd_use_windows_terminal}" />
+            Content="{DynamicResource flowlauncher_plugin_cmd_use_windows_terminal}"
+            FontFamily="{DynamicResource SettingWindowFont}" />
         <ComboBox
             x:Name="ShellComboBox"
             Grid.Row="5"
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
-            HorizontalAlignment="Left">
+            HorizontalAlignment="Left"
+            FontFamily="{DynamicResource SettingWindowFont}">
             <ComboBoxItem>CMD</ComboBoxItem>
             <ComboBoxItem>PowerShell</ComboBoxItem>
             <ComboBoxItem>Pwsh</ComboBoxItem>
@@ -62,11 +68,13 @@
             <CheckBox
                 x:Name="ShowOnlyMostUsedCMDs"
                 Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
-                Content="{DynamicResource flowlauncher_plugin_cmd_history}" />
+                Content="{DynamicResource flowlauncher_plugin_cmd_history}"
+                FontFamily="{DynamicResource SettingWindowFont}" />
             <ComboBox
                 x:Name="ShowOnlyMostUsedCMDsNumber"
                 Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
-                HorizontalAlignment="Left" />
+                HorizontalAlignment="Left"
+                FontFamily="{DynamicResource SettingWindowFont}" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Plugins/Flow.Launcher.Plugin.Sys/CommandKeywordSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Sys/CommandKeywordSetting.xaml
@@ -7,6 +7,7 @@
     Title="{DynamicResource lowlauncher_plugin_sys_command_keyword_setting_window_title}"
     Width="550"
     Background="{DynamicResource PopupBGColor}"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Foreground="{DynamicResource PopupTextColor}"
     ResizeMode="NoResize"
     SizeToContent="Height"
@@ -86,15 +87,17 @@
                         x:Name="CommandKeyword"
                         Grid.Column="1"
                         Margin="10"
-                        HorizontalAlignment="Stretch" />
+                        HorizontalAlignment="Stretch"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
                     <Button
-                        x:Name="btnTestActionKeyword"
+                        x:Name="btnResetCommand"
                         Grid.Row="1"
                         Grid.Column="2"
                         Margin="0 0 10 0"
                         Padding="10 5 10 5"
                         Click="OnResetButtonClick"
-                        Content="{DynamicResource flowlauncher_plugin_sys_reset}" />
+                        Content="{DynamicResource flowlauncher_plugin_sys_reset}"
+                        FontFamily="{DynamicResource SettingWindowFont}" />
                 </Grid>
             </StackPanel>
         </StackPanel>
@@ -108,12 +111,14 @@
                     MinWidth="140"
                     Margin="10 0 5 0"
                     Click="OnCancelButtonClick"
-                    Content="{DynamicResource flowlauncher_plugin_sys_cancel}" />
+                    Content="{DynamicResource flowlauncher_plugin_sys_cancel}"
+                    FontFamily="{DynamicResource SettingWindowFont}" />
                 <Button
                     MinWidth="140"
                     Margin="5 0 10 0"
                     Click="OnConfirmButtonClick"
                     Content="{DynamicResource flowlauncher_plugin_sys_confirm}"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     Style="{DynamicResource AccentButtonStyle}" />
             </StackPanel>
         </Border>

--- a/Plugins/Flow.Launcher.Plugin.Sys/SysSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Sys/SysSettings.xaml
@@ -65,7 +65,8 @@
                 Width="100"
                 Margin="{StaticResource SettingPanelItemLeftMargin}"
                 Click="OnEditCommandKeywordClick"
-                Content="{DynamicResource flowlauncher_plugin_sys_edit}" />
+                Content="{DynamicResource flowlauncher_plugin_sys_edit}"
+                FontFamily="{DynamicResource SettingWindowFont}" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
@@ -9,6 +9,7 @@
     Width="550"
     d:DataContext="{d:DesignInstance vm:SearchSourceViewModel}"
     Background="{DynamicResource PopupBGColor}"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Foreground="{DynamicResource PopupTextColor}"
     ResizeMode="NoResize"
     SizeToContent="Height"
@@ -76,6 +77,7 @@
                                 TextWrapping="WrapWithOverflow" />
                             <TextBox
                                 Margin="0 12 0 12"
+                                FontFamily="{DynamicResource SettingWindowFont}"
                                 FontSize="14"
                                 FontWeight="SemiBold"
                                 IsReadOnly="True"
@@ -116,6 +118,7 @@
                                     Margin="10"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Center"
+                                    FontFamily="{DynamicResource SettingWindowFont}"
                                     Text="{Binding SearchSource.Title}" />
                                 <TextBlock
                                     Grid.Row="1"
@@ -134,7 +137,8 @@
                                         Margin="10 0 0 0"
                                         VerticalAlignment="Center"
                                         Click="OnSelectIconClick"
-                                        Content="{DynamicResource flowlauncher_plugin_websearch_select_icon}" />
+                                        Content="{DynamicResource flowlauncher_plugin_websearch_select_icon}"
+                                        FontFamily="{DynamicResource SettingWindowFont}" />
                                     <Image
                                         Name="imgPreviewIcon"
                                         Width="24"
@@ -156,6 +160,7 @@
                                     Margin="10"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Center"
+                                    FontFamily="{DynamicResource SettingWindowFont}"
                                     Text="{Binding SearchSource.Url}" />
                                 <TextBlock
                                     Grid.Row="3"
@@ -172,6 +177,7 @@
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Center"
                                     DataObject.Pasting="TextBox_Pasting"
+                                    FontFamily="{DynamicResource SettingWindowFont}"
                                     PreviewKeyDown="TextBox_PreviewKeyDown"
                                     Text="{Binding SearchSource.ActionKeyword}" />
                                 <TextBlock
@@ -187,6 +193,7 @@
                                     Grid.Column="1"
                                     Margin="10 10 10 15"
                                     VerticalAlignment="Center"
+                                    FontFamily="{DynamicResource SettingWindowFont}"
                                     IsChecked="{Binding SearchSource.Enabled}" />
                             </Grid>
                         </StackPanel>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
@@ -109,17 +109,20 @@
                 Width="100"
                 Margin="{StaticResource SettingPanelItemLeftMargin}"
                 Click="OnDeleteSearchSearchClick"
-                Content="{DynamicResource flowlauncher_plugin_websearch_delete}" />
+                Content="{DynamicResource flowlauncher_plugin_websearch_delete}"
+                FontFamily="{DynamicResource SettingWindowFont}" />
             <Button
                 Width="100"
                 Margin="{StaticResource SettingPanelItemLeftMargin}"
                 Click="OnEditSearchSourceClick"
-                Content="{DynamicResource flowlauncher_plugin_websearch_edit}" />
+                Content="{DynamicResource flowlauncher_plugin_websearch_edit}"
+                FontFamily="{DynamicResource SettingWindowFont}" />
             <Button
                 Width="100"
                 Margin="{StaticResource SettingPanelItemLeftMargin}"
                 Click="OnAddSearchSearchClick"
-                Content="{DynamicResource flowlauncher_plugin_websearch_add}" />
+                Content="{DynamicResource flowlauncher_plugin_websearch_add}"
+                FontFamily="{DynamicResource SettingWindowFont}" />
         </StackPanel>
 
         <Separator Grid.Row="2" Style="{StaticResource SettingPanelSeparatorStyle}" />
@@ -137,6 +140,7 @@
                     Height="30"
                     Margin="{StaticResource SettingPanelItemLeftMargin}"
                     VerticalAlignment="Center"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     FontSize="11"
                     IsEnabled="{Binding ElementName=EnableSuggestion, Path=IsChecked}"
                     ItemsSource="{Binding Settings.Suggestions}"
@@ -147,6 +151,7 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Center"
                     Content="{DynamicResource flowlauncher_plugin_websearch_enable_suggestion}"
+                    FontFamily="{DynamicResource SettingWindowFont}"
                     IsChecked="{Binding Settings.EnableSuggestion}" />
             </StackPanel>
             <!--  Not sure why binding IsEnabled directly to Settings.EnableWebSearchSuggestion is not working  -->


### PR DESCRIPTION
# Let more controls follow setting window font

Follow on with #3470.

This PR adds more controls like button, combo box, plugin settings control (preinstalled Csharp plugins & JsonRPC plugins), etc. And this PR also exposes setting window font in `{DynamicResource SettingWindowFont}` so that plugin developers can use them in their settings control.

# Allow users to enable Use Logon Task in welcome page 5

This PR adds Use Logon Task check box in welcome page 5.