### PR TITLE
Improve PropertyChanged.Fody Code Quality

### DIFF
--- a/Flow.Launcher.Infrastructure/Flow.Launcher.Infrastructure.csproj
+++ b/Flow.Launcher.Infrastructure/Flow.Launcher.Infrastructure.csproj
@@ -66,7 +66,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NLog" Version="4.7.10" />
-    <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" />
+    <PackageReference Include="PropertyChanged.Fody" Version="3.4.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="SharpVectors.Wpf" Version="1.8.4.2" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <!--ToolGood.Words.Pinyin v3.0.2.6 results in high memory usage when search with pinyin is enabled-->

--- a/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
+++ b/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
@@ -76,7 +76,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" />
+    <PackageReference Include="PropertyChanged.Fody" Version="3.4.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Flow.Launcher/ActionKeywords.xaml.cs
+++ b/Flow.Launcher/ActionKeywords.xaml.cs
@@ -80,7 +80,7 @@ namespace Flow.Launcher
             }
 
             // Update action keywords text and close window
-            _pluginViewModel.OnActionKeywordsChanged();
+            _pluginViewModel.OnActionKeywordsTextChanged();
             Close();
         }
     }

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -98,7 +98,9 @@
     <!-- https://github.com/Flow-Launcher/Flow.Launcher/issues/1772#issuecomment-1502440801 -->
     <PackageReference Include="ModernWpfUI" Version="0.9.4" />
     <PackageReference Include="NHotkey.Wpf" Version="3.0.0" />
-    <PackageReference Include="PropertyChanged.Fody" Version="3.4.0" />
+    <PackageReference Include="PropertyChanged.Fody" Version="3.4.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="SemanticVersioning" Version="3.0.0" />
     <PackageReference Include="TaskScheduler" Version="2.12.1" />
     <PackageReference Include="VirtualizingWrapPanel" Version="2.1.1" />

--- a/Flow.Launcher/ViewModel/PluginViewModel.cs
+++ b/Flow.Launcher/ViewModel/PluginViewModel.cs
@@ -155,14 +155,9 @@ namespace Flow.Launcher.ViewModel
         public bool SearchDelayEnabled => Settings.SearchQueryResultsWithDelay;
         public string DefaultSearchDelay => Settings.SearchDelayTime.ToString();
 
-        public void OnActionKeywordsChanged()
+        public void OnActionKeywordsTextChanged()
         {
             OnPropertyChanged(nameof(ActionKeywordsText));
-        }
-
-        public void OnSearchDelayTimeChanged()
-        {
-            OnPropertyChanged(nameof(SearchDelayTimeText));
         }
 
         [RelayCommand]


### PR DESCRIPTION
# Set private assets all for PropertyChanged.Fody

Fix build warning `MSBUILD : warning FodyPackageReference: Fody: The package reference for PropertyChanged.Fody does not contain PrivateAssets='All'

# Change function name and remove unused function

Fix build warning

```
PluginViewModel.cs(159,9,159,10): warning : Fody/PropertyChanged: Type Flow.Launcher.ViewModel.PluginViewModel contains a method OnActionKeywordsChanged which will not be called as ActionKeywords is not found. You can suppress this warning with [SuppressPropertyChangedWarnings].
PluginViewModel.cs(164,9,164,10): warning : Fody/PropertyChanged: Type Flow.Launcher.ViewModel.PluginViewModel contains a method OnSearchDelayTimeChanged which will not be called as SearchDelayTime is not found. You can suppress this warning with [SuppressPropertyChangedWarnings].

```