### PR TITLE
Fix clean cache issue

### DIFF
--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -186,8 +186,8 @@ public partial class SettingsPaneAboutViewModel : BaseModel
             {
                 try
                 {
-                    // Make sure directory clean
-                    dir.Delete(true);
+                    // Log folders are the last level of folders
+                    dir.Delete(false);
                 }
                 catch (Exception e)
                 {
@@ -249,21 +249,16 @@ public partial class SettingsPaneAboutViewModel : BaseModel
             });
 
         // Then, delete plugin directory
-        cacheDirectory.EnumerateDirectories("*", SearchOption.TopDirectoryOnly)
-            .ToList()
-            .ForEach(dir =>
-            {
-                try
-                {
-                    // Make sure directory clean
-                    dir.Delete(true);
-                }
-                catch (Exception e)
-                {
-                    App.API.LogException(ClassName, $"Failed to delete cache directory: {dir.Name}", e);
-                    success = false;
-                }
-            });
+        try
+        {
+            // Log folders are the last level of folders
+            GetPluginCacheDir().Delete(false);
+        }
+        catch (Exception e)
+        {
+            App.API.LogException(ClassName, $"Failed to delete cache directory: {dir.Name}", e);
+            success = false;
+        }
 
         OnPropertyChanged(nameof(CacheFolderSize));
 

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -187,7 +187,7 @@ public partial class SettingsPaneAboutViewModel : BaseModel
                 try
                 {
                     // Log folders are the last level of folders
-                    dir.Delete(false);
+                    dir.Delete(recursive: false);
                 }
                 catch (Exception e)
                 {
@@ -239,7 +239,7 @@ public partial class SettingsPaneAboutViewModel : BaseModel
                 try
                 {
                     // Plugin may create directories in its cache directory
-                    dir.Delete(true);
+                    dir.Delete(recursive: true);
                 }
                 catch (Exception e)
                 {
@@ -249,10 +249,11 @@ public partial class SettingsPaneAboutViewModel : BaseModel
             });
 
         // Then, delete plugin directory
+        var dir = GetPluginCacheDir();
         try
         {
             // Log folders are the last level of folders
-            GetPluginCacheDir().Delete(false);
+            dir.Delete(recursive: false);
         }
         catch (Exception e)
         {

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -186,6 +186,7 @@ public partial class SettingsPaneAboutViewModel : BaseModel
             {
                 try
                 {
+                    // Make sure directory clean
                     dir.Delete(true);
                 }
                 catch (Exception e)
@@ -214,6 +215,7 @@ public partial class SettingsPaneAboutViewModel : BaseModel
     {
         var success = true;
         var cacheDirectory = GetCacheDir();
+        var pluginCacheDirectory = GetPluginCacheDir();
         var cacheFiles = GetCacheFiles();
 
         cacheFiles.ForEach(f =>
@@ -229,12 +231,31 @@ public partial class SettingsPaneAboutViewModel : BaseModel
             }
         });
 
+        // Firstly, delete plugin cache directories
+        pluginCacheDirectory.EnumerateDirectories("*", SearchOption.TopDirectoryOnly)
+            .ToList()
+            .ForEach(dir =>
+            {
+                try
+                {
+                    // Plugin may create directories in its cache directory
+                    dir.Delete(true);
+                }
+                catch (Exception e)
+                {
+                    App.API.LogException(ClassName, $"Failed to delete cache directory: {dir.Name}", e);
+                    success = false;
+                }
+            });
+
+        // Then, delete plugin directory
         cacheDirectory.EnumerateDirectories("*", SearchOption.TopDirectoryOnly)
             .ToList()
             .ForEach(dir =>
             {
                 try
                 {
+                    // Make sure directory clean
                     dir.Delete(true);
                 }
                 catch (Exception e)
@@ -252,6 +273,11 @@ public partial class SettingsPaneAboutViewModel : BaseModel
     private static DirectoryInfo GetCacheDir()
     {
         return new DirectoryInfo(DataLocation.CacheDirectory);
+    }
+
+    private static DirectoryInfo GetPluginCacheDir()
+    {
+        return new DirectoryInfo(DataLocation.PluginCacheDirectory);
     }
 
     private static List<FileInfo> GetCacheFiles()

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -252,7 +252,6 @@ public partial class SettingsPaneAboutViewModel : BaseModel
         var dir = GetPluginCacheDir();
         try
         {
-            // Log folders are the last level of folders
             dir.Delete(recursive: false);
         }
         catch (Exception e)


### PR DESCRIPTION
Follow on with #3411.

- We should firstly delete plugin cache directories and then delete plugin directory, or the settings page will freeze.
- Reverted original changes to set recursive to true.

Test

- Clean logs & clean caches option can work.