### PR TITLE
Support Multiple Topmost Records

### DIFF
--- a/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
@@ -50,6 +50,22 @@ namespace Flow.Launcher.Infrastructure.Storage
             return File.Exists(FilePath);
         }
 
+        public void Delete()
+        {
+            if (File.Exists(FilePath))
+            {
+                File.Delete(FilePath);
+            }
+            if (File.Exists(BackupFilePath))
+            {
+                File.Delete(BackupFilePath);
+            }
+            if (File.Exists(TempFilePath))
+            {
+                File.Delete(TempFilePath);
+            }
+        }
+
         public async Task<T> LoadAsync()
         {
             if (Data != null)

--- a/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
@@ -52,17 +52,12 @@ namespace Flow.Launcher.Infrastructure.Storage
 
         public void Delete()
         {
-            if (File.Exists(FilePath))
+            foreach (var path in new[] { FilePath, BackupFilePath, TempFilePath })
             {
-                File.Delete(FilePath);
-            }
-            if (File.Exists(BackupFilePath))
-            {
-                File.Delete(BackupFilePath);
-            }
-            if (File.Exists(TempFilePath))
-            {
-                File.Delete(TempFilePath);
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
             }
         }
 

--- a/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
@@ -45,6 +45,11 @@ namespace Flow.Launcher.Infrastructure.Storage
             FilesFolders.ValidateDirectory(DirectoryPath);
         }
 
+        public bool Exists()
+        {
+            return File.Exists(FilePath);
+        }
+
         public async Task<T> LoadAsync()
         {
             if (Data != null)

--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -34,7 +34,7 @@ namespace Flow.Launcher.Storage
                 }
                 catch
                 {
-                    // Ignored
+                    // Ignored - Flow will delete the old data during next startup
                 }
                 _topMostRecord = _topMostRecordStorage.Load();
             }
@@ -52,7 +52,7 @@ namespace Flow.Launcher.Storage
                 }
                 catch
                 {
-                    // Ignored
+                    // Ignored - Flow will delete the old data during next startup
                 }
                 Save();
             }
@@ -84,7 +84,10 @@ namespace Flow.Launcher.Storage
         }
     }
 
-    public class TopMostRecord
+    /// <summary>
+    /// Old data structure to support only one top most record for the same query
+    /// </summary>
+    internal class TopMostRecord
     {
         [JsonInclude]
         public ConcurrentDictionary<string, Record> records { get; private set; } = new();
@@ -135,7 +138,10 @@ namespace Flow.Launcher.Storage
         }
     }
 
-    public class MultipleTopMostRecord
+    /// <summary>
+    /// New data structure to support multiple top most records for the same query
+    /// </summary>
+    internal class MultipleTopMostRecord
     {
         [JsonInclude]
         [JsonConverter(typeof(ConcurrentDictionaryConcurrentBagConverter))]
@@ -246,7 +252,7 @@ namespace Flow.Launcher.Storage
     /// <summary>
     /// Because ConcurrentBag does not support serialization, we need to convert it to a List
     /// </summary>
-    public class ConcurrentDictionaryConcurrentBagConverter : JsonConverter<ConcurrentDictionary<string, ConcurrentBag<Record>>>
+    internal class ConcurrentDictionaryConcurrentBagConverter : JsonConverter<ConcurrentDictionary<string, ConcurrentBag<Record>>>
     {
         public override ConcurrentDictionary<string, ConcurrentBag<Record>> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
@@ -270,7 +276,7 @@ namespace Flow.Launcher.Storage
         }
     }
 
-    public class Record
+    internal class Record
     {
         public string Title { get; init; }
         public string SubTitle { get; init; }

--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -188,6 +188,12 @@ namespace Flow.Launcher.Storage
             {
                 value.TryTake(out recordToRemove);
             }
+
+            // if the bag is empty, remove the bag from the dictionary
+            if (value.IsEmpty)
+            {
+                records.TryRemove(result.OriginQuery.RawQuery, out _);
+            }
         }
 
         internal void AddOrUpdate(Result result)

--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -1,10 +1,44 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin;
 
 namespace Flow.Launcher.Storage
 {
+    public class FlowLauncherJsonStorageTopMostRecord : ISavable
+    {
+        private readonly FlowLauncherJsonStorage<TopMostRecord> _topMostRecordStorage;
+
+        private readonly TopMostRecord _topMostRecord;
+
+        public FlowLauncherJsonStorageTopMostRecord()
+        {
+            _topMostRecordStorage = new FlowLauncherJsonStorage<TopMostRecord>();
+            _topMostRecord = _topMostRecordStorage.Load();
+        }
+
+        public void Save()
+        {
+            _topMostRecordStorage.Save();
+        }
+
+        public bool IsTopMost(Result result)
+        {
+            return _topMostRecord.IsTopMost(result);
+        }
+
+        public void Remove(Result result)
+        {
+            _topMostRecord.Remove(result);
+        }
+
+        public void AddOrUpdate(Result result)
+        {
+            _topMostRecord.AddOrUpdate(result);
+        }
+    }
+
     public class TopMostRecord
     {
         [JsonInclude]

--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -190,12 +190,15 @@ namespace Flow.Launcher.Storage
 
             // remove the record from the bag
             var bag = new ConcurrentQueue<Record>(value.Where(r => !r.Equals(result)));
-            records[result.OriginQuery.RawQuery] = new ConcurrentBag<Record>(bag);
-
-            // if the bag is empty, remove the bag from the dictionary
-            if (value.IsEmpty)
+            if (bag.IsEmpty)
             {
+                // if the bag is empty, remove the bag from the dictionary
                 records.TryRemove(result.OriginQuery.RawQuery, out _);
+            }
+            else
+            {
+                // change the bag in the dictionary
+                records[result.OriginQuery.RawQuery] = new ConcurrentBag<Record>(bag);
             }
         }
 

--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin;
@@ -8,14 +9,29 @@ namespace Flow.Launcher.Storage
 {
     public class FlowLauncherJsonStorageTopMostRecord : ISavable
     {
-        private readonly FlowLauncherJsonStorage<TopMostRecord> _topMostRecordStorage;
-
-        private readonly TopMostRecord _topMostRecord;
+        private readonly FlowLauncherJsonStorage<MultipleTopMostRecord> _topMostRecordStorage;
+        private readonly MultipleTopMostRecord _topMostRecord;
 
         public FlowLauncherJsonStorageTopMostRecord()
         {
-            _topMostRecordStorage = new FlowLauncherJsonStorage<TopMostRecord>();
-            _topMostRecord = _topMostRecordStorage.Load();
+            var topMostRecordStorage = new FlowLauncherJsonStorage<TopMostRecord>();
+            var exist = topMostRecordStorage.Exists();
+            if (exist)
+            {
+                // Get old data
+                var topMostRecord = topMostRecordStorage.Load();
+
+                // Convert to new data
+                _topMostRecordStorage = new FlowLauncherJsonStorage<MultipleTopMostRecord>();
+                _topMostRecord = _topMostRecordStorage.Load();
+                _topMostRecord.Add(topMostRecord);
+            }
+            else
+            {
+                // Get new data
+                _topMostRecordStorage = new FlowLauncherJsonStorage<MultipleTopMostRecord>();
+                _topMostRecord = _topMostRecordStorage.Load();
+            }
         }
 
         public void Save()
@@ -42,7 +58,7 @@ namespace Flow.Launcher.Storage
     public class TopMostRecord
     {
         [JsonInclude]
-        public ConcurrentDictionary<string, Record> records { get; private set; } = new ConcurrentDictionary<string, Record>();
+        public ConcurrentDictionary<string, Record> records { get; private set; } = new();
 
         internal bool IsTopMost(Result result)
         {
@@ -90,12 +106,113 @@ namespace Flow.Launcher.Storage
         }
     }
 
+    public class MultipleTopMostRecord
+    {
+        [JsonInclude]
+        public ConcurrentDictionary<string, ConcurrentBag<Record>> records { get; private set; } = new();
+
+        internal void Add(TopMostRecord topMostRecord)
+        {
+            if (topMostRecord == null || topMostRecord.records.IsEmpty)
+            {
+                return;
+            }
+
+            foreach (var record in topMostRecord.records)
+            {
+                records.AddOrUpdate(record.Key, new ConcurrentBag<Record> { record.Value }, (key, oldValue) =>
+                {
+                    oldValue.Add(record.Value);
+                    return oldValue;
+                });
+            }
+        }
+
+        internal bool IsTopMost(Result result)
+        {
+            // origin query is null when user select the context menu item directly of one item from query list
+            // in this case, we do not need to check if the result is top most
+            if (records.IsEmpty || result.OriginQuery == null ||
+                !records.TryGetValue(result.OriginQuery.RawQuery, out var value))
+            {
+                return false;
+            }
+
+            // since this dictionary should be very small (or empty) going over it should be pretty fast.
+            return value.Any(record => record.Equals(result));
+        }
+
+        internal void Remove(Result result)
+        {
+            // origin query is null when user select the context menu item directly of one item from query list
+            // in this case, we do not need to remove the record
+            if (result.OriginQuery == null ||
+                !records.TryGetValue(result.OriginQuery.RawQuery, out var value))
+            {
+                return;
+            }
+
+            // remove the record from the bag
+            var recordToRemove = value.FirstOrDefault(r => r.Equals(result));
+            if (recordToRemove != null)
+            {
+                value.TryTake(out recordToRemove);
+            }
+        }
+
+        internal void AddOrUpdate(Result result)
+        {
+            // origin query is null when user select the context menu item directly of one item from query list
+            // in this case, we do not need to add or update the record
+            if (result.OriginQuery == null)
+            {
+                return;
+            }
+
+            var record = new Record
+            {
+                PluginID = result.PluginID,
+                Title = result.Title,
+                SubTitle = result.SubTitle,
+                RecordKey = result.RecordKey
+            };
+            if (!records.TryGetValue(result.OriginQuery.RawQuery, out var value))
+            {
+                // create a new bag if it does not exist
+                value = new ConcurrentBag<Record>()
+                {
+                    record
+                };
+                records.TryAdd(result.OriginQuery.RawQuery, value);
+            }
+            else
+            {
+                // add or update the record in the bag
+                if (value.Any(r => r.Equals(result)))
+                {
+                    // update the record
+                    var recordToUpdate = value.FirstOrDefault(r => r.Equals(result));
+                    if (recordToUpdate != null)
+                    {
+                        value.TryTake(out recordToUpdate);
+                        value.Add(record);
+                    }
+                }
+                else
+                {
+                    // add the record
+                    value.Add(record);
+                }
+            }
+        }
+    }
+
     public class Record
     {
-        public string Title { get; set; }
-        public string SubTitle { get; set; }
-        public string PluginID { get; set; }
-        public string RecordKey { get; set; }
+        public string Title { get; init; }
+        public string SubTitle { get; init; }
+        public string PluginID { get; init; }
+        public string RecordKey { get; init; }
 
         public bool Equals(Result r)
         {

--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -189,11 +189,8 @@ namespace Flow.Launcher.Storage
             }
 
             // remove the record from the bag
-            var recordToRemove = value.FirstOrDefault(r => r.Equals(result));
-            if (recordToRemove != null)
-            {
-                value.TryTake(out recordToRemove);
-            }
+            var bag = new ConcurrentQueue<Record>(value.Where(r => !r.Equals(result)));
+            records[result.OriginQuery.RawQuery] = new ConcurrentBag<Record>(bag);
 
             // if the bag is empty, remove the bag from the dictionary
             if (value.IsEmpty)
@@ -230,21 +227,9 @@ namespace Flow.Launcher.Storage
             else
             {
                 // add or update the record in the bag
-                if (value.Any(r => r.Equals(result)))
-                {
-                    // update the record
-                    var recordToUpdate = value.FirstOrDefault(r => r.Equals(result));
-                    if (recordToUpdate != null)
-                    {
-                        value.TryTake(out recordToUpdate);
-                        value.Add(record);
-                    }
-                }
-                else
-                {
-                    // add the record
-                    value.Add(record);
-                }
+                var bag = new ConcurrentQueue<Record>(value.Where(r => !r.Equals(result))); // make sure we don't have duplicates
+                bag.Enqueue(record);
+                records[result.OriginQuery.RawQuery] = new ConcurrentBag<Record>(bag);
             }
         }
     }

--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -243,6 +243,9 @@ namespace Flow.Launcher.Storage
         }
     }
 
+    /// <summary>
+    /// Because ConcurrentBag does not support serialization, we need to convert it to a List
+    /// </summary>
     public class ConcurrentDictionaryConcurrentBagConverter : JsonConverter<ConcurrentDictionary<string, ConcurrentBag<Record>>>
     {
         public override ConcurrentDictionary<string, ConcurrentBag<Record>> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -37,11 +37,10 @@ namespace Flow.Launcher.ViewModel
 
         private readonly FlowLauncherJsonStorage<History> _historyItemsStorage;
         private readonly FlowLauncherJsonStorage<UserSelectedRecord> _userSelectedRecordStorage;
-        private readonly FlowLauncherJsonStorage<TopMostRecord> _topMostRecordStorage;
+        private readonly FlowLauncherJsonStorageTopMostRecord _topMostRecord;
         private readonly History _history;
         private int lastHistoryIndex = 1;
         private readonly UserSelectedRecord _userSelectedRecord;
-        private readonly TopMostRecord _topMostRecord;
 
         private CancellationTokenSource _updateSource;
         private CancellationToken _updateToken;
@@ -134,10 +133,9 @@ namespace Flow.Launcher.ViewModel
 
             _historyItemsStorage = new FlowLauncherJsonStorage<History>();
             _userSelectedRecordStorage = new FlowLauncherJsonStorage<UserSelectedRecord>();
-            _topMostRecordStorage = new FlowLauncherJsonStorage<TopMostRecord>();
+            _topMostRecord = new FlowLauncherJsonStorageTopMostRecord();
             _history = _historyItemsStorage.Load();
             _userSelectedRecord = _userSelectedRecordStorage.Load();
-            _topMostRecord = _topMostRecordStorage.Load();
 
             ContextMenu = new ResultsViewModel(Settings)
             {
@@ -1612,7 +1610,7 @@ namespace Flow.Launcher.ViewModel
         {
             _historyItemsStorage.Save();
             _userSelectedRecordStorage.Save();
-            _topMostRecordStorage.Save();
+            _topMostRecord.Save();
         }
 
         /// <summary>

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1643,9 +1643,10 @@ namespace Flow.Launcher.ViewModel
             {
                 foreach (var result in metaResults.Results)
                 {
-                    if (_topMostRecord.IsTopMost(result))
+                    var deviationIndex = _topMostRecord.GetTopMostIndex(result);
+                    if (deviationIndex != -1)
                     {
-                        result.Score = Result.MaxScore;
+                        result.Score = Result.MaxScore - deviationIndex;
                     }
                     else
                     {

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1646,6 +1646,8 @@ namespace Flow.Launcher.ViewModel
                     var deviationIndex = _topMostRecord.GetTopMostIndex(result);
                     if (deviationIndex != -1)
                     {
+                        // Adjust the score based on the result's position in the top-most list.
+                        // A lower deviationIndex (closer to the top) results in a higher score.
                         result.Score = Result.MaxScore - deviationIndex;
                     }
                     else


### PR DESCRIPTION
# Support Multiple Topmost Records

Currently, for one query, Flow can only support one topmost record. We should support multiple topmost records because users may want to set many records to be topmost.

The latter record is, the topper it be.

# Test

- Old data `TopMostRecord.json` will be converted into new data `MultipleTopMostRecord.json`.
- Flow can display multiple topmost records.
- Latter records are topper.

e.g.
MultipleTopMostRecord.json:
```
{
  "records": {
    "vs": [
      {
        "Title": "Visual Studio 2022",
        "SubTitle": "",
        "PluginID": "791FC278BA414111B8D1886DFE447410",
        "RecordKey": null
      },
      {
        "Title": "Visual Studio Installer",
        "SubTitle": "",
        "PluginID": "791FC278BA414111B8D1886DFE447410",
        "RecordKey": null
      },
      // This is the latest record and it should be the topmost
      {
        "Title": "Visual Studio Code",
        "SubTitle": "",
        "PluginID": "791FC278BA414111B8D1886DFE447410",
        "RecordKey": null
      }
    ]
  }
}
```

Screenshot:
![image](https://github.com/user-attachments/assets/cd0d634d-a755-4436-8dc5-0202dab66ee5)