### PR TITLE
Do not query again when setting private field of QueryText

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -34,6 +34,7 @@ namespace Flow.Launcher.ViewModel
         private bool _isQueryRunning;
         private Query _lastQuery;
         private string _queryTextBeforeLeaveResults;
+        private string _ignoredQueryText = null;
 
         private readonly FlowLauncherJsonStorage<History> _historyItemsStorage;
         private readonly FlowLauncherJsonStorage<UserSelectedRecord> _userSelectedRecordStorage;
@@ -730,6 +731,9 @@ namespace Flow.Launcher.ViewModel
                     if (isReturningFromContextMenu)
                     {
                         _queryText = _queryTextBeforeLeaveResults;
+                        // When executing OnPropertyChanged, QueryTextBox_TextChanged1 and Query will be called
+                        // So we need to ignore it so that we will not call Query again
+                        _ignoredQueryText = _queryText;
                         OnPropertyChanged(nameof(QueryText));
                         QueryTextCursorMovedToEnd = true;
                     }
@@ -1076,6 +1080,20 @@ namespace Flow.Launcher.ViewModel
 
         public void Query(bool searchDelay, bool isReQuery = false)
         {
+            if (_ignoredQueryText != null)
+            {
+                if (_ignoredQueryText == QueryText)
+                {
+                    _ignoredQueryText = null;
+                    return;
+                }
+                else
+                {
+                    // If _ignoredQueryText does not match current QueryText, we should still execute Query
+                    _ignoredQueryText = null;
+                }
+            }
+
             if (QueryResultsSelected())
             {
                 _ = QueryResultsAsync(searchDelay, isReQuery);

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1170,7 +1170,7 @@ namespace Flow.Launcher.ViewModel
                     OriginQuery = new Query { RawQuery = h.Query },
                     Action = _ =>
                     {
-                        SelectedResults = Results;
+                        App.API.BackToQueryResults();
                         App.API.ChangeQuery(h.Query);
                         return false;
                     }
@@ -1600,10 +1600,7 @@ namespace Flow.Launcher.ViewModel
                 await CloseExternalPreviewAsync();
             }
 
-            if (!QueryResultsSelected())
-            {
-                SelectedResults = Results;
-            }
+            BackToQueryResults();
 
             switch (Settings.LastQueryMode)
             {

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1432,10 +1432,10 @@ namespace Flow.Launcher.ViewModel
                 }
             }
 
+            // Show expanded builtin shortcuts
             if (queryChanged)
             {
-                // show expanded builtin shortcuts
-                // use private field to avoid infinite recursion
+                // Use private field to avoid infinite recursion
                 _queryText = queryBuilderTmp.ToString();
                 OnPropertyChanged(nameof(QueryText));
             }

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1437,6 +1437,9 @@ namespace Flow.Launcher.ViewModel
             {
                 // Use private field to avoid infinite recursion
                 _queryText = queryBuilderTmp.ToString();
+                // When executing OnPropertyChanged, QueryTextBox_TextChanged1 and Query will be called
+                // So we need to ignore it so that we will not call Query again
+                _ignoredQueryText = _queryText;
                 OnPropertyChanged(nameof(QueryText));
             }
         }


### PR DESCRIPTION
# Do not query again when setting private field of QueryText

From #3350, we use TextChanged event to invoke Query, which can cause duplicated call of Query if we use OnPropertyChange(nameof(QueryText)).

In this PR, we use 

```
// When executing OnPropertyChanged, QueryTextBox_TextChanged1 and Query will be called
// So we need to ignore it so that we will not call Query again
_ignoredQueryText = _queryText;
```

to resolve that.

Fix #3497, #3498.