### PR TITLE
Add more debug log info for query

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1215,10 +1215,14 @@ namespace Flow.Launcher.ViewModel
         {
             _updateSource?.Cancel();
 
+            App.API.LogDebug(ClassName, $"Start query with text: {QueryText}");
+
             var query = await ConstructQueryAsync(QueryText, Settings.CustomShortcuts, Settings.BuiltinShortcuts);
 
             if (query == null) // shortcut expanded
             {
+                App.API.LogDebug(ClassName, $"Clear query results");
+
                 // Hide and clear results again because running query may show and add some results
                 Results.Visibility = Visibility.Collapsed;
                 Results.Clear();
@@ -1232,6 +1236,8 @@ namespace Flow.Launcher.ViewModel
                 ProgressBarVisibility = Visibility.Hidden;
                 return;
             }
+
+            App.API.LogDebug(ClassName, $"Start query with ActionKeyword <{query.ActionKeyword}> and RawQuery <{query.RawQuery}>");
 
             _updateSource = new CancellationTokenSource();
 
@@ -1252,6 +1258,9 @@ namespace Flow.Launcher.ViewModel
             _lastQuery = query;
 
             var plugins = PluginManager.ValidPluginsForQuery(query);
+
+            var validPluginNames = plugins.Select(x => $"<{x.Metadata.Name}>");
+            App.API.LogDebug(ClassName, $"Valid <{plugins.Count}> plugins: {string.Join(" ", validPluginNames)}");
 
             if (plugins.Count == 1)
             {
@@ -1321,6 +1330,8 @@ namespace Flow.Launcher.ViewModel
             // Local function
             async Task QueryTaskAsync(PluginPair plugin, CancellationToken token)
             {
+                App.API.LogDebug(ClassName, $"Wait for querying plugin <{plugin.Metadata.Name}>");
+
                 if (searchDelay)
                 {
                     var searchDelayTime = plugin.Metadata.SearchDelayTime ?? Settings.SearchDelayTime;
@@ -1358,6 +1369,8 @@ namespace Flow.Launcher.ViewModel
                 }
 
                 if (token.IsCancellationRequested) return;
+
+                App.API.LogDebug(ClassName, $"Update results for plugin <{plugin.Metadata.Name}>");
 
                 if (!_resultsUpdateChannelWriter.TryWrite(new ResultsForUpdate(resultsCopy, plugin.Metadata, query,
                     token, reSelect)))
@@ -1448,6 +1461,8 @@ namespace Flow.Launcher.ViewModel
         {
             if (_lastQuery?.ActionKeyword != query?.ActionKeyword)
             {
+                App.API.LogDebug(ClassName, $"Remove old results");
+
                 Results.Clear();
             }
         }

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1215,7 +1215,7 @@ namespace Flow.Launcher.ViewModel
         {
             _updateSource?.Cancel();
 
-            App.API.LogDebug(ClassName, $"Start query with text: {QueryText}");
+            App.API.LogDebug(ClassName, $"Start query with text: <{QueryText}>");
 
             var query = await ConstructQueryAsync(QueryText, Settings.CustomShortcuts, Settings.BuiltinShortcuts);
 


### PR DESCRIPTION
When querying with `e`, we will get more debug info.

```
22:03:03.2597+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Start query with text: e
22:03:03.2597+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Start query with ActionKeyword <> and RawQuery <e>
22:03:03.2597+08:00 - DEBUG - MainViewModel.RemoveOldQueryResults - Remove old results
22:03:03.2762+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Valid <6> plugins: <Calculator> <Explorer> <Program> <System Commands> <URL> <Web Searches>
22:03:03.2762+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Wait for querying plugin <Calculator>
22:03:03.2762+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Wait for querying plugin <Explorer>
22:03:03.2762+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Wait for querying plugin <Program>
22:03:03.2904+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Wait for querying plugin <System Commands>
22:03:03.2904+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Wait for querying plugin <Web Searches>
22:03:03.2904+08:00 - DEBUG - PluginManager.QueryForPluginAsync - Cost for Calculator <4ms>
22:03:03.3041+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Update results for plugin <Calculator>
22:03:03.3383+08:00 - DEBUG - Http.GetStreamAsync - Url <https://www.google.com/complete/search?output=chrome&q=e>
22:03:03.3383+08:00 - DEBUG - PluginManager.QueryForPluginAsync - Cost for System Commands <47ms>
22:03:03.3383+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Update results for plugin <System Commands>
22:03:03.4933+08:00 - DEBUG - PluginManager.QueryForPluginAsync - Cost for Program <198ms>
22:03:03.4933+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Update results for plugin <Program>
22:03:03.7887+08:00 - DEBUG - PluginManager.QueryForPluginAsync - Cost for Web Searches <493ms>
22:03:03.7887+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Update results for plugin <Web Searches>
22:03:03.7887+08:00 - DEBUG - PluginManager.QueryForPluginAsync - Cost for Explorer <508ms>
22:03:03.8051+08:00 - DEBUG - MainViewModel.QueryResultsAsync - Update results for plugin <Explorer>
```

This can help us resolve #3508, etc.