### PR TITLE
Fix startup flicker

### DIFF
--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -203,7 +203,7 @@ namespace Flow.Launcher
                 // it will steal focus from main window which causes window hide
                 HotKeyMapper.Initialize();
 
-                // Main windows needs initialized before theme change because of blur settings
+                // Initialize theme for main window
                 Ioc.Default.GetRequiredService<Theme>().ChangeTheme();
 
                 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -166,9 +166,6 @@ namespace Flow.Launcher
             // Force update position
             UpdatePosition();
 
-            // Refresh frame
-            await _theme.RefreshFrameAsync();
-
             // Initialize resize mode after refreshing frame
             SetupResizeMode();
 


### PR DESCRIPTION
# Fix startup flicker for Win 11 theme

Remove `await _theme.RefreshFrameAsync();` in main window loaded event because in `App.xaml.cs`, it is already called in `Ioc.Default.GetRequiredService<Theme>().ChangeTheme();`

Resolve #3514.