### PR TITLE
Fix history results clear logic & Make sure results cleared

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -105,7 +105,7 @@ namespace Flow.Launcher
             Win32Helper.DisableControlBox(this);
         }
 
-        private async void OnLoaded(object sender, RoutedEventArgs _)
+        private void OnLoaded(object sender, RoutedEventArgs _)
         {
             // Check first launch
             if (_settings.FirstLaunch)

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1284,8 +1284,6 @@ namespace Flow.Launcher.ViewModel
             // Update the query's IsReQuery property to true if this is a re-query
             query.IsReQuery = isReQuery;
 
-            
-
             ICollection<PluginPair> plugins = Array.Empty<PluginPair>();
             if (currentIsHomeQuery)
             {
@@ -1458,8 +1456,13 @@ namespace Flow.Launcher.ViewModel
 
                 App.API.LogDebug(ClassName, $"Update results for history");
 
+                // Indicate if to clear existing results so to show only ones from plugins with action keywords
+                var shouldClearExistingResults = ShouldClearExistingResults(query, currentIsHomeQuery);
+                _lastQuery = query;
+                _previousIsHomeQuery = currentIsHomeQuery;
+
                 if (!_resultsUpdateChannelWriter.TryWrite(new ResultsForUpdate(results, _historyMetadata, query,
-                    token)))
+                    token, reSelect, shouldClearExistingResults)))
                 {
                     App.API.LogError(ClassName, "Unable to add item to Result Update Queue");
                 }

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1340,6 +1340,7 @@ namespace Flow.Launcher.ViewModel
 
             // plugins are ICollection, meaning LINQ will get the Count and preallocate Array
 
+            var resultsCleared = false;
             Task[] tasks;
             if (currentIsHomeQuery)
             {
@@ -1373,6 +1374,9 @@ namespace Flow.Launcher.ViewModel
             {
                 // nothing to do here
             }
+
+            // If results are not cleared, we need to clear the results
+            if (!resultsCleared) Results.Clear();
 
             if (currentCancellationToken.IsCancellationRequested) return;
 
@@ -1443,6 +1447,11 @@ namespace Flow.Launcher.ViewModel
                 {
                     App.API.LogError(ClassName, "Unable to add item to Result Update Queue");
                 }
+                else
+                {
+                    // Only update the clear flag when we successfully write to the channel
+                    resultsCleared = true;
+                }
             }
 
             void QueryHistoryTask(CancellationToken token)
@@ -1465,6 +1474,11 @@ namespace Flow.Launcher.ViewModel
                     token, reSelect, shouldClearExistingResults)))
                 {
                     App.API.LogError(ClassName, "Unable to add item to Result Update Queue");
+                }
+                else
+                {
+                    // Only update the clear flag when we successfully write to the channel
+                    resultsCleared = true;
                 }
             }
         }

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1375,6 +1375,8 @@ namespace Flow.Launcher.ViewModel
                 // nothing to do here
             }
 
+            if (currentCancellationToken.IsCancellationRequested) return;
+
             // If QueryTaskAsync or QueryHistoryTask is not called which means that results are not cleared
             // we need to clear the results
             if (!resultsCleared) Results.Clear();

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1375,7 +1375,8 @@ namespace Flow.Launcher.ViewModel
                 // nothing to do here
             }
 
-            // If results are not cleared, we need to clear the results
+            // If QueryTaskAsync or QueryHistoryTask is not called which means that results are not cleared
+            // we need to clear the results
             if (!resultsCleared) Results.Clear();
 
             if (currentCancellationToken.IsCancellationRequested) return;
@@ -1441,14 +1442,13 @@ namespace Flow.Launcher.ViewModel
                 var shouldClearExistingResults = ShouldClearExistingResults(query, currentIsHomeQuery);
                 _lastQuery = query;
                 _previousIsHomeQuery = currentIsHomeQuery;
+                resultsCleared = true;
 
                 if (!_resultsUpdateChannelWriter.TryWrite(new ResultsForUpdate(resultsCopy, plugin.Metadata, query,
                     token, reSelect, shouldClearExistingResults)))
                 {
                     App.API.LogError(ClassName, "Unable to add item to Result Update Queue");
                 }
-
-                resultsCleared = true;
             }
 
             void QueryHistoryTask(CancellationToken token)
@@ -1466,14 +1466,13 @@ namespace Flow.Launcher.ViewModel
                 var shouldClearExistingResults = ShouldClearExistingResults(query, currentIsHomeQuery);
                 _lastQuery = query;
                 _previousIsHomeQuery = currentIsHomeQuery;
+                resultsCleared = true;
 
                 if (!_resultsUpdateChannelWriter.TryWrite(new ResultsForUpdate(results, _historyMetadata, query,
                     token, reSelect, shouldClearExistingResults)))
                 {
                     App.API.LogError(ClassName, "Unable to add item to Result Update Queue");
                 }
-
-                resultsCleared = true;
             }
         }
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1447,11 +1447,8 @@ namespace Flow.Launcher.ViewModel
                 {
                     App.API.LogError(ClassName, "Unable to add item to Result Update Queue");
                 }
-                else
-                {
-                    // Only update the clear flag when we successfully write to the channel
-                    resultsCleared = true;
-                }
+
+                resultsCleared = true;
             }
 
             void QueryHistoryTask(CancellationToken token)
@@ -1475,11 +1472,8 @@ namespace Flow.Launcher.ViewModel
                 {
                     App.API.LogError(ClassName, "Unable to add item to Result Update Queue");
                 }
-                else
-                {
-                    // Only update the clear flag when we successfully write to the channel
-                    resultsCleared = true;
-                }
+
+                resultsCleared = true;
             }
         }
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1247,19 +1247,7 @@ namespace Flow.Launcher.ViewModel
 
             if (query == null) // shortcut expanded
             {
-                App.API.LogDebug(ClassName, $"Clear query results");
-
-                // Hide and clear results again because running query may show and add some results
-                Results.Visibility = Visibility.Collapsed;
-                Results.Clear();
-
-                // Reset plugin icon
-                PluginIconPath = null;
-                PluginIconSource = null;
-                SearchIconVisibility = Visibility.Visible;
-
-                // Hide progress bar again because running query may set this to visible
-                ProgressBarVisibility = Visibility.Hidden;
+                ClearResults();
                 return;
             }
 
@@ -1388,7 +1376,11 @@ namespace Flow.Launcher.ViewModel
 
             // If QueryTaskAsync or QueryHistoryTask is not called which means that results are not cleared
             // we need to clear the results
-            if (!resultsCleared) Results.Clear();
+            if (!resultsCleared)
+            {
+                ClearResults();
+                return;
+            }
 
             if (currentCancellationToken.IsCancellationRequested) return;
 
@@ -1403,6 +1395,23 @@ namespace Flow.Launcher.ViewModel
             }
 
             // Local function
+            void ClearResults()
+            {
+                App.API.LogDebug(ClassName, $"Clear query results");
+
+                // Hide and clear results again because running query may show and add some results
+                Results.Visibility = Visibility.Collapsed;
+                Results.Clear();
+
+                // Reset plugin icon
+                PluginIconPath = null;
+                PluginIconSource = null;
+                SearchIconVisibility = Visibility.Visible;
+
+                // Hide progress bar again because running query may set this to visible
+                ProgressBarVisibility = Visibility.Hidden;
+            }
+
             async Task QueryTaskAsync(PluginPair plugin, CancellationToken token)
             {
                 App.API.LogDebug(ClassName, $"Wait for querying plugin <{plugin.Metadata.Name}>");

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1579,6 +1579,13 @@ namespace Flow.Launcher.ViewModel
         /// <returns>True if the existing results should be cleared, false otherwise.</returns>
         private bool ShouldClearExistingResults(Query query, bool currentIsHomeQuery)
         {
+            // If the results are not cleared temporarily, we need to clear this time
+            if (_needClearResults)
+            {
+                _needClearResults = false;
+                return true;
+            }
+
             // If previous or current results are from home query, we need to clear them
             if (_previousIsHomeQuery || currentIsHomeQuery)
             {
@@ -1590,13 +1597,6 @@ namespace Flow.Launcher.ViewModel
             if (_lastQuery?.ActionKeyword != query?.ActionKeyword)
             {
                 App.API.LogDebug(ClassName, $"Cleared old results");
-                return true;
-            }
-
-            // If the results are not cleared temporarily, we need to clear this time
-            if (_needClearResults)
-            {
-                _needClearResults = false;
                 return true;
             }
 


### PR DESCRIPTION
Follow on with #3524 to fix two issues in that PR.

### 1. Clear existing results for history results query function

We also need to check `shouldClearExistingResults` when querying history results.

### 2. Make sure results cleared when update tasks are not called

When update tasks are not called, we need to clear results manually afterwards. This can fix an issue that results are not cleared when Home Page feature is off, and `QueryTaskAsync` and `QueryHistoryTask` are not called.