### PR TITLE
Check spelling workflow ignore release PR targeting master branch

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -41,9 +41,8 @@ on:
 #     tags-ignore:
 #     - "**"
   pull_request_target:
-    branches:
-    - '**'
-    # - '!l10n_dev'
+    branches-ignore:
+      - dev
     tags-ignore:
     - "**"
     types:

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -42,7 +42,7 @@ on:
 #     - "**"
   pull_request_target:
     branches-ignore:
-      - dev
+      - master
     tags-ignore:
     - "**"
     types:


### PR DESCRIPTION
Check spelling workflow ignore release PR targeting master branch, otherwise too much noise. Checking should occur and be resolved on PRs before merging to dev.