### PR TITLE
Fix Homepage with triggers history results on arrow up

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -520,7 +520,7 @@ namespace Flow.Launcher.ViewModel
         {
             if (QueryResultsSelected() // Results selected
                 && string.IsNullOrEmpty(QueryText) // No input
-                && Results.Visibility != Visibility.Visible // Results closed which means no items in Results 
+                && Results.Visibility != Visibility.Visible // No items in result list, e.g. when home page is off and no query text is entered, therefore the view is collapsed.
                 && _history.Items.Count > 0) // Have history items
             {
                 lastHistoryIndex = 1;

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -518,9 +518,10 @@ namespace Flow.Launcher.ViewModel
         [RelayCommand]
         private void SelectPrevItem()
         {
-            if (_history.Items.Count > 0
-                && QueryText == string.Empty
-                && QueryResultsSelected())
+            if (QueryResultsSelected() // Results selected
+                && string.IsNullOrEmpty(QueryText) // No input
+                && Results.Visibility != Visibility.Visible // Results closed which means no items in Results 
+                && _history.Items.Count > 0) // Have history items
             {
                 lastHistoryIndex = 1;
                 ReverseHistory();


### PR DESCRIPTION
Resolve #3519.

Tested:
- When home page feature is on and input is empty, if there are items in result list box, arrow up will trigger result index change instead of history results change.