### PR TITLE
Fix null origin query issue

### DIFF
--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -12,8 +12,7 @@ namespace Flow.Launcher.Storage
 
         internal bool IsTopMost(Result result)
         {
-            if (records.IsEmpty ||
-                !records.TryGetValue(result.OriginQuery.RawQuery, out var value))
+            if (records.IsEmpty || !records.TryGetValue(result.OriginQuery.RawQuery, out var value))
             {
                 return false;
             }

--- a/Flow.Launcher/Storage/TopMostRecord.cs
+++ b/Flow.Launcher/Storage/TopMostRecord.cs
@@ -12,9 +12,7 @@ namespace Flow.Launcher.Storage
 
         internal bool IsTopMost(Result result)
         {
-            // origin query is null when user select the context menu item directly of one item from query list
-            // in this case, we do not need to check if the result is top most
-            if (records.IsEmpty || result.OriginQuery == null ||
+            if (records.IsEmpty ||
                 !records.TryGetValue(result.OriginQuery.RawQuery, out var value))
             {
                 return false;
@@ -26,25 +24,11 @@ namespace Flow.Launcher.Storage
 
         internal void Remove(Result result)
         {
-            // origin query is null when user select the context menu item directly of one item from query list
-            // in this case, we do not need to remove the record
-            if (result.OriginQuery == null)
-            {
-                return;
-            }
-
             records.Remove(result.OriginQuery.RawQuery, out _);
         }
 
         internal void AddOrUpdate(Result result)
         {
-            // origin query is null when user select the context menu item directly of one item from query list
-            // in this case, we do not need to add or update the record
-            if (result.OriginQuery == null)
-            {
-                return;
-            }
-
             var record = new Record
             {
                 PluginID = result.PluginID,

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -444,12 +444,7 @@ namespace Flow.Launcher.ViewModel
             if (QueryResultsSelected())
             {
                 _userSelectedRecord.Add(result);
-                // origin query is null when user select the context menu item directly of one item from query list
-                // so we don't want to add it to history
-                if (result.OriginQuery != null)
-                {
-                    _history.Add(result.OriginQuery.RawQuery);
-                }
+                _history.Add(result.OriginQuery.RawQuery);
                 lastHistoryIndex = 1;
             }
 
@@ -1158,7 +1153,7 @@ namespace Flow.Launcher.ViewModel
                 {
                     results = PluginManager.GetContextMenusForPlugin(selected);
                     results.Add(ContextMenuTopMost(selected));
-                    results.Add(ContextMenuPluginInfo(selected.PluginID));
+                    results.Add(ContextMenuPluginInfo(selected));
                 }
 
                 if (!string.IsNullOrEmpty(query))
@@ -1592,7 +1587,8 @@ namespace Flow.Launcher.ViewModel
                         App.API.ReQuery();
                         return false;
                     },
-                    Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\uE74B")
+                    Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\uE74B"),
+                    OriginQuery = result.OriginQuery
                 };
             }
             else
@@ -1609,15 +1605,17 @@ namespace Flow.Launcher.ViewModel
                         App.API.ReQuery();
                         return false;
                     },
-                    Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\uE74A")
+                    Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\uE74A"),
+                    OriginQuery = result.OriginQuery
                 };
             }
 
             return menu;
         }
 
-        private static Result ContextMenuPluginInfo(string id)
+        private static Result ContextMenuPluginInfo(Result result)
         {
+            var id = result.PluginID;
             var metadata = PluginManager.GetPluginForId(id).Metadata;
             var translator = App.API;
 
@@ -1639,7 +1637,8 @@ namespace Flow.Launcher.ViewModel
                 {
                     App.API.OpenUrl(metadata.Website);
                     return true;
-                }
+                },
+                OriginQuery = result.OriginQuery
             };
             return menu;
         }


### PR DESCRIPTION
Follow on with #3203.

Add `OriginQuery` for topmost results & plugin info results so that we can remove `result.OriginQuery` null check.