### PR TITLE
Fix temp files deleting issue & Validate the cache directory before loading all bookmarks

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
@@ -131,7 +131,17 @@ public abstract class ChromiumBookmarkLoader : IBookmarkLoader
         }
         catch (Exception ex)
         {
-            File.Delete(tempDbPath);
+            try
+            {
+                if (File.Exists(tempDbPath))
+                {
+                    File.Delete(tempDbPath);
+                }
+            }
+            catch (Exception ex1)
+            {
+                Main._context.API.LogException(ClassName, $"Failed to delete temporary favicon DB: {tempDbPath}", ex1);
+            }
             Main._context.API.LogException(ClassName, $"Failed to copy favicon DB: {dbPath}", ex);
             return;
         }

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
@@ -37,8 +37,6 @@ public class Main : ISettingProvider, IPlugin, IReloadable, IPluginI18n, IContex
             context.CurrentPluginMetadata.PluginCacheDirectoryPath,
             "FaviconCache");
 
-        FilesFolders.ValidateDirectory(_faviconCacheDir);
-
         LoadBookmarksIfEnabled();
     }
 
@@ -49,6 +47,9 @@ public class Main : ISettingProvider, IPlugin, IReloadable, IPluginI18n, IContex
             // Don't load or monitor files if disabled
             return;
         }
+
+        // Validate the cache directory before loading all bookmarks because Flow needs this directory to storage favicons
+        FilesFolders.ValidateDirectory(_faviconCacheDir);
 
         _cachedBookmarks = BookmarkLoader.LoadAllBookmarks(_settings);
         _ = MonitorRefreshQueueAsync();


### PR DESCRIPTION
Follow on with #3361.

## 1. Fix temp files deleting issue

Fix issue:

```
Please open new issue in https://github.com/Flow-Launcher/Flow.Launcher/issues
1. Upload log file: C:\Users\11602\AppData\Roaming\FlowLauncher\Logs\1.19.5\2025-05-12.txt
2. Copy below exception message

Flow Launcher version: 1.19.5
OS Version: 26100.3915
IntPtr Length: 8
x64: True

Python Path: C:\Users\11602\AppData\Roaming\FlowLauncher\Environments\Python\PythonEmbeddable-v3.11.4\pythonw.exe
Node Path: C:\Program Files\nodejs\node.exe

Date: 05/12/2025 15:09:38
Exception:
System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Could not find a part of the path 'C:\Users\11602\AppData\Roaming\FlowLauncher\Cache\Plugins\Flow.Launcher.Plugin.BrowserBookmark\FaviconCache\tempfavicons_ee7ee9e2-9903-4cf1-94de-a08dcbc1357f.db'.)
 ---> System.IO.DirectoryNotFoundException: Could not find a part of the path 'C:\Users\11602\AppData\Roaming\FlowLauncher\Cache\Plugins\Flow.Launcher.Plugin.BrowserBookmark\FaviconCache\tempfavicons_ee7ee9e2-9903-4cf1-94de-a08dcbc1357f.db'.
   at System.IO.FileSystem.DeleteFile(String fullPath)
   at Flow.Launcher.Plugin.BrowserBookmark.ChromiumBookmarkLoader.LoadFaviconsFromDb(String dbPath, List`1 bookmarks) in C:\projects\flow-launcher\Plugins\Flow.Launcher.Plugin.BrowserBookmark\ChromiumBookmarkLoader.cs:line 134
   at Flow.Launcher.Plugin.BrowserBookmark.ChromiumBookmarkLoader.LoadBookmarks(String browserDataPath, String name) in C:\projects\flow-launcher\Plugins\Flow.Launcher.Plugin.BrowserBookmark\ChromiumBookmarkLoader.cs:line 55
...
```

## 2. Validate the cache directory before loading all bookmarks

Validate the cache directory before loading all bookmarks because Flow needs this directory to storage favicons.

Or loading will fail when the cache directory is missing.