### PR TITLE
Do not show error message for initialization if plugin is already disabled

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -224,7 +224,7 @@ namespace Flow.Launcher.Core.Plugin
                     {
                         // If this plugin is already disabled, do not show error message again
                         // Or else it will be shown every time
-                        API.LogDebug(ClassName, $"Skip init for <{pair.Metadata.Name}>");
+                        API.LogDebug(ClassName, $"Skipped init for <{pair.Metadata.Name}> due to error");
                     }
                     else
                     {

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -220,9 +220,17 @@ namespace Flow.Launcher.Core.Plugin
                 catch (Exception e)
                 {
                     API.LogException(ClassName, $"Fail to Init plugin: {pair.Metadata.Name}", e);
-                    pair.Metadata.Disabled = true;
-                    pair.Metadata.HomeDisabled = true;
-                    failedPlugins.Enqueue(pair);
+                    if (pair.Metadata.Disabled && pair.Metadata.HomeDisabled)
+                    {
+                        // If this plugin is already disabled, do not show error message again
+                        // Or else it will be shown every time
+                    }
+                    else
+                    {
+                        pair.Metadata.Disabled = true;
+                        pair.Metadata.HomeDisabled = true;
+                        failedPlugins.Enqueue(pair);
+                    }
                 }
             }));
 

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -219,17 +219,18 @@ namespace Flow.Launcher.Core.Plugin
                 }
                 catch (Exception e)
                 {
-                    API.LogException(ClassName, $"Fail to Init plugin: {pair.Metadata.Name}", e);
                     if (pair.Metadata.Disabled && pair.Metadata.HomeDisabled)
                     {
                         // If this plugin is already disabled, do not show error message again
                         // Or else it will be shown every time
+                        API.LogDebug(ClassName, $"Skip init for <{pair.Metadata.Name}>");
                     }
                     else
                     {
                         pair.Metadata.Disabled = true;
                         pair.Metadata.HomeDisabled = true;
                         failedPlugins.Enqueue(pair);
+                        API.LogException(ClassName, $"Fail to Init plugin: {pair.Metadata.Name}", e);
                     }
                 }
             }));

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -219,6 +219,7 @@ namespace Flow.Launcher.Core.Plugin
                 }
                 catch (Exception e)
                 {
+                    API.LogException(ClassName, $"Fail to Init plugin: {pair.Metadata.Name}", e);
                     if (pair.Metadata.Disabled && pair.Metadata.HomeDisabled)
                     {
                         // If this plugin is already disabled, do not show error message again
@@ -230,7 +231,7 @@ namespace Flow.Launcher.Core.Plugin
                         pair.Metadata.Disabled = true;
                         pair.Metadata.HomeDisabled = true;
                         failedPlugins.Enqueue(pair);
-                        API.LogException(ClassName, $"Fail to Init plugin: {pair.Metadata.Name}", e);
+                        API.LogDebug(ClassName, $"Disable plugin <{pair.Metadata.Name}> because init failed");
                     }
                 }
             }));


### PR DESCRIPTION
When one plugin is already disabled, we do not need to show initialization failure notification and we just need to log exception for it.

Or else the error message will be shown every time Flow starts which can be really annoying.

Resolve #1216.