### PR TITLE
Fix results context menu display issue

### DIFF
--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
@@ -479,7 +479,7 @@ public partial class SettingsPaneThemeViewModel : BaseModel
                     )
                 }
             };
-        // Set main view model to null because this results are for preview only
+        // Set main view model to null because the results are for preview only
         var vm = new ResultsViewModel(Settings, null);
         vm.AddResults(results, "PREVIEW");
         PreviewResults = vm;

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
@@ -479,6 +479,7 @@ public partial class SettingsPaneThemeViewModel : BaseModel
                     )
                 }
             };
+        // Set main view model to null because this results are for preview only
         var vm = new ResultsViewModel(Settings, null);
         vm.AddResults(results, "PREVIEW");
         PreviewResults = vm;

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
@@ -479,7 +479,7 @@ public partial class SettingsPaneThemeViewModel : BaseModel
                     )
                 }
             };
-        var vm = new ResultsViewModel(Settings);
+        var vm = new ResultsViewModel(Settings, null);
         vm.AddResults(results, "PREVIEW");
         PreviewResults = vm;
     }

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -148,19 +148,19 @@ namespace Flow.Launcher.ViewModel
             _userSelectedRecord = _userSelectedRecordStorage.Load();
             _topMostRecord = _topMostRecordStorage.Load();
 
-            ContextMenu = new ResultsViewModel(Settings)
+            ContextMenu = new ResultsViewModel(Settings, this)
             {
                 LeftClickResultCommand = OpenResultCommand,
                 RightClickResultCommand = LoadContextMenuCommand,
                 IsPreviewOn = Settings.AlwaysPreview
             };
-            Results = new ResultsViewModel(Settings)
+            Results = new ResultsViewModel(Settings, this)
             {
                 LeftClickResultCommand = OpenResultCommand,
                 RightClickResultCommand = LoadContextMenuCommand,
                 IsPreviewOn = Settings.AlwaysPreview
             };
-            History = new ResultsViewModel(Settings)
+            History = new ResultsViewModel(Settings, this)
             {
                 LeftClickResultCommand = OpenResultCommand,
                 RightClickResultCommand = LoadContextMenuCommand,
@@ -1659,6 +1659,12 @@ namespace Flow.Launcher.ViewModel
         private bool HistorySelected()
         {
             var selected = SelectedResults == History;
+            return selected;
+        }
+
+        internal bool ResultsSelected(ResultsViewModel results)
+        {
+            var selected = SelectedResults == results;
             return selected;
         }
 

--- a/Flow.Launcher/ViewModel/ResultsViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultsViewModel.cs
@@ -211,8 +211,8 @@ namespace Flow.Launcher.ViewModel
             switch (Visibility)
             {
                 case Visibility.Collapsed when Results.Count > 0:
-                    // Show it only if the results are selected
-                    if (_mainVM == null || _mainVM.ResultsSelected(this))
+                    if (_mainVM == null || // The results is for preview only in apprerance page
+                        _mainVM.ResultsSelected(this)) // The results are selected
                     {
                         SelectedIndex = 0;
                         Visibility = Visibility.Visible;

--- a/Flow.Launcher/ViewModel/ResultsViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultsViewModel.cs
@@ -211,7 +211,7 @@ namespace Flow.Launcher.ViewModel
             switch (Visibility)
             {
                 case Visibility.Collapsed when Results.Count > 0:
-                    if (_mainVM == null || // The results is for preview only in apprerance page
+                    if (_mainVM == null || // The results are for preview only in apprerance page
                         _mainVM.ResultsSelected(this)) // The results are selected
                     {
                         SelectedIndex = 0;


### PR DESCRIPTION
# Fix the issue that results and context menu showing at the same time

Check if the results are selected and then set its visibility in `if (_mainVM == null || _mainVM.ResultsSelected(this))`. So if we click right arrow and input some characters at the same time, because the selected results are from context menu already, the visibility of the results will not be updated in `private void UpdateResults(List<ResultViewModel> newResults, bool reselect = true, CancellationToken token = default)`.

Resolve #2026.