### PR TITLE
Improve Program plugin delete button logic

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
@@ -48,8 +48,8 @@
 
     <system:String x:Key="flowlauncher_plugin_program_pls_select_program_source">Please select a program source</system:String>
     <system:String x:Key="flowlauncher_plugin_program_delete_program_source">Are you sure you want to delete the selected program sources?</system:String>
-    <system:String x:Key="flowlauncher_plugin_program_delete_program_source_not_user_added">Please select program sources that are not added by you</system:String>
-    <system:String x:Key="flowlauncher_plugin_program_delete_program_source_user_added">Please select program sources that are added by you</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_delete_program_source_select_not_user_added">Please select program sources that are not added by you</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_delete_program_source_select_user_added">Please select program sources that are added by you</system:String>
     <system:String x:Key="flowlauncher_plugin_program_duplicate_program_source">Another program source with the same location already exists.</system:String>
 
     <system:String x:Key="flowlauncher_plugin_program_edit_program_source_title">Program Source</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
@@ -48,6 +48,7 @@
 
     <system:String x:Key="flowlauncher_plugin_program_pls_select_program_source">Please select a program source</system:String>
     <system:String x:Key="flowlauncher_plugin_program_delete_program_source">Are you sure you want to delete the selected program sources?</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_delete_program_source_not_user_added">Please select program sources that you added</system:String>
     <system:String x:Key="flowlauncher_plugin_program_duplicate_program_source">Another program source with the same location already exists.</system:String>
 
     <system:String x:Key="flowlauncher_plugin_program_edit_program_source_title">Program Source</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
@@ -48,8 +48,8 @@
 
     <system:String x:Key="flowlauncher_plugin_program_pls_select_program_source">Please select a program source</system:String>
     <system:String x:Key="flowlauncher_plugin_program_delete_program_source">Are you sure you want to delete the selected program sources?</system:String>
-    <system:String x:Key="flowlauncher_plugin_program_delete_program_source_user_added">Please select program sources that are not added by you</system:String>
-    <system:String x:Key="flowlauncher_plugin_program_delete_program_source_not_user_added">Please select program sources that are added by you</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_delete_program_source_not_user_added">Please select program sources that are not added by you</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_delete_program_source_user_added">Please select program sources that are added by you</system:String>
     <system:String x:Key="flowlauncher_plugin_program_duplicate_program_source">Another program source with the same location already exists.</system:String>
 
     <system:String x:Key="flowlauncher_plugin_program_edit_program_source_title">Program Source</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Languages/en.xaml
@@ -48,7 +48,8 @@
 
     <system:String x:Key="flowlauncher_plugin_program_pls_select_program_source">Please select a program source</system:String>
     <system:String x:Key="flowlauncher_plugin_program_delete_program_source">Are you sure you want to delete the selected program sources?</system:String>
-    <system:String x:Key="flowlauncher_plugin_program_delete_program_source_not_user_added">Please select program sources that you added</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_delete_program_source_user_added">Please select program sources that are not added by you</system:String>
+    <system:String x:Key="flowlauncher_plugin_program_delete_program_source_not_user_added">Please select program sources that are added by you</system:String>
     <system:String x:Key="flowlauncher_plugin_program_duplicate_program_source">Another program source with the same location already exists.</system:String>
 
     <system:String x:Key="flowlauncher_plugin_program_edit_program_source_title">Program Source</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml
@@ -204,6 +204,12 @@
                     Click="btnEditProgramSource_OnClick"
                     Content="{DynamicResource flowlauncher_plugin_program_edit}" />
                 <Button
+                    x:Name="btnDeleteProgramSource"
+                    MinWidth="100"
+                    Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
+                    Click="btnDeleteProgramSource_OnClick"
+                    Content="{DynamicResource flowlauncher_plugin_program_delete}" />
+                <Button
                     x:Name="btnAddProgramSource"
                     MinWidth="100"
                     Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
@@ -303,6 +303,13 @@ namespace Flow.Launcher.Plugin.Program.Views
                 return;
             }
 
+            if (IsAllItemsUserAdded(selectedItems))
+            {
+                var msg1 = context.API.GetTranslation("flowlauncher_plugin_program_delete_program_source_not_user_added");
+                context.API.ShowMsgBox(msg1);
+                return;
+            }
+
             if (HasMoreOrEqualEnabledItems(selectedItems))
             {
                 await ProgramSettingDisplay.SetProgramSourcesStatusAsync(selectedItems, false);

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
@@ -428,7 +428,7 @@ namespace Flow.Launcher.Plugin.Program.Views
 
             if (!IsAllItemsUserAdded(selectedItems))
             {
-                var msg1 = context.API.GetTranslation("flowlauncher_plugin_program_delete_program_source_not_user_added");
+                var msg1 = context.API.GetTranslation("flowlauncher_plugin_program_delete_program_source_user_added");
                 context.API.ShowMsgBox(msg1);
                 return;
             }

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
@@ -305,7 +305,7 @@ namespace Flow.Launcher.Plugin.Program.Views
 
             if (IsAllItemsUserAdded(selectedItems))
             {
-                var msg1 = context.API.GetTranslation("flowlauncher_plugin_program_delete_program_source_not_user_added");
+                var msg1 = context.API.GetTranslation("flowlauncher_plugin_program_delete_program_source_select_not_user_added");
                 context.API.ShowMsgBox(msg1);
                 return;
             }
@@ -428,7 +428,7 @@ namespace Flow.Launcher.Plugin.Program.Views
 
             if (!IsAllItemsUserAdded(selectedItems))
             {
-                var msg1 = context.API.GetTranslation("flowlauncher_plugin_program_delete_program_source_user_added");
+                var msg1 = context.API.GetTranslation("flowlauncher_plugin_program_delete_program_source_select_user_added");
                 context.API.ShowMsgBox(msg1);
                 return;
             }

--- a/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Views/ProgramSetting.xaml.cs
@@ -298,15 +298,7 @@ namespace Flow.Launcher.Plugin.Program.Views
 
             if (selectedItems.Count == 0)
             {
-                var msg = context.API.GetTranslation("flowlauncher_plugin_program_pls_select_program_source");
-                context.API.ShowMsgBox(msg);
-                return;
-            }
-
-            if (IsAllItemsUserAdded(selectedItems))
-            {
-                var msg1 = context.API.GetTranslation("flowlauncher_plugin_program_delete_program_source_select_not_user_added");
-                context.API.ShowMsgBox(msg1);
+                context.API.ShowMsgBox(context.API.GetTranslation("flowlauncher_plugin_program_pls_select_program_source"));
                 return;
             }
 
@@ -376,7 +368,7 @@ namespace Flow.Launcher.Plugin.Program.Views
             var dataView = CollectionViewSource.GetDefaultView(programSourceView.ItemsSource);
 
             dataView.SortDescriptions.Clear();
-            SortDescription sd = new SortDescription(sortBy, direction);
+            var sd = new SortDescription(sortBy, direction);
             dataView.SortDescriptions.Add(sd);
             dataView.Refresh();
         }
@@ -421,20 +413,18 @@ namespace Flow.Launcher.Plugin.Program.Views
 
             if (selectedItems.Count == 0)
             {
-                var msg = context.API.GetTranslation("flowlauncher_plugin_program_pls_select_program_source");
-                context.API.ShowMsgBox(msg);
+                context.API.ShowMsgBox(context.API.GetTranslation("flowlauncher_plugin_program_pls_select_program_source"));
                 return;
             }
 
             if (!IsAllItemsUserAdded(selectedItems))
             {
-                var msg1 = context.API.GetTranslation("flowlauncher_plugin_program_delete_program_source_select_user_added");
-                context.API.ShowMsgBox(msg1);
+                context.API.ShowMsgBox(context.API.GetTranslation("flowlauncher_plugin_program_delete_program_source_select_user_added"));
                 return;
             }
 
-            var msg2 = context.API.GetTranslation("flowlauncher_plugin_program_delete_program_source");
-            if (context.API.ShowMsgBox(msg2, string.Empty, MessageBoxButton.YesNo) == MessageBoxResult.No)
+            if (context.API.ShowMsgBox(context.API.GetTranslation("flowlauncher_plugin_program_delete_program_source"),
+                string.Empty, MessageBoxButton.YesNo) == MessageBoxResult.No)
             {
                 return;
             }


### PR DESCRIPTION
# Improve Program plugin delete button logic

Originally, Flow only uses three buttons: Enable/Disable/Delete, Edit, Add which can cause confusion.

Now Flow uses four buttons for program source management: Enable/Disable, Edit, Delete, Add.

I think it can help users know our logic as follows. And if we use buttons for wrong actions, Flow will notify users with message box.

* Enable/Disable: Use to enable/disable **auto-loaded** and **non-auto-loaded** program sources.
* Edit:  Use to edit **auto-loaded** and **non-auto-loaded** program sources.
* Delete: Use to delete **non-auto-loaded** program sources.
* Add: Use to add **non-auto-loaded** program sources.

Note:

* **auto-loaded** program sources are the programs in the common paths of Window applications. They will be loaded and indexed every time Flow starts and reloads.
* **non-auto-loaded** program sources are the program sources added by users. Normally, they are in the custom paths like `D:\Test`. They will not be loaded automatically so users need to add and delete them manually.

Resolve #3196.

# Test

* Load all programs and use four buttons for it.
* Add one program and then use four buttons for it.

https://github.com/user-attachments/assets/04925571-0d13-4b82-91ec-89f19cff0290