### PR TITLE
Fix system ColorScheme update handling

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -99,6 +99,11 @@ namespace Flow.Launcher
 
 #pragma warning disable VSTHRD100 // Avoid async void methods
 
+        private void ThemeManager_ActualApplicationThemeChanged(ModernWpf.ThemeManager sender, object args)
+        {
+            _theme.RefreshFrameAsync();
+        }
+
         private void OnSourceInitialized(object sender, EventArgs e)
         {
             var handle = Win32Helper.GetWindowHandle(this, true);
@@ -543,10 +548,6 @@ namespace Flow.Launcher
 
         #region Window Sound Effects
 
-        private void ThemeManager_ActualApplicationThemeChanged(ModernWpf.ThemeManager sender, object args)
-        {
-            _theme.RefreshFrameAsync();
-        }
         private void SystemEvents_PowerModeChanged(object sender, PowerModeChangedEventArgs e)
         {
             // Fix for sound not playing after sleep / hibernate
@@ -1184,6 +1185,7 @@ namespace Flow.Launcher
                     _notifyIcon?.Dispose();
                     animationSoundWMP?.Close();
                     animationSoundWPF?.Dispose();
+                    ModernWpf.ThemeManager.Current.ActualApplicationThemeChanged -= ThemeManager_ActualApplicationThemeChanged;
                     SystemEvents.PowerModeChanged -= SystemEvents_PowerModeChanged;
                 }
 

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -89,7 +89,7 @@ namespace Flow.Launcher
 
             InitSoundEffects();
             DataObject.AddPastingHandler(QueryTextBox, QueryTextBox_OnPaste);
-
+            ModernWpf.ThemeManager.Current.ActualApplicationThemeChanged += ThemeManager_ActualApplicationThemeChanged;
             SystemEvents.PowerModeChanged += SystemEvents_PowerModeChanged;
         }
 
@@ -543,6 +543,10 @@ namespace Flow.Launcher
 
         #region Window Sound Effects
 
+        private void ThemeManager_ActualApplicationThemeChanged(ModernWpf.ThemeManager sender, object args)
+        {
+            _theme.RefreshFrameAsync();
+        }
         private void SystemEvents_PowerModeChanged(object sender, PowerModeChangedEventArgs e)
         {
             // Fix for sound not playing after sleep / hibernate


### PR DESCRIPTION
# Fix system ColorScheme update handling

## Summary
- Fixed an issue where changes to the system ColorScheme (e.g., via AutoDarkMode or OS settings) were not properly reflected in Flow's window background color.

## Steps to Reproduce
- In Dev mode, select a theme that includes both Light and Dark modes (e.g., `win11light`).
- Set the ColorScheme option to **Follow system setting**.
- Change the OS ColorScheme (e.g., switch from Light to Dark).
- Observe that, although the system is in Dark mode, the window background remains white.

## Cause
- The window background color is updated during the `RefreshFrame` process.
- Due to changes in the timing of `RefreshFrame`, the background color update was no longer triggered properly.

## Solution
- Since `ModernWpf` already listens for system ColorScheme changes, we subscribe to its event.
- When the system ColorScheme change event is received, we explicitly call `RefreshFrame` once to apply the correct background color.
