### PR TITLE
Add dynamic font family to SettingWindow

### DIFF
--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -13,6 +13,7 @@
     MinHeight="600"
     d:DataContext="{d:DesignInstance vm:SettingWindowViewModel}"
     Closed="OnClosed"
+    FontFamily="{DynamicResource SettingWindowFont}"
     Icon="Images\app.ico"
     Left="{Binding SettingWindowLeft, Mode=TwoWay}"
     Loaded="OnLoaded"


### PR DESCRIPTION
## Summary

![image](https://github.com/user-attachments/assets/9cdf3a47-c28d-4ad2-a402-3ffa5bba363b)


- Fixed an issue where the font was not applied to certain elements in the settings window.

## Reproduce
- In the Dev environment, the font in the settings window is changed. You can observe that the font is not applied to titles and card elements within the settings window, while it is correctly applied to regular controls.

## Details

- The root cause is unclear; the font application was working correctly at the time of the previous merge.

- To resolve the issue, the style was explicitly applied to the settings window itself, following the initial implementation approach.

- Verified that other windows still apply fonts correctly without needing explicit style settings.