### PR TITLE
Fix setting window navigation update issue

### DIFF
--- a/Flow.Launcher/Resources/Pages/WelcomePage1.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage1.xaml.cs
@@ -9,24 +9,19 @@ namespace Flow.Launcher.Resources.Pages
 {
     public partial class WelcomePage1
     {
-        public Settings Settings { get; private set; }
-        private WelcomeViewModel _viewModel;
+        public Settings Settings { get; } = Ioc.Default.GetRequiredService<Settings>();
+        private readonly WelcomeViewModel _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            // If the navigation is not triggered by button click, view model will be null again
-            if (_viewModel == null)
-            {
-                Settings = Ioc.Default.GetRequiredService<Settings>();
-                _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
-            }
+            // Sometimes the navigation is not triggered by button click,
+            // so we need to reset the page number
+            _viewModel.PageNum = 1;
+
             if (!IsInitialized)
             {
                 InitializeComponent();
             }
-            // Sometimes the navigation is not triggered by button click,
-            // so we need to reset the page number
-            _viewModel.PageNum = 1;
             base.OnNavigatedTo(e);
         }
 

--- a/Flow.Launcher/Resources/Pages/WelcomePage1.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage1.xaml.cs
@@ -14,10 +14,14 @@ namespace Flow.Launcher.Resources.Pages
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            // If the navigation is not triggered by button click, view model will be null again
             if (_viewModel == null)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
                 _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
+            }
+            if (!IsInitialized)
+            {
                 InitializeComponent();
             }
             // Sometimes the navigation is not triggered by button click,

--- a/Flow.Launcher/Resources/Pages/WelcomePage1.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage1.xaml.cs
@@ -14,7 +14,7 @@ namespace Flow.Launcher.Resources.Pages
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            if (!IsInitialized)
+            if (_viewModel == null)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
                 _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();

--- a/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
@@ -11,24 +11,19 @@ namespace Flow.Launcher.Resources.Pages
 {
     public partial class WelcomePage2
     {
-        public Settings Settings { get; private set; }
-        private WelcomeViewModel _viewModel;
+        public Settings Settings { get; } = Ioc.Default.GetRequiredService<Settings>();
+        private readonly WelcomeViewModel _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            // If the navigation is not triggered by button click, view model will be null again
-            if (_viewModel == null)
-            {
-                Settings = Ioc.Default.GetRequiredService<Settings>();
-                _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
-            }
+            // Sometimes the navigation is not triggered by button click,
+            // so we need to reset the page number
+            _viewModel.PageNum = 2;
+
             if (!IsInitialized)
             {
                 InitializeComponent();
             }
-            // Sometimes the navigation is not triggered by button click,
-            // so we need to reset the page number
-            _viewModel.PageNum = 2;
             base.OnNavigatedTo(e);
         }
 

--- a/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
@@ -16,7 +16,7 @@ namespace Flow.Launcher.Resources.Pages
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            if (!IsInitialized)
+            if (_viewModel == null)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
                 _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();

--- a/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage2.xaml.cs
@@ -16,10 +16,14 @@ namespace Flow.Launcher.Resources.Pages
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            // If the navigation is not triggered by button click, view model will be null again
             if (_viewModel == null)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
                 _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
+            }
+            if (!IsInitialized)
+            {
                 InitializeComponent();
             }
             // Sometimes the navigation is not triggered by button click,

--- a/Flow.Launcher/Resources/Pages/WelcomePage3.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage3.xaml.cs
@@ -12,7 +12,7 @@ namespace Flow.Launcher.Resources.Pages
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            if (!IsInitialized)
+            if (_viewModel == null)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
                 _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();

--- a/Flow.Launcher/Resources/Pages/WelcomePage3.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage3.xaml.cs
@@ -7,24 +7,19 @@ namespace Flow.Launcher.Resources.Pages
 {
     public partial class WelcomePage3
     {
-        public Settings Settings { get; private set; }
-        private WelcomeViewModel _viewModel;
+        public Settings Settings { get; } = Ioc.Default.GetRequiredService<Settings>();
+        private readonly WelcomeViewModel _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            // If the navigation is not triggered by button click, view model will be null again
-            if (_viewModel == null)
-            {
-                Settings = Ioc.Default.GetRequiredService<Settings>();
-                _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
-            }
+            // Sometimes the navigation is not triggered by button click,
+            // so we need to reset the page number
+            _viewModel.PageNum = 3;
+
             if (!IsInitialized)
             {
                 InitializeComponent();
             }
-            // Sometimes the navigation is not triggered by button click,
-            // so we need to reset the page number
-            _viewModel.PageNum = 3;
             base.OnNavigatedTo(e);
         }
     }

--- a/Flow.Launcher/Resources/Pages/WelcomePage3.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage3.xaml.cs
@@ -12,10 +12,14 @@ namespace Flow.Launcher.Resources.Pages
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            // If the navigation is not triggered by button click, view model will be null again
             if (_viewModel == null)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
                 _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
+            }
+            if (!IsInitialized)
+            {
                 InitializeComponent();
             }
             // Sometimes the navigation is not triggered by button click,

--- a/Flow.Launcher/Resources/Pages/WelcomePage4.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage4.xaml.cs
@@ -12,7 +12,7 @@ namespace Flow.Launcher.Resources.Pages
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            if (!IsInitialized)
+            if (_viewModel == null)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
                 _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();

--- a/Flow.Launcher/Resources/Pages/WelcomePage4.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage4.xaml.cs
@@ -7,24 +7,19 @@ namespace Flow.Launcher.Resources.Pages
 {
     public partial class WelcomePage4
     {
-        public Settings Settings { get; private set; }
-        private WelcomeViewModel _viewModel;
+        public Settings Settings { get; } = Ioc.Default.GetRequiredService<Settings>();
+        private readonly WelcomeViewModel _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            // If the navigation is not triggered by button click, view model will be null again
-            if (_viewModel == null)
-            {
-                Settings = Ioc.Default.GetRequiredService<Settings>();
-                _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
-            }
+            // Sometimes the navigation is not triggered by button click,
+            // so we need to reset the page number
+            _viewModel.PageNum = 4;
+
             if (!IsInitialized)
             {
                 InitializeComponent();
             }
-            // Sometimes the navigation is not triggered by button click,
-            // so we need to reset the page number
-            _viewModel.PageNum = 4;
             base.OnNavigatedTo(e);
         }
     }

--- a/Flow.Launcher/Resources/Pages/WelcomePage4.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage4.xaml.cs
@@ -12,10 +12,14 @@ namespace Flow.Launcher.Resources.Pages
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            // If the navigation is not triggered by button click, view model will be null again
             if (_viewModel == null)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
                 _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
+            }
+            if (!IsInitialized)
+            {
                 InitializeComponent();
             }
             // Sometimes the navigation is not triggered by button click,

--- a/Flow.Launcher/Resources/Pages/WelcomePage5.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage5.xaml.cs
@@ -15,10 +15,14 @@ namespace Flow.Launcher.Resources.Pages
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            // If the navigation is not triggered by button click, view model will be null again
             if (_viewModel == null)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
                 _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
+            }
+            if (!IsInitialized)
+            {
                 InitializeComponent();
             }
             // Sometimes the navigation is not triggered by button click,

--- a/Flow.Launcher/Resources/Pages/WelcomePage5.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage5.xaml.cs
@@ -10,24 +10,19 @@ namespace Flow.Launcher.Resources.Pages
 {
     public partial class WelcomePage5
     {
-        public Settings Settings { get; private set; }
-        private WelcomeViewModel _viewModel;
+        public Settings Settings { get; } = Ioc.Default.GetRequiredService<Settings>();
+        private readonly WelcomeViewModel _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            // If the navigation is not triggered by button click, view model will be null again
-            if (_viewModel == null)
-            {
-                Settings = Ioc.Default.GetRequiredService<Settings>();
-                _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();
-            }
+            // Sometimes the navigation is not triggered by button click,
+            // so we need to reset the page number
+            _viewModel.PageNum = 5;
+
             if (!IsInitialized)
             {
                 InitializeComponent();
             }
-            // Sometimes the navigation is not triggered by button click,
-            // so we need to reset the page number
-            _viewModel.PageNum = 5;
             base.OnNavigatedTo(e);
         }
 

--- a/Flow.Launcher/Resources/Pages/WelcomePage5.xaml.cs
+++ b/Flow.Launcher/Resources/Pages/WelcomePage5.xaml.cs
@@ -15,7 +15,7 @@ namespace Flow.Launcher.Resources.Pages
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            if (!IsInitialized)
+            if (_viewModel == null)
             {
                 Settings = Ioc.Default.GetRequiredService<Settings>();
                 _viewModel = Ioc.Default.GetRequiredService<WelcomeViewModel>();

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml.cs
@@ -8,24 +8,24 @@ namespace Flow.Launcher.SettingPages.Views;
 public partial class SettingsPaneAbout
 {
     private SettingsPaneAboutViewModel _viewModel = null!;
-    private SettingWindowViewModel _settingViewModel = null;
+    private readonly SettingWindowViewModel _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPaneAbout);
+
         // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneAboutViewModel>();
-            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
         }
         if (!IsInitialized)
         {
             InitializeComponent();
         }
-        // Sometimes the navigation is not triggered by button click,
-        // so we need to reset the page type
-        _settingViewModel.PageType = typeof(SettingsPaneAbout);
         base.OnNavigatedTo(e);
     }
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml.cs
@@ -12,11 +12,15 @@ public partial class SettingsPaneAbout
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneAboutViewModel>();
             _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
+        }
+        if (!IsInitialized)
+        {
             InitializeComponent();
         }
         // Sometimes the navigation is not triggered by button click,

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml.cs
@@ -1,21 +1,27 @@
 ﻿using System.Windows.Navigation;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.SettingPages.ViewModels;
+using Flow.Launcher.ViewModel;
 
 namespace Flow.Launcher.SettingPages.Views;
 
 public partial class SettingsPaneAbout
 {
     private SettingsPaneAboutViewModel _viewModel = null!;
+    private SettingWindowViewModel _settingViewModel = null;
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        if (!IsInitialized)
+        if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneAboutViewModel>();
+            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
             InitializeComponent();
         }
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPaneAbout);
         base.OnNavigatedTo(e);
     }
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml.cs
@@ -1,21 +1,27 @@
 ﻿using System.Windows.Navigation;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.SettingPages.ViewModels;
+using Flow.Launcher.ViewModel;
 
 namespace Flow.Launcher.SettingPages.Views;
 
 public partial class SettingsPaneGeneral
 {
     private SettingsPaneGeneralViewModel _viewModel = null!;
+    private SettingWindowViewModel _settingViewModel = null;
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        if (!IsInitialized)
+        if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneGeneralViewModel>();
+            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
             InitializeComponent();
         }
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPaneGeneral);
         base.OnNavigatedTo(e);
     }
 }

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml.cs
@@ -8,24 +8,24 @@ namespace Flow.Launcher.SettingPages.Views;
 public partial class SettingsPaneGeneral
 {
     private SettingsPaneGeneralViewModel _viewModel = null!;
-    private SettingWindowViewModel _settingViewModel = null;
+    private readonly SettingWindowViewModel _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPaneGeneral);
+
         // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneGeneralViewModel>();
-            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
         }
         if (!IsInitialized)
         {
             InitializeComponent();
         }
-        // Sometimes the navigation is not triggered by button click,
-        // so we need to reset the page type
-        _settingViewModel.PageType = typeof(SettingsPaneGeneral);
         base.OnNavigatedTo(e);
     }
 }

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml.cs
@@ -12,11 +12,15 @@ public partial class SettingsPaneGeneral
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneGeneralViewModel>();
             _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
+        }
+        if (!IsInitialized)
+        {
             InitializeComponent();
         }
         // Sometimes the navigation is not triggered by button click,

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneHotkey.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneHotkey.xaml.cs
@@ -8,24 +8,24 @@ namespace Flow.Launcher.SettingPages.Views;
 public partial class SettingsPaneHotkey
 {
     private SettingsPaneHotkeyViewModel _viewModel = null!;
-    private SettingWindowViewModel _settingViewModel = null;
+    private readonly SettingWindowViewModel _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPaneHotkey);
+
         // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneHotkeyViewModel>();
-            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
         }
         if (!IsInitialized)
         {
             InitializeComponent();
         }
-        // Sometimes the navigation is not triggered by button click,
-        // so we need to reset the page type
-        _settingViewModel.PageType = typeof(SettingsPaneHotkey);
         base.OnNavigatedTo(e);
     }
 }

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneHotkey.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneHotkey.xaml.cs
@@ -12,11 +12,15 @@ public partial class SettingsPaneHotkey
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneHotkeyViewModel>();
             _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
+        }
+        if (!IsInitialized)
+        {
             InitializeComponent();
         }
         // Sometimes the navigation is not triggered by button click,

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneHotkey.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneHotkey.xaml.cs
@@ -1,21 +1,27 @@
 ﻿using System.Windows.Navigation;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.SettingPages.ViewModels;
+using Flow.Launcher.ViewModel;
 
 namespace Flow.Launcher.SettingPages.Views;
 
 public partial class SettingsPaneHotkey
 {
     private SettingsPaneHotkeyViewModel _viewModel = null!;
+    private SettingWindowViewModel _settingViewModel = null;
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        if (!IsInitialized)
+        if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneHotkeyViewModel>();
+            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
             InitializeComponent();
         }
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPaneHotkey);
         base.OnNavigatedTo(e);
     }
 }

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
@@ -15,11 +15,15 @@ public partial class SettingsPanePluginStore
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPanePluginStoreViewModel>();
             _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
+        }
+        if (!IsInitialized)
+        {
             InitializeComponent();
         }
         _viewModel.PropertyChanged += ViewModel_PropertyChanged;

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
@@ -11,15 +11,18 @@ namespace Flow.Launcher.SettingPages.Views;
 public partial class SettingsPanePluginStore
 {
     private SettingsPanePluginStoreViewModel _viewModel = null!;
-    private SettingWindowViewModel _settingViewModel = null;
+    private readonly SettingWindowViewModel _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPanePluginStore);
+
         // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPanePluginStoreViewModel>();
-            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
         }
         if (!IsInitialized)
@@ -27,9 +30,6 @@ public partial class SettingsPanePluginStore
             InitializeComponent();
         }
         _viewModel.PropertyChanged += ViewModel_PropertyChanged;
-        // Sometimes the navigation is not triggered by button click,
-        // so we need to reset the page type
-        _settingViewModel.PageType = typeof(SettingsPanePluginStore);
         base.OnNavigatedTo(e);
     }
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
@@ -11,16 +11,21 @@ namespace Flow.Launcher.SettingPages.Views;
 public partial class SettingsPanePluginStore
 {
     private SettingsPanePluginStoreViewModel _viewModel = null!;
+    private SettingWindowViewModel _settingViewModel = null;
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        if (!IsInitialized)
+        if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPanePluginStoreViewModel>();
+            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
             InitializeComponent();
         }
         _viewModel.PropertyChanged += ViewModel_PropertyChanged;
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPanePluginStore);
         base.OnNavigatedTo(e);
     }
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
@@ -11,16 +11,21 @@ namespace Flow.Launcher.SettingPages.Views;
 public partial class SettingsPanePlugins
 {
     private SettingsPanePluginsViewModel _viewModel = null!;
+    private SettingWindowViewModel _settingViewModel = null;
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        if (!IsInitialized)
+        if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPanePluginsViewModel>();
+            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
             InitializeComponent();
         }
         _viewModel.PropertyChanged += ViewModel_PropertyChanged;
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPanePlugins);
         base.OnNavigatedTo(e);
     }
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
@@ -15,11 +15,15 @@ public partial class SettingsPanePlugins
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPanePluginsViewModel>();
             _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
+        }
+        if (!IsInitialized)
+        {
             InitializeComponent();
         }
         _viewModel.PropertyChanged += ViewModel_PropertyChanged;

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
@@ -11,15 +11,18 @@ namespace Flow.Launcher.SettingPages.Views;
 public partial class SettingsPanePlugins
 {
     private SettingsPanePluginsViewModel _viewModel = null!;
-    private SettingWindowViewModel _settingViewModel = null;
+    private readonly SettingWindowViewModel _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPanePlugins);
+
         // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPanePluginsViewModel>();
-            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
         }
         if (!IsInitialized)
@@ -27,9 +30,6 @@ public partial class SettingsPanePlugins
             InitializeComponent();
         }
         _viewModel.PropertyChanged += ViewModel_PropertyChanged;
-        // Sometimes the navigation is not triggered by button click,
-        // so we need to reset the page type
-        _settingViewModel.PageType = typeof(SettingsPanePlugins);
         base.OnNavigatedTo(e);
     }
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneProxy.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneProxy.xaml.cs
@@ -12,11 +12,15 @@ public partial class SettingsPaneProxy
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneProxyViewModel>();
             _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
+        }
+        if (!IsInitialized)
+        {
             InitializeComponent();
         }
         // Sometimes the navigation is not triggered by button click,

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneProxy.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneProxy.xaml.cs
@@ -8,24 +8,24 @@ namespace Flow.Launcher.SettingPages.Views;
 public partial class SettingsPaneProxy
 {
     private SettingsPaneProxyViewModel _viewModel = null!;
-    private SettingWindowViewModel _settingViewModel = null;
+    private readonly SettingWindowViewModel _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPaneProxy);
+
         // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneProxyViewModel>();
-            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
         }
         if (!IsInitialized)
         {
             InitializeComponent();
         }
-        // Sometimes the navigation is not triggered by button click,
-        // so we need to reset the page type
-        _settingViewModel.PageType = typeof(SettingsPaneProxy);
         base.OnNavigatedTo(e);
     }
 }

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneProxy.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneProxy.xaml.cs
@@ -1,21 +1,27 @@
 ﻿using System.Windows.Navigation;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.SettingPages.ViewModels;
+using Flow.Launcher.ViewModel;
 
 namespace Flow.Launcher.SettingPages.Views;
 
 public partial class SettingsPaneProxy
 {
     private SettingsPaneProxyViewModel _viewModel = null!;
+    private SettingWindowViewModel _settingViewModel = null;
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        if (!IsInitialized)
+        if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneProxyViewModel>();
+            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
             InitializeComponent();
         }
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPaneProxy);
         base.OnNavigatedTo(e);
     }
 }

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml.cs
@@ -8,24 +8,24 @@ namespace Flow.Launcher.SettingPages.Views;
 public partial class SettingsPaneTheme
 {
     private SettingsPaneThemeViewModel _viewModel = null!;
-    private SettingWindowViewModel _settingViewModel = null;
+    private readonly SettingWindowViewModel _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPaneTheme);
+
         // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneThemeViewModel>();
-            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
         }
         if (!IsInitialized)
         {
             InitializeComponent();
         }
-        // Sometimes the navigation is not triggered by button click,
-        // so we need to reset the page type
-        _settingViewModel.PageType = typeof(SettingsPaneTheme);
         base.OnNavigatedTo(e);
     }
 }

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml.cs
@@ -12,11 +12,15 @@ public partial class SettingsPaneTheme
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
+        // If the navigation is not triggered by button click, view model will be null again
         if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneThemeViewModel>();
             _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
+        }
+        if (!IsInitialized)
+        {
             InitializeComponent();
         }
         // Sometimes the navigation is not triggered by button click,

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml.cs
@@ -1,21 +1,27 @@
 ﻿using System.Windows.Navigation;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.SettingPages.ViewModels;
+using Flow.Launcher.ViewModel;
 
 namespace Flow.Launcher.SettingPages.Views;
 
 public partial class SettingsPaneTheme
 {
     private SettingsPaneThemeViewModel _viewModel = null!;
+    private SettingWindowViewModel _settingViewModel = null;
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        if (!IsInitialized)
+        if (_viewModel == null)
         {
             _viewModel = Ioc.Default.GetRequiredService<SettingsPaneThemeViewModel>();
+            _settingViewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
             DataContext = _viewModel;
             InitializeComponent();
         }
+        // Sometimes the navigation is not triggered by button click,
+        // so we need to reset the page type
+        _settingViewModel.PageType = typeof(SettingsPaneTheme);
         base.OnNavigatedTo(e);
     }
 }

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -241,6 +241,7 @@ public partial class SettingWindow
     {
         if (args.IsSettingsSelected)
         {
+            _viewModel.SetPageType(typeof(SettingsPaneGeneral));
             ContentFrame.Navigate(typeof(SettingsPaneGeneral));
         }
         else
@@ -263,8 +264,11 @@ public partial class SettingWindow
                 nameof(About) => typeof(SettingsPaneAbout),
                 _ => typeof(SettingsPaneGeneral)
             };
-            _viewModel.SetPageType(pageType);
-            ContentFrame.Navigate(pageType);
+            // Only navigate if the page type changes to fix navigation forward/back issue
+            if (_viewModel.SetPageType(pageType))
+            {
+                ContentFrame.Navigate(pageType);
+            }
         }
     }
 
@@ -282,7 +286,8 @@ public partial class SettingWindow
 
     private void ContentFrame_Loaded(object sender, RoutedEventArgs e)
     {
-        NavView.SelectedItem ??= NavView.MenuItems[0]; /* Set First Page */
+        _viewModel.SetPageType(null); // Set page type to null so that NavigationView_SelectionChanged can navigate the frame
+        NavView.SelectedItem = NavView.MenuItems[0]; /* Set First Page */
     }
 
     #endregion

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -263,6 +263,7 @@ public partial class SettingWindow
                 nameof(About) => typeof(SettingsPaneAbout),
                 _ => typeof(SettingsPaneGeneral)
             };
+            _viewModel.SetPageType(pageType);
             ContentFrame.Navigate(pageType);
         }
     }

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -14,6 +14,11 @@ public partial class SettingWindowViewModel : BaseModel
         _settings = settings;
     }
 
+    public void SetPageType(Type pageType)
+    {
+        _pageType = pageType;
+    }
+
     private Type _pageType = typeof(SettingsPaneGeneral);
     public Type PageType
     {

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
-using Flow.Launcher.SettingPages.Views;
 
 namespace Flow.Launcher.ViewModel;
 
@@ -14,12 +13,15 @@ public partial class SettingWindowViewModel : BaseModel
         _settings = settings;
     }
 
-    public void SetPageType(Type pageType)
+    public bool SetPageType(Type pageType)
     {
+        if (_pageType == pageType) return false;
+
         _pageType = pageType;
+        return true;
     }
 
-    private Type _pageType = typeof(SettingsPaneGeneral);
+    private Type _pageType = null;
     public Type PageType
     {
         get => _pageType;

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -1,5 +1,7 @@
-﻿using Flow.Launcher.Infrastructure.UserSettings;
+﻿using System;
+using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
+using Flow.Launcher.SettingPages.Views;
 
 namespace Flow.Launcher.ViewModel;
 
@@ -10,6 +12,20 @@ public partial class SettingWindowViewModel : BaseModel
     public SettingWindowViewModel(Settings settings)
     {
         _settings = settings;
+    }
+
+    private Type _pageType = typeof(SettingsPaneGeneral);
+    public Type PageType
+    {
+        get => _pageType;
+        set
+        {
+            if (_pageType != value)
+            {
+                _pageType = value;
+                OnPropertyChanged();
+            }
+        }
     }
 
     public double SettingWindowWidth


### PR DESCRIPTION
# Fix setting window navigation update issue

If the navigation is not triggered by button click, so we need to reset the page type in all setting pages.

And in setting window, we need to update the selected item in navigation view.

# Check view model null instead of `IsInitialized` flag

If we use forward/backward button, `IsInitialized` is still true so we need to check nullability of view model instance instead.

# Test

- Use click / navigation button to navigate pages.

Confirmed by [vzabrodin](https://github.com/vzabrodin).

Resolve #3546.