### PR TITLE
initialize position before InitializeComponent

### DIFF
--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -30,9 +30,9 @@ public partial class SettingWindow
         _settings = Ioc.Default.GetRequiredService<Settings>();
         _viewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
         DataContext = _viewModel;
-        InitializeComponent();
-
+        // Because WindowStartupLocation is Manual, so we need to initialize position before InitializeComponent
         UpdatePositionAndState();
+        InitializeComponent();
     }
 
     #endregion

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -30,7 +30,7 @@ public partial class SettingWindow
         _settings = Ioc.Default.GetRequiredService<Settings>();
         _viewModel = Ioc.Default.GetRequiredService<SettingWindowViewModel>();
         DataContext = _viewModel;
-        // Because WindowStartupLocation is Manual, so we need to initialize position before InitializeComponent
+        // Since WindowStartupLocation is set to Manual, initialize the window position before calling InitializeComponent
         UpdatePositionAndState();
         InitializeComponent();
     }


### PR DESCRIPTION
Follow on with #3470. 

Because WindowStartupLocation is Manual, so we need to initialize position before InitializeComponent.

Fix:
![image](https://github.com/user-attachments/assets/d5638969-1a8c-44fa-9757-5435f0744f5b)
