### PR TITLE
Fix prevent zombie explorer.exe processes when opening folders

### DIFF
--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -314,19 +314,19 @@ namespace Flow.Launcher
             ((PluginJsonStorage<T>)_pluginJsonStorages[type]).Save();
         }
 
-        public void OpenDirectory(string directoryPath, string fileNameOrFilePath = null)
+        public void OpenDirectory(string DirectoryPath, string FileNameOrFilePath = null)
         {
             string targetPath;
 
-            if (fileNameOrFilePath is null)
+            if (FileNameOrFilePath is null)
             {
-                targetPath = directoryPath;
+                targetPath = DirectoryPath;
             }
             else
             {
-                targetPath = Path.IsPathRooted(fileNameOrFilePath)
-                    ? fileNameOrFilePath
-                    : Path.Combine(directoryPath, fileNameOrFilePath);
+                targetPath = Path.IsPathRooted(FileNameOrFilePath)
+                    ? FileNameOrFilePath
+                    : Path.Combine(DirectoryPath, FileNameOrFilePath);
             }
 
             var explorerInfo = _settings.CustomExplorer;
@@ -346,12 +346,12 @@ namespace Flow.Launcher
             // Custom File Manager
             var psi = new ProcessStartInfo
             {
-                FileName = explorerInfo.Path.Replace("%d", directoryPath),
+                FileName = explorerInfo.Path.Replace("%d", DirectoryPath),
                 UseShellExecute = true,
-                Arguments = fileNameOrFilePath is null
-                    ? explorerInfo.DirectoryArgument.Replace("%d", directoryPath)
+                Arguments = FileNameOrFilePath is null
+                    ? explorerInfo.DirectoryArgument.Replace("%d", DirectoryPath)
                     : explorerInfo.FileArgument
-                        .Replace("%d", directoryPath)
+                        .Replace("%d", DirectoryPath)
                         .Replace("%f", targetPath)
             };
 

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -349,8 +349,6 @@ namespace Flow.Launcher
                             .Replace("%f", targetPath)
                 };
             }
-
-            // Start the process
             explorer.Start();
         }
 

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -316,6 +316,7 @@ namespace Flow.Launcher
 
         public void OpenDirectory(string DirectoryPath, string FileNameOrFilePath = null)
         {
+            using var explorer = new Process();
             var explorerInfo = _settings.CustomExplorer;
             var explorerPath = explorerInfo.Path.Trim().ToLowerInvariant();
             var targetPath = FileNameOrFilePath is null
@@ -324,7 +325,6 @@ namespace Flow.Launcher
                     ? FileNameOrFilePath
                     : Path.Combine(DirectoryPath, FileNameOrFilePath);
 
-            using var explorer = new Process();
             if (Path.GetFileNameWithoutExtension(explorerPath) == "explorer")
             {
                 // Windows File Manager


### PR DESCRIPTION
## Summary
- Fixes #3550
- This PR resolves an issue where launching `explorer.exe` to open a folder path would result in a lingering zombie process even after the File Explorer window is closed.

## Problem

Previously, we used `ProcessStartInfo` with `FileName = "explorer.exe"` and `Arguments = "folder path"` to open directories. However, when launched this way from a WPF application, `explorer.exe` remains as a child process and does not exit even after its window is closed.

## Solution

Instead of launching `explorer.exe` directly, this PR updates the logic to:

- Use `Process.Start("folder path")` with `UseShellExecute = true` when the custom explorer is set to `explorer.exe`.
- This leverages the Windows Shell to open the folder using the default handler (usually File Explorer), avoiding the need to explicitly invoke `explorer.exe`.

This method ensures that:
- No zombie `explorer.exe` processes are left behind.
- The folder is still opened as expected in the File Explorer.

## Additional Notes

- Custom explorers still work as before using the original logic.
- This change only affects when the custom explorer is explicitly set to `"explorer.exe"`.