### PR TITLE
Unify all default built-in plugins' version

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Browser Bookmarks",
   "Description": "Search your browser bookmarks",
   "Author": "qianlifeng, Ioannis G.",
-  "Version": "3.3.4",
+  "Version": "1.0.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.BrowserBookmark.dll",

--- a/Plugins/Flow.Launcher.Plugin.Calculator/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Calculator",
   "Description": "Provide mathematical calculations.(Try 5*3-2 in Flow Launcher)",
   "Author": "cxfksword",
-  "Version": "3.1.5",
+  "Version": "1.0.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Calculator.dll",

--- a/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/plugin.json
@@ -11,7 +11,7 @@
   "Name": "Explorer",
   "Description": "Find and manage files and folders via Windows Search or Everything",
   "Author": "Jeremy Wu",
-  "Version": "3.2.4",
+  "Version": "1.0.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Explorer.dll",

--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Plugin Indicator",
   "Description": "Provides plugin action keyword suggestions",
   "Author": "qianlifeng",
-  "Version": "3.0.7",
+  "Version": "1.0.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.PluginIndicator.dll",

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/plugin.json
@@ -6,7 +6,7 @@
   "Name": "Plugins Manager",
   "Description": "Management of installing, uninstalling or updating Flow Launcher plugins",
   "Author": "Jeremy Wu",
-  "Version": "3.2.4",
+  "Version": "1.0.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.PluginsManager.dll",

--- a/Plugins/Flow.Launcher.Plugin.ProcessKiller/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.ProcessKiller/plugin.json
@@ -4,7 +4,7 @@
     "Name":"Process Killer",
     "Description":"Kill running processes from Flow",
     "Author":"Flow-Launcher",
-    "Version":"3.0.8",
+    "Version": "1.0.0",
     "Language":"csharp",
     "Website":"https://github.com/Flow-Launcher/Flow.Launcher.Plugin.ProcessKiller",
     "IcoPath":"Images\\app.png",

--- a/Plugins/Flow.Launcher.Plugin.Program/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Program/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Program",
   "Description": "Search programs in Flow.Launcher",
   "Author": "qianlifeng",
-  "Version": "3.3.4",
+  "Version": "1.0.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Program.dll",

--- a/Plugins/Flow.Launcher.Plugin.Shell/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Shell/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Shell",
   "Description": "Provide executing commands from Flow Launcher",
   "Author": "qianlifeng",
-  "Version": "3.2.5",
+  "Version": "1.0.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Shell.dll",

--- a/Plugins/Flow.Launcher.Plugin.Sys/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Sys/plugin.json
@@ -4,7 +4,7 @@
   "Name": "System Commands",
   "Description": "Provide System related commands. e.g. shutdown,lock, setting etc.",
   "Author": "qianlifeng",
-  "Version": "3.1.7",
+  "Version": "1.0.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Sys.dll",

--- a/Plugins/Flow.Launcher.Plugin.Url/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.Url/plugin.json
@@ -4,7 +4,7 @@
   "Name": "URL",
   "Description": "Open the typed URL from Flow Launcher",
   "Author": "qianlifeng",
-  "Version": "3.0.8",
+  "Version": "1.0.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.Url.dll",

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/plugin.json
@@ -27,7 +27,7 @@
   "Name": "Web Searches",
   "Description": "Provide the web search ability",
   "Author": "qianlifeng",
-  "Version": "3.1.4",
+  "Version": "1.0.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.WebSearch.dll",

--- a/Plugins/Flow.Launcher.Plugin.WindowsSettings/plugin.json
+++ b/Plugins/Flow.Launcher.Plugin.WindowsSettings/plugin.json
@@ -4,7 +4,7 @@
   "Description": "Search settings inside Control Panel and Settings App",
   "Name": "Windows Settings",
   "Author": "TobiasSekan",
-  "Version": "4.0.12",
+  "Version": "1.0.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher",
   "ExecuteFileName": "Flow.Launcher.Plugin.WindowsSettings.dll",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,14 +8,6 @@ init:
       {
         $env:prereleaseTag = "{0}.{1}.{2}.{3}" -f $version.Major, $version.Minor, $version.Build, $version.Revision
       }
-
-      $jsonFiles = Get-ChildItem -Path ".\Plugins\*\plugin.json"
-      foreach ($file in $jsonFiles) {
-          $plugin_old_ver = Get-Content $file.FullName -Raw | ConvertFrom-Json
-          (Get-Content $file) -replace '"Version"\s*:\s*".*?"', "`"Version`": `"$env:flowVersion`"" | Set-Content $file
-          $plugin_new_ver = Get-Content $file.FullName -Raw | ConvertFrom-Json
-          Write-Host "Updated" $plugin_old_ver.Name "version from" $plugin_old_ver.Version "to" $plugin_new_ver.Version
-      }
 - sc config WSearch start= auto # Starts Windows Search service- Needed for running ExplorerTest
 - net start WSearch
 
@@ -34,7 +26,16 @@ image: Visual Studio 2022
 platform: Any CPU
 configuration: Release
 before_build:
-- ps: nuget restore
+- ps: |
+      nuget restore
+
+      $jsonFiles = Get-ChildItem -Path ".\Plugins\*\plugin.json"
+      foreach ($file in $jsonFiles) {
+          $plugin_old_ver = Get-Content $file.FullName -Raw | ConvertFrom-Json
+          (Get-Content $file) -replace '"Version"\s*:\s*".*?"', "`"Version`": `"$env:flowVersion`"" | Set-Content $file
+          $plugin_new_ver = Get-Content $file.FullName -Raw | ConvertFrom-Json
+          Write-Host "Updated" $plugin_old_ver.Name "version from" $plugin_old_ver.Version "to" $plugin_new_ver.Version
+      }
 build:
   project: Flow.Launcher.sln
   verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,14 @@ init:
       {
         $env:prereleaseTag = "{0}.{1}.{2}.{3}" -f $version.Major, $version.Minor, $version.Build, $version.Revision
       }
+
+      $jsonFiles = Get-ChildItem -Path ".\Plugins\*\plugin.json"
+      foreach ($file in $jsonFiles) {
+          $plugin_old_ver = Get-Content $file.FullName -Raw | ConvertFrom-Json
+          (Get-Content $file) -replace '"Version"\s*:\s*".*?"', "`"Version`": `"$env:flowVersion`"" | Set-Content $file
+          $plugin_new_ver = Get-Content $file.FullName -Raw | ConvertFrom-Json
+          Write-Host "Updated" $plugin_old_ver.Name "version from" $plugin_old_ver.Version "to" $plugin_new_ver.Version
+      }
 - sc config WSearch start= auto # Starts Windows Search service- Needed for running ExplorerTest
 - net start WSearch
 


### PR DESCRIPTION
Context:
Currently all default built-in plugins have their own versioning. This creates manual work to bump them individually and accordingly.

We need to change this to have them all set to uniform versioning following flow's. Since they always get published along with flow there is little need for them to be different. Instead we bump them all at the same time to the same version as flow regardless of there are changes to them. This also will indicate which release they are from.

Changes:
- Set their version to 1.0.0, which will be the version displayed when built locally.
- Use AppVeyor CI to set them to flow's current version when built.

Tested:
- Build passes
- When built by CI the version displayed on all plugins are they same as flow's version in abouts settings page.