### PR TITLE
Improve File Manager Configuration Error Handling

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -226,8 +226,8 @@ namespace Flow.Launcher.Infrastructure.UserSettings
             new()
             {
                 Name = "Files",
-                Path = "Files",
-                DirectoryArgument = "-select \"%d\"",
+                Path = "Files-Stable",
+                DirectoryArgument = "\"%d\"",
                 FileArgument = "-select \"%f\""
             }
         };

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -373,6 +373,8 @@
     <system:String x:Key="fileManager_path">File Manager Path</system:String>
     <system:String x:Key="fileManager_directory_arg">Arg For Folder</system:String>
     <system:String x:Key="fileManager_file_arg">Arg For File</system:String>
+    <system:String x:Key="fileManagerPathNotFound">The path for the file manager '{0}' could not be found: {1}\n\nDo you want to continue?</system:String>
+    <system:String x:Key="fileManagerPathError">File Manager Path Error</system:String>
 
     <!--  DefaultBrowser Setting Dialog  -->
     <system:String x:Key="defaultBrowserTitle">Default Web Browser</system:String>
@@ -461,6 +463,10 @@
     <system:String x:Key="reportWindow_please_open_issue">Please open new issue in</system:String>
     <system:String x:Key="reportWindow_upload_log">1. Upload log file: {0}</system:String>
     <system:String x:Key="reportWindow_copy_below">2. Copy below exception message</system:String>
+
+    <!--  File Open Error  -->
+    <system:String x:Key="folderOpenError">An error occurred while opening the folder.:\n{0}</system:String>
+    <system:String x:Key="errorTitle">Error</system:String>
 
     <!--  General Notice  -->
     <system:String x:Key="pleaseWait">Please wait...</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -366,6 +366,8 @@
 
     <!--  FileManager Setting Dialog  -->
     <system:String x:Key="fileManagerWindow">Select File Manager</system:String>
+    <system:String x:Key="fileManager_files_btn">Do you use Files?</system:String>
+    <system:String x:Key="fileManager_files_tips">Depending on the version, Files may use either "Files" or "Files-stable" as its path. (This can vary depending on which version you're using.) For more details, see:</system:String>
     <system:String x:Key="fileManager_tips">Please specify the file location of the file manager you using and add arguments as required. The &quot;%d&quot; represents the directory path to open for, used by the Arg for Folder field and for commands opening specific directories. The &quot;%f&quot; represents the file path to open for, used by the Arg for File field and for commands opening specific files.</system:String>
     <system:String x:Key="fileManager_tips2">For example, if the file manager uses a command such as &quot;totalcmd.exe /A c:\windows&quot; to open the c:\windows directory, the File Manager Path will be totalcmd.exe, and the Arg For Folder will be /A &quot;%d&quot;. Certain file managers like QTTabBar may just require a path to be supplied, in this instance use &quot;%d&quot; as the File Manager Path and leave the rest of the fileds blank.</system:String>
     <system:String x:Key="fileManager_name">File Manager</system:String>
@@ -373,7 +375,7 @@
     <system:String x:Key="fileManager_path">File Manager Path</system:String>
     <system:String x:Key="fileManager_directory_arg">Arg For Folder</system:String>
     <system:String x:Key="fileManager_file_arg">Arg For File</system:String>
-    <system:String x:Key="fileManagerPathNotFound">The path for the file manager '{0}' could not be found: {1}\n\nDo you want to continue?</system:String>
+    <system:String x:Key="fileManagerPathNotFound">The path for the file manager '{0}' could not be found: '{1}' Do you want to continue?</system:String>
     <system:String x:Key="fileManagerPathError">File Manager Path Error</system:String>
 
     <!--  DefaultBrowser Setting Dialog  -->
@@ -465,8 +467,12 @@
     <system:String x:Key="reportWindow_copy_below">2. Copy below exception message</system:String>
 
     <!--  File Open Error  -->
-    <system:String x:Key="folderOpenError">An error occurred while opening the folder.:\n{0}</system:String>
+    <system:String x:Key="fileManagerNotFoundTitle">File Manager Error</system:String>
+    <system:String x:Key="fileManagerNotFound">
+        The specified file manager could not be found. Please check the Custom File Manager setting under Settings >General.
+    </system:String>
     <system:String x:Key="errorTitle">Error</system:String>
+    <system:String x:Key="folderOpenError">An error occurred while opening the folder. {0}</system:String>
 
     <!--  General Notice  -->
     <system:String x:Key="pleaseWait">Please wait...</system:String>

--- a/Flow.Launcher/SelectFileManagerWindow.xaml
+++ b/Flow.Launcher/SelectFileManagerWindow.xaml
@@ -73,9 +73,18 @@
                         <TextBlock Margin="0 14 0 0" FontSize="14">
                             <TextBlock Text="{DynamicResource fileManager_tips2}" TextWrapping="WrapWithOverflow" />
                         </TextBlock>
+                        <Button
+                            x:Name="btnTips"
+                            Margin="0 14 0 0"
+                            HorizontalAlignment="Left"
+                            Click="btnTips_Click"
+                            Content="{DynamicResource fileManager_files_btn}" />
                     </StackPanel>
-
-                    <StackPanel Margin="14 28 0 0" Orientation="Horizontal">
+                    <Rectangle
+                        Height="1"
+                        Margin="0 20 0 20"
+                        Fill="{StaticResource SeparatorForeground}" />
+                    <StackPanel Margin="14 0 0 0" Orientation="Horizontal">
                         <TextBlock
                             Grid.Column="1"
                             HorizontalAlignment="Left"
@@ -111,7 +120,7 @@
                     <Rectangle
                         Height="1"
                         Margin="0 20 0 12"
-                        Fill="{StaticResource Color03B}" />
+                        Fill="{StaticResource SeparatorForeground}" />
                     <StackPanel
                         Margin="0 0 0 0"
                         HorizontalAlignment="Stretch"

--- a/Flow.Launcher/SelectFileManagerWindow.xaml.cs
+++ b/Flow.Launcher/SelectFileManagerWindow.xaml.cs
@@ -6,9 +6,11 @@ using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.ViewModel;
+using ModernWpf.Controls;
 
 namespace Flow.Launcher
 {
@@ -102,6 +104,50 @@ namespace Flow.Launcher
             }
         }
 
+        private async void btnTips_Click(object sender, RoutedEventArgs e)
+        {
+            string tipText = (string)Application.Current.Resources["fileManager_files_tips"];
+            string url = "https://files.community/docs/contributing/updates";
+    
+            var textBlock = new TextBlock
+            {
+                FontSize = 14,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 0, 0, 0)
+            };
+            
+            textBlock.Inlines.Add(tipText);
+            
+            Hyperlink hyperlink = new Hyperlink
+            {
+                NavigateUri = new Uri(url)
+            };
+            hyperlink.Inlines.Add(url);
+            hyperlink.RequestNavigate += (s, args) =>
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = args.Uri.AbsoluteUri,
+                    UseShellExecute = true
+                });
+                args.Handled = true;
+            };
+    
+            textBlock.Inlines.Add(hyperlink);
+    
+            var tipsDialog = new ContentDialog()
+            {
+                Owner = Window.GetWindow(sender as DependencyObject),
+                Title = (string)Application.Current.Resources["fileManager_files_btn"],
+                Content = textBlock,
+                PrimaryButtonText = (string)Application.Current.Resources["commonOK"],
+                CornerRadius = new CornerRadius(8),
+                Style = (Style)Application.Current.Resources["ContentDialog"]
+            };
+
+            await tipsDialog.ShowAsync();
+        }
+        
         private void btnAdd_Click(object sender, RoutedEventArgs e)
         {
             CustomExplorers.Add(new()

--- a/Flow.Launcher/SelectFileManagerWindow.xaml.cs
+++ b/Flow.Launcher/SelectFileManagerWindow.xaml.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -43,9 +46,60 @@ namespace Flow.Launcher
 
         private void btnDone_Click(object sender, RoutedEventArgs e)
         {
+            // Check if the selected file manager path is valid
+            if (!IsFileManagerValid(CustomExplorer.Path))
+            {
+                MessageBoxResult result = MessageBoxEx.Show(
+                    string.Format((string)Application.Current.FindResource("fileManagerPathNotFound"), 
+                        CustomExplorer.Name, CustomExplorer.Path),
+                    (string)Application.Current.FindResource("fileManagerPathError"),
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Warning);
+
+                if (result == MessageBoxResult.No)
+                {
+                    return;
+                }
+            }
+
             _settings.CustomExplorerList = CustomExplorers.ToList();
             _settings.CustomExplorerIndex = SelectedCustomExplorerIndex;
             Close();
+        }
+
+        private bool IsFileManagerValid(string path)
+        {
+            if (string.Equals(path, "explorer", StringComparison.OrdinalIgnoreCase))
+                return true;
+            
+            if (Path.IsPathRooted(path))
+            {
+                return File.Exists(path);
+            }
+
+            try
+            {
+                var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = "where",
+                        Arguments = path,
+                        RedirectStandardOutput = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    }
+                };
+                process.Start();
+                string output = process.StandardOutput.ReadToEnd();
+                process.WaitForExit();
+
+                return !string.IsNullOrEmpty(output);
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private void btnAdd_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION

## Improve File Manager Configuration Error Handling

<img src="https://github.com/user-attachments/assets/dea6c2d3-9de7-4757-96a2-68ea5429dcd5" width="300" />
<img src="https://github.com/user-attachments/assets/c85d2b9b-322f-4ba5-a56a-50b6d17869e7" width="300" />
<img src="https://github.com/user-attachments/assets/58008b81-ac87-4a65-8cee-c28b38d382bb" width="300" />


### Summary
- Fix #3217, #3353, #3418
- When attempting to open a file using a file manager that no longer exists, a more informative message is shown instead of a generic error dialog.
- A warning message is now displayed if the specified file manager does not exist at the time of configuration.
- Updated the default path for Files.
- Added an informational note about Files in the Custom File Manager configuration window.

### Details

- The default executable path for **Files** has changed from `Files` to `Files-stable`. The default setting has been adjusted accordingly.
- Since the path may vary depending on the installed version, a note has been added to explain this. Additionally, warnings will be shown if the user tries to add or use an invalid path.
- Migration logic was considered, but due to complexity and edge cases, it was not implemented.

### Future

- In the future, it would be helpful to create a dedicated webpage where users can share configuration examples for various file managers.

### Test
- A warning popup should appear when attempting to register a file manager with a non-existent path.

- An error message should be shown when trying to open a folder using a file manager that was registered with a non-existent path.