### PR TITLE
Fix WinForm Culture Info Issue

### DIFF
--- a/Flow.Launcher.Core/Resource/Internationalization.cs
+++ b/Flow.Launcher.Core/Resource/Internationalization.cs
@@ -1,16 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
-using System.Globalization;
-using System.Threading.Tasks;
-using CommunityToolkit.Mvvm.DependencyInjection;
 
 namespace Flow.Launcher.Core.Resource
 {
@@ -29,13 +30,12 @@ namespace Flow.Launcher.Core.Resource
         private readonly Settings _settings;
         private readonly List<string> _languageDirectories = new();
         private readonly List<ResourceDictionary> _oldResources = new();
-        private readonly string SystemLanguageCode;
+        private static string SystemLanguageCode;
 
         public Internationalization(Settings settings)
         {
             _settings = settings;
             AddFlowLauncherLanguageDirectory();
-            SystemLanguageCode = GetSystemLanguageCodeAtStartup();
         }
 
         private void AddFlowLauncherLanguageDirectory()
@@ -44,7 +44,7 @@ namespace Flow.Launcher.Core.Resource
             _languageDirectories.Add(directory);
         }
 
-        private static string GetSystemLanguageCodeAtStartup()
+        public static void InitSystemLanguageCode()
         {
             var availableLanguages = AvailableLanguages.GetAvailableLanguages();
 
@@ -65,11 +65,11 @@ namespace Flow.Launcher.Core.Resource
                     string.Equals(languageCode, threeLetterCode, StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(languageCode, fullName, StringComparison.OrdinalIgnoreCase))
                 {
-                    return languageCode;
+                    SystemLanguageCode = languageCode;
                 }
             }
 
-            return DefaultLanguageCode;
+            SystemLanguageCode = DefaultLanguageCode;
         }
 
         private void AddPluginLanguageDirectories()
@@ -173,13 +173,23 @@ namespace Flow.Launcher.Core.Resource
                 LoadLanguage(language);
             }
 
-            // Culture of main thread
-            // Use CreateSpecificCulture to preserve possible user-override settings in Windows, if Flow's language culture is the same as Windows's
-            CultureInfo.CurrentCulture = CultureInfo.CreateSpecificCulture(language.LanguageCode);
-            CultureInfo.CurrentUICulture = CultureInfo.CurrentCulture;
+            // Change culture info
+            ChangeCultureInfo(language.LanguageCode);
 
             // Raise event for plugins after culture is set
             await Task.Run(UpdatePluginMetadataTranslations);
+        }
+
+        public static void ChangeCultureInfo(string languageCode)
+        {
+            // Culture of main thread
+            // Use CreateSpecificCulture to preserve possible user-override settings in Windows, if Flow's language culture is the same as Windows's
+            var currentCulture = CultureInfo.CreateSpecificCulture(languageCode);
+            CultureInfo.CurrentCulture = currentCulture;
+            CultureInfo.CurrentUICulture = currentCulture;
+            var thread = Thread.CurrentThread;
+            thread.CurrentCulture = currentCulture;
+            thread.CurrentUICulture = currentCulture;
         }
 
         public bool PromptShouldUsePinyin(string languageCodeToSet)

--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -25,7 +25,13 @@ namespace Flow.Launcher.Infrastructure.UserSettings
 
         public void Initialize()
         {
+            // Initialize dependency injection instances after Ioc.Default is created
             _stringMatcher = Ioc.Default.GetRequiredService<StringMatcher>();
+
+            // Initialize application resources after application is created
+            var settingWindowFont = new FontFamily(SettingWindowFont);
+            Application.Current.Resources["SettingWindowFont"] = settingWindowFont;
+            Application.Current.Resources["ContentControlThemeFontFamily"] = settingWindowFont;
         }
 
         public void Save()
@@ -114,8 +120,11 @@ namespace Flow.Launcher.Infrastructure.UserSettings
                 {
                     _settingWindowFont = value;
                     OnPropertyChanged();
-                    Application.Current.Resources["SettingWindowFont"] = new FontFamily(value);
-                    Application.Current.Resources["ContentControlThemeFontFamily"] = new FontFamily(value);
+                    if (Application.Current != null)
+                    {
+                        Application.Current.Resources["SettingWindowFont"] = new FontFamily(value);
+                        Application.Current.Resources["ContentControlThemeFontFamily"] = new FontFamily(value);
+                    }
                 }
             }
         }

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -41,9 +41,9 @@ namespace Flow.Launcher
         private static readonly string ClassName = nameof(App);
 
         private static bool _disposed;
+        private static Settings _settings;
         private static MainWindow _mainWindow;
         private readonly MainViewModel _mainVM;
-        private readonly Settings _settings;
 
         // To prevent two disposals running at the same time.
         private static readonly object _disposingLock = new();
@@ -55,19 +55,7 @@ namespace Flow.Launcher
         public App()
         {
             // Initialize settings
-            try
-            {
-                var storage = new FlowLauncherJsonStorage<Settings>();
-                _settings = storage.Load();
-                _settings.SetStorage(storage);
-                _settings.WMPInstalled = WindowsMediaPlayerHelper.IsWindowsMediaPlayerInstalled();
-            }
-            catch (Exception e)
-            {
-                ShowErrorMsgBoxAndFailFast("Cannot load setting storage, please check local data directory", e);
-                return;
-            }
-
+            _settings.WMPInstalled = WindowsMediaPlayerHelper.IsWindowsMediaPlayerInstalled();
             // Configure the dependency injection container
             try
             {
@@ -119,16 +107,6 @@ namespace Flow.Launcher
                 ShowErrorMsgBoxAndFailFast("Cannot initialize api and settings, please open new issue in Flow.Launcher", e);
                 return;
             }
-
-            // Local function
-            static void ShowErrorMsgBoxAndFailFast(string message, Exception e)
-            {
-                // Firstly show users the message
-                MessageBox.Show(e.ToString(), message, MessageBoxButton.OK, MessageBoxImage.Error);
-
-                // Flow cannot construct its App instance, so ensure Flow crashes w/ the exception info.
-                Environment.FailFast(message, e);
-            }
         }
 
         #endregion
@@ -138,12 +116,48 @@ namespace Flow.Launcher
         [STAThread]
         public static void Main()
         {
+            // Initialize settings so that we can get language code
+            try
+            {
+                var storage = new FlowLauncherJsonStorage<Settings>();
+                _settings = storage.Load();
+                _settings.SetStorage(storage);
+            }
+            catch (Exception e)
+            {
+                ShowErrorMsgBoxAndFailFast("Cannot load setting storage, please check local data directory", e);
+                return;
+            }
+
+            // Initialize system language before changing culture info
+            Internationalization.InitSystemLanguageCode();
+
+            // Change culture info before application creation to localize WinForm windows
+            if (_settings.Language != Constant.SystemLanguageCode)
+            {
+                Internationalization.ChangeCultureInfo(_settings.Language);
+            }
+
+            // Start the application as a single instance
             if (SingleInstance<App>.InitializeAsFirstInstance())
             {
                 using var application = new App();
                 application.InitializeComponent();
                 application.Run();
             }
+        }
+
+        #endregion
+
+        #region Fail Fast
+
+        private static void ShowErrorMsgBoxAndFailFast(string message, Exception e)
+        {
+            // Firstly show users the message
+            MessageBox.Show(e.ToString(), message, MessageBoxButton.OK, MessageBoxImage.Error);
+
+            // Flow cannot construct its App instance, so ensure Flow crashes w/ the exception info.
+            Environment.FailFast(message, e);
         }
 
         #endregion


### PR DESCRIPTION
# Fix WinForm Culture Info Issue

For WinForm localization, we need to set culture info before creating application so that WinForm can follow the set language. This is helpful for plugins with WinForm windows.

To implement this, we also need to initialize settings so that we can get language code and initialize system language before changing culture info.

# Test

* Install one plugin with WinForm windows and change the application language to one language different from system language. Open the WinForm windows and check localization.