### PR TITLE
Fix: Ensure QueryTextBox receives focus after Win+R

### DIFF
--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -88,6 +88,11 @@ namespace Flow.Launcher.Plugin
         /// Show the MainWindow when hiding
         /// </summary>
         void ShowMainWindow();
+        
+        /// <summary>
+        /// Focus the query text box in the main window
+        /// </summary>
+        void FocusQueryTextBox();
 
         /// <summary>
         /// Hide MainWindow

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -10,6 +11,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Input;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Core;
@@ -32,8 +34,6 @@ using Flow.Launcher.ViewModel;
 using JetBrains.Annotations;
 using Squirrel;
 using Stopwatch = Flow.Launcher.Infrastructure.Stopwatch;
-using System.ComponentModel;
-using System.Windows.Input;
 
 namespace Flow.Launcher
 {
@@ -93,18 +93,8 @@ namespace Flow.Launcher
         }
 
         public void ShowMainWindow() => _mainVM.Show();
-        
-        public void FocusQueryTextBox()
-        {
-            Application.Current.Dispatcher.Invoke(new Action(() =>
-            {
-                if (Application.Current.MainWindow is MainWindow mw)
-                {
-                    mw.QueryTextBox.Focus();
-                    Keyboard.Focus(mw.QueryTextBox);
-                }
-            }));
-        }
+
+        public void FocusQueryTextBox() => _mainVM.FocusQueryTextBox();
 
         public void HideMainWindow() => _mainVM.Hide();
 

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -33,6 +33,7 @@ using JetBrains.Annotations;
 using Squirrel;
 using Stopwatch = Flow.Launcher.Infrastructure.Stopwatch;
 using System.ComponentModel;
+using System.Windows.Input;
 
 namespace Flow.Launcher
 {
@@ -92,6 +93,18 @@ namespace Flow.Launcher
         }
 
         public void ShowMainWindow() => _mainVM.Show();
+        
+        public void FocusQueryTextBox()
+        {
+            Application.Current.Dispatcher.Invoke(new Action(() =>
+            {
+                if (Application.Current.MainWindow is MainWindow mw)
+                {
+                    mw.QueryTextBox.Focus();
+                    Keyboard.Focus(mw.QueryTextBox);
+                }
+            }));
+        }
 
         public void HideMainWindow() => _mainVM.Hide();
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1926,6 +1926,21 @@ namespace Flow.Launcher.ViewModel
             Results.AddResults(resultsForUpdates, token, reSelect);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "<Pending>")]
+        public void FocusQueryTextBox()
+        {
+            // When application is exiting, the Application.Current will be null
+            Application.Current?.Dispatcher.Invoke(() =>
+            {
+                // When application is exiting, the Application.Current will be null
+                if (Application.Current?.MainWindow is MainWindow window)
+                {
+                    window.QueryTextBox.Focus();
+                    Keyboard.Focus(window.QueryTextBox);
+                }
+            });
+        }
+
         #endregion
 
         #region IDisposable

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -378,10 +378,13 @@ namespace Flow.Launcher.Plugin.Shell
 
         private void OnWinRPressed()
         {
+            Context.API.ShowMainWindow();
             // show the main window and set focus to the query box
-            _ = Task.Run(() =>
+            _ = Task.Run(async () =>
             {
-                Context.API.ShowMainWindow();
+                await Task.Delay(50);  // 💡 키보드 이벤트 처리가 끝난 뒤
+                Context.API.FocusQueryTextBox();
+
                 Context.API.ChangeQuery($"{Context.CurrentPluginMetadata.ActionKeywords[0]}{Plugin.Query.TermSeparator}");
             });
         }

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -382,10 +382,13 @@ namespace Flow.Launcher.Plugin.Shell
             // show the main window and set focus to the query box
             _ = Task.Run(async () =>
             {
-                await Task.Delay(50);  // 💡 키보드 이벤트 처리가 끝난 뒤
-                Context.API.FocusQueryTextBox();
-
                 Context.API.ChangeQuery($"{Context.CurrentPluginMetadata.ActionKeywords[0]}{Plugin.Query.TermSeparator}");
+
+                // Win+R is a system-reserved shortcut, and though the plugin intercepts the keyboard event and
+                // shows the main window, Windows continues to process the Win key and briefly reclaims focus.
+                // So we need to wait until the keyboard event processing is completed and then set focus
+                await Task.Delay(50);
+                Context.API.FocusQueryTextBox();
             });
         }
 


### PR DESCRIPTION
## What's the PR
- Fixes an issue where QueryTextBox did not receive focus when the launcher was shown via Win+R shortcut. (Shell Plugin)
- This was due to OS-level focus interference. Resolved by introducing a short delay before applying focus.

### Reproduce
- In dev build, enable the Win+R setting in the Shell plugin and run the launcher
- Verify that the input box does not receive focus.

### Problem
When launching Flow Launcher via the Win+R shortcut (with the Shell plugin's setting enabled), the main window appears, but the input box (QueryTextBox) does not receive focus, preventing immediate typing.

### Cause
This happens because Win+R is a system-reserved shortcut. Even though the plugin intercepts the keyboard event and shows the main window, Windows continues to process the Win key, and briefly reclaims focus, typically sending it to the Start menu or background. As a result, any Focus() call issued immediately after ShowMainWindow() is overridden.

### Solution 
To work around the OS-level focus interference:

- We introduced a slight delay (Task.Delay) after showing the main window before explicitly calling FocusQueryTextBox().

- This ensures that Windows has completed handling the Win key and the plugin regains control to correctly apply focus.