### PR TITLE
Fix main window null when checking exiting

### DIFF
--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -32,7 +32,7 @@ namespace Flow.Launcher
         #region Public Properties
 
         public static IPublicAPI API { get; private set; }
-        public static bool Exiting => _mainWindow.CanClose;
+        public static bool LoadingOrExiting => _mainWindow == null || _mainWindow.CanClose;
 
         #endregion
 

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -82,7 +82,7 @@ public partial class SettingWindow
         _viewModel.PropertyChanged -= ViewModel_PropertyChanged;
 
         // If app is exiting, settings save is not needed because main window closing event will handle this
-        if (App.Exiting) return;
+        if (App.LoadingOrExiting) return;
         // Save settings when window is closed
         _settings.Save();
         App.API.SavePluginSettings();

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1729,7 +1729,7 @@ namespace Flow.Launcher.ViewModel
         public void Show()
         {
             // When application is exiting, we should not show the main window
-            if (App.Exiting) return;
+            if (App.LoadingOrExiting) return;
 
             // When application is exiting, the Application.Current will be null
             Application.Current?.Dispatcher.Invoke(() =>

--- a/Flow.Launcher/WelcomeWindow.xaml.cs
+++ b/Flow.Launcher/WelcomeWindow.xaml.cs
@@ -96,7 +96,7 @@ namespace Flow.Launcher
         private void Window_Closed(object sender, EventArgs e)
         {
             // If app is exiting, settings save is not needed because main window closing event will handle this
-            if (App.Exiting) return;
+            if (App.LoadingOrExiting) return;
             // Save settings when window is closed
             _settings.Save();
         }


### PR DESCRIPTION
If we call Win+R before creating main window, the Show will be called before main window constructor. So we need to check if main window is created.

```
Please open new issue in https://github.com/Flow-Launcher/Flow.Launcher/issues
1. Upload log file: C:\Users\11602\AppData\Roaming\FlowLauncher\Logs\1.19.5\2025-05-22.txt
2. Copy below exception message

Flow Launcher version: 1.19.5
OS Version: 26100.4061
IntPtr Length: 8
x64: True

Python Path: C:\Users\11602\AppData\Roaming\FlowLauncher\Environments\Python\PythonEmbeddable-v3.11.4\pythonw.exe
Node Path: C:\Program Files\nodejs\node.exe

Date: 05/22/2025 18:33:08
Exception:
System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Object reference not set to an instance of an object.)
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Flow.Launcher.App.get_Exiting() in C:\projects\flow-launcher\Flow.Launcher\App.xaml.cs:line 35
   at Flow.Launcher.ViewModel.MainViewModel.Show() in C:\projects\flow-launcher\Flow.Launcher\ViewModel\MainViewModel.cs:line 1732
   at Flow.Launcher.PublicAPIInstance.ShowMainWindow() in C:\projects\flow-launcher\Flow.Launcher\PublicAPIInstance.cs:line 95
   at Flow.Launcher.App.OnSecondAppStarted() in C:\projects\flow-launcher\Flow.Launcher\App.xaml.cs:line 379
   at Flow.Launcher.Helper.SingleInstance`1.ActivateFirstInstance() in C:\projects\flow-launcher\Flow.Launcher\Helper\SingleInstance.cs:line 138
   at System.Windows.Threading.DispatcherOperation.InvokeDelegateCore()
   at System.Windows.Threading.DispatcherOperation.InvokeImpl()
--- End of stack trace from previous location ---
   at System.Windows.Threading.DispatcherOperation.Wait(TimeSpan timeout)
   at System.Windows.Threading.Dispatcher.InvokeImpl(DispatcherOperation operation, CancellationToken cancellationToken, TimeSpan timeout)
   at System.Windows.Threading.Dispatcher.Invoke(Action callback, DispatcherPriority priority, CancellationToken cancellationToken, TimeSpan timeout)
   at System.Windows.Threading.Dispatcher.Invoke(Action callback)
   at Flow.Launcher.Helper.SingleInstance`1.CreateRemoteServiceAsync(String channelName) in C:\projects\flow-launcher\Flow.Launcher\Helper\SingleInstance.cs:line 103
   --- End of inner exception stack trace ---
```

![image](https://github.com/user-attachments/assets/09f0f49d-5c97-4d24-a921-89e8237dd7e9)