### PR TITLE
Display the file age in preview panel

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -167,4 +167,12 @@
     <system:String x:Key="plugin_explorer_native_context_menu_display_context_menu">Display native context menu (experimental)</system:String>
     <system:String x:Key="plugin_explorer_native_context_menu_include_patterns_guide">Below you can specify items you want to include in the context menu, they can be partial (e.g. 'pen wit') or complete ('Open with').</system:String>
     <system:String x:Key="plugin_explorer_native_context_menu_exclude_patterns_guide">Below you can specify items you want to exclude from context menu, they can be partial (e.g. 'pen wit') or complete ('Open with').</system:String>
+
+    <!--  Preview Info  -->
+    <system:String x:Key="Today">Today</system:String>
+    <system:String x:Key="DaysAgo">{0} days ago</system:String>
+    <system:String x:Key="OneMonthAgo">1 month ago</system:String>
+    <system:String x:Key="MonthsAgo">{0} months ago</system:String>
+    <system:String x:Key="OneYearAgo">1 year ago</system:String>
+    <system:String x:Key="YearsAgo">{0} years ago</system:String>
 </ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -33,7 +33,7 @@
     <system:String x:Key="plugin_explorer_previewpanel_display_file_size_checkbox">Size</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_display_file_creation_checkbox">Date Created</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_display_file_modification_checkbox">Date Modified</system:String>
-    <system:String x:Key="plugin_explorer_previewpanel_display_file_relative_date_checkbox">Relative Date</system:String>
+    <system:String x:Key="plugin_explorer_previewpanel_display_file_age_checkbox">File Age</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_file_info_label">Display File Info</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_date_and_time_format_label">Date and time format</system:String>
     <system:String x:Key="plugin_explorer_everything_sort_option">Sort Option:</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -33,6 +33,7 @@
     <system:String x:Key="plugin_explorer_previewpanel_display_file_size_checkbox">Size</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_display_file_creation_checkbox">Date Created</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_display_file_modification_checkbox">Date Modified</system:String>
+    <system:String x:Key="plugin_explorer_previewpanel_display_file_relative_date_checkbox">Relative Date</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_file_info_label">Display File Info</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_date_and_time_format_label">Date and time format</system:String>
     <system:String x:Key="plugin_explorer_everything_sort_option">Sort Option:</system:String>
@@ -125,6 +126,8 @@
     <system:String x:Key="plugin_explorer_openresultfolder_subtitle">
         Use '>' to search in this directory, '*' to search for file extensions or '>*' to combine both searches.
     </system:String>
+    
+    
 
     <!--  Everything  -->
     <system:String x:Key="flowlauncher_plugin_everything_sdk_issue">Failed to load Everything SDK</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -126,8 +126,6 @@
     <system:String x:Key="plugin_explorer_openresultfolder_subtitle">
         Use '>' to search in this directory, '*' to search for file extensions or '>*' to combine both searches.
     </system:String>
-    
-    
 
     <!--  Everything  -->
     <system:String x:Key="flowlauncher_plugin_everything_sdk_issue">Failed to load Everything SDK</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/pt-br.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/pt-br.xaml
@@ -31,7 +31,7 @@
     <system:String x:Key="plugin_explorer_previewpanel_display_file_size_checkbox">Tamanho</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_display_file_creation_checkbox">Data de Criação</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_display_file_modification_checkbox">Data de Modificação</system:String>
-    <system:String x:Key="plugin_explorer_previewpanel_display_file_relative_date_checkbox">Data Relativa</system:String>
+    <system:String x:Key="plugin_explorer_previewpanel_display_file_age_checkbox">Idade do Arquivo</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_file_info_label">Display File Info</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_date_and_time_format_label">Date and time format</system:String>
     <system:String x:Key="plugin_explorer_everything_sort_option">Sort Option:</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/pt-br.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/pt-br.xaml
@@ -29,9 +29,8 @@
     <system:String x:Key="plugin_explorer_everything_setting_header">Everything Setting</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_setting_header">Preview Panel</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_display_file_size_checkbox">Tamanho</system:String>
-    <system:String x:Key="plugin_explorer_previewpanel_display_file_creation_checkbox">Data de Criação</system:String>
-    <system:String x:Key="plugin_explorer_previewpanel_display_file_modification_checkbox">Data de Modificação</system:String>
-    <system:String x:Key="plugin_explorer_previewpanel_display_file_age_checkbox">Idade do Arquivo</system:String>
+    <system:String x:Key="plugin_explorer_previewpanel_display_file_creation_checkbox">Date Created</system:String>
+    <system:String x:Key="plugin_explorer_previewpanel_display_file_modification_checkbox">Date Modified</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_file_info_label">Display File Info</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_date_and_time_format_label">Date and time format</system:String>
     <system:String x:Key="plugin_explorer_everything_sort_option">Sort Option:</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/pt-br.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/pt-br.xaml
@@ -29,8 +29,8 @@
     <system:String x:Key="plugin_explorer_everything_setting_header">Everything Setting</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_setting_header">Preview Panel</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_display_file_size_checkbox">Tamanho</system:String>
-    <system:String x:Key="plugin_explorer_previewpanel_display_file_creation_checkbox">Data Criação</system:String>
-    <system:String x:Key="plugin_explorer_previewpanel_display_file_modification_checkbox">Data Modificação</system:String>
+    <system:String x:Key="plugin_explorer_previewpanel_display_file_creation_checkbox">Data de Criação</system:String>
+    <system:String x:Key="plugin_explorer_previewpanel_display_file_modification_checkbox">Data de Modificação</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_display_file_relative_date_checkbox">Data Relativa</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_file_info_label">Display File Info</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_date_and_time_format_label">Date and time format</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/pt-br.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/pt-br.xaml
@@ -29,8 +29,9 @@
     <system:String x:Key="plugin_explorer_everything_setting_header">Everything Setting</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_setting_header">Preview Panel</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_display_file_size_checkbox">Tamanho</system:String>
-    <system:String x:Key="plugin_explorer_previewpanel_display_file_creation_checkbox">Date Created</system:String>
-    <system:String x:Key="plugin_explorer_previewpanel_display_file_modification_checkbox">Date Modified</system:String>
+    <system:String x:Key="plugin_explorer_previewpanel_display_file_creation_checkbox">Data Criação</system:String>
+    <system:String x:Key="plugin_explorer_previewpanel_display_file_modification_checkbox">Data Modificação</system:String>
+    <system:String x:Key="plugin_explorer_previewpanel_display_file_relative_date_checkbox">Data Relativa</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_file_info_label">Display File Info</system:String>
     <system:String x:Key="plugin_explorer_previewpanel_date_and_time_format_label">Date and time format</system:String>
     <system:String x:Key="plugin_explorer_everything_sort_option">Sort Option:</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -67,7 +67,7 @@ namespace Flow.Launcher.Plugin.Explorer
 
         public bool ShowModifiedDateInPreviewPanel { get; set; } = true;
         
-        public bool ShowFileAgeInPreviewPanel { get; set; } = true;
+        public bool ShowFileAgeInPreviewPanel { get; set; } = false;
 
 
         public string PreviewPanelDateFormat { get; set; } = "yyyy-MM-dd";

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -27,7 +27,6 @@ namespace Flow.Launcher.Plugin.Explorer
 
         public string ExcludedFileTypes { get; set; } = "";
 
-
         public bool UseLocationAsWorkingDir { get; set; } = false;
 
         public bool ShowInlinedWindowsContextMenu { get; set; } = false;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -66,6 +66,9 @@ namespace Flow.Launcher.Plugin.Explorer
         public bool ShowCreatedDateInPreviewPanel { get; set; } = true;
 
         public bool ShowModifiedDateInPreviewPanel { get; set; } = true;
+        
+        public bool ShowRelativeDateInPreviewPanel { get; set; } = true;
+
 
         public string PreviewPanelDateFormat { get; set; } = "yyyy-MM-dd";
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -67,7 +67,7 @@ namespace Flow.Launcher.Plugin.Explorer
 
         public bool ShowModifiedDateInPreviewPanel { get; set; } = true;
         
-        public bool ShowRelativeDateInPreviewPanel { get; set; } = true;
+        public bool ShowFileAgeInPreviewPanel { get; set; } = true;
 
 
         public string PreviewPanelDateFormat { get; set; } = "yyyy-MM-dd";

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -169,6 +169,18 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
             }
         }
 
+        public bool ShowRelativeDateInPreviewPanel
+        {
+            get => Settings.ShowRelativeDateInPreviewPanel;
+            set
+            {
+                Settings.ShowRelativeDateInPreviewPanel = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(ShowPreviewPanelDateTimeChoices));
+                OnPropertyChanged(nameof(PreviewPanelDateTimeChoicesVisibility));
+            }
+        }
+
         public string PreviewPanelDateFormat
         {
             get => Settings.PreviewPanelDateFormat;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -169,12 +169,12 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
             }
         }
 
-        public bool ShowRelativeDateInPreviewPanel
+        public bool ShowFileAgeInPreviewPanel
         {
-            get => Settings.ShowRelativeDateInPreviewPanel;
+            get => Settings.ShowFileAgeInPreviewPanel;
             set
             {
-                Settings.ShowRelativeDateInPreviewPanel = value;
+                Settings.ShowFileAgeInPreviewPanel = value;
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(ShowPreviewPanelDateTimeChoices));
                 OnPropertyChanged(nameof(PreviewPanelDateTimeChoicesVisibility));

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -508,8 +508,8 @@
                             
                             <CheckBox
                                 Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
-                                Content="{DynamicResource plugin_explorer_previewpanel_display_file_relative_date_checkbox}"
-                                IsChecked="{Binding ShowRelativeDateInPreviewPanel}" />
+                                Content="{DynamicResource plugin_explorer_previewpanel_display_file_age_checkbox}"
+                                IsChecked="{Binding ShowFileAgeInPreviewPanel}" />
                         </WrapPanel>
                     </DockPanel>
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -505,6 +505,11 @@
                                 Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                                 Content="{DynamicResource plugin_explorer_previewpanel_display_file_modification_checkbox}"
                                 IsChecked="{Binding ShowModifiedDateInPreviewPanel}" />
+                            
+                            <CheckBox
+                                Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
+                                Content="{DynamicResource plugin_explorer_previewpanel_display_file_relative_date_checkbox}"
+                                IsChecked="{Binding ShowRelativeDateInPreviewPanel}" />
                         </WrapPanel>
                     </DockPanel>
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
@@ -73,7 +73,7 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
             );
 
             string result = formattedDate;
-            if (Settings.ShowRelativeDateInPreviewPanel) result = $"{GetRelativeDate(createdDate)} - {formattedDate}";
+            if (Settings.ShowFileAgeInPreviewPanel) result = $"{GetRelativeDate(createdDate)} - {formattedDate}";
             CreatedAt = result;
         }
 
@@ -85,7 +85,7 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
                 CultureInfo.CurrentCulture
             );
             string result = formattedDate;
-            if (Settings.ShowRelativeDateInPreviewPanel) result = $"{GetRelativeDate(lastModifiedDate)} - {formattedDate}";
+            if (Settings.ShowFileAgeInPreviewPanel) result = $"{GetRelativeDate(lastModifiedDate)} - {formattedDate}";
             LastModifiedAt = result;
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
@@ -71,7 +71,10 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
                 $"{Settings.PreviewPanelDateFormat} {Settings.PreviewPanelTimeFormat}",
                 CultureInfo.CurrentCulture
             );
-            CreatedAt = $"{GetDiffTimeString(createdDate)} - {formattedDate}";
+
+            string result = formattedDate;
+            if (Settings.ShowRelativeDateInPreviewPanel) result = $"{GetFileAge(createdDate)} - {formattedDate}";
+            CreatedAt = result;
         }
 
         if (Settings.ShowModifiedDateInPreviewPanel)
@@ -81,7 +84,9 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
                 $"{Settings.PreviewPanelDateFormat} {Settings.PreviewPanelTimeFormat}",
                 CultureInfo.CurrentCulture
             );
-            LastModifiedAt = $"{GetDiffTimeString(lastModifiedDate)} - {formattedDate}";
+            string result = formattedDate;
+            if (Settings.ShowRelativeDateInPreviewPanel) result = $"{GetFileAge(lastModifiedDate)} - {formattedDate}";
+            LastModifiedAt = result;
         }
 
         _ = LoadImageAsync();
@@ -92,7 +97,7 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
         PreviewImage = await Main.Context.API.LoadImageAsync(FilePath, true).ConfigureAwait(false);
     }
     
-    private string GetDiffTimeString(DateTime fileDateTime)
+    private string GetFileAge(DateTime fileDateTime)
     {
         DateTime now = DateTime.Now;
         TimeSpan difference = now - fileDateTime;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
@@ -97,26 +97,27 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
         PreviewImage = await Main.Context.API.LoadImageAsync(FilePath, true).ConfigureAwait(false);
     }
     
-    private string GetFileAge(DateTime fileDateTime)
+    private static string GetFileAge(DateTime fileDateTime)
     {
-        DateTime now = DateTime.Now;
-        TimeSpan difference = now - fileDateTime;
+        var now = DateTime.Now;
+        var difference = now - fileDateTime;
 
         if (difference.TotalDays < 1)
             return "Today";
         if (difference.TotalDays < 30)
             return $"{(int)difference.TotalDays} days ago";
 
-        int monthsDiff = (now.Year - fileDateTime.Year) * 12 + now.Month - fileDateTime.Month;
+        var monthsDiff = (now.Year - fileDateTime.Year) * 12 + now.Month - fileDateTime.Month;
         if (monthsDiff < 12)
             return monthsDiff == 1 ? "1 month ago" : $"{monthsDiff} months ago";
 
-        int yearsDiff = now.Year - fileDateTime.Year;
+        var yearsDiff = now.Year - fileDateTime.Year;
         if (now.Month < fileDateTime.Month || (now.Month == fileDateTime.Month && now.Day < fileDateTime.Day))
             yearsDiff--; 
 
         return yearsDiff == 1 ? "1 year ago" : $"{yearsDiff} years ago";
     }
+
     public event PropertyChangedEventHandler? PropertyChanged;
 
     protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
@@ -103,19 +103,22 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
         var difference = now - fileDateTime;
 
         if (difference.TotalDays < 1)
-            return "Today";
+            return Main.Context.API.GetTranslation("Today");
         if (difference.TotalDays < 30)
-            return $"{(int)difference.TotalDays} days ago";
+            return string.Format(Main.Context.API.GetTranslation("DaysAgo"), (int)difference.TotalDays);
 
         var monthsDiff = (now.Year - fileDateTime.Year) * 12 + now.Month - fileDateTime.Month;
+        if (monthsDiff == 1)
+            return Main.Context.API.GetTranslation("OneMonthAgo");
         if (monthsDiff < 12)
-            return monthsDiff == 1 ? "1 month ago" : $"{monthsDiff} months ago";
+            return string.Format(Main.Context.API.GetTranslation("MonthsAgo"), monthsDiff);
 
         var yearsDiff = now.Year - fileDateTime.Year;
         if (now.Month < fileDateTime.Month || (now.Month == fileDateTime.Month && now.Day < fileDateTime.Day))
             yearsDiff--; 
 
-        return yearsDiff == 1 ? "1 year ago" : $"{yearsDiff} years ago";
+        return yearsDiff == 1 ? Main.Context.API.GetTranslation("OneYearAgo") :
+            string.Format(Main.Context.API.GetTranslation("YearsAgo"), yearsDiff);
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
@@ -73,7 +73,7 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
             );
 
             string result = formattedDate;
-            if (Settings.ShowRelativeDateInPreviewPanel) result = $"{GetFileAge(createdDate)} - {formattedDate}";
+            if (Settings.ShowRelativeDateInPreviewPanel) result = $"{GetRelativeDate(createdDate)} - {formattedDate}";
             CreatedAt = result;
         }
 
@@ -85,7 +85,7 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
                 CultureInfo.CurrentCulture
             );
             string result = formattedDate;
-            if (Settings.ShowRelativeDateInPreviewPanel) result = $"{GetFileAge(lastModifiedDate)} - {formattedDate}";
+            if (Settings.ShowRelativeDateInPreviewPanel) result = $"{GetRelativeDate(lastModifiedDate)} - {formattedDate}";
             LastModifiedAt = result;
         }
 
@@ -97,7 +97,7 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
         PreviewImage = await Main.Context.API.LoadImageAsync(FilePath, true).ConfigureAwait(false);
     }
     
-    private string GetFileAge(DateTime fileDateTime)
+    private string GetRelativeDate(DateTime fileDateTime)
     {
         DateTime now = DateTime.Now;
         TimeSpan difference = now - fileDateTime;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
@@ -73,7 +73,7 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
             );
 
             string result = formattedDate;
-            if (Settings.ShowFileAgeInPreviewPanel) result = $"{GetRelativeDate(createdDate)} - {formattedDate}";
+            if (Settings.ShowFileAgeInPreviewPanel) result = $"{GetFileAge(createdDate)} - {formattedDate}";
             CreatedAt = result;
         }
 
@@ -85,7 +85,7 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
                 CultureInfo.CurrentCulture
             );
             string result = formattedDate;
-            if (Settings.ShowFileAgeInPreviewPanel) result = $"{GetRelativeDate(lastModifiedDate)} - {formattedDate}";
+            if (Settings.ShowFileAgeInPreviewPanel) result = $"{GetFileAge(lastModifiedDate)} - {formattedDate}";
             LastModifiedAt = result;
         }
 
@@ -97,7 +97,7 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
         PreviewImage = await Main.Context.API.LoadImageAsync(FilePath, true).ConfigureAwait(false);
     }
     
-    private string GetRelativeDate(DateTime fileDateTime)
+    private string GetFileAge(DateTime fileDateTime)
     {
         DateTime now = DateTime.Now;
         TimeSpan difference = now - fileDateTime;


### PR DESCRIPTION
## What's the PR
- Resolve https://github.com/Flow-Launcher/Flow.Launcher/issues/3533
- Adds a display of the file's creation or modification period in the preview area.

### Example
![image](https://github.com/user-attachments/assets/98181a07-dda5-48ac-a249-09994718e2d0)

### Todo
- [x] Adds an on/off checkbox to the plugin preview settings.