### PR TITLE
Fix crash on ×32 devices

### DIFF
--- a/Flow.Launcher.Infrastructure/NativeMethods.txt
+++ b/Flow.Launcher.Infrastructure/NativeMethods.txt
@@ -22,7 +22,7 @@ SystemParametersInfo
 
 SetForegroundWindow
 
-GetWindowLong
+WINDOW_LONG_PTR_INDEX
 GetForegroundWindow
 GetDesktopWindow
 GetShellWindow

--- a/Flow.Launcher.Infrastructure/PInvokeExtensions.cs
+++ b/Flow.Launcher.Infrastructure/PInvokeExtensions.cs
@@ -4,14 +4,16 @@ using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Windows.Win32;
 
-// Edited from: https://github.com/files-community/Files
 internal static partial class PInvoke
 {
+    // SetWindowLong
+    // Edited from: https://github.com/files-community/Files
+
     [DllImport("User32", EntryPoint = "SetWindowLongW", ExactSpelling = true)]
-    static extern int _SetWindowLong(HWND hWnd, int nIndex, int dwNewLong);
+    private static extern int _SetWindowLong(HWND hWnd, int nIndex, int dwNewLong);
 
     [DllImport("User32", EntryPoint = "SetWindowLongPtrW", ExactSpelling = true)]
-    static extern nint _SetWindowLongPtr(HWND hWnd, int nIndex, nint dwNewLong);
+    private static extern nint _SetWindowLongPtr(HWND hWnd, int nIndex, nint dwNewLong);
 
     // NOTE:
     //  CsWin32 doesn't generate SetWindowLong on other than x86 and vice versa.
@@ -21,5 +23,23 @@ internal static partial class PInvoke
         return sizeof(nint) is 4
           ? _SetWindowLong(hWnd, (int)nIndex, (int)dwNewLong)
           : _SetWindowLongPtr(hWnd, (int)nIndex, dwNewLong);
+    }
+
+    // GetWindowLong
+
+    [DllImport("User32", EntryPoint = "GetWindowLongW", ExactSpelling = true)]
+    private static extern int _GetWindowLong(HWND hWnd, int nIndex);
+
+    [DllImport("User32", EntryPoint = "GetWindowLongPtrW", ExactSpelling = true)]
+    private static extern nint _GetWindowLongPtr(HWND hWnd, int nIndex);
+
+    // NOTE:
+    //  CsWin32 doesn't generate GetWindowLong on other than x86 and vice versa.
+    //  For more info, visit https://github.com/microsoft/CsWin32/issues/882
+    public static unsafe nint GetWindowLongPtr(HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex)
+    {
+        return sizeof(nint) is 4
+          ? _GetWindowLong(hWnd, (int)nIndex)
+          : _GetWindowLongPtr(hWnd, (int)nIndex);
     }
 }

--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -192,9 +192,9 @@ namespace Flow.Launcher.Infrastructure
             SetWindowStyle(hwnd, WINDOW_LONG_PTR_INDEX.GWL_STYLE, style);
         }
 
-        private static int GetWindowStyle(HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex)
+        private static nint GetWindowStyle(HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex)
         {
-            var style = PInvoke.GetWindowLong(hWnd, nIndex);
+            var style = PInvoke.GetWindowLongPtr(hWnd, nIndex);
             if (style == 0 && Marshal.GetLastPInvokeError() != 0)
             {
                 throw new Win32Exception(Marshal.GetLastPInvokeError());
@@ -202,7 +202,7 @@ namespace Flow.Launcher.Infrastructure
             return style;
         }
 
-        private static nint SetWindowStyle(HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex, int dwNewLong)
+        private static nint SetWindowStyle(HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex, nint dwNewLong)
         {
             PInvoke.SetLastError(WIN32_ERROR.NO_ERROR); // Clear any existing error
 


### PR DESCRIPTION
CsWin32 doesn't generate GetWindowLong on other than x86 and vice versa. So we should use DllImport instead of CSWin32

For more info, visit https://github.com/microsoft/CsWin32/issues/882.