### PR TITLE
Fix argument null exception when updating plugin directories for erroneous plugins

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -189,7 +189,7 @@ namespace Flow.Launcher.Core.Plugin
                 {
                     if (string.IsNullOrEmpty(metadata.AssemblyName))
                     {
-                        continue; // Skip if AssemblyName is not set, which can happen for errornous plugins
+                        continue; // Skip if AssemblyName is not set, which can happen for erroneous plugins
                     }
                     metadata.PluginSettingsDirectoryPath = Path.Combine(DataLocation.PluginSettingsDirectory, metadata.AssemblyName);
                     metadata.PluginCacheDirectoryPath = Path.Combine(DataLocation.PluginCacheDirectory, metadata.AssemblyName);
@@ -198,7 +198,7 @@ namespace Flow.Launcher.Core.Plugin
                 {
                     if (string.IsNullOrEmpty(metadata.Name))
                     {
-                        continue; // Skip if Name is not set, which can happen for errornous plugins
+                        continue; // Skip if Name is not set, which can happen for erroneous plugins
                     }
                     metadata.PluginSettingsDirectoryPath = Path.Combine(DataLocation.PluginSettingsDirectory, metadata.Name);
                     metadata.PluginCacheDirectoryPath = Path.Combine(DataLocation.PluginCacheDirectory, metadata.Name);

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -187,11 +187,19 @@ namespace Flow.Launcher.Core.Plugin
             {
                 if (AllowedLanguage.IsDotNet(metadata.Language))
                 {
+                    if (string.IsNullOrEmpty(metadata.AssemblyName))
+                    {
+                        continue; // Skip if AssemblyName is not set, which can happen for errornous plugins
+                    }
                     metadata.PluginSettingsDirectoryPath = Path.Combine(DataLocation.PluginSettingsDirectory, metadata.AssemblyName);
                     metadata.PluginCacheDirectoryPath = Path.Combine(DataLocation.PluginCacheDirectory, metadata.AssemblyName);
                 }
                 else
                 {
+                    if (string.IsNullOrEmpty(metadata.Name))
+                    {
+                        continue; // Skip if Name is not set, which can happen for errornous plugins
+                    }
                     metadata.PluginSettingsDirectoryPath = Path.Combine(DataLocation.PluginSettingsDirectory, metadata.Name);
                     metadata.PluginCacheDirectoryPath = Path.Combine(DataLocation.PluginCacheDirectory, metadata.Name);
                 }

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -189,7 +189,7 @@ namespace Flow.Launcher.Core.Plugin
                 {
                     if (string.IsNullOrEmpty(metadata.AssemblyName))
                     {
-                        Log.Warn($"Plugin skipped: AssemblyName is empty for plugin with metadata: {metadata.Name}", typeof(PluginManager));
+                        API.LogWarn(ClassName, $"AssemblyName is empty for plugin with metadata: {metadata.Name}");
                         continue; // Skip if AssemblyName is not set, which can happen for erroneous plugins
                     }
                     metadata.PluginSettingsDirectoryPath = Path.Combine(DataLocation.PluginSettingsDirectory, metadata.AssemblyName);
@@ -199,7 +199,7 @@ namespace Flow.Launcher.Core.Plugin
                 {
                     if (string.IsNullOrEmpty(metadata.Name))
                     {
-                        Log.Warn($"Plugin with empty Name encountered. Skipping plugin initialization. Metadata: {metadata}");
+                        API.LogWarn(ClassName, $"Name is empty for plugin with metadata: {metadata.Name}");
                         continue; // Skip if Name is not set, which can happen for erroneous plugins
                     }
                     metadata.PluginSettingsDirectoryPath = Path.Combine(DataLocation.PluginSettingsDirectory, metadata.Name);

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -189,6 +189,7 @@ namespace Flow.Launcher.Core.Plugin
                 {
                     if (string.IsNullOrEmpty(metadata.AssemblyName))
                     {
+                        Log.Warn($"Plugin skipped: AssemblyName is empty for plugin with metadata: {metadata.Name}", typeof(PluginManager));
                         continue; // Skip if AssemblyName is not set, which can happen for erroneous plugins
                     }
                     metadata.PluginSettingsDirectoryPath = Path.Combine(DataLocation.PluginSettingsDirectory, metadata.AssemblyName);

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -198,6 +198,7 @@ namespace Flow.Launcher.Core.Plugin
                 {
                     if (string.IsNullOrEmpty(metadata.Name))
                     {
+                        Log.Warn($"Plugin with empty Name encountered. Skipping plugin initialization. Metadata: {metadata}");
                         continue; // Skip if Name is not set, which can happen for erroneous plugins
                     }
                     metadata.PluginSettingsDirectoryPath = Path.Combine(DataLocation.PluginSettingsDirectory, metadata.Name);


### PR DESCRIPTION
If some plugins failed to construct, `Name` or `AssemblyName` property will not be initialized and could be null. This can cause this issue:

```

Please open new issue in https://github.com/Flow-Launcher/Flow.Launcher/issues
1. Upload log file: C:\Users\11602\AppData\Roaming\FlowLauncher\Logs\1.20.0\2025-05-24.txt
2. Copy below exception message

Flow Launcher version: 1.20.0
OS Version: 26100.4061
IntPtr Length: 8
x64: True

Python Path: C:\Users\11602\AppData\Roaming\FlowLauncher\Environments\Python\PythonEmbeddable-v3.11.4\pythonw.exe
Node Path: C:\Program Files\nodejs\node.exe

Date: 05/24/2025 22:45:22
Exception:
System.ArgumentNullException: Value cannot be null. (Parameter 'path2')
   at System.ArgumentNullException.Throw(String paramName)
   at System.IO.Path.Combine(String path1, String path2)
   at Flow.Launcher.Core.Plugin.PluginManager.UpdatePluginDirectory(List`1 metadatas) in C:\projects\flow-launcher\Flow.Launcher.Core\Plugin\PluginManager.cs:line 190
   at Flow.Launcher.Core.Plugin.PluginManager.LoadPlugins(PluginsSettings settings) in C:\projects\flow-launcher\Flow.Launcher.Core\Plugin\PluginManager.cs:line 181
   at Flow.Launcher.App.<OnStartup>b__14_0() in C:\projects\flow-launcher\Flow.Launcher\App.xaml.cs:line 187
   at Flow.Launcher.Infrastructure.Stopwatch.InfoAsync(String className, String message, Func`1 action, String methodName) in C:\projects\flow-launcher\Flow.Launcher.Infrastructure\Stopwatch.cs:line 53
   at Flow.Launcher.App.OnStartup(Object sender, StartupEventArgs e) in C:\projects\flow-launcher\Flow.Launcher\App.xaml.cs:line 161
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_0(Object state)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```

So we need to check it when updating plugin directories for erroneous plugins.