### PR TITLE
Fix file explorer invocation to ensure correct file selection behavior

### DIFF
--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -338,7 +338,10 @@ namespace Flow.Launcher
                     // Windows File Manager
                     explorer.StartInfo = new ProcessStartInfo
                     {
-                        FileName = targetPath,
+                        FileName = "explorer.exe",
+                        Arguments = FileNameOrFilePath is null
+                            ? DirectoryPath  // only open the directory
+                            : $"/select,\"{targetPath}\"", // open the directory and select the file
                         UseShellExecute = true
                     };
                 }


### PR DESCRIPTION
## What's the PR
- Related #3561 
- Fixes an issue in the Explorer plugin where using "Open Containing Folder" on a file (instead of a folder path) with the default file explorer setting would launch the file's associated program instead of opening its containing folder.

### Cause
- When using the default explorer setting, the plugin attempted to open the full path directly—even when the path pointed to a file (including the filename itself).

- This has been fixed to work correctly. The -select option now functions as expected.