### PR TITLE
Move to iNKORE.UI.WPF.Modern UI Framework

### DIFF
--- a/Flow.Launcher/App.xaml
+++ b/Flow.Launcher/App.xaml
@@ -2,7 +2,7 @@
     x:Class="Flow.Launcher.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     ShutdownMode="OnMainWindowClose"
     Startup="OnStartup">
     <Application.Resources>

--- a/Flow.Launcher/Converters/BoolToIMEConversionModeConverter.cs
+++ b/Flow.Launcher/Converters/BoolToIMEConversionModeConverter.cs
@@ -5,7 +5,7 @@ using System.Windows.Input;
 
 namespace Flow.Launcher.Converters;
 
-internal class BoolToIMEConversionModeConverter : IValueConverter
+public class BoolToIMEConversionModeConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
@@ -22,7 +22,7 @@ internal class BoolToIMEConversionModeConverter : IValueConverter
     }
 }
 
-internal class BoolToIMEStateConverter : IValueConverter
+public class BoolToIMEStateConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {

--- a/Flow.Launcher/Converters/CornerRadiusFilterConverter.cs
+++ b/Flow.Launcher/Converters/CornerRadiusFilterConverter.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Flow.Launcher.Converters;
+
+public class CornerRadiusFilterConverter : DependencyObject, IValueConverter
+{
+    public CornerRadiusFilterKind Filter { get; set; }
+
+    public double Scale { get; set; } = 1.0;
+
+    public static CornerRadius Convert(CornerRadius radius, CornerRadiusFilterKind filterKind)
+    {
+        CornerRadius result = radius;
+
+        switch (filterKind)
+        {
+            case CornerRadiusFilterKind.Top:
+                result.BottomLeft = 0;
+                result.BottomRight = 0;
+                break;
+            case CornerRadiusFilterKind.Right:
+                result.TopLeft = 0;
+                result.BottomLeft = 0;
+                break;
+            case CornerRadiusFilterKind.Bottom:
+                result.TopLeft = 0;
+                result.TopRight = 0;
+                break;
+            case CornerRadiusFilterKind.Left:
+                result.TopRight = 0;
+                result.BottomRight = 0;
+                break;
+        }
+
+        return result;
+    }
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var cornerRadius = (CornerRadius)value;
+
+        var scale = Scale;
+        if (!double.IsNaN(scale))
+        {
+            cornerRadius.TopLeft *= scale;
+            cornerRadius.TopRight *= scale;
+            cornerRadius.BottomRight *= scale;
+            cornerRadius.BottomLeft *= scale;
+        }
+
+        var filterType = Filter;
+        if (filterType == CornerRadiusFilterKind.TopLeftValue ||
+            filterType == CornerRadiusFilterKind.BottomRightValue)
+        {
+            return GetDoubleValue(cornerRadius, filterType);
+        }
+
+        return Convert(cornerRadius, filterType);
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static double GetDoubleValue(CornerRadius radius, CornerRadiusFilterKind filterKind)
+    {
+        switch (filterKind)
+        {
+            case CornerRadiusFilterKind.TopLeftValue:
+                return radius.TopLeft;
+            case CornerRadiusFilterKind.BottomRightValue:
+                return radius.BottomRight;
+        }
+        return 0;
+    }
+}
+
+public enum CornerRadiusFilterKind
+{
+    None,
+    Top,
+    Right,
+    Bottom,
+    Left,
+    TopLeftValue,
+    BottomRightValue
+}

--- a/Flow.Launcher/Converters/PlacementRectangleConverter.cs
+++ b/Flow.Launcher/Converters/PlacementRectangleConverter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Flow.Launcher.Converters;
+
+public class PlacementRectangleConverter : IMultiValueConverter
+{
+    public Thickness Margin { get; set; }
+
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length == 2 &&
+            values[0] is double width &&
+            values[1] is double height)
+        {
+            var margin = Margin;
+            var topLeft = new Point(margin.Left, margin.Top);
+            var bottomRight = new Point(width - margin.Right, height - margin.Bottom);
+            var rect = new Rect(topLeft, bottomRight);
+            return rect;
+        }
+
+        return Rect.Empty;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Flow.Launcher/Converters/SharedSizeGroupConverter.cs
+++ b/Flow.Launcher/Converters/SharedSizeGroupConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Flow.Launcher.Converters;
+
+public class SharedSizeGroupConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return (Visibility)value != Visibility.Collapsed ? (string)parameter : null;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Flow.Launcher/Converters/StringToKeyBindingConverter.cs
+++ b/Flow.Launcher/Converters/StringToKeyBindingConverter.cs
@@ -5,7 +5,7 @@ using System.Windows.Input;
 
 namespace Flow.Launcher.Converters;
 
-class StringToKeyBindingConverter : IValueConverter
+public class StringToKeyBindingConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -89,14 +89,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="iNKORE.UI.WPF.Modern" Version="0.10.0" />
     <PackageReference Include="InputSimulator" Version="1.0.4" />
     <!-- Do not upgrade Microsoft.Extensions.DependencyInjection and Microsoft.Extensions.Hosting since we are .Net7.0 -->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-    <!-- ModernWpfUI v0.9.5 introduced WinRT changes that causes Notification platform unavailable error on some machines -->
-    <!-- https://github.com/Flow-Launcher/Flow.Launcher/issues/1772#issuecomment-1502440801 -->
-    <PackageReference Include="ModernWpfUI" Version="0.9.4" />
     <PackageReference Include="NHotkey.Wpf" Version="3.0.0" />
     <PackageReference Include="PropertyChanged.Fody" Version="3.4.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Flow.Launcher/Helper/BorderHelper.cs
+++ b/Flow.Launcher/Helper/BorderHelper.cs
@@ -1,0 +1,33 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace Flow.Launcher.Helper;
+
+public static class BorderHelper
+{
+    #region Child
+
+    public static readonly DependencyProperty ChildProperty =
+        DependencyProperty.RegisterAttached(
+            "Child",
+            typeof(UIElement),
+            typeof(BorderHelper),
+            new PropertyMetadata(default(UIElement), OnChildChanged));
+
+    public static UIElement GetChild(Border border)
+    {
+        return (UIElement)border.GetValue(ChildProperty);
+    }
+
+    public static void SetChild(Border border, UIElement value)
+    {
+        border.SetValue(ChildProperty, value);
+    }
+
+    private static void OnChildChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        ((Border)d).Child = (UIElement)e.NewValue;
+    }
+
+    #endregion
+}

--- a/Flow.Launcher/HotkeyControlDialog.xaml
+++ b/Flow.Launcher/HotkeyControlDialog.xaml
@@ -2,7 +2,7 @@
     x:Class="Flow.Launcher.HotkeyControlDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     Background="{DynamicResource PopuBGColor}"
     BorderBrush="{DynamicResource PopupButtonAreaBorderColor}"
     BorderThickness="0 1 0 0"

--- a/Flow.Launcher/HotkeyControlDialog.xaml.cs
+++ b/Flow.Launcher/HotkeyControlDialog.xaml.cs
@@ -9,7 +9,7 @@ using Flow.Launcher.Helper;
 using Flow.Launcher.Infrastructure.Hotkey;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
-using ModernWpf.Controls;
+using iNKORE.UI.WPF.Modern.Controls;
 
 namespace Flow.Launcher;
 

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:flowlauncher="clr-namespace:Flow.Launcher"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:vm="clr-namespace:Flow.Launcher.ViewModel"
     Name="FlowMainWindow"
     Title="Flow Launcher"

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -22,8 +22,9 @@ using Flow.Launcher.Infrastructure.Image;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin.SharedCommands;
 using Flow.Launcher.ViewModel;
+using iNKORE.UI.WPF.Modern;
+using iNKORE.UI.WPF.Modern.Controls;
 using Microsoft.Win32;
-using ModernWpf.Controls;
 using DataObject = System.Windows.DataObject;
 using Key = System.Windows.Input.Key;
 using MouseButtons = System.Windows.Forms.MouseButtons;
@@ -89,7 +90,7 @@ namespace Flow.Launcher
 
             InitSoundEffects();
             DataObject.AddPastingHandler(QueryTextBox, QueryTextBox_OnPaste);
-            ModernWpf.ThemeManager.Current.ActualApplicationThemeChanged += ThemeManager_ActualApplicationThemeChanged;
+            ThemeManager.Current.ActualApplicationThemeChanged += ThemeManager_ActualApplicationThemeChanged;
             SystemEvents.PowerModeChanged += SystemEvents_PowerModeChanged;
         }
 
@@ -99,9 +100,9 @@ namespace Flow.Launcher
 
 #pragma warning disable VSTHRD100 // Avoid async void methods
 
-        private void ThemeManager_ActualApplicationThemeChanged(ModernWpf.ThemeManager sender, object args)
+        private void ThemeManager_ActualApplicationThemeChanged(ThemeManager sender, object args)
         {
-            _theme.RefreshFrameAsync();
+            _ = _theme.RefreshFrameAsync();
         }
 
         private void OnSourceInitialized(object sender, EventArgs e)
@@ -161,11 +162,11 @@ namespace Flow.Launcher
             // Initialize color scheme
             if (_settings.ColorScheme == Constant.Light)
             {
-                ModernWpf.ThemeManager.Current.ApplicationTheme = ModernWpf.ApplicationTheme.Light;
+                ThemeManager.Current.ApplicationTheme = ApplicationTheme.Light;
             }
             else if (_settings.ColorScheme == Constant.Dark)
             {
-                ModernWpf.ThemeManager.Current.ApplicationTheme = ModernWpf.ApplicationTheme.Dark;
+                ThemeManager.Current.ApplicationTheme = ApplicationTheme.Dark;
             }
 
             // Initialize position
@@ -1257,7 +1258,7 @@ namespace Flow.Launcher
                     _notifyIcon?.Dispose();
                     animationSoundWMP?.Close();
                     animationSoundWPF?.Dispose();
-                    ModernWpf.ThemeManager.Current.ActualApplicationThemeChanged -= ThemeManager_ActualApplicationThemeChanged;
+                    ThemeManager.Current.ActualApplicationThemeChanged -= ThemeManager_ActualApplicationThemeChanged;
                     SystemEvents.PowerModeChanged -= SystemEvents_PowerModeChanged;
                 }
 

--- a/Flow.Launcher/Resources/Controls/Card.xaml
+++ b/Flow.Launcher/Resources/Controls/Card.xaml
@@ -6,7 +6,7 @@
     xmlns:local="clr-namespace:Flow.Launcher.Resources.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     d:DesignHeight="450"
     d:DesignWidth="800"
     mc:Ignorable="d">

--- a/Flow.Launcher/Resources/Controls/ExCard.xaml
+++ b/Flow.Launcher/Resources/Controls/ExCard.xaml
@@ -6,7 +6,7 @@
     xmlns:local="clr-namespace:Flow.Launcher.Resources.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     mc:Ignorable="d">
     <UserControl.Template>
         <ControlTemplate TargetType="UserControl">

--- a/Flow.Launcher/Resources/Controls/InfoBar.xaml
+++ b/Flow.Launcher/Resources/Controls/InfoBar.xaml
@@ -5,7 +5,7 @@
     xmlns:cc="clr-namespace:Flow.Launcher.Resources.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     d:DesignHeight="45"
     d:DesignWidth="400"
     mc:Ignorable="d">

--- a/Flow.Launcher/Resources/Controls/InstalledPluginDisplay.xaml
+++ b/Flow.Launcher/Resources/Controls/InstalledPluginDisplay.xaml
@@ -6,7 +6,7 @@
     xmlns:converters="clr-namespace:Flow.Launcher.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:viewModel="clr-namespace:Flow.Launcher.ViewModel"
     d:DataContext="{d:DesignInstance viewModel:PluginViewModel}"
     d:DesignHeight="300"

--- a/Flow.Launcher/Resources/Controls/InstalledPluginDisplay.xaml.cs
+++ b/Flow.Launcher/Resources/Controls/InstalledPluginDisplay.xaml.cs
@@ -1,4 +1,4 @@
-﻿using ModernWpf.Controls;
+﻿using iNKORE.UI.WPF.Modern.Controls;
 
 namespace Flow.Launcher.Resources.Controls;
 

--- a/Flow.Launcher/Resources/CustomControlTemplate.xaml
+++ b/Flow.Launcher/Resources/CustomControlTemplate.xaml
@@ -1,8 +1,10 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="clr-namespace:Flow.Launcher.Converters"
+    xmlns:helper="clr-namespace:Flow.Launcher.Helper"
     xmlns:system="clr-namespace:System;assembly=mscorlib"
-    xmlns:ui="http://schemas.modernwpf.com/2019">
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern">
 
     <!--  Setting Window Font  -->
     <FontFamily x:Key="SettingWindowFont">Segoe UI</FontFamily>
@@ -474,8 +476,8 @@
     <Style BasedOn="{StaticResource DefaultRadioButtonStyle}" TargetType="RadioButton" />
 
     <!--  CheckBox  -->
-    <ui:CornerRadiusFilterConverter x:Key="TopLeftCornerRadiusDoubleValueConverter" Filter="TopLeftValue" />
-    <ui:CornerRadiusFilterConverter x:Key="BottomRightCornerRadiusDoubleValueConverter" Filter="BottomRightValue" />
+    <converters:CornerRadiusFilterConverter x:Key="TopLeftCornerRadiusDoubleValueConverter" Filter="TopLeftValue" />
+    <converters:CornerRadiusFilterConverter x:Key="BottomRightCornerRadiusDoubleValueConverter" Filter="BottomRightValue" />
 
     <Style x:Key="DefaultCheckBoxStyle" TargetType="CheckBox">
         <Setter Property="OverridesDefaultStyle" Value="True" />
@@ -1144,7 +1146,7 @@
                             <Popup.PlacementRectangle>
                                 <MultiBinding>
                                     <MultiBinding.Converter>
-                                        <ui:PlacementRectangleConverter Margin="-1 1 0 1" />
+                                        <converters:PlacementRectangleConverter Margin="-1 1 0 1" />
                                     </MultiBinding.Converter>
                                     <Binding ElementName="Background" Path="ActualWidth" />
                                     <Binding ElementName="Background" Path="ActualHeight" />
@@ -1354,7 +1356,7 @@
 
     <!--  Text Box  -->
     <Thickness x:Key="TextBoxTopHeaderMargin">0,0,0,4</Thickness>
-    <ui:CornerRadiusFilterConverter x:Key="RightCornerRadiusFilterConverter" Filter="Right" />
+    <converters:CornerRadiusFilterConverter x:Key="RightCornerRadiusFilterConverter" Filter="Right" />
     <Style x:Key="DefaultTextBoxStyle" TargetType="TextBox">
         <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
@@ -3055,7 +3057,7 @@
     <Thickness x:Key="ToggleMenuFlyoutItemRevealBorderThickness">1</Thickness>
     <Thickness x:Key="MenuFlyoutSubItemRevealBorderThickness">1</Thickness>
 
-    <ui:SharedSizeGroupConverter x:Key="SharedSizeGroupConverter" />
+    <converters:SharedSizeGroupConverter x:Key="SharedSizeGroupConverter" />
 
     <Style x:Key="{ComponentResourceKey TypeInTargetAssembly={x:Type FrameworkElement}, ResourceId=MenuScrollViewer}" TargetType="ScrollViewer">
         <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
@@ -3363,7 +3365,7 @@
                     <Popup.PlacementRectangle>
                         <MultiBinding>
                             <MultiBinding.Converter>
-                                <ui:PlacementRectangleConverter Margin="4 -1" />
+                                <converters:PlacementRectangleConverter Margin="4 -1" />
                             </MultiBinding.Converter>
                             <Binding ElementName="LayoutRoot" Path="ActualWidth" />
                             <Binding ElementName="LayoutRoot" Path="ActualHeight" />
@@ -5056,7 +5058,7 @@
                                     </ui:ItemsRepeater>
 
                                 </Grid>
-                                <Border x:Name="TopNavContentOverlayAreaGrid" ui:BorderHelper.Child="{TemplateBinding ContentOverlay}" />
+                                <Border x:Name="TopNavContentOverlayAreaGrid" helper:BorderHelper.Child="{TemplateBinding ContentOverlay}" />
                             </StackPanel>
 
                             <!--  Displaymode (compact/minimal/normal) left  -->

--- a/Flow.Launcher/Resources/Dark.xaml
+++ b/Flow.Launcher/Resources/Dark.xaml
@@ -1,9 +1,9 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="http://schemas.modernwpf.com/2019"
-    xmlns:m="http://schemas.modernwpf.com/2019"
-    xmlns:primitives="http://schemas.modernwpf.com/2019"
+    xmlns:m="clr-namespace:iNKORE.UI.WPF.Modern.Markup;assembly=iNKORE.UI.WPF.Modern"
+    xmlns:common="clr-namespace:iNKORE.UI.WPF.Modern.Common;assembly=iNKORE.UI.WPF.Modern"
+    xmlns:chelper="clr-namespace:iNKORE.UI.WPF.Modern.Controls.Helpers;assembly=iNKORE.UI.WPF.Modern"
     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
     <SolidColorBrush x:Key="SystemThemeBorder" Color="#3f3f3f" />
@@ -1263,8 +1263,8 @@
     <m:StaticResource x:Key="RatingControlDisabledSelectedForeground" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
     <!--  If this Foreground property is removed/renamed, please update ThemeResourcesTests::VerifyOverrides:  -->
     <m:StaticResource x:Key="RatingControlCaptionForeground" ResourceKey="SystemControlForegroundBaseMediumBrush" />
-    <local:RatingItemFontInfo x:Key="RatingControlDefaultFontInfo" Glyph="&#xE735;" />
-    <local:RatingItemPathInfo x:Key="RatingControlDefaultPathInfo" Data="M 13.828125 12.246094 L 16.25 20 L 10 15.195313 L 3.75 20 L 6.171875 12.246094 L 0 7.5 L 7.65625 7.5 L 10 0 L 12.34375 7.5 L 20 7.5 Z" />
+    <common:RatingItemFontInfo x:Key="RatingControlDefaultFontInfo" Glyph="&#xE735;" />
+    <common:RatingItemPathInfo x:Key="RatingControlDefaultPathInfo" Data="M 13.828125 12.246094 L 16.25 20 L 10 15.195313 L 3.75 20 L 6.171875 12.246094 L 0 7.5 L 7.65625 7.5 L 10 0 L 12.34375 7.5 L 20 7.5 Z" />
 
     <!--  Resources for RepeatButton  -->
     <Thickness x:Key="RepeatButtonBorderThemeThickness">1</Thickness>
@@ -1649,17 +1649,17 @@
     <sys:Boolean x:Key="IsApplicationFocusVisualKindReveal">False</sys:Boolean>
 
     <Style x:Key="HighVisibilityFocusVisual">
-        <Setter Property="primitives:FocusVisualHelper.FocusVisualPrimaryBrush" Value="{StaticResource SystemControlFocusVisualPrimaryBrush}" />
-        <Setter Property="primitives:FocusVisualHelper.FocusVisualSecondaryBrush" Value="{StaticResource SystemControlFocusVisualSecondaryBrush}" />
-        <Setter Property="primitives:FocusVisualHelper.IsSystemFocusVisual" Value="True" />
+        <Setter Property="chelper:FocusVisualHelper.FocusVisualPrimaryBrush" Value="{StaticResource SystemControlFocusVisualPrimaryBrush}" />
+        <Setter Property="chelper:FocusVisualHelper.FocusVisualSecondaryBrush" Value="{StaticResource SystemControlFocusVisualSecondaryBrush}" />
+        <Setter Property="chelper:FocusVisualHelper.IsSystemFocusVisual" Value="True" />
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
                     <Border
-                        BorderBrush="{TemplateBinding primitives:FocusVisualHelper.FocusVisualPrimaryBrush}"
-                        BorderThickness="{TemplateBinding primitives:FocusVisualHelper.FocusVisualPrimaryThickness}"
+                        BorderBrush="{TemplateBinding chelper:FocusVisualHelper.FocusVisualPrimaryBrush}"
+                        BorderThickness="{TemplateBinding chelper:FocusVisualHelper.FocusVisualPrimaryThickness}"
                         SnapsToDevicePixels="True">
-                        <Border BorderBrush="{TemplateBinding primitives:FocusVisualHelper.FocusVisualSecondaryBrush}" BorderThickness="{TemplateBinding primitives:FocusVisualHelper.FocusVisualSecondaryThickness}" />
+                        <Border BorderBrush="{TemplateBinding chelper:FocusVisualHelper.FocusVisualSecondaryBrush}" BorderThickness="{TemplateBinding chelper:FocusVisualHelper.FocusVisualSecondaryThickness}" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/Flow.Launcher/Resources/Light.xaml
+++ b/Flow.Launcher/Resources/Light.xaml
@@ -1,9 +1,9 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="http://schemas.modernwpf.com/2019"
-    xmlns:m="http://schemas.modernwpf.com/2019"
-    xmlns:primitives="http://schemas.modernwpf.com/2019"
+    xmlns:common="clr-namespace:iNKORE.UI.WPF.Modern.Common;assembly=iNKORE.UI.WPF.Modern"
+    xmlns:chelper="clr-namespace:iNKORE.UI.WPF.Modern.Controls.Helpers;assembly=iNKORE.UI.WPF.Modern"
+    xmlns:m="clr-namespace:iNKORE.UI.WPF.Modern.Markup;assembly=iNKORE.UI.WPF.Modern"
     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
     <SolidColorBrush x:Key="SystemThemeBorder" Color="#aaaaaa" />
@@ -1265,8 +1265,8 @@
     <m:StaticResource x:Key="RatingControlPointerOverSelectedForeground" ResourceKey="SystemControlForegroundAccentBrush" />
     <m:StaticResource x:Key="RatingControlDisabledSelectedForeground" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
     <m:StaticResource x:Key="RatingControlCaptionForeground" ResourceKey="SystemControlForegroundBaseMediumBrush" />
-    <local:RatingItemFontInfo x:Key="RatingControlDefaultFontInfo" Glyph="&#xE735;" />
-    <local:RatingItemPathInfo x:Key="RatingControlDefaultPathInfo" Data="M 13.828125 12.246094 L 16.25 20 L 10 15.195313 L 3.75 20 L 6.171875 12.246094 L 0 7.5 L 7.65625 7.5 L 10 0 L 12.34375 7.5 L 20 7.5 Z" />
+    <common:RatingItemFontInfo x:Key="RatingControlDefaultFontInfo" Glyph="&#xE735;" />
+    <common:RatingItemPathInfo x:Key="RatingControlDefaultPathInfo" Data="M 13.828125 12.246094 L 16.25 20 L 10 15.195313 L 3.75 20 L 6.171875 12.246094 L 0 7.5 L 7.65625 7.5 L 10 0 L 12.34375 7.5 L 20 7.5 Z" />
 
     <!--  Resources for RepeatButton  -->
     <Thickness x:Key="RepeatButtonBorderThemeThickness">1</Thickness>
@@ -1648,17 +1648,17 @@
     <sys:Boolean x:Key="IsApplicationFocusVisualKindReveal">False</sys:Boolean>
 
     <Style x:Key="HighVisibilityFocusVisual">
-        <Setter Property="primitives:FocusVisualHelper.FocusVisualPrimaryBrush" Value="{StaticResource SystemControlFocusVisualPrimaryBrush}" />
-        <Setter Property="primitives:FocusVisualHelper.FocusVisualSecondaryBrush" Value="{StaticResource SystemControlFocusVisualSecondaryBrush}" />
-        <Setter Property="primitives:FocusVisualHelper.IsSystemFocusVisual" Value="True" />
+        <Setter Property="chelper:FocusVisualHelper.FocusVisualPrimaryBrush" Value="{StaticResource SystemControlFocusVisualPrimaryBrush}" />
+        <Setter Property="chelper:FocusVisualHelper.FocusVisualSecondaryBrush" Value="{StaticResource SystemControlFocusVisualSecondaryBrush}" />
+        <Setter Property="chelper:FocusVisualHelper.IsSystemFocusVisual" Value="True" />
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
                     <Border
-                        BorderBrush="{TemplateBinding primitives:FocusVisualHelper.FocusVisualPrimaryBrush}"
-                        BorderThickness="{TemplateBinding primitives:FocusVisualHelper.FocusVisualPrimaryThickness}"
+                        BorderBrush="{TemplateBinding chelper:FocusVisualHelper.FocusVisualPrimaryBrush}"
+                        BorderThickness="{TemplateBinding chelper:FocusVisualHelper.FocusVisualPrimaryThickness}"
                         SnapsToDevicePixels="True">
-                        <Border BorderBrush="{TemplateBinding primitives:FocusVisualHelper.FocusVisualSecondaryBrush}" BorderThickness="{TemplateBinding primitives:FocusVisualHelper.FocusVisualSecondaryThickness}" />
+                        <Border BorderBrush="{TemplateBinding chelper:FocusVisualHelper.FocusVisualSecondaryBrush}" BorderThickness="{TemplateBinding chelper:FocusVisualHelper.FocusVisualSecondaryThickness}" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/Flow.Launcher/Resources/Pages/WelcomePage1.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage1.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Flow.Launcher.Resources.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     Title="WelcomePage1"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
     mc:Ignorable="d">

--- a/Flow.Launcher/Resources/Pages/WelcomePage2.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage2.xaml
@@ -7,7 +7,7 @@
     xmlns:flowlauncher="clr-namespace:Flow.Launcher"
     xmlns:local="clr-namespace:Flow.Launcher.Resources.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     Title="WelcomePage2"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"
     mc:Ignorable="d">

--- a/Flow.Launcher/Resources/Pages/WelcomePage3.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage3.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Flow.Launcher.Resources.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     Title="WelcomePage3"
     VerticalAlignment="Stretch"
     mc:Ignorable="d">

--- a/Flow.Launcher/Resources/Pages/WelcomePage4.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage4.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Flow.Launcher.Resources.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     Title="WelcomePage4"
     d:DesignHeight="450"
     d:DesignWidth="800"

--- a/Flow.Launcher/Resources/Pages/WelcomePage5.xaml
+++ b/Flow.Launcher/Resources/Pages/WelcomePage5.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Flow.Launcher.Resources.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:userSettings="clr-namespace:Flow.Launcher.Infrastructure.UserSettings;assembly=Flow.Launcher.Infrastructure"
     Title="WelcomePage5"
     d:DesignHeight="450"

--- a/Flow.Launcher/SelectBrowserWindow.xaml
+++ b/Flow.Launcher/SelectBrowserWindow.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Flow.Launcher"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:vm="clr-namespace:Flow.Launcher.ViewModel"
     Title="{DynamicResource defaultBrowserTitle}"
     Width="550"

--- a/Flow.Launcher/SelectFileManagerWindow.xaml
+++ b/Flow.Launcher/SelectFileManagerWindow.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Flow.Launcher"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:vm="clr-namespace:Flow.Launcher.ViewModel"
     Title="{DynamicResource fileManagerWindow}"
     Width="600"

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginsViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginsViewModel.cs
@@ -8,7 +8,7 @@ using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.ViewModel;
-using ModernWpf.Controls;
+using iNKORE.UI.WPF.Modern.Controls;
 
 #nullable enable
 

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
@@ -14,8 +14,7 @@ using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.SharedModels;
 using Flow.Launcher.ViewModel;
-using ModernWpf;
-using ThemeManagerForColorSchemeSwitch = ModernWpf.ThemeManager;
+using iNKORE.UI.WPF.Modern;
 
 namespace Flow.Launcher.SettingPages.ViewModels;
 
@@ -127,12 +126,12 @@ public partial class SettingsPaneThemeViewModel : BaseModel
         get => Settings.ColorScheme;
         set
         {
-            ThemeManagerForColorSchemeSwitch.Current.ApplicationTheme = value switch
+            ThemeManager.Current.ApplicationTheme = value switch
             {
                 Constant.Light => ApplicationTheme.Light,
                 Constant.Dark => ApplicationTheme.Dark,
                 Constant.System => null,
-                _ => ThemeManagerForColorSchemeSwitch.Current.ApplicationTheme
+                _ => ThemeManager.Current.ApplicationTheme
             };
             Settings.ColorScheme = value;
             _ = _theme.RefreshFrameAsync();

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:settingsVm="clr-namespace:Flow.Launcher.SettingPages.ViewModels"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     Title="About"
     d:DataContext="{d:DesignInstance Type=settingsVm:SettingsPaneAboutViewModel}"
     d:DesignHeight="450"

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
@@ -8,7 +8,7 @@
     xmlns:ext="clr-namespace:Flow.Launcher.Resources.MarkupExtensions"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:settingsViewModels="clr-namespace:Flow.Launcher.SettingPages.ViewModels"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:userSettings="clr-namespace:Flow.Launcher.Infrastructure.UserSettings;assembly=Flow.Launcher.Infrastructure"
     Title="General"
     d:DataContext="{d:DesignInstance settingsViewModels:SettingsPaneGeneralViewModel}"

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneHotkey.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneHotkey.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:flowlauncher="clr-namespace:Flow.Launcher"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:userSettings="clr-namespace:Flow.Launcher.Infrastructure.UserSettings;assembly=Flow.Launcher.Infrastructure"
     xmlns:viewModels="clr-namespace:Flow.Launcher.SettingPages.ViewModels"
     Title="Hotkey"

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:viewModels="clr-namespace:Flow.Launcher.SettingPages.ViewModels"
     xmlns:wpftk="clr-namespace:WpfToolkit.Controls;assembly=VirtualizingWrapPanel"
     Title="PluginStore"

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:viewModels="clr-namespace:Flow.Launcher.SettingPages.ViewModels"
     Title="Plugins"
     d:DataContext="{d:DesignInstance viewModels:SettingsPanePluginsViewModel}"

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneProxy.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneProxy.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:viewModels="clr-namespace:Flow.Launcher.SettingPages.ViewModels"
     Title="Proxy"
     d:DataContext="{d:DesignInstance viewModels:SettingsPaneProxyViewModel}"

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml
@@ -7,7 +7,7 @@
     xmlns:ext="clr-namespace:Flow.Launcher.Resources.MarkupExtensions"
     xmlns:flowlauncher="clr-namespace:Flow.Launcher"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:userSettings="clr-namespace:Flow.Launcher.Infrastructure.UserSettings;assembly=Flow.Launcher.Infrastructure"
     xmlns:viewModels="clr-namespace:Flow.Launcher.SettingPages.ViewModels"
     Title="Theme"

--- a/Flow.Launcher/SettingWindow.xaml
+++ b/Flow.Launcher/SettingWindow.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:vm="clr-namespace:Flow.Launcher.ViewModel"
     Title="{DynamicResource flowlauncher_settings}"
     Width="{Binding SettingWindowWidth, Mode=TwoWay}"

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -9,7 +9,7 @@ using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.SettingPages.Views;
 using Flow.Launcher.ViewModel;
-using ModernWpf.Controls;
+using iNKORE.UI.WPF.Modern.Controls;
 using Screen = System.Windows.Forms.Screen;
 
 namespace Flow.Launcher;

--- a/Flow.Launcher/Themes/Circle System.xaml
+++ b/Flow.Launcher/Themes/Circle System.xaml
@@ -6,7 +6,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:m="http://schemas.modernwpf.com/2019"
+    xmlns:m="clr-namespace:iNKORE.UI.WPF.Modern.Markup;assembly=iNKORE.UI.WPF.Modern"
     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <ResourceDictionary.MergedDictionaries>

--- a/Flow.Launcher/Themes/Win10System.xaml
+++ b/Flow.Launcher/Themes/Win10System.xaml
@@ -6,7 +6,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:m="http://schemas.modernwpf.com/2019"
+    xmlns:m="clr-namespace:iNKORE.UI.WPF.Modern.Markup;assembly=iNKORE.UI.WPF.Modern"
     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/Themes/Base.xaml" />

--- a/Flow.Launcher/Themes/Win11Light.xaml
+++ b/Flow.Launcher/Themes/Win11Light.xaml
@@ -6,7 +6,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:m="http://schemas.modernwpf.com/2019"
+    xmlns:m="clr-namespace:iNKORE.UI.WPF.Modern.Markup;assembly=iNKORE.UI.WPF.Modern"
     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <ResourceDictionary.MergedDictionaries>

--- a/Flow.Launcher/WelcomeWindow.xaml
+++ b/Flow.Launcher/WelcomeWindow.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Flow.Launcher"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:vm="clr-namespace:Flow.Launcher.ViewModel"
     Name="FlowWelcomeWindow"
     Title="{DynamicResource Welcome_Page1_Title}"

--- a/Flow.Launcher/WelcomeWindow.xaml.cs
+++ b/Flow.Launcher/WelcomeWindow.xaml.cs
@@ -6,7 +6,7 @@ using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.Resources.Pages;
 using Flow.Launcher.ViewModel;
-using ModernWpf.Media.Animation;
+using iNKORE.UI.WPF.Modern.Media.Animation;
 
 namespace Flow.Launcher
 {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:qa="clr-namespace:Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     xmlns:viewModels="clr-namespace:Flow.Launcher.Plugin.Explorer.ViewModels"
     xmlns:views="clr-namespace:Flow.Launcher.Plugin.Explorer.Views"
     d:DataContext="{d:DesignInstance viewModels:SettingsViewModel}"

--- a/Plugins/Flow.Launcher.Plugin.Program/ProgramSuffixes.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Program/ProgramSuffixes.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     Title="{DynamicResource flowlauncher_plugin_program_suffixes}"
     Width="600"
     Background="{DynamicResource PopuBGColor}"


### PR DESCRIPTION
# Use ModernWPF successor iNKORE.UI.WPF.Modern

# TODO
- Use controls in `iNKORE.UI.WPF.Modern` to replace our controls like `Card`, `ExCard`, etc.