### PR TITLE
Update delete confirmation message

### DIFF
--- a/Flow.Launcher/MessageBoxEx.xaml.cs
+++ b/Flow.Launcher/MessageBoxEx.xaml.cs
@@ -159,12 +159,19 @@ namespace Flow.Launcher
 
         private void KeyEsc_OnPress(object sender, ExecutedRoutedEventArgs e)
         {
-            if (_button == MessageBoxButton.YesNo)
-                return;
-            else if (_button == MessageBoxButton.OK)
-                _result = MessageBoxResult.OK;
-            else
-                _result = MessageBoxResult.Cancel;
+            switch (_button)
+            {
+                case MessageBoxButton.OK:
+                    _result = MessageBoxResult.None; 
+                    break;
+                case MessageBoxButton.OKCancel:
+                case MessageBoxButton.YesNoCancel:
+                    _result = MessageBoxResult.Cancel;
+                    break;
+                case MessageBoxButton.YesNo:
+                    _result = MessageBoxResult.No; 
+                    break;
+            }
             DialogResult = false;
             Close();
         }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
@@ -199,7 +199,7 @@ namespace Flow.Launcher.Plugin.Explorer
                             {
                                 if (Context.API.ShowMsgBox(
                                         string.Format(Context.API.GetTranslation("plugin_explorer_delete_folder_link"), record.FullPath),
-                                        string.Empty,
+                                        Context.API.GetTranslation("plugin_explorer_deletefilefolder"),
                                         MessageBoxButton.YesNo,
                                         MessageBoxImage.Warning)
                                     == MessageBoxResult.No)


### PR DESCRIPTION
## What's the PR
**Before**
![image](https://github.com/user-attachments/assets/94aaf42b-8b18-4319-9601-2c4a14ce0014)

**After**
![image](https://github.com/user-attachments/assets/56f00c9b-bb1c-4d01-9c13-37c6cc03e975)


- Added a "Title" to the delete confirmation MessageBox in the Explorer plugin.
- The title uses the same key as the "Delete" option in the context menu.
- Fixed an issue where the dialog could not be closed using the ESC key.