### PR TITLE
Use ResultContextMenu instead of ContextMenu

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -359,7 +359,7 @@
                                 <MultiDataTrigger>
                                     <MultiDataTrigger.Conditions>
                                         <Condition Binding="{Binding ElementName=ResultListBox, Path=Items.Count}" Value="0" />
-                                        <Condition Binding="{Binding ElementName=ContextMenu, Path=Visibility}" Value="Collapsed" />
+                                        <Condition Binding="{Binding ElementName=ResultContextMenu, Path=Visibility}" Value="Collapsed" />
                                         <Condition Binding="{Binding ElementName=History, Path=Visibility}" Value="Collapsed" />
                                     </MultiDataTrigger.Conditions>
                                     <MultiDataTrigger.Setters>
@@ -373,7 +373,7 @@
                                 <DataTrigger Binding="{Binding ElementName=ResultListBox, Path=Visibility}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible" />
                                 </DataTrigger>
-                                <DataTrigger Binding="{Binding ElementName=ContextMenu, Path=Visibility}" Value="Visible">
+                                <DataTrigger Binding="{Binding ElementName=ResultContextMenu, Path=Visibility}" Value="Visible">
                                     <Setter Property="Visibility" Value="Visible" />
                                 </DataTrigger>
                                 <DataTrigger Binding="{Binding ElementName=History, Path=Visibility}" Value="Visible">
@@ -419,7 +419,7 @@
                         </ContentControl>
                         <ContentControl>
                             <flowlauncher:ResultListBox
-                                x:Name="ContextMenu"
+                                x:Name="ResultContextMenu"
                                 DataContext="{Binding ContextMenu}"
                                 LeftClickResultCommand="{Binding LeftClickResultCommand}"
                                 RightClickResultCommand="{Binding RightClickResultCommand}" />

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -295,14 +295,14 @@ namespace Flow.Launcher
             // QueryTextBox.Text change detection (modified to only work when character count is 1 or higher)
             QueryTextBox.TextChanged += (s, e) => UpdateClockPanelVisibility();
 
-            // Detecting ContextMenu.Visibility changes
+            // Detecting ResultContextMenu.Visibility changes
             DependencyPropertyDescriptor
-                .FromProperty(VisibilityProperty, typeof(ContextMenu))
-                .AddValueChanged(ContextMenu, (s, e) => UpdateClockPanelVisibility());
+                .FromProperty(VisibilityProperty, typeof(ResultListBox))
+                .AddValueChanged(ResultContextMenu, (s, e) => UpdateClockPanelVisibility());
 
             // Detect History.Visibility changes
             DependencyPropertyDescriptor
-                .FromProperty(VisibilityProperty, typeof(StackPanel))
+                .FromProperty(VisibilityProperty, typeof(ResultListBox))
                 .AddValueChanged(History, (s, e) => UpdateClockPanelVisibility());
 
             // Initialize query state
@@ -1016,7 +1016,7 @@ namespace Flow.Launcher
 
         private void UpdateClockPanelVisibility()
         {
-            if (QueryTextBox == null || ContextMenu == null || History == null || ClockPanel == null)
+            if (QueryTextBox == null || ResultContextMenu == null || History == null || ClockPanel == null)
             {
                 return;
             }
@@ -1031,20 +1031,20 @@ namespace Flow.Launcher
             };
             var animationDuration = TimeSpan.FromMilliseconds(animationLength * 2 / 3);
 
-            // ✅ Conditions for showing ClockPanel (No query input & ContextMenu, History are closed)
+            // ✅ Conditions for showing ClockPanel (No query input / ResultContextMenu & History are closed)
             var shouldShowClock = QueryTextBox.Text.Length == 0 &&
-                ContextMenu.Visibility != Visibility.Visible &&
+                ResultContextMenu.Visibility != Visibility.Visible &&
                 History.Visibility != Visibility.Visible;
 
-            // ✅ 1. When ContextMenu opens, immediately set Visibility.Hidden (force hide without animation)
-            if (ContextMenu.Visibility == Visibility.Visible)
+            // ✅ 1. When ResultContextMenu opens, immediately set Visibility.Hidden (force hide without animation)
+            if (ResultContextMenu.Visibility == Visibility.Visible)
             {
                 _viewModel.ClockPanelVisibility = Visibility.Hidden;
                 _viewModel.ClockPanelOpacity = 0.0;  // Set to 0 in case Opacity animation affects it
                 return;
             }
 
-            // ✅ 2. When ContextMenu is closed, keep it Hidden if there's text in the query (remember previous state)
+            // ✅ 2. When ResultContextMenu is closed, keep it Hidden if there's text in the query (remember previous state)
             else if (QueryTextBox.Text.Length > 0)
             {
                 _viewModel.ClockPanelVisibility = Visibility.Hidden;

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml
@@ -374,7 +374,7 @@
                                                 IsHitTestVisible="False"
                                                 Visibility="Visible" />
                                         </ContentControl>
-                                        <Border x:Name="ContextMenu" Visibility="Collapsed" />
+                                        <Border x:Name="ResultContextMenu" Visibility="Collapsed" />
                                         <Border x:Name="History" Visibility="Collapsed" />
                                     </Grid>
                                 </Border>

--- a/Flow.Launcher/Themes/Base.xaml
+++ b/Flow.Launcher/Themes/Base.xaml
@@ -479,7 +479,7 @@
                 <MultiDataTrigger.Conditions>
                     <!--
                     <Condition Binding="{Binding ElementName=ResultListBox, Path=Visibility}" Value="Collapsed" />
-                    <Condition Binding="{Binding ElementName=ContextMenu, Path=Visibility}" Value="Collapsed" />-->
+                    <Condition Binding="{Binding ElementName=ResultContextMenu, Path=Visibility}" Value="Collapsed" />-->
                     <Condition Binding="{Binding ElementName=History, Path=Visibility}" Value="Collapsed" />
                     <Condition Binding="{Binding ElementName=ResultListBox, Path=Items.Count}" Value="0" />
                 </MultiDataTrigger.Conditions>


### PR DESCRIPTION
We should use ResultContextMenu instead of ContextMenu because for Window, it already has one element called `ContextMenu`.