### PR TITLE
Fix Incorrect Translation | 修正错误翻译

### DIFF
--- a/Flow.Launcher/Languages/zh-cn.xaml
+++ b/Flow.Launcher/Languages/zh-cn.xaml
@@ -388,7 +388,7 @@
     <system:String x:Key="defaultBrowser_name">浏览器</system:String>
     <system:String x:Key="defaultBrowser_profile_name">浏览器名称</system:String>
     <system:String x:Key="defaultBrowser_path">浏览器路径</system:String>
-    <system:String x:Key="defaultBrowser_newWindow">新窗户</system:String>
+    <system:String x:Key="defaultBrowser_newWindow">新窗口</system:String>
     <system:String x:Key="defaultBrowser_newTab">新标签</system:String>
     <system:String x:Key="defaultBrowser_parameter">隐身模式</system:String>
 

--- a/Plugins/Flow.Launcher.Plugin.Url/Languages/zh-cn.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Url/Languages/zh-cn.xaml
@@ -2,7 +2,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <system:String x:Key="flowlauncher_plugin_url_open_search_in">在以下位置打开</system:String>
-    <system:String x:Key="flowlauncher_plugin_new_window">新窗户</system:String>
+    <system:String x:Key="flowlauncher_plugin_new_window">新窗口</system:String>
     <system:String x:Key="flowlauncher_plugin_new_tab">新标签</system:String>
     
     <system:String x:Key="flowlauncher_plugin_url_open_url">打开链接:{0}</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/zh-cn.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/zh-cn.xaml
@@ -3,7 +3,7 @@
 
     <system:String x:Key="flowlauncher_plugin_websearch_window_title">搜索源设置</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_open_search_in">在以下位置打开</system:String>
-    <system:String x:Key="flowlauncher_plugin_websearch_new_window">新窗户</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_new_window">新窗口</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_new_tab">新标签页</system:String>
     <system:String x:Key="flowlaucnher_plugin_websearch_set_browser_path">设置浏览器路径:</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_choose">选择</system:String>


### PR DESCRIPTION
Update the Chinese translation of "new window" from "新窗户" to "新窗口" for accuracy.
将“new window”的中文翻译从“新窗户”更改为“新窗口”，以确保准确性。