### PR TITLE
Update Advanced title and reset button content to use dynamic resources

### DIFF
--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -359,6 +359,7 @@
     <system:String x:Key="userdatapath">User Data Location</system:String>
     <system:String x:Key="userdatapathToolTip">User settings and installed plugins are saved in the user data folder. This location may vary depending on whether it's in portable mode or not.</system:String>
     <system:String x:Key="userdatapathButton">Open Folder</system:String>
+    <system:String x:Key="advanced">Advanced</system:String>
     <system:String x:Key="logLevel">Log Level</system:String>
     <system:String x:Key="LogLevelDEBUG">Debug</system:String>
     <system:String x:Key="LogLevelINFO">Info</system:String>

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -137,7 +137,7 @@
             </cc:Card>
 
             <cc:ExCard
-                Title="Advanced"
+                Title="{DynamicResource advanced}"
                 Margin="0 14 0 0"
                 Icon="&#xE8B7;">
                 <StackPanel>
@@ -156,7 +156,7 @@
                         Icon="&#xf259;"
                         Type="Inside">
                         <StackPanel Orientation="Horizontal">
-                            <Button Command="{Binding ResetSettingWindowFontCommand}" Content="Reset" />
+                            <Button Command="{Binding ResetSettingWindowFontCommand}" Content="{DynamicResource commonReset}" />
                             <ComboBox
                                 Margin="12 8 0 8"
                                 HorizontalAlignment="Stretch"


### PR DESCRIPTION
Two hardcoded texts have been replaced with string resources.