### PR TITLE
Use try-catch to resolve SendAsync issue

### DIFF
--- a/Flow.Launcher.Infrastructure/Http/Http.cs
+++ b/Flow.Launcher.Infrastructure/Http/Http.cs
@@ -182,7 +182,6 @@ namespace Flow.Launcher.Infrastructure.Http
         public static Task<Stream> GetStreamAsync([NotNull] string url,
             CancellationToken token = default) => GetStreamAsync(new Uri(url), token);
 
-
         /// <summary>
         /// Send a GET request to the specified Uri with an HTTP completion option and a cancellation token as an asynchronous operation.
         /// </summary>
@@ -212,7 +211,14 @@ namespace Flow.Launcher.Infrastructure.Http
         /// </summary>
         public static async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead, CancellationToken token = default)
         {
-            return await client.SendAsync(request, completionOption, token);
+            try
+            {
+                return await client.SendAsync(request, completionOption, token);
+            }
+            catch (System.Exception)
+            {
+                return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            }
         }
     }
 }


### PR DESCRIPTION
Handle SendAsync issue so that we will not get error message like those:

```

Please open new issue in https://github.com/Flow-Launcher/Flow.Launcher/issues
1. Upload log file: C:\Users\11602\AppData\Roaming\FlowLauncher\Logs\1.0.0\2025-06-01.txt
2. Copy below exception message

Flow Launcher version: 1.0.0
OS Version: 26100.4202
IntPtr Length: 8
x64: True

Python Path: C:\Users\11602\AppData\Roaming\FlowLauncher\Environments\Python\PythonEmbeddable-v3.11.4\pythonw.exe
Node Path: C:\Program Files\nodejs\node.exe

Date: 06/01/2025 19:25:33
Exception:
System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (No such host is known. (gcore.jsdelivr.net:443))
 ---> System.Net.Http.HttpRequestException: No such host is known. (gcore.jsdelivr.net:443)
 ---> System.Net.Sockets.SocketException (11001): No such host is known.
   at void System.Net.Sockets.Socket+AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at async bool System.Net.Sockets.Socket.ConnectAsync(SocketAsyncEventArgs e)+WaitForConnectWithCancellation(?)
   at async ValueTask<Stream> System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(string host, int port, HttpRequestMessage initialRequest, bool async, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.HttpConnectionPool.ConnectToTcpHostAsync(String host, Int32 port, HttpRequestMessage initialRequest, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.AddHttp11ConnectionAsync(QueueItem queueItem)
   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1.WaitWithCancellationAsync(CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.HttpConnectionWaiter`1.WaitForConnectionAsync(Boolean async, CancellationToken requestCancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Flow.Launcher.Infrastructure.Http.Http.SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken token) in D:\Source\Repos\Flow.Launcher\Flow.Launcher.Infrastructure\Http\Http.cs:line 215
   at Flow.Launcher.Core.ExternalPlugins.CommunityPluginSource.FetchAsync(CancellationToken token) in D:\Source\Repos\Flow.Launcher\Flow.Launcher.Core\ExternalPlugins\CommunityPluginSource.cs:line 52
   at Flow.Launcher.Infrastructure.Logger.Log.Exception(String className, String message, Exception exception, String methodName) in D:\Source\Repos\Flow.Launcher\Flow.Launcher.Infrastructure\Logger\Log.cs:line 101
   at Flow.Launcher.PublicAPIInstance.LogException(String className, String message, Exception e, String methodName) in D:\Source\Repos\Flow.Launcher\Flow.Launcher\PublicAPIInstance.cs:line 277
   at Flow.Launcher.Core.ExternalPlugins.CommunityPluginSource.FetchAsync(CancellationToken token) in D:\Source\Repos\Flow.Launcher\Flow.Launcher.Core\ExternalPlugins\CommunityPluginSource.cs:line 80
   --- End of inner exception stack trace ---
```

```

Please open new issue in https://github.com/Flow-Launcher/Flow.Launcher/issues
1. Upload log file: C:\Users\11602\AppData\Roaming\FlowLauncher\Logs\1.0.0\2025-06-01.txt
2. Copy below exception message

Flow Launcher version: 1.0.0
OS Version: 26100.4202
IntPtr Length: 8
x64: True

Python Path: C:\Users\11602\AppData\Roaming\FlowLauncher\Environments\Python\PythonEmbeddable-v3.11.4\pythonw.exe
Node Path: C:\Program Files\nodejs\node.exe

Date: 06/01/2025 15:57:21
Exception:
System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The SSL connection could not be established, see inner exception.)
 ---> System.Net.Http.HttpRequestException: The SSL connection could not be established, see inner exception.
 ---> System.IO.IOException:  Received an unexpected EOF or 0 bytes from the transport stream.
   at async ValueTask<ProtocolToken> System.Net.Security.SslStream.ReceiveBlobAsync<TIOAdapter>(CancellationToken cancellationToken)
   at async Task System.Net.Security.SslStream.ForceAuthenticationAsync<TIOAdapter>(bool receiveFirst, byte[] reAuthenticationData, CancellationToken cancellationToken)
   at async Task System.Net.Security.SslStream.ProcessAuthenticationWithTelemetryAsync(bool isAsync, CancellationToken cancellationToken)
   at async ValueTask<SslStream> System.Net.Http.ConnectHelper.EstablishSslConnectionAsync(SslClientAuthenticationOptions sslOptions, HttpRequestMessage request, bool async, Stream stream, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.ConnectHelper.EstablishSslConnectionAsync(SslClientAuthenticationOptions sslOptions, HttpRequestMessage request, Boolean async, Stream stream, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.AddHttp11ConnectionAsync(QueueItem queueItem)
   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1.WaitWithCancellationAsync(CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.HttpConnectionWaiter`1.WaitForConnectionAsync(Boolean async, CancellationToken requestCancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Flow.Launcher.Infrastructure.Http.Http.SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken token) in D:\Source\Repos\Flow.Launcher - UI\Flow.Launcher.Infrastructure\Http\Http.cs:line 215
   at Flow.Launcher.Core.ExternalPlugins.CommunityPluginSource.FetchAsync(CancellationToken token) in D:\Source\Repos\Flow.Launcher - UI\Flow.Launcher.Core\ExternalPlugins\CommunityPluginSource.cs:line 52
   at Flow.Launcher.Infrastructure.Logger.Log.Exception(String className, String message, Exception exception, String methodName) in D:\Source\Repos\Flow.Launcher - UI\Flow.Launcher.Infrastructure\Logger\Log.cs:line 101
   at Flow.Launcher.PublicAPIInstance.LogException(String className, String message, Exception e, String methodName) in D:\Source\Repos\Flow.Launcher - UI\Flow.Launcher\PublicAPIInstance.cs:line 277
   at Flow.Launcher.Core.ExternalPlugins.CommunityPluginSource.FetchAsync(CancellationToken token) in D:\Source\Repos\Flow.Launcher - UI\Flow.Launcher.Core\ExternalPlugins\CommunityPluginSource.cs:line 80
   --- End of inner exception stack trace ---


```