### PR TITLE
Use dynamic resource instead of binding

### DIFF
--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
@@ -154,7 +154,7 @@
                 Title="{DynamicResource AlwaysPreview}"
                 Margin="0 14 0 0"
                 Icon="&#xe8a1;"
-                Sub="{Binding AlwaysPreviewToolTip}">
+                Sub="{DynamicResource AlwaysPreviewToolTip}">
                 <ui:ToggleSwitch
                     IsOn="{Binding Settings.AlwaysPreview}"
                     OffContent="{DynamicResource disable}"


### PR DESCRIPTION
Use dynamic resource instead of binding for string resources to make sure it can listen to resource changed event