### PR TITLE
Add New API to Force Web Url

### DIFF
--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -319,13 +319,15 @@ namespace Flow.Launcher.Plugin
         public void OpenWebUrl(string url, bool? inPrivate = null);
 
         /// <summary>
-        /// Opens the URL with the given Uri object. 
+        /// Opens the URL with the given Uri object in browser if scheme is Http or Https.
+        /// If the URL is a local file, it will instead be opened with the default application for that file type.
         /// The browser and mode used is based on what's configured in Flow's default browser settings.
         /// </summary>
         public void OpenUrl(Uri url, bool? inPrivate = null);
 
         /// <summary>
-        /// Opens the URL with the given string. 
+        /// Opens the URL with the given string in browser if scheme is Http or Https.
+        /// If the URL is a local file, it will instead be opened with the default application for that file type.
         /// The browser and mode used is based on what's configured in Flow's default browser settings.
         /// Non-C# plugins should use this method.
         /// </summary>

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -309,14 +309,14 @@ namespace Flow.Launcher.Plugin
         /// Opens the URL using the browser with the given Uri object, even if the URL is a local file.
         /// The browser and mode used is based on what's configured in Flow's default browser settings.
         /// </summary>
-        public void OpenWebUrl(Uri url, bool? inPrivate = null, bool forceBrower = false);
+        public void OpenWebUrl(Uri url, bool? inPrivate = null);
 
         /// <summary>
         /// Opens the URL using the browser with the given string, even if the URL is a local file.
         /// The browser and mode used is based on what's configured in Flow's default browser settings.
         /// Non-C# plugins should use this method.
         /// </summary>
-        public void OpenWebUrl(string url, bool? inPrivate = null, bool forceBrower = false);
+        public void OpenWebUrl(string url, bool? inPrivate = null);
 
         /// <summary>
         /// Opens the URL with the given Uri object. 

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -306,6 +306,19 @@ namespace Flow.Launcher.Plugin
         public void OpenDirectory(string DirectoryPath, string FileNameOrFilePath = null);
 
         /// <summary>
+        /// Opens the URL using the browser with the given Uri object, even if the URL is a local file.
+        /// The browser and mode used is based on what's configured in Flow's default browser settings.
+        /// </summary>
+        public void OpenWebUrl(Uri url, bool? inPrivate = null, bool forceBrower = false);
+
+        /// <summary>
+        /// Opens the URL using the browser with the given string, even if the URL is a local file.
+        /// The browser and mode used is based on what's configured in Flow's default browser settings.
+        /// Non-C# plugins should use this method.
+        /// </summary>
+        public void OpenWebUrl(string url, bool? inPrivate = null, bool forceBrower = false);
+
+        /// <summary>
         /// Opens the URL with the given Uri object. 
         /// The browser and mode used is based on what's configured in Flow's default browser settings.
         /// </summary>

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -390,9 +390,9 @@ namespace Flow.Launcher
             }
         }
 
-        private void OpenUri(Uri uri, bool? inPrivate = null, bool forceBrower = false)
+        private void OpenUri(Uri uri, bool? inPrivate = null, bool forceBrowser = false)
         {
-            if (forceBrower || uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+            if (forceBrowser || uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
             {
                 var browserInfo = _settings.CustomBrowser;
 

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -390,7 +390,6 @@ namespace Flow.Launcher
             }
         }
 
-
         private void OpenUri(Uri uri, bool? inPrivate = null, bool forceBrower = false)
         {
             if (forceBrower || uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
@@ -420,14 +419,14 @@ namespace Flow.Launcher
             }
         }
 
-        public void OpenUrl(string url, bool? inPrivate = null, bool forceBrower = false)
+        public void OpenWebUrl(string url, bool? inPrivate = null)
         {
-            OpenUri(new Uri(url), inPrivate, forceBrower);
+            OpenUri(new Uri(url), inPrivate, true);
         }
 
-        public void OpenUrl(Uri url, bool? inPrivate = null, bool forceBrower = false)
+        public void OpenWebUrl(Uri url, bool? inPrivate = null)
         {
-            OpenUri(url, inPrivate, forceBrower);
+            OpenUri(url, inPrivate, true);
         }
 
         public void OpenUrl(string url, bool? inPrivate = null)

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -391,9 +391,9 @@ namespace Flow.Launcher
         }
 
 
-        private void OpenUri(Uri uri, bool? inPrivate = null)
+        private void OpenUri(Uri uri, bool? inPrivate = null, bool forceBrower = false)
         {
-            if (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
+            if (forceBrower || uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
             {
                 var browserInfo = _settings.CustomBrowser;
 
@@ -418,6 +418,16 @@ namespace Flow.Launcher
 
                 return;
             }
+        }
+
+        public void OpenUrl(string url, bool? inPrivate = null, bool forceBrower = false)
+        {
+            OpenUri(new Uri(url), inPrivate, forceBrower);
+        }
+
+        public void OpenUrl(Uri url, bool? inPrivate = null, bool forceBrower = false)
+        {
+            OpenUri(url, inPrivate, forceBrower);
         }
 
         public void OpenUrl(string url, bool? inPrivate = null)

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -71,7 +71,7 @@ namespace Flow.Launcher.Plugin.WebSearch
                         Score = score,
                         Action = c =>
                         {
-                            _context.API.OpenUrl(searchSource.Url.Replace("{q}", Uri.EscapeDataString(keyword)));
+                            _context.API.OpenWebUrl(searchSource.Url.Replace("{q}", Uri.EscapeDataString(keyword)));
 
                             return true;
                         },
@@ -135,7 +135,7 @@ namespace Flow.Launcher.Plugin.WebSearch
                 ActionKeywordAssigned = searchSource.ActionKeyword == SearchSourceGlobalPluginWildCardSign ? string.Empty : searchSource.ActionKeyword,
                 Action = c =>
                 {
-                    _context.API.OpenUrl(searchSource.Url.Replace("{q}", Uri.EscapeDataString(o)));
+                    _context.API.OpenWebUrl(searchSource.Url.Replace("{q}", Uri.EscapeDataString(o)));
 
                     return true;
                 },


### PR DESCRIPTION
# Context

In WebSearch plugin, users may input url like `file:///D:/search/index.html?query={q}` which is regarded as files url in C# standard process. So we need to a new api to force using web brower to open it.

Resolve #3608.

# Test
- Go to the plugin settings of web search plugin.
- Add a new search engine.
- Set the URL to something with `file://` prefix like "file:///D:/search/index.html?query={q}"
- Search anything, for example casino. It will open "file:///D:/search/index.html?query=casino" in brower tab.