### PR TITLE
Silent handle TaskSchedulerUnobservedTaskException

### DIFF
--- a/Flow.Launcher/Helper/ErrorReporting.cs
+++ b/Flow.Launcher/Helper/ErrorReporting.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Threading;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Exception;
+using Flow.Launcher.Infrastructure.Logger;
 using NLog;
 
 namespace Flow.Launcher.Helper;
@@ -36,8 +36,9 @@ public static class ErrorReporting
 
     public static void TaskSchedulerUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
     {
-        // handle unobserved task exceptions on UI thread
-        Application.Current.Dispatcher.Invoke(() => Report(e.Exception, true));
+        // log exception but do not handle unobserved task exceptions on UI thread
+        //Application.Current.Dispatcher.Invoke(() => Report(e.Exception, true));
+        Log.Exception(nameof(ErrorReporting), "Unobserved task exception occurred.", e.Exception);
         // prevent application exit, so the user can copy the prompted error info
         e.SetObserved();
     }

--- a/Flow.Launcher/Helper/ErrorReporting.cs
+++ b/Flow.Launcher/Helper/ErrorReporting.cs
@@ -11,10 +11,11 @@ namespace Flow.Launcher.Helper;
 
 public static class ErrorReporting
 {
-    private static void Report(Exception e, [CallerMemberName] string methodName = "UnHandledException")
+    private static void Report(Exception e, bool silent = false, [CallerMemberName] string methodName = "UnHandledException")
     {
         var logger = LogManager.GetLogger(methodName);
         logger.Fatal(ExceptionFormatter.FormatExcpetion(e));
+        if (silent) return;
         var reportWindow = new ReportWindow(e);
         reportWindow.Show();
     }
@@ -36,7 +37,7 @@ public static class ErrorReporting
     public static void TaskSchedulerUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
     {
         // handle unobserved task exceptions on UI thread
-        Application.Current.Dispatcher.Invoke(() => Report(e.Exception));
+        Application.Current.Dispatcher.Invoke(() => Report(e.Exception, true));
         // prevent application exit, so the user can copy the prompted error info
         e.SetObserved();
     }


### PR DESCRIPTION
Since many plugins do not follow strict coding rules and they do not handle exception in async void functions, we should just log the exception and do not open exception message box.

Resolve #3619, #3622, #3628.