### PR TITLE
Handle download exception

### DIFF
--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -251,7 +251,7 @@ namespace Flow.Launcher
             Http.GetStreamAsync(url, token);
 
         public Task HttpDownloadAsync([NotNull] string url, [NotNull] string filePath, Action<double> reportProgress = null,
-            CancellationToken token = default) =>Http.DownloadAsync(url, filePath, reportProgress, token);
+            CancellationToken token = default) => Http.DownloadAsync(url, filePath, reportProgress, token);
 
         public void AddActionKeyword(string pluginId, string newActionKeyword) =>
             PluginManager.AddActionKeyword(pluginId, newActionKeyword);

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -316,61 +316,75 @@ namespace Flow.Launcher.Plugin.PluginsManager
                             var downloadToFilePath = Path.Combine(Path.GetTempPath(),
                                 $"{x.Name}-{x.NewVersion}.zip");
 
-                            _ = Task.Run(async delegate
+                            _ = Task.Run(async () =>
                             {
-                                using var cts = new CancellationTokenSource();
+                                try
+                                {
+                                    using var cts = new CancellationTokenSource();
 
-                                if (!x.PluginNewUserPlugin.IsFromLocalInstallPath)
-                                {
-                                    await DownloadFileAsync(
-                                        $"{Context.API.GetTranslation("plugin_pluginsmanager_downloading_plugin")} {x.PluginNewUserPlugin.Name}",
-                                        x.PluginNewUserPlugin.UrlDownload, downloadToFilePath, cts);
-                                }
-                                else
-                                {
-                                    downloadToFilePath = x.PluginNewUserPlugin.LocalInstallPath;
-                                }
-
-                                // check if user cancelled download before installing plugin
-                                if (cts.IsCancellationRequested)
-                                {
-                                    return;
-                                }
-                                else
-                                {
-                                    await Context.API.UpdatePluginAsync(x.PluginExistingMetadata, x.PluginNewUserPlugin,
-                                        downloadToFilePath);
-
-                                    if (Settings.AutoRestartAfterChanging)
+                                    if (!x.PluginNewUserPlugin.IsFromLocalInstallPath)
                                     {
-                                        Context.API.ShowMsg(
-                                            Context.API.GetTranslation("plugin_pluginsmanager_update_title"),
-                                            string.Format(
-                                                Context.API.GetTranslation(
-                                                    "plugin_pluginsmanager_update_success_restart"),
-                                                x.Name));
-                                        Context.API.RestartApp();
+                                        await DownloadFileAsync(
+                                            $"{Context.API.GetTranslation("plugin_pluginsmanager_downloading_plugin")} {x.PluginNewUserPlugin.Name}",
+                                            x.PluginNewUserPlugin.UrlDownload, downloadToFilePath, cts);
                                     }
                                     else
                                     {
-                                        Context.API.ShowMsg(
-                                            Context.API.GetTranslation("plugin_pluginsmanager_update_title"),
-                                            string.Format(
-                                                Context.API.GetTranslation(
-                                                    "plugin_pluginsmanager_update_success_no_restart"),
-                                                x.Name));
+                                        downloadToFilePath = x.PluginNewUserPlugin.LocalInstallPath;
+                                    }
+
+                                    // check if user cancelled download before installing plugin
+                                    if (cts.IsCancellationRequested)
+                                    {
+                                        return;
+                                    }
+                                    else
+                                    {
+                                        await Context.API.UpdatePluginAsync(x.PluginExistingMetadata, x.PluginNewUserPlugin,
+                                            downloadToFilePath);
+
+                                        if (Settings.AutoRestartAfterChanging)
+                                        {
+                                            Context.API.ShowMsg(
+                                                Context.API.GetTranslation("plugin_pluginsmanager_update_title"),
+                                                string.Format(
+                                                    Context.API.GetTranslation(
+                                                        "plugin_pluginsmanager_update_success_restart"),
+                                                    x.Name));
+                                            Context.API.RestartApp();
+                                        }
+                                        else
+                                        {
+                                            Context.API.ShowMsg(
+                                                Context.API.GetTranslation("plugin_pluginsmanager_update_title"),
+                                                string.Format(
+                                                    Context.API.GetTranslation(
+                                                        "plugin_pluginsmanager_update_success_no_restart"),
+                                                    x.Name));
+                                        }
                                     }
                                 }
-                            }).ContinueWith(t =>
-                            {
-                                Context.API.LogException(ClassName, $"Update failed for {x.Name}",
-                                    t.Exception.InnerException);
-                                Context.API.ShowMsg(
-                                    Context.API.GetTranslation("plugin_pluginsmanager_install_error_title"),
-                                    string.Format(
-                                        Context.API.GetTranslation("plugin_pluginsmanager_install_error_subtitle"),
-                                        x.Name));
-                            }, token, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+                                catch (HttpRequestException e)
+                                {
+                                    // show error message
+                                    Context.API.ShowMsgError(
+                                        string.Format(Context.API.GetTranslation("plugin_pluginsmanager_downloading_plugin"), x.Name),
+                                        Context.API.GetTranslation("plugin_pluginsmanager_download_error"));
+                                    Context.API.LogException(ClassName, "An error occurred while downloading plugin", e);
+                                    return;
+                                }
+                                catch (Exception e)
+                                {
+                                    // show error message
+                                    Context.API.LogException(ClassName, $"Update failed for {x.Name}", e);
+                                    Context.API.ShowMsgError(
+                                        Context.API.GetTranslation("plugin_pluginsmanager_install_error_title"),
+                                        string.Format(
+                                            Context.API.GetTranslation("plugin_pluginsmanager_install_error_subtitle"),
+                                            x.Name));
+                                    return;
+                                }
+                            });
 
                             return true;
                         },

--- a/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginsManager/PluginsManager.cs
@@ -436,7 +436,7 @@ namespace Flow.Launcher.Plugin.PluginsManager
                             catch (Exception ex)
                             {
                                 Context.API.LogException(ClassName, $"Update failed for {plugin.Name}", ex.InnerException);
-                                Context.API.ShowMsg(
+                                Context.API.ShowMsgError(
                                     Context.API.GetTranslation("plugin_pluginsmanager_install_error_title"),
                                     string.Format(
                                         Context.API.GetTranslation("plugin_pluginsmanager_install_error_subtitle"),


### PR DESCRIPTION
Handle exception in task. Issue from #3617.

Resolve exception message like:
```
Flow Launcher version: 1.20.0
OS Version: 19045.5854
IntPtr Length: 8
x64: True

Python Path: C:\Mamba\pythonw.exe
Node Path: C:\Program Files\nodejs\node.exe

Date: 06/03/2025 20:00:18
Exception:
System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Error code returned from https://github.com/Flow-Launcher/Flow.Launcher.Plugin.Explorer/releases/download/v3.2.4/Flow.Launcher.Plugin.Explorer.zip)
---> System.Net.Http.HttpRequestException: Error code returned from https://github.com/Flow-Launcher/Flow.Launcher.Plugin.Explorer/releases/download/v3.2.4/Flow.Launcher.Plugin.Explorer.zip
at Flow.Launcher.Infrastructure.Http.Http.DownloadAsync(String url, String filePath, Action`1 reportProgress, CancellationToken token) in C:\projects\flow-launcher\Flow.Launcher.Infrastructure\Http\Http.cs:line 133
at Flow.Launcher.Plugin.PluginsManager.PluginsManager.DownloadFileAsync(String prgBoxTitle, String downloadUrl, String filePath, CancellationTokenSource cts, Boolean deleteFile, Boolean showProgress) in C:\projects\flow-launcher\Plugins\Flow.Launcher.Plugin.PluginsManager\PluginsManager.cs:line 226
at Flow.Launcher.Plugin.PluginsManager.PluginsManager.<>c__DisplayClass19_2.<b__7>d.MoveNext() in C:\projects\flow-launcher\Plugins\Flow.Launcher.Plugin.PluginsManager\PluginsManager.cs:line 325
--- End of inner exception stack trace ---
```