### PR TITLE
Support More Information for Files and Folders Tooltips & Add Custom Preview Panel Support for Folder Results

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -43,6 +43,7 @@
     <system:String x:Key="plugin_explorer_shell_path">Shell Path</system:String>
     <system:String x:Key="plugin_explorer_indexsearchexcludedpaths_header">Index Search Excluded Paths</system:String>
     <system:String x:Key="plugin_explorer_use_location_as_working_dir">Use search result's location as the working directory of the executable</system:String>
+    <system:String x:Key="plugin_explorer_display_more_info_in_tooltip">Display more information like size and age in tooltips</system:String>
     <system:String x:Key="plugin_explorer_default_open_in_file_manager">Hit Enter to open folder in Default File Manager</system:String>
     <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch">Use Index Search For Path Search</system:String>
     <system:String x:Key="plugin_explorer_manageindexoptions">Indexing Options</system:String>
@@ -79,6 +80,8 @@
     <!--  Plugin Tooltip  -->
     <system:String x:Key="plugin_explorer_plugin_ToolTipOpenDirectory">Ctrl + Enter to open the directory</system:String>
     <system:String x:Key="plugin_explorer_plugin_ToolTipOpenContainingFolder">Ctrl + Enter to open the containing folder</system:String>
+    <system:String x:Key="plugin_explorer_plugin_tooltip_more_info">{0}{4}Size: {1}{4}Date created: {2}{4}Date modified: {3}</system:String>
+    <system:String x:Key="plugin_explorer_plugin_tooltip_more_info_unknown">Unknown</system:String>
 
     <!--  Context menu items  -->
     <system:String x:Key="plugin_explorer_copypath">Copy path</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -163,7 +163,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 },
                 Score = score,
                 TitleToolTip = Main.Context.API.GetTranslation("plugin_explorer_plugin_ToolTipOpenDirectory"),
-                SubTitleToolTip = path,
+                SubTitleToolTip = Settings.DisplayMoreInformationInToolTip ? GetMoreInfoToolTip(path, ResultType.Folder) : path,
                 ContextData = new SearchResult { Type = ResultType.Folder, FullPath = path, WindowsIndexed = windowsIndexed }
             };
         }
@@ -269,7 +269,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             bool isMedia = IsMedia(Path.GetExtension(filePath));
             var title = Path.GetFileName(filePath);
 
-
             /* Preview Detail */
 
             var result = new Result
@@ -318,7 +317,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                     return true;
                 },
                 TitleToolTip = Main.Context.API.GetTranslation("plugin_explorer_plugin_ToolTipOpenContainingFolder"),
-                SubTitleToolTip = filePath,
+                SubTitleToolTip = Settings.DisplayMoreInformationInToolTip ? GetMoreInfoToolTip(filePath, ResultType.File) : filePath,
                 ContextData = new SearchResult { Type = ResultType.File, FullPath = filePath, WindowsIndexed = windowsIndexed }
             };
             return result;
@@ -347,6 +346,28 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         {
             if (Settings.EverythingEnabled && Settings.EverythingEnableRunCount)
                 _ = Task.Run(() => EverythingApi.IncrementRunCounterAsync(fileOrFolder));
+        }
+
+        private static string GetMoreInfoToolTip(string filePath, ResultType type)
+        {
+            switch (type)
+            {
+                case ResultType.Folder:
+                    var folderSize = PreviewPanel.GetFolderSize(filePath);
+                    if (string.IsNullOrEmpty(folderSize)) folderSize = Context.API.GetTranslation("plugin_explorer_plugin_tooltip_more_info_unknown");
+                    var folderCreatedAt = PreviewPanel.GetFolderCreatedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
+                    var folderModifiedAt = PreviewPanel.GetFolderLastModifiedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
+                    return string.Format(Context.API.GetTranslation("plugin_explorer_plugin_tooltip_more_info"),
+                        filePath, folderSize, folderCreatedAt, folderModifiedAt, Environment.NewLine);
+                case ResultType.File:
+                    var fileSize = PreviewPanel.GetFileSize(filePath);
+                    var fileCreatedAt = PreviewPanel.GetFileCreatedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
+                    var fileModifiedAt = PreviewPanel.GetFileLastModifiedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
+                    return string.Format(Context.API.GetTranslation("plugin_explorer_plugin_tooltip_more_info"),
+                        filePath, fileSize, fileCreatedAt, fileModifiedAt, Environment.NewLine);
+                default:
+                    return filePath;
+            }
         }
 
         private static readonly string[] MediaExtensions = { ".jpg", ".png", ".avi", ".mkv", ".bmp", ".gif", ".wmv", ".mp3", ".flac", ".mp4" };

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -99,10 +99,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 AutoCompleteText = GetAutoCompleteText(title, query, path, ResultType.Folder),
                 TitleHighlightData = Context.API.FuzzySearch(query.Search, title).MatchData,
                 CopyText = path,
-                Preview = new Result.PreviewInfo
-                {
-                    FilePath = path,
-                },
+                PreviewPanel = new Lazy<UserControl>(() => new PreviewPanel(Settings, path, ResultType.Folder)),
                 Action = c =>
                 {
                     if (c.SpecialKeyState.ToModifierKeys() == ModifierKeys.Alt)
@@ -286,7 +283,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 TitleHighlightData = Context.API.FuzzySearch(query.Search, title).MatchData,
                 Score = score,
                 CopyText = filePath,
-                PreviewPanel = new Lazy<UserControl>(() => new PreviewPanel(Settings, filePath)),
+                PreviewPanel = new Lazy<UserControl>(() => new PreviewPanel(Settings, filePath, ResultType.File)),
                 Action = c =>
                 {
                     if (c.SpecialKeyState.ToModifierKeys() == ModifierKeys.Alt)
@@ -354,7 +351,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             {
                 case ResultType.Folder:
                     var folderSize = PreviewPanel.GetFolderSize(filePath);
-                    if (string.IsNullOrEmpty(folderSize)) folderSize = Context.API.GetTranslation("plugin_explorer_plugin_tooltip_more_info_unknown");
                     var folderCreatedAt = PreviewPanel.GetFolderCreatedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
                     var folderModifiedAt = PreviewPanel.GetFolderLastModifiedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
                     return string.Format(Context.API.GetTranslation("plugin_explorer_plugin_tooltip_more_info"),

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -37,6 +37,8 @@ namespace Flow.Launcher.Plugin.Explorer
 
         public bool DefaultOpenFolderInFileManager { get; set; } = false;
 
+        public bool DisplayMoreInformationInToolTip { get; set; } = false;
+
         public string SearchActionKeyword { get; set; } = Query.GlobalPluginWildcardSign;
 
         public bool SearchActionKeywordEnabled { get; set; } = true;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -198,6 +198,7 @@
                         <RowDefinition />
                         <RowDefinition />
                         <RowDefinition />
+                        <RowDefinition />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -222,8 +223,17 @@
                         Content="{DynamicResource plugin_explorer_default_open_in_file_manager}"
                         IsChecked="{Binding Settings.DefaultOpenFolderInFileManager}" />
 
-                    <TextBlock
+                    <CheckBox
                         Grid.Row="2"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2"
+                        Margin="{StaticResource SettingPanelItemTopBottomMargin}"
+                        HorizontalAlignment="Left"
+                        Content="{DynamicResource plugin_explorer_display_more_info_in_tooltip}"
+                        IsChecked="{Binding Settings.DisplayMoreInformationInToolTip}" />
+
+                    <TextBlock
+                        Grid.Row="3"
                         Grid.Column="0"
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         HorizontalAlignment="Left"
@@ -231,7 +241,7 @@
                         Foreground="{DynamicResource Color05B}"
                         Text="{DynamicResource plugin_explorer_file_editor_path}" />
                     <StackPanel
-                        Grid.Row="2"
+                        Grid.Row="3"
                         Grid.Column="1"
                         Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                         Orientation="Horizontal">
@@ -250,7 +260,7 @@
                     </StackPanel>
 
                     <TextBlock
-                        Grid.Row="3"
+                        Grid.Row="4"
                         Grid.Column="0"
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         HorizontalAlignment="Left"
@@ -258,7 +268,7 @@
                         Foreground="{DynamicResource Color05B}"
                         Text="{DynamicResource plugin_explorer_folder_editor_path}" />
                     <StackPanel
-                        Grid.Row="3"
+                        Grid.Row="4"
                         Grid.Column="1"
                         Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                         Orientation="Horizontal">
@@ -277,7 +287,7 @@
                     </StackPanel>
 
                     <TextBlock
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Grid.Column="0"
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         HorizontalAlignment="Left"
@@ -285,7 +295,7 @@
                         Foreground="{DynamicResource Color05B}"
                         Text="{DynamicResource plugin_explorer_shell_path}" />
                     <StackPanel
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Grid.Column="1"
                         Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                         Orientation="Horizontal">
@@ -304,14 +314,14 @@
                     </StackPanel>
 
                     <TextBlock
-                        Grid.Row="5"
+                        Grid.Row="6"
                         Grid.Column="0"
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         VerticalAlignment="Center"
                         Foreground="{DynamicResource Color05B}"
                         Text="{DynamicResource plugin_explorer_Index_Search_Engine}" />
                     <ComboBox
-                        Grid.Row="5"
+                        Grid.Row="6"
                         Grid.Column="1"
                         Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                         HorizontalAlignment="Left"
@@ -321,14 +331,14 @@
                         SelectedItem="{Binding SelectedIndexSearchEngine}" />
 
                     <TextBlock
-                        Grid.Row="6"
+                        Grid.Row="7"
                         Grid.Column="0"
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         VerticalAlignment="Center"
                         Foreground="{DynamicResource Color05B}"
                         Text="{DynamicResource plugin_explorer_Content_Search_Engine}" />
                     <ComboBox
-                        Grid.Row="6"
+                        Grid.Row="7"
                         Grid.Column="1"
                         Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                         HorizontalAlignment="Left"
@@ -338,14 +348,14 @@
                         SelectedItem="{Binding SelectedContentSearchEngine}" />
 
                     <TextBlock
-                        Grid.Row="7"
+                        Grid.Row="8"
                         Grid.Column="0"
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         VerticalAlignment="Center"
                         Foreground="{DynamicResource Color05B}"
                         Text="{DynamicResource plugin_explorer_Directory_Recursive_Search_Engine}" />
                     <ComboBox
-                        Grid.Row="7"
+                        Grid.Row="8"
                         Grid.Column="1"
                         Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                         HorizontalAlignment="Left"
@@ -355,14 +365,14 @@
                         SelectedItem="{Binding SelectedPathEnumerationEngine}" />
 
                     <TextBlock
-                        Grid.Row="8"
+                        Grid.Row="9"
                         Grid.Column="0"
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         VerticalAlignment="Center"
                         Foreground="{DynamicResource Color05B}"
                         Text="{DynamicResource plugin_explorer_Excluded_File_Types}" />
                     <TextBox
-                        Grid.Row="8"
+                        Grid.Row="9"
                         Grid.Column="1"
                         MinWidth="{StaticResource SettingPanelTextBoxMinWidth}"
                         Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
@@ -371,14 +381,14 @@
                         ToolTip="{DynamicResource plugin_explorer_Excluded_File_Types_Tooltip}" />
 
                     <TextBlock
-                        Grid.Row="9"
+                        Grid.Row="10"
                         Grid.Column="0"
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                         VerticalAlignment="Center"
                         Foreground="{DynamicResource Color05B}"
                         Text="{DynamicResource plugin_explorer_Maximum_Results}" />
                     <TextBox
-                        Grid.Row="9"
+                        Grid.Row="10"
                         Grid.Column="1"
                         MinWidth="{StaticResource SettingPanelTextBoxMinWidth}"
                         Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
@@ -390,7 +400,7 @@
                         ToolTip="{DynamicResource plugin_explorer_Maximum_Results_Tooltip}" />
 
                     <Button
-                        Grid.Row="10"
+                        Grid.Row="11"
                         Grid.Column="0"
                         Grid.ColumnSpan="2"
                         Margin="{StaticResource SettingPanelItemTopBottomMargin}"
@@ -505,7 +515,7 @@
                                 Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                                 Content="{DynamicResource plugin_explorer_previewpanel_display_file_modification_checkbox}"
                                 IsChecked="{Binding ShowModifiedDateInPreviewPanel}" />
-                            
+
                             <CheckBox
                                 Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                                 Content="{DynamicResource plugin_explorer_previewpanel_display_file_age_checkbox}"

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
@@ -50,7 +50,7 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
         ? Visibility.Visible
         : Visibility.Collapsed;
 
-    public PreviewPanel(Settings settings, string filePath)
+    public PreviewPanel(Settings settings, string filePath, ResultType type)
     {
         InitializeComponent();
 
@@ -60,17 +60,21 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
 
         if (Settings.ShowFileSizeInPreviewPanel)
         {
-            FileSize = GetFileSize(filePath);
+            FileSize = type == ResultType.File ? GetFileSize(filePath) : GetFolderSize(filePath);
         }
 
         if (Settings.ShowCreatedDateInPreviewPanel)
         {
-            CreatedAt = GetFileCreatedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
+            CreatedAt = type == ResultType.File ?
+                GetFileCreatedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel) :
+                GetFolderCreatedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
         }
 
         if (Settings.ShowModifiedDateInPreviewPanel)
         {
-            LastModifiedAt = GetFileLastModifiedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
+            LastModifiedAt = type == ResultType.File ? 
+                GetFileLastModifiedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel) :
+                GetFolderLastModifiedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
         }
 
         _ = LoadImageAsync();
@@ -126,7 +130,7 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
         }
         catch (Exception)
         {
-            return string.Empty;
+            return Main.Context.API.GetTranslation("plugin_explorer_plugin_tooltip_more_info_unknown");
         }
         return ResultManager.ToReadableSize(size, 2);
     }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
@@ -65,12 +65,12 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
 
         if (Settings.ShowCreatedDateInPreviewPanel)
         {
-            CreatedAt = GetCreatedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
+            CreatedAt = GetFileCreatedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
         }
 
         if (Settings.ShowModifiedDateInPreviewPanel)
         {
-            LastModifiedAt = GetLastModifiedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
+            LastModifiedAt = GetFileLastModifiedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
         }
 
         _ = LoadImageAsync();
@@ -87,7 +87,7 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
         return ResultManager.ToReadableSize(fileInfo.Length, 2);
     }
 
-    public static string GetCreatedAt(string filePath, string previewPanelDateFormat, string previewPanelTimeFormat, bool showFileAgeInPreviewPanel)
+    public static string GetFileCreatedAt(string filePath, string previewPanelDateFormat, string previewPanelTimeFormat, bool showFileAgeInPreviewPanel)
     {
         var createdDate = File.GetCreationTime(filePath);
         var formattedDate = createdDate.ToString(
@@ -100,9 +100,53 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
         return result;
     }
 
-    public static string GetLastModifiedAt(string filePath, string previewPanelDateFormat, string previewPanelTimeFormat, bool showFileAgeInPreviewPanel)
+    public static string GetFileLastModifiedAt(string filePath, string previewPanelDateFormat, string previewPanelTimeFormat, bool showFileAgeInPreviewPanel)
     {
         var lastModifiedDate = File.GetLastWriteTime(filePath);
+        var formattedDate = lastModifiedDate.ToString(
+            $"{previewPanelDateFormat} {previewPanelTimeFormat}",
+            CultureInfo.CurrentCulture
+        );
+
+        var result = formattedDate;
+        if (showFileAgeInPreviewPanel) result = $"{GetFileAge(lastModifiedDate)} - {formattedDate}";
+        return result;
+    }
+
+    public static string GetFolderSize(string folderPath)
+    {
+        var directoryInfo = new DirectoryInfo(folderPath);
+        long size = 0;
+        try
+        {
+            foreach (var file in directoryInfo.GetFiles("*", SearchOption.AllDirectories))
+            {
+                size += file.Length;
+            }
+        }
+        catch (Exception)
+        {
+            return string.Empty;
+        }
+        return ResultManager.ToReadableSize(size, 2);
+    }
+
+    public static string GetFolderCreatedAt(string folderPath, string previewPanelDateFormat, string previewPanelTimeFormat, bool showFileAgeInPreviewPanel)
+    {
+        var createdDate = Directory.GetCreationTime(folderPath);
+        var formattedDate = createdDate.ToString(
+            $"{previewPanelDateFormat} {previewPanelTimeFormat}",
+            CultureInfo.CurrentCulture
+        );
+
+        var result = formattedDate;
+        if (showFileAgeInPreviewPanel) result = $"{GetFileAge(createdDate)} - {formattedDate}";
+        return result;
+    }
+
+    public static string GetFolderLastModifiedAt(string folderPath, string previewPanelDateFormat, string previewPanelTimeFormat, bool showFileAgeInPreviewPanel)
+    {
+        var lastModifiedDate = Directory.GetLastWriteTime(folderPath);
         var formattedDate = lastModifiedDate.ToString(
             $"{previewPanelDateFormat} {previewPanelTimeFormat}",
             CultureInfo.CurrentCulture

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
@@ -60,33 +60,17 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
 
         if (Settings.ShowFileSizeInPreviewPanel)
         {
-            var fileSize = new FileInfo(filePath).Length;
-            FileSize = ResultManager.ToReadableSize(fileSize, 2);
+            FileSize = GetFileSize(filePath);
         }
 
         if (Settings.ShowCreatedDateInPreviewPanel)
         {
-            DateTime createdDate = File.GetCreationTime(filePath);
-            string formattedDate = createdDate.ToString(
-                $"{Settings.PreviewPanelDateFormat} {Settings.PreviewPanelTimeFormat}",
-                CultureInfo.CurrentCulture
-            );
-
-            string result = formattedDate;
-            if (Settings.ShowFileAgeInPreviewPanel) result = $"{GetFileAge(createdDate)} - {formattedDate}";
-            CreatedAt = result;
+            CreatedAt = GetCreatedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
         }
 
         if (Settings.ShowModifiedDateInPreviewPanel)
         {
-            DateTime lastModifiedDate = File.GetLastWriteTime(filePath);
-            string formattedDate = lastModifiedDate.ToString(
-                $"{Settings.PreviewPanelDateFormat} {Settings.PreviewPanelTimeFormat}",
-                CultureInfo.CurrentCulture
-            );
-            string result = formattedDate;
-            if (Settings.ShowFileAgeInPreviewPanel) result = $"{GetFileAge(lastModifiedDate)} - {formattedDate}";
-            LastModifiedAt = result;
+            LastModifiedAt = GetLastModifiedAt(filePath, Settings.PreviewPanelDateFormat, Settings.PreviewPanelTimeFormat, Settings.ShowFileAgeInPreviewPanel);
         }
 
         _ = LoadImageAsync();
@@ -96,7 +80,39 @@ public partial class PreviewPanel : UserControl, INotifyPropertyChanged
     {
         PreviewImage = await Main.Context.API.LoadImageAsync(FilePath, true).ConfigureAwait(false);
     }
-    
+
+    public static string GetFileSize(string filePath)
+    {
+        var fileInfo = new FileInfo(filePath);
+        return ResultManager.ToReadableSize(fileInfo.Length, 2);
+    }
+
+    public static string GetCreatedAt(string filePath, string previewPanelDateFormat, string previewPanelTimeFormat, bool showFileAgeInPreviewPanel)
+    {
+        var createdDate = File.GetCreationTime(filePath);
+        var formattedDate = createdDate.ToString(
+            $"{previewPanelDateFormat} {previewPanelTimeFormat}",
+            CultureInfo.CurrentCulture
+        );
+
+        var result = formattedDate;
+        if (showFileAgeInPreviewPanel) result = $"{GetFileAge(createdDate)} - {formattedDate}";
+        return result;
+    }
+
+    public static string GetLastModifiedAt(string filePath, string previewPanelDateFormat, string previewPanelTimeFormat, bool showFileAgeInPreviewPanel)
+    {
+        var lastModifiedDate = File.GetLastWriteTime(filePath);
+        var formattedDate = lastModifiedDate.ToString(
+            $"{previewPanelDateFormat} {previewPanelTimeFormat}",
+            CultureInfo.CurrentCulture
+        );
+
+        var result = formattedDate;
+        if (showFileAgeInPreviewPanel) result = $"{GetFileAge(lastModifiedDate)} - {formattedDate}";
+        return result;
+    }
+
     private static string GetFileAge(DateTime fileDateTime)
     {
         var now = DateTime.Now;


### PR DESCRIPTION
# Changes

- Support More Information for Files and Folders Tooltips
- Add Custom Preview Panel Support for Folder Results

Resolve #3518.

# Test

Change option here:

![image](https://github.com/user-attachments/assets/d4ca361c-2258-4fb9-9390-074afb20414a)

And search for files & folders:

![Screenshot 2025-06-04 171040](https://github.com/user-attachments/assets/870d4897-289c-4025-b60b-26e970a5b5ae)

![Screenshot 2025-06-04 171046](https://github.com/user-attachments/assets/0d5a6b8d-397a-4837-b108-4c3c889d8595)