### PR TITLE
Fix OpenUri Exception

### DIFF
--- a/Flow.Launcher.Plugin/SharedCommands/SearchWeb.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/SearchWeb.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.Win32;
-using System;
+﻿using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Microsoft.Win32;
 
 namespace Flow.Launcher.Plugin.SharedCommands
 {
@@ -13,7 +14,7 @@ namespace Flow.Launcher.Plugin.SharedCommands
     {
         private static string GetDefaultBrowserPath()
         {
-            string name = string.Empty;
+            var name = string.Empty;
             try
             {
                 using var regDefault = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice", false);
@@ -23,8 +24,7 @@ namespace Flow.Launcher.Plugin.SharedCommands
                 name = regKey.GetValue(null).ToString().ToLower().Replace("\"", "");
 
                 if (!name.EndsWith("exe"))
-                    name = name.Substring(0, name.LastIndexOf(".exe") + 4);
-
+                    name = name[..(name.LastIndexOf(".exe") + 4)];
             }
             catch
             {
@@ -65,7 +65,8 @@ namespace Flow.Launcher.Plugin.SharedCommands
             {
                 Process.Start(psi)?.Dispose();
             }
-            catch (System.ComponentModel.Win32Exception)
+            // This error may be thrown if browser path is incorrect
+            catch (Win32Exception)
             {
                 Process.Start(new ProcessStartInfo
                 {
@@ -100,7 +101,7 @@ namespace Flow.Launcher.Plugin.SharedCommands
                 Process.Start(psi)?.Dispose();
             }
             // This error may be thrown if browser path is incorrect
-            catch (System.ComponentModel.Win32Exception)
+            catch (Win32Exception)
             {
                 Process.Start(new ProcessStartInfo
                 {

--- a/Flow.Launcher.Plugin/SharedCommands/SearchWeb.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/SearchWeb.cs
@@ -68,10 +68,18 @@ namespace Flow.Launcher.Plugin.SharedCommands
             // This error may be thrown if browser path is incorrect
             catch (Win32Exception)
             {
-                Process.Start(new ProcessStartInfo
+                try
                 {
-                    FileName = url, UseShellExecute = true
-                });
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = url,
+                        UseShellExecute = true
+                    });
+                }
+                catch
+                {
+                    throw; // Re-throw the exception if we cannot open the URL in the default browser
+                }
             }
         }
 
@@ -103,10 +111,18 @@ namespace Flow.Launcher.Plugin.SharedCommands
             // This error may be thrown if browser path is incorrect
             catch (Win32Exception)
             {
-                Process.Start(new ProcessStartInfo
+                try
                 {
-                    FileName = url, UseShellExecute = true
-                });
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = url,
+                        UseShellExecute = true
+                    });
+                }
+                catch
+                {
+                    throw; // Re-throw the exception if we cannot open the URL in the default browser
+                }
             }
         }
     }

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -473,6 +473,7 @@
     </system:String>
     <system:String x:Key="errorTitle">Error</system:String>
     <system:String x:Key="folderOpenError">An error occurred while opening the folder. {0}</system:String>
+    <system:String x:Key="browserOpenError">An error occurred while opening the url in browser. Please check your setting in Default Web Browser of general page.</system:String>
 
     <!--  General Notice  -->
     <system:String x:Key="pleaseWait">Please wait...</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -473,7 +473,7 @@
     </system:String>
     <system:String x:Key="errorTitle">Error</system:String>
     <system:String x:Key="folderOpenError">An error occurred while opening the folder. {0}</system:String>
-    <system:String x:Key="browserOpenError">An error occurred while opening the url in browser. Please check your setting in Default Web Browser of general page.</system:String>
+    <system:String x:Key="browserOpenError">An error occurred while opening the URL in the browser. Please check your Default Web Browser configuration in the General section of the settings window</system:String>
 
     <!--  General Notice  -->
     <system:String x:Key="pleaseWait">Please wait...</system:String>

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -399,13 +399,27 @@ namespace Flow.Launcher
 
                 var path = browserInfo.Path == "*" ? "" : browserInfo.Path;
 
-                if (browserInfo.OpenInTab)
+                try
                 {
-                    uri.AbsoluteUri.OpenInBrowserTab(path, inPrivate ?? browserInfo.EnablePrivate, browserInfo.PrivateArg);
+                    if (browserInfo.OpenInTab)
+                    {
+                        uri.AbsoluteUri.OpenInBrowserTab(path, inPrivate ?? browserInfo.EnablePrivate, browserInfo.PrivateArg);
+                    }
+                    else
+                    {
+                        uri.AbsoluteUri.OpenInBrowserWindow(path, inPrivate ?? browserInfo.EnablePrivate, browserInfo.PrivateArg);
+                    }
                 }
-                else
+                catch (Exception e)
                 {
-                    uri.AbsoluteUri.OpenInBrowserWindow(path, inPrivate ?? browserInfo.EnablePrivate, browserInfo.PrivateArg);
+                    var tabOrWindow = browserInfo.OpenInTab ? "tab" : "window";
+                    LogException(ClassName, $"Failed to open URL in browser {tabOrWindow}: {path}, {inPrivate ?? browserInfo.EnablePrivate}, {browserInfo.PrivateArg}", e);
+                    ShowMsgBox(
+                        GetTranslation("browserOpenError"),
+                        GetTranslation("errorTitle"),
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error
+                    );
                 }
             }
             else


### PR DESCRIPTION
Throw exception from `OpenInBrowserWindow` & `OpenInBrowserTab` function in `SearchWeb` and handle them in `OpenUri` of `PublicAPIInstance`.

Resolve #3473.