### PR TITLE
Catch exception when installing Everything

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -162,6 +162,9 @@
     <system:String x:Key="flowlauncher_plugin_everything_enable_content_search">Do you want to enable content search for Everything?</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_enable_content_search_tips">It can be very slow without index (which is only supported in Everything v1.5+)</system:String>
 
+    <system:String x:Key="flowlauncher_plugin_everything_not_found">Unable to find Everything.exe</system:String>
+    <system:String x:Key="flowlauncher_plugin_everything_install_issue">Failed to install Everything, please install it manually</system:String>
+
     <!--  Native Context Menu  -->
     <system:String x:Key="plugin_explorer_native_context_menu_header">Native Context Menu</system:String>
     <system:String x:Key="plugin_explorer_native_context_menu_display_context_menu">Display native context menu (experimental)</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingSearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingSearchManager.cs
@@ -11,6 +11,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
 {
     public class EverythingSearchManager : IIndexProvider, IContentIndexProvider, IPathIndexProvider
     {
+        private static readonly string ClassName = nameof(EverythingSearchManager);
+
         private Settings Settings { get; }
 
         public EverythingSearchManager(Settings settings)
@@ -42,19 +44,32 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
 
         private async ValueTask<bool> ClickToInstallEverythingAsync(ActionContext _)
         {
-            var installedPath = await EverythingDownloadHelper.PromptDownloadIfNotInstallAsync(Settings.EverythingInstalledPath, Main.Context.API);
-
-            if (installedPath == null)
+            try
             {
-                Main.Context.API.ShowMsgError("Unable to find Everything.exe");
+                var installedPath = await EverythingDownloadHelper.PromptDownloadIfNotInstallAsync(Settings.EverythingInstalledPath, Main.Context.API);
+
+                if (installedPath == null)
+                {
+                    Main.Context.API.ShowMsgError(Main.Context.API.GetTranslation("flowlauncher_plugin_everything_not_found"));
+                    Main.Context.API.LogError(ClassName, "Unable to find Everything.exe");
+
+                    return false;
+                }
+
+                Settings.EverythingInstalledPath = installedPath;
+                Process.Start(installedPath, "-startup");
+
+                return true;
+            }
+            // Sometimes Everything installation will fail because of permission issues or file not found issues
+            // Just let the user know that Everything is not installed properly and ask them to install it manually
+            catch (Exception e)
+            {
+                Main.Context.API.ShowMsgError(Main.Context.API.GetTranslation("flowlauncher_plugin_everything_install_issue"));
+                Main.Context.API.LogException(ClassName, "Failed to install Everything", e);
 
                 return false;
             }
-
-            Settings.EverythingInstalledPath = installedPath;
-            Process.Start(installedPath, "-startup");
-
-            return true;
         }
 
         public async IAsyncEnumerable<SearchResult> SearchAsync(string search, [EnumeratorCancellation] CancellationToken token)


### PR DESCRIPTION
Sometimes Everything installation will fail because of permission issues or file not found issues, so we should let the user know that Everything is not installed properly and ask them to install it manually.

Resolve #3184, #3381, #3393.