### PR TITLE
Do not show UI when shortcuts cannot be resolved

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/ShellLinkHelper.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/ShellLinkHelper.cs
@@ -8,9 +8,8 @@ using Windows.Win32.Storage.FileSystem;
 
 namespace Flow.Launcher.Plugin.Program.Programs
 {
-    class ShellLinkHelper
+    public class ShellLinkHelper
     {
-        
         // Reference : http://www.pinvoke.net/default.aspx/Interfaces.IShellLinkW
         [ComImport(), Guid("00021401-0000-0000-C000-000000000046")]
         public class ShellLink
@@ -28,7 +27,9 @@ namespace Flow.Launcher.Plugin.Program.Programs
             const int STGM_READ = 0;
             ((IPersistFile)link).Load(path, STGM_READ);
             var hwnd = new HWND(IntPtr.Zero);
-            ((IShellLinkW)link).Resolve(hwnd, 0);
+            // Use SLR_NO_UI to avoid showing any UI during resolution, like Problem with Shortcut dialogs
+            // https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ishelllinka-resolve
+            ((IShellLinkW)link).Resolve(hwnd, (uint)SLR_FLAGS.SLR_NO_UI);
 
             const int MAX_PATH = 260;
             Span<char> buffer = stackalloc char[MAX_PATH];
@@ -79,6 +80,6 @@ namespace Flow.Launcher.Plugin.Program.Programs
             Marshal.ReleaseComObject(link);
 
             return target;
-            }
+        }
     }
 }


### PR DESCRIPTION
Use `SLR_NO_UI` to avoid showing any UI during link resolving, like Problem with Shortcut dialogs
From: https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ishelllinka-resolve

Resolve #3386.