### PR TITLE
Support Loading Msix FireFox Bookmarks & Fix IsRelative logic

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
@@ -264,9 +264,10 @@ public class FirefoxBookmarkLoader : FirefoxBookmarkLoaderBase
     /// </summary>
     public override List<Bookmark> GetBookmarks()
     {
-        var bookmarks1 = GetBookmarksFromPath(PlacesPath);
-        var bookmarks2 = GetBookmarksFromPath(MsixPlacesPath);
-        return bookmarks1.Concat(bookmarks2).ToList();
+        var bookmarks = new List<Bookmark>();
+        bookmarks.AddRange(GetBookmarksFromPath(PlacesPath));
+        bookmarks.AddRange(GetBookmarksFromPath(MsixPlacesPath));
+        return bookmarks;
     }
 
     /// <summary>

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
@@ -365,21 +365,21 @@ public class FirefoxBookmarkLoader : FirefoxBookmarkLoaderBase
         // Seen in the example above, the IsRelative attribute is always above the Path attribute
 
         var relativePath = Path.Combine(defaultProfileFolderName, "places.sqlite");
-        var absoluePath = Path.Combine(profileFolderPath, relativePath);
+        var absolutePath = Path.Combine(profileFolderPath, relativePath);
 
         // If the index is out of range, it means that the default profile is in a custom location or the file is malformed
         // If the profile is in a custom location, we need to check 
         if (indexOfDefaultProfileAttributePath - 1 < 0 ||
             indexOfDefaultProfileAttributePath - 1 >= lines.Count)
         {
-            return Directory.Exists(absoluePath) ? absoluePath : relativePath;
+            return Directory.Exists(absolutePath) ? absolutePath : relativePath;
         }
 
         var relativeAttribute = lines[indexOfDefaultProfileAttributePath - 1];
 
         // See above, the profile is located in a custom location, path is not relative, so IsRelative=0
         return (relativeAttribute == "0" || relativeAttribute == "IsRelative=0")
-            ? relativePath : absoluePath;
+            ? relativePath : absolutePath;
     }
 }
 

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
@@ -294,16 +294,22 @@ public class FirefoxBookmarkLoader : FirefoxBookmarkLoaderBase
         {
             var platformPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
             var packagesPath = Path.Combine(platformPath, "Packages");
-            
-            // Search for folder with Mozilla.Firefox prefix
-            var firefoxPackageFolder = Directory.EnumerateDirectories(packagesPath, "Mozilla.Firefox*",
-                SearchOption.TopDirectoryOnly).FirstOrDefault();
+            try
+            {
+                // Search for folder with Mozilla.Firefox prefix
+                var firefoxPackageFolder = Directory.EnumerateDirectories(packagesPath, "Mozilla.Firefox*",
+                    SearchOption.TopDirectoryOnly).FirstOrDefault();
 
-            // Msix FireFox not installed
-            if (firefoxPackageFolder == null) return string.Empty;
+                // Msix FireFox not installed
+                if (firefoxPackageFolder == null) return string.Empty;
 
-            var profileFolderPath = Path.Combine(firefoxPackageFolder, @"LocalCache\Roaming\Mozilla\Firefox");
-            return GetProfileIniPath(profileFolderPath);
+                var profileFolderPath = Path.Combine(firefoxPackageFolder, @"LocalCache\Roaming\Mozilla\Firefox");
+                return GetProfileIniPath(profileFolderPath);
+            }
+            catch
+            {
+                return string.Empty;
+            }
         }
     }
 

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
@@ -343,9 +343,9 @@ public class FirefoxBookmarkLoader : FirefoxBookmarkLoaderBase
             Locked=1
 
             [Profile2]
-            Name=newblahprofile
+            Name=dummyprofile
             IsRelative=0
-            Path=C:\t6h2yuq8.newblahprofile  <== Note this is a custom location path for the profile user can set, we need to cater for this in code.
+            Path=C:\t6h2yuq8.dummyprofile  <== Note this is a custom location path for the profile user can set, we need to cater for this in code.
 
             [Profile1]
             Name=default

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
@@ -370,7 +370,8 @@ public class FirefoxBookmarkLoader : FirefoxBookmarkLoaderBase
 
         var relativeAttribute = lines[indexOfDefaultProfileAttributePath - 1];
 
-        return relativeAttribute == "0" // See above, the profile is located in a custom location, path is not relative, so IsRelative=0
+        // See above, the profile is located in a custom location, path is not relative, so IsRelative=0
+        return (relativeAttribute == "0" || relativeAttribute == "IsRelative=0")
             ? relativePath : absoluePath;
     }
 }


### PR DESCRIPTION
- Support Loading Msix FireFox Bookmarks
Since Win11 has introduced Msix package installer in Microsoft Store, Flow should support path to places.sqlite of MSIX installer: `C:\Users\{UserName}\AppData\Local\Packages\Mozilla.Firefox_n80bbvh6b1yt2\LocalCache\Roaming\Mozilla\Firefox`.

See more: https://support.mozilla.org/en-US/kb/profiles-where-firefox-stores-user-data#w_finding-your-profile-without-opening-firefox.

- Fix IsRelative logic in #3659
`(relativeAttribute == "0" || relativeAttribute == "IsRelative=0")`

- Fix incorrect Directory.Exists check on file path
Use `File.Exist` instead of `Directory.Exist`

# Test
- Use FireFox installed from Microsoft Store and its bookmarks can be loaded.