### PR TITLE
Fix Derive Class Save Method Calling Issue

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -12,7 +12,7 @@ using Flow.Launcher.Plugin;
 
 namespace Flow.Launcher.Core.Plugin
 {
-    public class JsonRPCPluginSettings
+    public class JsonRPCPluginSettings : ISavable
     {
         public required JsonRpcConfigurationModel? Configuration { get; init; }
 

--- a/Flow.Launcher.Infrastructure/Storage/FlowLauncherJsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/FlowLauncherJsonStorage.cs
@@ -2,11 +2,13 @@
 using System.Threading.Tasks;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.UserSettings;
+using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Infrastructure.Storage
 {
-    public class FlowLauncherJsonStorage<T> : JsonStorage<T> where T : new()
+    // Expose ISaveable interface in derived class to make sure we are calling the new version of Save method
+    public class FlowLauncherJsonStorage<T> : JsonStorage<T>, ISavable where T : new()
     {
         private static readonly string ClassName = "FlowLauncherJsonStorage";
 

--- a/Flow.Launcher.Infrastructure/Storage/PluginBinaryStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/PluginBinaryStorage.cs
@@ -1,11 +1,13 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using Flow.Launcher.Infrastructure.Logger;
+using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Infrastructure.Storage
 {
-    public class PluginBinaryStorage<T> : BinaryStorage<T> where T : new()
+    // Expose ISaveable interface in derived class to make sure we are calling the new version of Save method
+    public class PluginBinaryStorage<T> : BinaryStorage<T>, ISavable where T : new()
     {
         private static readonly string ClassName = "PluginBinaryStorage";
 

--- a/Flow.Launcher.Infrastructure/Storage/PluginJsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/PluginJsonStorage.cs
@@ -2,11 +2,13 @@
 using System.Threading.Tasks;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.UserSettings;
+using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.SharedCommands;
 
 namespace Flow.Launcher.Infrastructure.Storage
 {
-    public class PluginJsonStorage<T> : JsonStorage<T> where T : new()
+    // Expose ISaveable interface in derived class to make sure we are calling the new version of Save method
+    public class PluginJsonStorage<T> : JsonStorage<T>, ISavable where T : new()
     {
         // Use assembly name to check which plugin is using this storage
         public readonly string AssemblyName;

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -276,7 +276,7 @@ namespace Flow.Launcher
         public void LogException(string className, string message, Exception e, [CallerMemberName] string methodName = "") =>
             Log.Exception(className, message, e, methodName);
 
-        private readonly ConcurrentDictionary<Type, object> _pluginJsonStorages = new();
+        private readonly ConcurrentDictionary<Type, ISavable> _pluginJsonStorages = new();
 
         public void RemovePluginSettings(string assemblyName)
         {
@@ -294,9 +294,8 @@ namespace Flow.Launcher
 
         public void SavePluginSettings()
         {
-            foreach (var value in _pluginJsonStorages.Values)
+            foreach (var savable in _pluginJsonStorages.Values)
             {
-                var savable = value as ISavable;
                 savable?.Save();
             }
         }
@@ -496,7 +495,7 @@ namespace Flow.Launcher
         public bool SetCurrentTheme(ThemeData theme) =>
             Theme.ChangeTheme(theme.FileNameWithoutExtension);
 
-        private readonly ConcurrentDictionary<(string, string, Type), object> _pluginBinaryStorages = new();
+        private readonly ConcurrentDictionary<(string, string, Type), ISavable> _pluginBinaryStorages = new();
 
         public void RemovePluginCaches(string cacheDirectory)
         {
@@ -513,9 +512,8 @@ namespace Flow.Launcher
 
         public void SavePluginCaches()
         {
-            foreach (var value in _pluginBinaryStorages.Values)
+            foreach (var savable in _pluginBinaryStorages.Values)
             {
-                var savable = value as ISavable;
                 savable?.Save();
             }
         }

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -296,7 +296,7 @@ namespace Flow.Launcher
         {
             foreach (var savable in _pluginJsonStorages.Values)
             {
-                savable?.Save();
+                savable.Save();
             }
         }
 
@@ -514,7 +514,7 @@ namespace Flow.Launcher
         {
             foreach (var savable in _pluginBinaryStorages.Values)
             {
-                savable?.Save();
+                savable.Save();
             }
         }
 


### PR DESCRIPTION
# Changes

- Expose `ISavable` interface in derived class to make sure we are calling the new version of `Save` method. This can make sure we are calling the version of `Save` with error handling.
- Use `ISavable` instead of `object` for code quality

Since all `Save` methods are called with error handling, we can resolve #3043, #3130.