### PR TITLE
Release Notes Window

### DIFF
--- a/Flow.Launcher.Infrastructure/Http/Http.cs
+++ b/Flow.Launcher.Infrastructure/Http/Http.cs
@@ -220,5 +220,18 @@ namespace Flow.Launcher.Infrastructure.Http
                 return new HttpResponseMessage(HttpStatusCode.InternalServerError);
             }
         }
+
+        public static async Task<string> GetStringAsync(string url, CancellationToken token = default)
+        {
+            try
+            {
+                Log.Debug(ClassName, $"Url <{url}>");
+                return await client.GetStringAsync(url, token);
+            }
+            catch (System.Exception e)
+            {
+                return string.Empty;
+            }
+        }
     }
 }

--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -33,7 +33,6 @@ namespace Flow.Launcher.Infrastructure.UserSettings
             _storage.Save();
         }
 
-        private string _theme = Constant.DefaultTheme;
         public string Hotkey { get; set; } = $"{KeyConstant.Alt} + {KeyConstant.Space}";
         public string OpenResultModifiers { get; set; } = KeyConstant.Alt;
         public string ColorScheme { get; set; } = "System";
@@ -64,6 +63,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
                 OnPropertyChanged();
             }
         }
+        private string _theme = Constant.DefaultTheme;
         public string Theme
         {
             get => _theme;
@@ -79,6 +79,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         }
         public bool UseDropShadowEffect { get; set; } = true;
         public BackdropTypes BackdropType{ get; set; } = BackdropTypes.None;
+        public string ReleaseNotesVersion { get; set; } = string.Empty;
 
         /* Appearance Settings. It should be separated from the setting later.*/
         public double WindowHeightSize { get; set; } = 42;

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -90,6 +90,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="InputSimulator" Version="1.0.4" />
+    <PackageReference Include="MdXaml" Version="1.27.0" />
     <!-- Do not upgrade Microsoft.Extensions.DependencyInjection and Microsoft.Extensions.Hosting since we are .Net7.0 -->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />

--- a/Flow.Launcher/Flow.Launcher.csproj
+++ b/Flow.Launcher/Flow.Launcher.csproj
@@ -91,6 +91,10 @@
     </PackageReference>
     <PackageReference Include="InputSimulator" Version="1.0.4" />
     <PackageReference Include="MdXaml" Version="1.27.0" />
+    <PackageReference Include="MdXaml.AnimatedGif" Version="1.27.0" />
+    <PackageReference Include="MdXaml.Html" Version="1.27.0" />
+    <PackageReference Include="MdXaml.Plugins" Version="1.27.0" />
+    <PackageReference Include="MdXaml.Svg" Version="1.27.0" />
     <!-- Do not upgrade Microsoft.Extensions.DependencyInjection and Microsoft.Extensions.Hosting since we are .Net7.0 -->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -365,6 +365,9 @@
     <system:String x:Key="LogLevelINFO">Info</system:String>
     <system:String x:Key="settingWindowFontTitle">Setting Window Font</system:String>
 
+    <!--  Release Notes Window  -->
+    <system:String x:Key="seeMoreReleaseNotes">See more release notes on GitHub</system:String>
+
     <!--  FileManager Setting Dialog  -->
     <system:String x:Key="fileManagerWindow">Select File Manager</system:String>
     <system:String x:Key="fileManager_learnMore">Learn more</system:String>

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -121,6 +121,9 @@ namespace Flow.Launcher
                 // Set First Launch to false
                 _settings.FirstLaunch = false;
 
+                // Update release notes version
+                _settings.ReleaseNotesVersion = Constant.Version;
+
                 // Set Backdrop Type to Acrylic for Windows 11 when First Launch. Default is None
                 if (Win32Helper.IsBackdropSupported()) _settings.BackdropType = BackdropTypes.Acrylic;
 
@@ -132,8 +135,14 @@ namespace Flow.Launcher
                 welcomeWindow.Show();
             }
 
-            var releaseNotesWindow = new ReleaseNotesWindow();
-            releaseNotesWindow.Show();
+            if (_settings.ReleaseNotesVersion != Constant.Version)
+            {
+                // Update release notes version
+                _settings.ReleaseNotesVersion = Constant.Version;
+
+                var releaseNotesWindow = new ReleaseNotesWindow();
+                releaseNotesWindow.Show();
+            }
 
             // Initialize place holder
             SetupPlaceholderText();

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -132,6 +132,9 @@ namespace Flow.Launcher
                 welcomeWindow.Show();
             }
 
+            var releaseNotesWindow = new ReleaseNotesWindow();
+            releaseNotesWindow.Show();
+
             // Initialize place holder
             SetupPlaceholderText();
             _viewModel.PlaceholderText = _settings.PlaceholderText;

--- a/Flow.Launcher/ReleaseNotesWindow.xaml
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml
@@ -163,6 +163,29 @@
                     VerticalAlignment="Stretch"
                     ClickAction="SafetyDisplayWithRelativePath"
                     Loaded="MarkdownViewer_Loaded" />
+
+                <!--  Put this Grid in the same position as MarkdownViewer  -->
+                <Grid
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="5"
+                    Height="510"
+                    Margin="15 0 20 0">
+                    <ui:ProgressRing
+                        x:Name="RefreshProgressRing"
+                        Width="30"
+                        Height="30"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        IsActive="True" />
+                    <Button
+                        x:Name="RefreshButton"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Click="RefreshButton_Click"
+                        Content="{DynamicResource refresh}"
+                        Visibility="Collapsed" />
+                </Grid>
             </Grid>
         </Border>
     </Grid>

--- a/Flow.Launcher/ReleaseNotesWindow.xaml
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml
@@ -10,7 +10,10 @@
     xmlns:ui="http://schemas.modernwpf.com/2019"
     xmlns:vm="clr-namespace:Flow.Launcher.ViewModel"
     Title="{DynamicResource releaseNotes}"
-    Width="700"
+    Width="940"
+    Height="600"
+    MinWidth="940"
+    MinHeight="600"
     Background="{DynamicResource PopuBGColor}"
     Closed="Window_Closed"
     Foreground="{DynamicResource PopupTextColor}"
@@ -42,8 +45,8 @@
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="32" />
-                    <RowDefinition />
-                    <RowDefinition />
+                    <RowDefinition Height="24" />
+                    <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <!--  TitleBar and Control  -->
                 <Image
@@ -168,7 +171,6 @@
                     Grid.Row="2"
                     Grid.Column="0"
                     Grid.ColumnSpan="5"
-                    Height="510"
                     Margin="15 0 20 0"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
@@ -181,8 +183,9 @@
                     Grid.Row="2"
                     Grid.Column="0"
                     Grid.ColumnSpan="5"
-                    Height="510"
-                    Margin="15 0 20 0">
+                    Margin="15 0 20 0"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch">
                     <ui:ProgressRing
                         x:Name="RefreshProgressRing"
                         Width="32"

--- a/Flow.Launcher/ReleaseNotesWindow.xaml
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml
@@ -161,7 +161,8 @@
                     Margin="15 0 20 0"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
-                    ClickAction="SafetyDisplayWithRelativePath" />
+                    ClickAction="SafetyDisplayWithRelativePath"
+                    Loaded="MarkdownViewer_Loaded" />
             </Grid>
         </Border>
     </Grid>

--- a/Flow.Launcher/ReleaseNotesWindow.xaml
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml
@@ -1,0 +1,168 @@
+﻿<Window
+    x:Class="Flow.Launcher.ReleaseNotesWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:Flow.Launcher"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:mdxam="clr-namespace:MdXaml;assembly=MdXaml"
+    xmlns:ui="http://schemas.modernwpf.com/2019"
+    xmlns:vm="clr-namespace:Flow.Launcher.ViewModel"
+    Title="{DynamicResource releaseNotes}"
+    Width="700"
+    Background="{DynamicResource PopuBGColor}"
+    Foreground="{DynamicResource PopupTextColor}"
+    Loaded="Window_Loaded"
+    ResizeMode="CanResize"
+    SizeToContent="Height"
+    StateChanged="Window_StateChanged"
+    WindowStartupLocation="CenterScreen"
+    mc:Ignorable="d">
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="32" ResizeBorderThickness="{x:Static SystemParameters.WindowResizeBorderThickness}" />
+    </WindowChrome.WindowChrome>
+    <Window.InputBindings>
+        <KeyBinding Key="Escape" Command="Close" />
+    </Window.InputBindings>
+    <Window.CommandBindings>
+        <CommandBinding Command="Close" Executed="OnCloseExecuted" />
+    </Window.CommandBindings>
+
+    <Grid>
+        <Border Style="{StaticResource WindowMainPanelStyle}">
+            <Grid Background="{DynamicResource Color01B}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="32" />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <!--  TitleBar and Control  -->
+                <Image
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    Width="16"
+                    Height="16"
+                    Margin="10 4 4 4"
+                    RenderOptions.BitmapScalingMode="HighQuality"
+                    Source="/Images/app.png" />
+                <TextBlock
+                    Grid.Row="0"
+                    Grid.Column="1"
+                    Margin="4 0 0 0"
+                    VerticalAlignment="Center"
+                    FontSize="12"
+                    Foreground="{DynamicResource Color05B}"
+                    Text="{DynamicResource releaseNotes}" />
+
+                <Button
+                    Grid.Row="0"
+                    Grid.Column="2"
+                    Click="OnMinimizeButtonClick"
+                    RenderOptions.EdgeMode="Aliased"
+                    Style="{DynamicResource TitleBarButtonStyle}">
+                    <Path
+                        Width="46"
+                        Height="32"
+                        Data="M 18,15 H 28"
+                        Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                        StrokeThickness="1">
+                        <Path.Style>
+                            <Style TargetType="Path">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                        <Setter Property="Opacity" Value="0.5" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Path.Style>
+                    </Path>
+                </Button>
+                <Button
+                    Name="MaximizeButton"
+                    Grid.Row="0"
+                    Grid.Column="3"
+                    Click="OnMaximizeRestoreButtonClick"
+                    Style="{StaticResource TitleBarButtonStyle}">
+                    <Path
+                        Width="46"
+                        Height="32"
+                        Data="M 18.5,10.5 H 27.5 V 19.5 H 18.5 Z"
+                        Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                        StrokeThickness="1">
+                        <Path.Style>
+                            <Style TargetType="Path">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                        <Setter Property="Opacity" Value="0.5" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Path.Style>
+                    </Path>
+                </Button>
+                <Button
+                    Name="RestoreButton"
+                    Grid.Row="0"
+                    Grid.Column="3"
+                    Click="OnMaximizeRestoreButtonClick"
+                    Style="{StaticResource TitleBarButtonStyle}">
+                    <Path
+                        Width="46"
+                        Height="32"
+                        Data="M 18.5,12.5 H 25.5 V 19.5 H 18.5 Z M 20.5,12.5 V 10.5 H 27.5 V 17.5 H 25.5"
+                        Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                        StrokeThickness="1">
+                        <Path.Style>
+                            <Style TargetType="Path">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                        <Setter Property="Opacity" Value="0.5" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Path.Style>
+                    </Path>
+                </Button>
+                <Button
+                    Grid.Row="0"
+                    Grid.Column="4"
+                    Click="OnCloseButtonClick"
+                    Style="{StaticResource TitleBarCloseButtonStyle}">
+                    <Path
+                        Width="46"
+                        Height="32"
+                        Data="M 18,11 27,20 M 18,20 27,11"
+                        Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                        StrokeThickness="1">
+                        <Path.Style>
+                            <Style TargetType="Path">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                        <Setter Property="Opacity" Value="0.5" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Path.Style>
+                    </Path>
+                </Button>
+
+                <mdxam:MarkdownScrollViewer
+                    x:Name="MarkdownViewer"
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="5"
+                    MaxHeight="510"
+                    Margin="15 0 20 0"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    ClickAction="SafetyDisplayWithRelativePath" />
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/Flow.Launcher/ReleaseNotesWindow.xaml
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml
@@ -173,8 +173,8 @@
                     Margin="15 0 20 0">
                     <ui:ProgressRing
                         x:Name="RefreshProgressRing"
-                        Width="30"
-                        Height="30"
+                        Width="32"
+                        Height="32"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
                         IsActive="True" />

--- a/Flow.Launcher/ReleaseNotesWindow.xaml
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml
@@ -11,6 +11,7 @@
     Title="{DynamicResource releaseNotes}"
     Width="700"
     Background="{DynamicResource PopuBGColor}"
+    Closed="Window_Closed"
     Foreground="{DynamicResource PopupTextColor}"
     Loaded="Window_Loaded"
     ResizeMode="CanResize"

--- a/Flow.Launcher/ReleaseNotesWindow.xaml
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml
@@ -2,6 +2,7 @@
     x:Class="Flow.Launcher.ReleaseNotesWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:cc="clr-namespace:Flow.Launcher.Resources.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Flow.Launcher"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -41,6 +42,7 @@
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="32" />
+                    <RowDefinition />
                     <RowDefinition />
                 </Grid.RowDefinitions>
                 <!--  TitleBar and Control  -->
@@ -153,9 +155,17 @@
                     </Path>
                 </Button>
 
+                <Grid
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="5"
+                    Margin="10 0 20 0">
+                    <cc:HyperLink x:Name="SeeMore" Text="{DynamicResource seeMoreReleaseNotes}" />
+                </Grid>
+
                 <mdxam:MarkdownScrollViewer
                     x:Name="MarkdownViewer"
-                    Grid.Row="1"
+                    Grid.Row="2"
                     Grid.Column="0"
                     Grid.ColumnSpan="5"
                     Height="510"
@@ -168,7 +178,7 @@
 
                 <!--  Put this Grid in the same position as MarkdownViewer  -->
                 <Grid
-                    Grid.Row="1"
+                    Grid.Row="2"
                     Grid.Column="0"
                     Grid.ColumnSpan="5"
                     Height="510"

--- a/Flow.Launcher/ReleaseNotesWindow.xaml
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml
@@ -157,7 +157,7 @@
                     Grid.Row="1"
                     Grid.Column="0"
                     Grid.ColumnSpan="5"
-                    MaxHeight="510"
+                    Height="510"
                     Margin="15 0 20 0"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"

--- a/Flow.Launcher/ReleaseNotesWindow.xaml
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml
@@ -171,21 +171,25 @@
                     Grid.Row="2"
                     Grid.Column="0"
                     Grid.ColumnSpan="5"
+                    Height="500"
                     Margin="15 0 20 0"
                     HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
                     ClickAction="SafetyDisplayWithRelativePath"
                     Loaded="MarkdownViewer_Loaded"
-                    Plugins="{StaticResource MdXamlPlugins}" />
+                    Plugins="{StaticResource MdXamlPlugins}"
+                    Visibility="Collapsed" />
 
-                <!--  Put this Grid in the same position as MarkdownViewer  -->
+                <!--  This Grid is for display progress ring and refresh button.  -->
+                <!--  And it is also for changing the size of the MarkdownViewer.  -->
+                <!--  Because VerticalAlignment="Stretch" can cause size issue with MarkdownViewer.  -->
                 <Grid
                     Grid.Row="2"
                     Grid.Column="0"
                     Grid.ColumnSpan="5"
                     Margin="15 0 20 0"
                     HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch">
+                    VerticalAlignment="Stretch"
+                    SizeChanged="Grid_SizeChanged">
                     <ui:ProgressRing
                         x:Name="RefreshProgressRing"
                         Width="32"

--- a/Flow.Launcher/ReleaseNotesWindow.xaml
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml
@@ -163,7 +163,8 @@
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     ClickAction="SafetyDisplayWithRelativePath"
-                    Loaded="MarkdownViewer_Loaded" />
+                    Loaded="MarkdownViewer_Loaded"
+                    Plugins="{StaticResource MdXamlPlugins}" />
 
                 <!--  Put this Grid in the same position as MarkdownViewer  -->
                 <Grid

--- a/Flow.Launcher/ReleaseNotesWindow.xaml.cs
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using Flow.Launcher.Infrastructure.Http;
+using MdXaml;
 
 namespace Flow.Launcher
 {
@@ -21,11 +22,9 @@ namespace Flow.Launcher
 
         #region Window Events
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "<Pending>")]
-        private async void Window_Loaded(object sender, RoutedEventArgs e)
+        private void Window_Loaded(object sender, RoutedEventArgs e)
         {
             RefreshMaximizeRestoreButton();
-            MarkdownViewer.Markdown = await GetReleaseNotesMarkdownAsync();
         }
 
         private void OnCloseExecuted(object sender, ExecutedRoutedEventArgs e)
@@ -82,6 +81,11 @@ namespace Flow.Launcher
         private static async Task<string> GetReleaseNotesMarkdownAsync()
         {
             var releaseNotesJSON = await Http.GetStringAsync("https://api.github.com/repos/Flow-Launcher/Flow.Launcher/releases");
+            
+            if (string.IsNullOrEmpty(releaseNotesJSON))
+            {
+                return string.Empty;
+            }
             var releases = JsonSerializer.Deserialize<List<GitHubReleaseInfo>>(releaseNotesJSON);
 
             // Get the latest releases
@@ -145,5 +149,12 @@ namespace Flow.Launcher
         private static partial Regex ImageUnitRegex();
 
         #endregion
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "<Pending>")]
+        private async void MarkdownViewer_Loaded(object sender, RoutedEventArgs e)
+        {
+            MarkdownViewer.MarkdownStyle = MarkdownStyle.GithubLike;
+            MarkdownViewer.Markdown = await GetReleaseNotesMarkdownAsync();
+        }
     }
 }

--- a/Flow.Launcher/ReleaseNotesWindow.xaml.cs
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml.cs
@@ -34,6 +34,11 @@ namespace Flow.Launcher
             Close();
         }
 
+        private void Window_Closed(object sender, EventArgs e)
+        {
+            ModernWpf.ThemeManager.Current.ActualApplicationThemeChanged -= ThemeManager_ActualApplicationThemeChanged;
+        }
+
         #endregion
 
         #region Window Custom TitleBar
@@ -99,7 +104,9 @@ namespace Flow.Launcher
             {
                 releaseNotesHtmlBuilder.AppendLine("# " + release.Name);
 
-                // Add unit for images: Replace <img src="..." width="500"> with <img src="..." width="500px">
+                // Because MdXaml.Html package cannot correctly render images without units,
+                // We need to manually add unit for images
+                // E.g. Replace <img src="..." width="500"> with <img src="..." width="500px">
                 var notes = ImageUnitRegex().Replace(release.ReleaseNotes, m =>
                     {
                         var prefix = m.Groups[1].Value;
@@ -182,11 +189,6 @@ namespace Flow.Launcher
                     MarkdownViewer.Markdown = output;
                 }
             });
-        }
-
-        private void Window_Closed(object sender, EventArgs e)
-        {
-            ModernWpf.ThemeManager.Current.ActualApplicationThemeChanged -= ThemeManager_ActualApplicationThemeChanged;
         }
 
         private void ThemeManager_ActualApplicationThemeChanged(ModernWpf.ThemeManager sender, object args)

--- a/Flow.Launcher/ReleaseNotesWindow.xaml.cs
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml.cs
@@ -15,9 +15,12 @@ namespace Flow.Launcher
 {
     public partial class ReleaseNotesWindow : Window
     {
+        private static readonly string ReleaseNotes = Properties.Settings.Default.GithubRepo + "/releases";
+
         public ReleaseNotesWindow()
         {
             InitializeComponent();
+            SeeMore.Uri = ReleaseNotes;
             ModernWpf.ThemeManager.Current.ActualApplicationThemeChanged += ThemeManager_ActualApplicationThemeChanged;
         }
 

--- a/Flow.Launcher/ReleaseNotesWindow.xaml.cs
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml.cs
@@ -113,7 +113,7 @@ namespace Flow.Launcher
                     });
 
                 releaseNotesHtmlBuilder.AppendLine(notes);
-                releaseNotesHtmlBuilder.AppendLine("&nbsp;");
+                releaseNotesHtmlBuilder.AppendLine();
             }
 
             return releaseNotesHtmlBuilder.ToString();

--- a/Flow.Launcher/ReleaseNotesWindow.xaml.cs
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml.cs
@@ -81,7 +81,7 @@ namespace Flow.Launcher
         private static async Task<string> GetReleaseNotesMarkdownAsync()
         {
             var releaseNotesJSON = await Http.GetStringAsync("https://api.github.com/repos/Flow-Launcher/Flow.Launcher/releases");
-            
+
             if (string.IsNullOrEmpty(releaseNotesJSON))
             {
                 return string.Empty;
@@ -150,11 +150,37 @@ namespace Flow.Launcher
 
         #endregion
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "<Pending>")]
-        private async void MarkdownViewer_Loaded(object sender, RoutedEventArgs e)
+        private void MarkdownViewer_Loaded(object sender, RoutedEventArgs e)
         {
             MarkdownViewer.MarkdownStyle = MarkdownStyle.GithubLike;
-            MarkdownViewer.Markdown = await GetReleaseNotesMarkdownAsync();
+            RefreshMarkdownViewer();
+        }
+
+        private void RefreshButton_Click(object sender, RoutedEventArgs e)
+        {
+            RefreshButton.Visibility = Visibility.Collapsed;
+            RefreshProgressRing.Visibility = Visibility.Visible;
+            RefreshMarkdownViewer();
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "<Pending>")]
+        private async void RefreshMarkdownViewer()
+        {
+            var output = await GetReleaseNotesMarkdownAsync().ConfigureAwait(false);
+
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                RefreshProgressRing.Visibility = Visibility.Collapsed;
+                if (string.IsNullOrEmpty(output))
+                {
+                    RefreshButton.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    RefreshButton.Visibility = Visibility.Collapsed;
+                    MarkdownViewer.Markdown = output;
+                }
+            });
         }
     }
 }

--- a/Flow.Launcher/ReleaseNotesWindow.xaml.cs
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml.cs
@@ -185,11 +185,13 @@ namespace Flow.Launcher
                 if (string.IsNullOrEmpty(output))
                 {
                     RefreshButton.Visibility = Visibility.Visible;
+                    MarkdownViewer.Visibility = Visibility.Collapsed;
                 }
                 else
                 {
                     RefreshButton.Visibility = Visibility.Collapsed;
                     MarkdownViewer.Markdown = output;
+                    MarkdownViewer.Visibility = Visibility.Visible;
                 }
             });
         }
@@ -211,6 +213,12 @@ namespace Flow.Launcher
                     MarkdownViewer.Background = Brushes.Black;
                 }
             });
+        }
+
+        private void Grid_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            MarkdownViewer.Height = e.NewSize.Height;
+            MarkdownViewer.Width = e.NewSize.Width;
         }
     }
 }

--- a/Flow.Launcher/ReleaseNotesWindow.xaml.cs
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml.cs
@@ -10,7 +10,6 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using Flow.Launcher.Infrastructure.Http;
-using MdXaml;
 
 namespace Flow.Launcher
 {
@@ -155,7 +154,6 @@ namespace Flow.Launcher
 
         private void MarkdownViewer_Loaded(object sender, RoutedEventArgs e)
         {
-            MarkdownViewer.MarkdownStyle = MarkdownStyle.GithubLike;
             RefreshMarkdownViewer();
         }
 
@@ -197,11 +195,13 @@ namespace Flow.Launcher
             {
                 if (ModernWpf.ThemeManager.Current.ActualApplicationTheme == ModernWpf.ApplicationTheme.Light)
                 {
+                    MarkdownViewer.MarkdownStyle = (Style)Application.Current.Resources["DocumentStyleGithubLikeLight"];
                     MarkdownViewer.Foreground = Brushes.Black;
                     MarkdownViewer.Background = Brushes.White;
                 }
                 else
                 {
+                    MarkdownViewer.MarkdownStyle = (Style)Application.Current.Resources["DocumentStyleGithubLikeDark"];
                     MarkdownViewer.Foreground = Brushes.White;
                     MarkdownViewer.Background = Brushes.Black;
                 }

--- a/Flow.Launcher/ReleaseNotesWindow.xaml.cs
+++ b/Flow.Launcher/ReleaseNotesWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Media;
 using Flow.Launcher.Infrastructure.Http;
 using MdXaml;
 
@@ -18,6 +19,7 @@ namespace Flow.Launcher
         public ReleaseNotesWindow()
         {
             InitializeComponent();
+            ModernWpf.ThemeManager.Current.ActualApplicationThemeChanged += ThemeManager_ActualApplicationThemeChanged;
         }
 
         #region Window Events
@@ -25,6 +27,7 @@ namespace Flow.Launcher
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
             RefreshMaximizeRestoreButton();
+            ThemeManager_ActualApplicationThemeChanged(null, null);
         }
 
         private void OnCloseExecuted(object sender, ExecutedRoutedEventArgs e)
@@ -179,6 +182,28 @@ namespace Flow.Launcher
                 {
                     RefreshButton.Visibility = Visibility.Collapsed;
                     MarkdownViewer.Markdown = output;
+                }
+            });
+        }
+
+        private void Window_Closed(object sender, EventArgs e)
+        {
+            ModernWpf.ThemeManager.Current.ActualApplicationThemeChanged -= ThemeManager_ActualApplicationThemeChanged;
+        }
+
+        private void ThemeManager_ActualApplicationThemeChanged(ModernWpf.ThemeManager sender, object args)
+        {
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                if (ModernWpf.ThemeManager.Current.ActualApplicationTheme == ModernWpf.ApplicationTheme.Light)
+                {
+                    MarkdownViewer.Foreground = Brushes.Black;
+                    MarkdownViewer.Background = Brushes.White;
+                }
+                else
+                {
+                    MarkdownViewer.Foreground = Brushes.White;
+                    MarkdownViewer.Background = Brushes.Black;
                 }
             });
         }

--- a/Flow.Launcher/Resources/CustomControlTemplate.xaml
+++ b/Flow.Launcher/Resources/CustomControlTemplate.xaml
@@ -2408,12 +2408,15 @@
         </Setter>
     </Style>
 
-    <!-- Explorer Plugin Expander -->
+    <!--  Explorer Plugin Expander  -->
     <Style x:Key="ExpanderHeaderRightArrowStyle" TargetType="ToggleButton">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleButton">
-                    <Border x:Name="RootBorder" Background="Transparent" Padding="16,15,16,15">
+                    <Border
+                        x:Name="RootBorder"
+                        Padding="16 15 16 15"
+                        Background="Transparent">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
@@ -2421,41 +2424,43 @@
                             </Grid.ColumnDefinitions>
 
                             <ContentPresenter
-                            Grid.Column="0"
-                            VerticalAlignment="Center"
-                            HorizontalAlignment="Left"
-                            RecognizesAccessKey="True"
-                            SnapsToDevicePixels="True"
-                            Content="{TemplateBinding Content}"
-                            Margin="8 0 0 0"
-                            ContentTemplate="{TemplateBinding ContentTemplate}" />
+                                Grid.Column="0"
+                                Margin="8 0 0 0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="True" />
 
-                            <Grid Grid.Column="1"
-                              Width="20" Height="20"
-                              Margin="8 0 4 0"
-                              VerticalAlignment="Center"
-                              HorizontalAlignment="Right"
-                              Background="Transparent"
-                              RenderTransformOrigin="0.5,0.5"
-                              x:Name="ChevronGrid">
+                            <Grid
+                                x:Name="ChevronGrid"
+                                Grid.Column="1"
+                                Width="20"
+                                Height="20"
+                                Margin="8 0 4 0"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                Background="Transparent"
+                                RenderTransformOrigin="0.5,0.5">
                                 <Grid.RenderTransform>
-                                    <RotateTransform Angle="0"/>
+                                    <RotateTransform Angle="0" />
                                 </Grid.RenderTransform>
                                 <Ellipse
-                                x:Name="circle"
-                                Width="19"
-                                Height="19"
-                                Stroke="Transparent"
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center"/>
+                                    x:Name="circle"
+                                    Width="19"
+                                    Height="19"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Stroke="Transparent" />
                                 <Path
-                                x:Name="arrow"
-                                Data="M 1,1.5 L 4.5,5 L 8,1.5"
-                                Stroke="#666"
-                                StrokeThickness="1"
-                                SnapsToDevicePixels="False"
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center" />
+                                    x:Name="arrow"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Data="M 1,1.5 L 4.5,5 L 8,1.5"
+                                    SnapsToDevicePixels="False"
+                                    Stroke="#666"
+                                    StrokeThickness="1" />
                             </Grid>
                         </Grid>
                     </Border>
@@ -5753,5 +5758,335 @@
         <Setter Property="FontSize" Value="12" />
         <Setter Property="Margin" Value="0 2 0 0" />
         <Setter Property="Foreground" Value="{DynamicResource Color04B}" />
+    </Style>
+
+    <!--  Release Notes  -->
+    <Style x:Key="DocumentStyleGithubLikeLight" TargetType="FlowDocument">
+        <Setter Property="FontFamily" Value="Calibri" />
+        <Setter Property="TextAlignment" Value="Left" />
+        <Setter Property="PagePadding" Value="0" />
+        <Setter Property="FontSize" Value="14" />
+
+        <Style.Resources>
+            <Style TargetType="Section">
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="Blockquote">
+                        <Setter Property="Padding" Value="10 5" />
+                        <Setter Property="BorderBrush" Value="#DEDEDE" />
+                        <Setter Property="BorderThickness" Value="5 0 0 0" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit" TargetType="avalonEdit:TextEditor">
+                <Setter Property="Background" Value="#EEEEEE" />
+                <Setter Property="HorizontalScrollBarVisibility" Value="Auto" />
+                <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
+                <Setter Property="Margin" Value="2 0 2 0" />
+                <Setter Property="Padding" Value="3" />
+            </Style>
+
+            <Style TargetType="Paragraph">
+                <Setter Property="Margin" Value="0 7 0 0" />
+
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="Heading1">
+                        <Setter Property="Margin" Value="0 0 15 0" />
+
+                        <Setter Property="Foreground" Value="#ff000000" />
+                        <Setter Property="FontSize" Value="28" />
+                        <Setter Property="FontWeight" Value="UltraBold" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="Heading2">
+                        <Setter Property="Margin" Value="0 0 15 0" />
+
+                        <Setter Property="Foreground" Value="#ff000000" />
+                        <Setter Property="FontSize" Value="21" />
+                        <Setter Property="FontWeight" Value="Bold" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="Heading3">
+                        <Setter Property="Margin" Value="0 0 10 0" />
+
+                        <Setter Property="Foreground" Value="#ff000000" />
+                        <Setter Property="FontSize" Value="17.5" />
+                        <Setter Property="FontWeight" Value="Bold" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="Heading4">
+                        <Setter Property="Margin" Value="0 0 5 0" />
+
+                        <Setter Property="Foreground" Value="#ff000000" />
+                        <Setter Property="FontSize" Value="14" />
+                        <Setter Property="FontWeight" Value="Bold" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="CodeBlock">
+                        <Setter Property="FontFamily" Value="Courier New" />
+                        <Setter Property="FontSize" Value="11.9" />
+                        <Setter Property="Background" Value="#12181F25" />
+                        <Setter Property="Padding" Value="20 10" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="Note">
+                        <Setter Property="Margin" Value="5 0 5 0" />
+                        <Setter Property="Padding" Value="10 5" />
+                        <Setter Property="BorderBrush" Value="#DEDEDE" />
+                        <Setter Property="BorderThickness" Value="3 3 3 3" />
+                        <Setter Property="Background" Value="#FAFAFA" />
+                    </Trigger>
+
+                </Style.Triggers>
+            </Style>
+
+            <Style TargetType="Run">
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="CodeSpan">
+                        <Setter Property="FontFamily" Value="Courier New" />
+                        <Setter Property="FontSize" Value="11.9" />
+                        <Setter Property="Background" Value="#12181F25" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+            <Style TargetType="Span">
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="CodeSpan">
+                        <Setter Property="FontFamily" Value="Courier New" />
+                        <Setter Property="FontSize" Value="11.9" />
+                        <Setter Property="Background" Value="#12181F25" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style TargetType="Hyperlink">
+                <Setter Property="TextDecorations" Value="None" />
+            </Style>
+
+            <Style TargetType="Image">
+                <Setter Property="RenderOptions.BitmapScalingMode" Value="NearestNeighbor" />
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="imageright">
+                        <Setter Property="Margin" Value="20 0 0 0" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <!--
+                The Table's style don't seem to support border-collapse.
+                By making the ruled line width 0.5 and applying it to cell and table,
+                it looks like the ruled lines are not doubled.
+            -->
+            <Style TargetType="Table">
+                <Setter Property="CellSpacing" Value="0" />
+                <Setter Property="BorderThickness" Value="0.5" />
+                <Setter Property="BorderBrush" Value="#DFE2E5" />
+                <Style.Resources>
+                    <Style TargetType="TableCell">
+                        <Setter Property="BorderThickness" Value="0.5" />
+                        <Setter Property="BorderBrush" Value="#DFE2E5" />
+                        <Setter Property="Padding" Value="13 6" />
+                    </Style>
+                </Style.Resources>
+            </Style>
+
+            <Style TargetType="TableRowGroup">
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="TableHeader">
+                        <Setter Property="FontWeight" Value="DemiBold" />
+                        <Setter Property="FontWeight" Value="Bold" />
+                        <Setter Property="Background" Value="#FFFFFF" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style TargetType="TableRow">
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="EvenTableRow">
+                        <Setter Property="Background" Value="#F6F8FA" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style TargetType="BlockUIContainer">
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="RuleSingle">
+                        <Setter Property="Margin" Value="0 3" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="RuleDouble">
+                        <Setter Property="Margin" Value="0 3" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="RuleBold">
+                        <Setter Property="Margin" Value="0 3" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="RuleBoldWithSingle">
+                        <Setter Property="Margin" Value="0 3" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+        </Style.Resources>
+    </Style>
+
+    <Style x:Key="DocumentStyleGithubLikeDark" TargetType="FlowDocument">
+        <Setter Property="FontFamily" Value="Calibri" />
+        <Setter Property="TextAlignment" Value="Left" />
+        <Setter Property="PagePadding" Value="0" />
+        <Setter Property="FontSize" Value="14" />
+
+        <Style.Resources>
+            <Style TargetType="Section">
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="Blockquote">
+                        <Setter Property="Padding" Value="10 5" />
+                        <Setter Property="BorderBrush" Value="#212121" />
+                        <Setter Property="BorderThickness" Value="5 0 0 0" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit" TargetType="avalonEdit:TextEditor">
+                <Setter Property="Background" Value="#111111" />
+                <Setter Property="HorizontalScrollBarVisibility" Value="Auto" />
+                <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
+                <Setter Property="Margin" Value="2 0 2 0" />
+                <Setter Property="Padding" Value="3" />
+            </Style>
+
+            <Style TargetType="Paragraph">
+                <Setter Property="Margin" Value="0 7 0 0" />
+
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="Heading1">
+                        <Setter Property="Margin" Value="0 0 15 0" />
+                        <Setter Property="Foreground" Value="#FFFFFFFF" />
+                        <Setter Property="FontSize" Value="28" />
+                        <Setter Property="FontWeight" Value="UltraBold" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="Heading2">
+                        <Setter Property="Margin" Value="0 0 15 0" />
+                        <Setter Property="Foreground" Value="#FFFFFFFF" />
+                        <Setter Property="FontSize" Value="21" />
+                        <Setter Property="FontWeight" Value="Bold" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="Heading3">
+                        <Setter Property="Margin" Value="0 0 10 0" />
+                        <Setter Property="Foreground" Value="#FFFFFFFF" />
+                        <Setter Property="FontSize" Value="17.5" />
+                        <Setter Property="FontWeight" Value="Bold" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="Heading4">
+                        <Setter Property="Margin" Value="0 0 5 0" />
+                        <Setter Property="Foreground" Value="#FFFFFFFF" />
+                        <Setter Property="FontSize" Value="14" />
+                        <Setter Property="FontWeight" Value="Bold" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="CodeBlock">
+                        <Setter Property="FontFamily" Value="Courier New" />
+                        <Setter Property="FontSize" Value="11.9" />
+                        <Setter Property="Background" Value="#E0E7DFDA" />
+                        <Setter Property="Padding" Value="20 10" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="Note">
+                        <Setter Property="Margin" Value="5 0 5 0" />
+                        <Setter Property="Padding" Value="10 5" />
+                        <Setter Property="BorderBrush" Value="#212121" />
+                        <Setter Property="BorderThickness" Value="3 3 3 3" />
+                        <Setter Property="Background" Value="#050505" />
+                    </Trigger>
+
+                </Style.Triggers>
+            </Style>
+
+            <Style TargetType="Run">
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="CodeSpan">
+                        <Setter Property="FontFamily" Value="Courier New" />
+                        <Setter Property="FontSize" Value="11.9" />
+                        <Setter Property="Background" Value="#E0E7DFDA" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style TargetType="Span">
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="CodeSpan">
+                        <Setter Property="FontFamily" Value="Courier New" />
+                        <Setter Property="FontSize" Value="11.9" />
+                        <Setter Property="Background" Value="#E0E7DFDA" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style TargetType="Hyperlink">
+                <Setter Property="TextDecorations" Value="None" />
+            </Style>
+
+            <Style TargetType="Image">
+                <Setter Property="RenderOptions.BitmapScalingMode" Value="NearestNeighbor" />
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="imageright">
+                        <Setter Property="Margin" Value="20 0 0 0" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style TargetType="Table">
+                <Setter Property="CellSpacing" Value="0" />
+                <Setter Property="BorderThickness" Value="0.5" />
+                <Setter Property="BorderBrush" Value="#202020" />
+                <Style.Resources>
+                    <Style TargetType="TableCell">
+                        <Setter Property="BorderThickness" Value="0.5" />
+                        <Setter Property="BorderBrush" Value="#202020" />
+                        <Setter Property="Padding" Value="13 6" />
+                    </Style>
+                </Style.Resources>
+            </Style>
+
+            <Style TargetType="TableRowGroup">
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="TableHeader">
+                        <Setter Property="FontWeight" Value="Bold" />
+                        <Setter Property="Background" Value="#000000" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style TargetType="TableRow">
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="EvenTableRow">
+                        <Setter Property="Background" Value="#090708" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <Style TargetType="BlockUIContainer">
+                <Style.Triggers>
+                    <Trigger Property="Tag" Value="RuleSingle">
+                        <Setter Property="Margin" Value="0 3" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="RuleDouble">
+                        <Setter Property="Margin" Value="0 3" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="RuleBold">
+                        <Setter Property="Margin" Value="0 3" />
+                    </Trigger>
+
+                    <Trigger Property="Tag" Value="RuleBoldWithSingle">
+                        <Setter Property="Margin" Value="0 3" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+        </Style.Resources>
     </Style>
 </ResourceDictionary>

--- a/Flow.Launcher/Resources/CustomControlTemplate.xaml
+++ b/Flow.Launcher/Resources/CustomControlTemplate.xaml
@@ -1,6 +1,10 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mdagif="clr-namespace:MdXaml.AnimatedGif;assembly=MdXaml.AnimatedGif"
+    xmlns:mdhtml="clr-namespace:MdXaml.Html;assembly=MdXaml.Html"
+    xmlns:mdplugins="clr-namespace:MdXaml.Plugins;assembly=MdXaml.Plugins"
+    xmlns:mdsvg="clr-namespace:MdXaml.Svg;assembly=MdXaml.Svg"
     xmlns:system="clr-namespace:System;assembly=mscorlib"
     xmlns:ui="http://schemas.modernwpf.com/2019">
 
@@ -5761,6 +5765,12 @@
     </Style>
 
     <!--  Release Notes  -->
+    <mdplugins:MdXamlPlugins x:Key="MdXamlPlugins">
+        <mdhtml:HtmlPluginSetup />
+        <mdsvg:SvgPluginSetup />
+        <mdagif:AnimatedGifPluginSetup />
+    </mdplugins:MdXamlPlugins>
+
     <Style x:Key="DocumentStyleGithubLikeLight" TargetType="FlowDocument">
         <Setter Property="FontFamily" Value="Calibri" />
         <Setter Property="TextAlignment" Value="Left" />

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -314,4 +314,11 @@ public partial class SettingsPaneAboutViewModel : BaseModel
     {
         SettingWindowFont = Win32Helper.GetSystemDefaultFont(false);
     }
+
+    [RelayCommand]
+    private void OpenReleaseNotes()
+    {
+        var releaseNotesWindow = new ReleaseNotesWindow();
+        releaseNotesWindow.Show();
+    }
 }

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -55,7 +55,7 @@
             </cc:Card>
 
             <cc:Card Title="{DynamicResource releaseNotes}" Icon="&#xe8fd;">
-                <cc:HyperLink Text="{DynamicResource releaseNotes}" Uri="{Binding ReleaseNotes}" />
+                <Button Command="{Binding OpenReleaseNotesCommand}" Content="{DynamicResource releaseNotes}" />
             </cc:Card>
 
 


### PR DESCRIPTION
# Add release notes window

- Release notes window will show for one time when Flow is updated.
- In about page, we can open release window manually.
- It will fetch three latest release notes and show them in the window.
- If Flow failed to fetch release notes, it will pop up refresh button.

# Test
![Screenshot 2025-06-07 165139](https://github.com/user-attachments/assets/80695f98-a605-4630-aa0a-23e8931b62b0)
![Screenshot 2025-06-07 165444](https://github.com/user-attachments/assets/4f6e4351-00af-44fb-a485-d8921c5b7c4f)
