### PR TITLE
BrowserBookmark do not use SqliteConnection pooling to avoid ObjectDisposedException

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Flow.Launcher.Plugin.BrowserBookmark.Helper;
 using Flow.Launcher.Plugin.BrowserBookmark.Models;
 using Microsoft.Data.Sqlite;
 
@@ -131,31 +132,7 @@ public abstract class ChromiumBookmarkLoader : IBookmarkLoader
 
     private void LoadFaviconsFromDb(string dbPath, List<Bookmark> bookmarks)
     {
-        // Use a copy to avoid lock issues with the original file
-        var tempDbPath = Path.Combine(_faviconCacheDir, $"tempfavicons_{Guid.NewGuid()}.db");
-
-        try
-        {
-            File.Copy(dbPath, tempDbPath, true);
-        }
-        catch (Exception ex)
-        {
-            try
-            {
-                if (File.Exists(tempDbPath))
-                {
-                    File.Delete(tempDbPath);
-                }
-            }
-            catch (Exception ex1)
-            {
-                Main._context.API.LogException(ClassName, $"Failed to delete temporary favicon DB: {tempDbPath}", ex1);
-            }
-            Main._context.API.LogException(ClassName, $"Failed to copy favicon DB: {dbPath}", ex);
-            return;
-        }
-
-        try
+        FaviconHelper.LoadFaviconsFromDb(_faviconCacheDir, dbPath, (tempDbPath) =>
         {
             // Since some bookmarks may have same favicon id, we need to record them to avoid duplicates
             var savedPaths = new ConcurrentDictionary<string, bool>();
@@ -181,13 +158,13 @@ public abstract class ChromiumBookmarkLoader : IBookmarkLoader
 
                     using var cmd = connection.CreateCommand();
                     cmd.CommandText = @"
-                            SELECT f.id, b.image_data
-                            FROM favicons f
-                            JOIN favicon_bitmaps b ON f.id = b.icon_id
-                            JOIN icon_mapping m ON f.id = m.icon_id
-                            WHERE m.page_url LIKE @url
-                            ORDER BY b.width DESC
-                            LIMIT 1";
+                        SELECT f.id, b.image_data
+                        FROM favicons f
+                        JOIN favicon_bitmaps b ON f.id = b.icon_id
+                        JOIN icon_mapping m ON f.id = m.icon_id
+                        WHERE m.page_url LIKE @url
+                        ORDER BY b.width DESC
+                        LIMIT 1";
 
                     cmd.Parameters.AddWithValue("@url", $"%{domain}%");
 
@@ -206,7 +183,7 @@ public abstract class ChromiumBookmarkLoader : IBookmarkLoader
                     // Filter out duplicate favicons
                     if (savedPaths.TryAdd(faviconPath, true))
                     {
-                        SaveBitmapData(imageData, faviconPath);
+                        FaviconHelper.SaveBitmapData(imageData, faviconPath);
                     }
 
                     bookmark.FaviconPath = faviconPath;
@@ -223,32 +200,6 @@ public abstract class ChromiumBookmarkLoader : IBookmarkLoader
                     connection.Dispose();
                 }
             });
-        }
-        catch (Exception ex)
-        {
-            Main._context.API.LogException(ClassName, $"Failed to connect to SQLite: {tempDbPath}", ex);
-        }
-
-        // Delete temporary file
-        try
-        {
-            File.Delete(tempDbPath);
-        }
-        catch (Exception ex)
-        {
-            Main._context.API.LogException(ClassName, $"Failed to delete temporary favicon DB: {tempDbPath}", ex);
-        }
-    }
-
-    private static void SaveBitmapData(byte[] imageData, string outputPath)
-    {
-        try
-        {
-            File.WriteAllBytes(outputPath, imageData);
-        }
-        catch (Exception ex)
-        {
-            Main._context.API.LogException(ClassName, $"Failed to save image: {outputPath}", ex);
-        }
+        });
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Flow.Launcher.Plugin.BrowserBookmark.Helper;
 using Flow.Launcher.Plugin.BrowserBookmark.Models;
 using Microsoft.Data.Sqlite;
 
@@ -118,31 +119,7 @@ public abstract class FirefoxBookmarkLoaderBase : IBookmarkLoader
 
     private void LoadFaviconsFromDb(string dbPath, List<Bookmark> bookmarks)
     {
-        // Use a copy to avoid lock issues with the original file
-        var tempDbPath = Path.Combine(_faviconCacheDir, $"tempfavicons_{Guid.NewGuid()}.sqlite");
-
-        try
-        {
-            File.Copy(dbPath, tempDbPath, true);
-        }
-        catch (Exception ex)
-        {
-            try
-            {
-                if (File.Exists(tempDbPath))
-                {
-                    File.Delete(tempDbPath);
-                }
-            }
-            catch (Exception ex1)
-            {
-                Main._context.API.LogException(ClassName, $"Failed to delete temporary favicon DB: {tempDbPath}", ex1);
-            }
-            Main._context.API.LogException(ClassName, $"Failed to copy favicon DB: {dbPath}", ex);
-            return;
-        }
-
-        try
+        FaviconHelper.LoadFaviconsFromDb(_faviconCacheDir, dbPath, (tempDbPath) =>
         {
             // Since some bookmarks may have same favicon id, we need to record them to avoid duplicates
             var savedPaths = new ConcurrentDictionary<string, bool>();
@@ -190,7 +167,7 @@ public abstract class FirefoxBookmarkLoaderBase : IBookmarkLoader
                         return;
 
                     string faviconPath;
-                    if (IsSvgData(imageData))
+                    if (FaviconHelper.IsSvgData(imageData))
                     {
                         faviconPath = Path.Combine(_faviconCacheDir, $"firefox_{domain}.svg");
                     }
@@ -202,7 +179,7 @@ public abstract class FirefoxBookmarkLoaderBase : IBookmarkLoader
                     // Filter out duplicate favicons
                     if (savedPaths.TryAdd(faviconPath, true))
                     {
-                        SaveBitmapData(imageData, faviconPath);
+                        FaviconHelper.SaveBitmapData(imageData, faviconPath);
                     }
 
                     bookmark.FaviconPath = faviconPath;
@@ -219,42 +196,7 @@ public abstract class FirefoxBookmarkLoaderBase : IBookmarkLoader
                     connection.Dispose();
                 }
             });
-        }
-        catch (Exception ex)
-        {
-            Main._context.API.LogException(ClassName, $"Failed to load Firefox favicon DB: {tempDbPath}", ex);
-        }
-
-        // Delete temporary file
-        try
-        {
-            File.Delete(tempDbPath);
-        }
-        catch (Exception ex)
-        {
-            Main._context.API.LogException(ClassName, $"Failed to delete temporary favicon DB: {tempDbPath}", ex);
-        }
-    }
-
-    private static void SaveBitmapData(byte[] imageData, string outputPath)
-    {
-        try
-        {
-            File.WriteAllBytes(outputPath, imageData);
-        }
-        catch (Exception ex)
-        {
-            Main._context.API.LogException(ClassName, $"Failed to save image: {outputPath}", ex);
-        }
-    }
-
-    private static bool IsSvgData(byte[] data)
-    {
-        if (data.Length < 5)
-            return false;
-        string start = System.Text.Encoding.ASCII.GetString(data, 0, Math.Min(100, data.Length));
-        return start.Contains("<svg") ||
-               (start.StartsWith("<?xml") && start.Contains("<svg"));
+        });
     }
 }
 

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Helper/FaviconHelper.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Helper/FaviconHelper.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.IO;
+
+namespace Flow.Launcher.Plugin.BrowserBookmark.Helper;
+
+public static class FaviconHelper
+{
+    private static readonly string ClassName = nameof(FaviconHelper);
+
+    public static void LoadFaviconsFromDb(string faviconCacheDir, string dbPath, Action<string> loadAction)
+    {
+        // Use a copy to avoid lock issues with the original file
+        var tempDbPath = Path.Combine(faviconCacheDir, $"tempfavicons_{Guid.NewGuid()}.db");
+
+        try
+        {
+            File.Copy(dbPath, tempDbPath, true);
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                if (File.Exists(tempDbPath))
+                {
+                    File.Delete(tempDbPath);
+                }
+            }
+            catch (Exception ex1)
+            {
+                Main._context.API.LogException(ClassName, $"Failed to delete temporary favicon DB: {tempDbPath}", ex1);
+            }
+            Main._context.API.LogException(ClassName, $"Failed to copy favicon DB: {dbPath}", ex);
+            return;
+        }
+
+        try
+        {
+            loadAction(tempDbPath);
+        }
+        catch (Exception ex)
+        {
+            Main._context.API.LogException(ClassName, $"Failed to connect to SQLite: {tempDbPath}", ex);
+        }
+
+        // Delete temporary file
+        try
+        {
+            File.Delete(tempDbPath);
+        }
+        catch (Exception ex)
+        {
+            Main._context.API.LogException(ClassName, $"Failed to delete temporary favicon DB: {tempDbPath}", ex);
+        }
+    }
+
+    public static void SaveBitmapData(byte[] imageData, string outputPath)
+    {
+        try
+        {
+            File.WriteAllBytes(outputPath, imageData);
+        }
+        catch (Exception ex)
+        {
+            Main._context.API.LogException(ClassName, $"Failed to save image: {outputPath}", ex);
+        }
+    }
+
+    public static bool IsSvgData(byte[] data)
+    {
+        if (data.Length < 5)
+            return false;
+        string start = System.Text.Encoding.ASCII.GetString(data, 0, Math.Min(100, data.Length));
+        return start.Contains("<svg") ||
+               (start.StartsWith("<?xml") && start.Contains("<svg"));
+    }
+}


### PR DESCRIPTION
Do not use pooling so that we do not need to clear pool to avoid ObjectDisposedException.

Follow on with #3641.

Issue:
```
EXCEPTION OCCURS: System.ObjectDisposedException: Safe handle has been closed.
Object name: 'SafeHandle'.
   at IntPtr System.StubHelpers.StubHelpers.SafeHandleAddRef(SafeHandle pHandle, ref bool success)
   at int SQLitePCL.SQLite3Provider_e_sqlite3+NativeMethods.sqlite3_prepare_v2(sqlite3 db, Byte* pSql, int nBytes, out IntPtr stmt, out Byte* ptrRemain)
   at int SQLitePCL.SQLite3Provider_e_sqlite3.SQLitePCL.ISQLite3Provider.sqlite3_prepare_v2(sqlite3 db, ReadOnlySpan<byte> sql, out IntPtr stm, out ReadOnlySpan<byte> tail)
   at IEnumerable<(sqlite3_stmt Statement, int ParamCount)> Microsoft.Data.Sqlite.SqliteCommand.PrepareAndEnumerateStatements()+MoveNext()
   at IEnumerable<sqlite3_stmt> Microsoft.Data.Sqlite.SqliteCommand.GetStatements()+MoveNext()
   at bool Microsoft.Data.Sqlite.SqliteDataReader.NextResult()
   at SqliteDataReader Microsoft.Data.Sqlite.SqliteCommand.ExecuteReader(CommandBehavior behavior)
   at void Flow.Launcher.Plugin.BrowserBookmark.ChromiumBookmarkLoader.LoadFaviconsFromDb(string dbPath, List<Bookmark> bookmarks)+(Bookmark bookmark) => { } in C:/projects/flow-launcher/Plugins/Flow.Launcher.Plugin.BrowserBookmark/ChromiumBookmarkLoader.cs:line 224
```