### PR TITLE
Update Button width for responsive design

### DIFF
--- a/Flow.Launcher/Resources/Controls/InstalledPluginDisplayKeyword.xaml
+++ b/Flow.Launcher/Resources/Controls/InstalledPluginDisplayKeyword.xaml
@@ -36,7 +36,8 @@
                 Text="{DynamicResource actionKeywords}" />
             <!--  Here Margin="0 -4.5 0 -4.5" is to remove redundant top bottom margin from Margin="{StaticResource SettingPanelMargin}"  -->
             <Button
-                Width="100"
+                Width="auto"
+                MinWidth="100"
                 Margin="0 -4.5 0 -4.5"
                 HorizontalAlignment="Right"
                 Command="{Binding SetActionKeywordsCommand}"


### PR DESCRIPTION
Modified Button to use auto width with a minimum width of 100. This change allows the button to grow when keywords do not fit.
![image](https://github.com/user-attachments/assets/03ba985c-f740-4735-93a0-9ecf73ab40bc)
