### PR TITLE
Skip release note notification for dev builds

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -137,12 +137,11 @@ namespace Flow.Launcher
                 welcomeWindow.Show();
             }
 
-            if (_settings.ReleaseNotesVersion != Constant.Version)
+            if (Constant.Version != "1.0.0" && _settings.ReleaseNotesVersion != Constant.Version) // Skip release notes notification for developer builds (version 1.0.0)
             {
                 // Update release notes version
                 _settings.ReleaseNotesVersion = Constant.Version;
-
-                // Display message box with button
+                // Show release note popup with button
                 App.API.ShowMsgWithButton(
                     string.Format(App.API.GetTranslation("appUpdateTitle"), Constant.Version),
                     App.API.GetTranslation("appUpdateButtonContent"),


### PR DESCRIPTION
## What's the PR
- Skip release note notification for dev version (1.0.0)
- When we add the release‐channel switch feature later, we’ll need to adjust this part too. We should suppress the notification if the version number goes down (for example, when moving from the beta channel back to stable). 
- I totally forgot to mention that during the code review.