### PR TITLE
Remove on tag release upload & change NuGet publish to on master push

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ deploy:
     api_key:
       secure: sCSd5JWgdzJWDa9kpqECut5ACPKZqcoxKU8ERKC00k7VIjig3/+nFV5zzTcGb0w3
     on:
-      APPVEYOR_REPO_TAG: true
+      branch: master
 
   - provider: GitHub
     repository: Flow-Launcher/Prereleases
@@ -84,12 +84,3 @@ deploy:
     force_update: true
     on:
       branch: master
-
-  - provider: GitHub
-    release: v$(flowVersion)
-    auth_token:
-      secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
-    artifact: Squirrel Installer, Portable Version, Squirrel nupkg, Squirrel RELEASES
-    force_update: true
-    on:
-      APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
**Remove AppVeyor on tag release upload:**
I don't see a need for this in our release workflow. 
This builds new flow artifacts setup exe, portable zip, etc and uploads them again when the GitHub release is published (because publishing creates the tag). This causes the hash to be different to when the artifacts were uploaded during push from dev to master. Different hash causes duplicate deployments on those that rely on the publish action and causes validation failures for package manager projects if they are triggered on the publish release action, prior to the reupload of artifacts from tagging.
![image](https://github.com/user-attachments/assets/6c709003-c1d9-4f78-8181-8f269b5444cc)

**Change NuGet publish to on master push:**
Change to be consistent with the release artifact upload, triggered when pushed to main.