### PR TITLE
Add AppVeyor skip build on tag

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 version: '1.20.1.{build}'
 
+# Do not build on tags because we create a release on merge to master. Otherwise will upload artifacts twice changing the hash, as well as triggering duplicate GitHub release action & NuGet deployments.
+skip_tags: true
+
 init:
 - ps: |
       $version = new-object System.Version $env:APPVEYOR_BUILD_VERSION
@@ -13,7 +16,6 @@ init:
 
 cache:
   - '%USERPROFILE%\.nuget\packages -> **.sln, **.csproj'  # preserve nuget folder (packages) unless the solution or projects change
-
 
 assembly_info:
   patch: true


### PR DESCRIPTION
Do not build on tag. We create a release on merge to master and building on tag will with our current configuration result in:
- upload artifacts twice changing the hash,
- update GitHub release again, turning it to a draft and causing a republish
- trigger NuGet deployment
- from updating the GitHub release and having to republish will cause another GitHub New Release Deployments action