### PR TITLE
Fix tab sequence

### DIFF
--- a/Flow.Launcher/CustomShortcutSetting.xaml
+++ b/Flow.Launcher/CustomShortcutSetting.xaml
@@ -118,24 +118,26 @@
                             FontSize="14"
                             Text="{DynamicResource customShortcutExpansion}" />
 
-                        <DockPanel
-                            Grid.Row="1"
-                            Grid.Column="1"
-                            LastChildFill="True">
-                            <Button
-                                x:Name="btnTestShortcut"
-                                Margin="0 0 10 0"
-                                Padding="10 5 10 5"
-                                Click="BtnTestShortcut_OnClick"
-                                Content="{DynamicResource preview}"
-                                DockPanel.Dock="Right" />
+                        <Grid Grid.Row="1" Grid.Column="1">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
                             <TextBox
                                 x:Name="tbExpand"
+                                Grid.Column="0"
                                 Margin="10 0 10 0"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Center"
                                 Text="{Binding Value}" />
-                        </DockPanel>
+                            <Button
+                                x:Name="btnTestShortcut"
+                                Grid.Column="1"
+                                Margin="0 0 10 0"
+                                Padding="10 5 10 5"
+                                Click="BtnTestShortcut_OnClick"
+                                Content="{DynamicResource preview}" />
+                        </Grid>
                     </Grid>
                 </StackPanel>
             </StackPanel>


### PR DESCRIPTION
Fix tab focus sequence in custom shortcut setting window.

Continuously type `Tab`. And obverse the element which gets the focus.

Original: Preview button is the second to get the focus.

https://github.com/user-attachments/assets/d8b41f0e-4830-4953-9c0e-5a538d533a3a

After: Preview button is the third to get the focus.

https://github.com/user-attachments/assets/b4ba79d2-d2c0-4c14-baf7-0a35e2e0854e