### PR TITLE
Support select file & folder in quick link access add button

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -22,6 +22,8 @@
     <system:String x:Key="plugin_explorer_directoryinfosearch_error">Error occurred during search: {0}</system:String>
     <system:String x:Key="plugin_explorer_opendir_error">Could not open folder</system:String>
     <system:String x:Key="plugin_explorer_openfile_error">Could not open file</system:String>
+    <system:String x:Key="plugin_explorer_quickAccessLinkFileOrFolderTitle">Select type</system:String>
+    <system:String x:Key="plugin_explorer_quickAccessLinkFileOrFolderSubtitle">Do you want to select a file?{0}{0}Click 'Yes' for file, 'No' for folder.</system:String>
 
     <!--  Controls  -->
     <system:String x:Key="plugin_explorer_delete">Delete</system:String>


### PR DESCRIPTION
Since quick link access paths support volumn / file / folder type, we should support these three type in quick link access add button.

Now when we click this button, we will get a message box to choose whether to select a file or a folder:

<img width="416" alt="image" src="https://github.com/user-attachments/assets/bf6000dd-6dbb-43a3-880f-e609cb526188" />

Test:

* test edit & add feature function of these three types 
