### PR TITLE
Fix false failing spell check rules

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,3 +1,5 @@
+# This file should contain names of products, companies, or individuals that aren't in a standard dictionary (e.g., GitHub, Keptn, VSCode).
+
 crowdin
 DWM
 workflows

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -34,7 +34,6 @@ mscorlib
 pythonw
 dotnet
 winget
-jjw24
 wolframalpha
 gmail
 duckduckgo
@@ -49,7 +48,6 @@ srchadmin
 EWX
 dlgtext
 CMD
-appref-ms
 appref
 TSource
 runas
@@ -57,7 +55,6 @@ dpi
 popup
 ptr
 pluginindicator
-TobiasSekan
 img
 resx
 bak
@@ -68,9 +65,6 @@ dlg
 ddd
 dddd
 clearlogfolder
-ACCENT_ENABLE_TRANSPARENTGRADIENT
-ACCENT_ENABLE_BLURBEHIND
-WCA_ACCENT_POLICY
 HGlobal
 dopusrt
 firefox

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -95,7 +95,5 @@ errormetadatafile
 noresult
 pluginsmanager
 alreadyexists
-JsonRPC
-JsonRPCV2
 Softpedia
 img

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -85,15 +85,10 @@ keyevent
 KListener
 requery
 vkcode
-čeština
 Polski
 Srpski
-Português
-Português (Brasil)
 Italiano
-Slovenský
 quicklook
-Tiếng Việt
 Droplex
 Preinstalled
 errormetadatafile

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -121,3 +121,7 @@
 
 # version suffix <word>v#
 (?:(?<=[A-Z]{2})V|(?<=[a-z]{2}|[A-Z]{2})v)\d+(?:\b|(?=[a-zA-Z_]))
+
+\bjjw24\b
+\bappref-ms\b
+\bTobiasSekan\b

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -125,3 +125,8 @@
 \bjjw24\b
 \bappref-ms\b
 \bTobiasSekan\b
+\bJsonRPC\b
+\bTiếng Việt\b
+\bSlovenský\b
+\bPortuguês (Brasil)\b
+\bčeština\b

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -127,6 +127,7 @@
 \bTobiasSekan\b
 \bJsonRPC\b
 \bTiếng Việt\b
-\bSlovenský\b
 \bPortuguês (Brasil)\b
 \bčeština\b
+\bPortuguês\b
+\bJsonRPC\b

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -1,4 +1,6 @@
 # See https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples:-patterns
+# This file should contain strings that contain a mix of letters and numbers, or specific symbols
+
 
 # Questionably acceptable forms of `in to`
 # Personally, I prefer `log into`, but people object

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -126,8 +126,8 @@
 \bappref-ms\b
 \bTobiasSekan\b
 \bJsonRPC\b
+\bJsonRPCV2\b
 \bTiếng Việt\b
 \bPortuguês (Brasil)\b
 \bčeština\b
 \bPortuguês\b
-\bJsonRPC\b


### PR DESCRIPTION
Fix false failing spell check rules.

patterns.txt use Cases:
- Alphanumeric Identifiers: Strings that contain a mix of letters and numbers, or specific symbols, which are common in code (like jjw24, SHA1Hash, myVar_v2).
- Specific Code Constructs: Regex patterns to ignore things that look like URLs, file paths, UUIDs, or specific syntax within comments that shouldn't be spell-checked as words.
- Technical Terms with Punctuation/Numbers: Terms that are not simple words but are common and should be ignored (e.g., camelCase, snake_case).

expect.txt use cases:
- Proper Nouns: Names of products, companies, or individuals that aren't in a standard dictionary (e.g., GitHub, Keptn, VSCode).
- Project-Specific Terminology: Unique terms or acronyms used within your project (e.g., DevOps, Agile).
- Temporary Allowances: Words that might technically be "incorrect" but are being temporarily tolerated for a specific reason (though expect.txt is generally for stable, accepted terms).
