### PR TITLE
Add GitHub workflow to trigger comment when indicate interest label applied

### DIFF
--- a/.github/workflows/indicate_interest_label.yml
+++ b/.github/workflows/indicate_interest_label.yml
@@ -1,0 +1,20 @@
+name: Indicate interest label
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  comment-on-indicate-interest-label:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'Indicate interest required'
+    steps:
+      - name: Comment after applying indicate interest label
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Thumbs up on the issue description if you would also like this feature request


### PR DESCRIPTION
Add GitHub workflow to trigger comment to ask user to thumb up on issue description when indicate interest label applied.

TODO:
testing