### PR TITLE
Calculator: Support hex numbers

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
@@ -20,7 +20,7 @@ namespace Flow.Launcher.Plugin.Calculator
                         @"bin2dec|hex2dec|oct2dec|" +
                         @"factorial|sign|isprime|isinfty|" +
                         @"==|~=|&&|\|\||(?:\<|\>)=?|" +
-                        @"[ei]|[0-9]|[\+\%\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
+                        @"[ei]|[0-9]|0x[\da-fA-F]+|[\+\%\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
                         @")+$", RegexOptions.Compiled);
         private static readonly Regex RegBrackets = new Regex(@"[\(\)\[\]]", RegexOptions.Compiled);
         private static Engine MagesEngine;


### PR DESCRIPTION
Allows hex numbers like `0x4F` to be used in the calculator plugin.