### PR TITLE
Fix Plugin Uninstallation Issue

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -552,9 +552,9 @@ namespace Flow.Launcher.Core.Plugin
             InstallPlugin(plugin, zipFilePath, checkModified: true);
         }
 
-        public static async Task UninstallPluginAsync(PluginMetadata plugin, bool removePluginFromSettings = true, bool removePluginSettings = false)
+        public static async Task UninstallPluginAsync(PluginMetadata plugin, bool removePluginSettings = false)
         {
-            await UninstallPluginAsync(plugin, removePluginFromSettings, removePluginSettings, true);
+            await UninstallPluginAsync(plugin, removePluginFromSettings: true, removePluginSettings: removePluginSettings, checkModified: true);
         }
 
         #endregion


### PR DESCRIPTION
In 

https://github.com/Flow-Launcher/Flow.Launcher/blob/e965b5682468da026f4a4f2c87d9c2f798b834e3/Flow.Launcher/PublicAPIInstance.cs#L575-L576

we only pass `removePluginSettings` parameter.

But in

https://github.com/Flow-Launcher/Flow.Launcher/blob/e965b5682468da026f4a4f2c87d9c2f798b834e3/Flow.Launcher.Core/Plugin/PluginManager.cs#L555-L558

we have accepted four parameters and `removePluginSettings` parameter is passed to `removePluginFromSettings` parameter which can cause possible issues