### PR TITLE
Check if plugin is modified before querying

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -290,7 +290,14 @@ namespace Flow.Launcher.Core.Plugin
                 return Array.Empty<PluginPair>();
 
             if (!NonGlobalPlugins.TryGetValue(query.ActionKeyword, out var plugin))
-                return GlobalPlugins;
+            {
+                return GlobalPlugins.Where(p => !PluginModified(p.Metadata.ID)).ToList();
+            }
+
+            if (API.PluginModified(plugin.Metadata.ID))
+            {
+                return Array.Empty<PluginPair>();
+            }
 
             return new List<PluginPair>
             {
@@ -300,7 +307,7 @@ namespace Flow.Launcher.Core.Plugin
 
         public static ICollection<PluginPair> ValidPluginsForHomeQuery()
         {
-            return _homePlugins.ToList();
+            return _homePlugins.Where(p => !PluginModified(p.Metadata.ID)).ToList();
         }
 
         public static async Task<List<Result>> QueryForPluginAsync(PluginPair pair, Query query, CancellationToken token)


### PR DESCRIPTION
If one plugin is modified, do not use it when querying results. 

From #3572