### PR TITLE
Enable dark mode if the system is in dark mode for Win32 windows

### DIFF
--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -791,5 +791,35 @@ namespace Flow.Launcher.Infrastructure
         }
 
         #endregion
+
+        #region Win32 Dark Mode
+
+        /*
+         * Inspired by https://github.com/ysc3839/win32-darkmode
+         */
+
+        [DllImport("uxtheme.dll", EntryPoint = "#135", SetLastError = true)]
+        private static extern int SetPreferredAppMode(int appMode);
+
+        public static void EnableWin32DarkMode()
+        {
+            try
+            {
+                // From Windows 10 1809
+                // AppMode: 0=Default, 1=AllowDark, 2=ForceDark, 3=ForceLight, 4=Max
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                    Environment.OSVersion.Version.Build >= 17763)
+                {
+                    _ = SetPreferredAppMode(1);
+                }
+
+            }
+            catch
+            {
+                // Ignore errors on unsupported OS
+            }
+        }
+
+        #endregion
     }
 }

--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -801,16 +801,22 @@ namespace Flow.Launcher.Infrastructure
         [DllImport("uxtheme.dll", EntryPoint = "#135", SetLastError = true)]
         private static extern int SetPreferredAppMode(int appMode);
 
-        public static void EnableWin32DarkMode()
+        public static void EnableWin32DarkMode(string colorScheme)
         {
             try
             {
-                // From Windows 10 1809
-                // AppMode: 0=Default, 1=AllowDark, 2=ForceDark, 3=ForceLight, 4=Max
+                // Undocumented API from Windows 10 1809
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
                     Environment.OSVersion.Version.Build >= 17763)
                 {
-                    _ = SetPreferredAppMode(1);
+                    var flag = colorScheme switch
+                    {
+                        Constant.Light => 3, // ForceLight
+                        Constant.Dark => 2, // ForceDark
+                        Constant.System => 1, // AllowDark
+                        _ => 0 // Default
+                    };
+                    _ = SetPreferredAppMode(flag);
                 }
 
             }

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -188,6 +188,9 @@ namespace Flow.Launcher
 
                 Notification.Install();
 
+                // Enable Win32 dark mode if the system is in dark mode before creating all windows
+                Win32Helper.EnableWin32DarkMode();
+
                 Ioc.Default.GetRequiredService<Portable>().PreStartCleanUpAfterPortabilityUpdate();
 
                 API.LogInfo(ClassName, "Begin Flow Launcher startup ----------------------------------------------------");

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -189,7 +189,7 @@ namespace Flow.Launcher
                 Notification.Install();
 
                 // Enable Win32 dark mode if the system is in dark mode before creating all windows
-                Win32Helper.EnableWin32DarkMode();
+                Win32Helper.EnableWin32DarkMode(_settings.ColorScheme);
 
                 Ioc.Default.GetRequiredService<Portable>().PreStartCleanUpAfterPortabilityUpdate();
 

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
@@ -136,6 +136,7 @@ public partial class SettingsPaneThemeViewModel : BaseModel
             };
             Settings.ColorScheme = value;
             _ = _theme.RefreshFrameAsync();
+            Win32Helper.EnableWin32DarkMode(value);
         }
     }
 


### PR DESCRIPTION
# Enable dark mode if the system is in dark mode for Win32 windows

For Win32 windows which cannot be set to dark mode by ModerWPFUI, we need to call `EnableWin32DarkMode` API to enable its dark mode.

And when users change the application theme mode setting, we should reset this API.

Example: Explorer context menu window.

Before:

![Screenshot 2025-07-05 225314](https://github.com/user-attachments/assets/59533041-45be-4643-9d2c-bef5d03e6cbe)

After:

![Screenshot 2025-07-05 230356](https://github.com/user-attachments/assets/9ad03b0a-e4fd-4f7f-ace6-6e12afe87dbb)

# Test
- Force light / Force dark / System theme change all work well