### PR TITLE
Remove plugins from global & non-global plugins when they are removed from settings

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -700,10 +700,7 @@ namespace Flow.Launcher.Core.Plugin
                 }
                 Settings.RemovePluginSettings(plugin.ID);
                 AllPlugins.RemoveAll(p => p.Metadata.ID == plugin.ID);
-                foreach (var globalPlugin in GlobalPlugins.Where(p => p.Metadata.ID == plugin.ID))
-                {
-                    GlobalPlugins.Remove(globalPlugin);
-                }
+                GlobalPlugins.RemoveWhere(p => p.Metadata.ID == plugin.ID);
                 foreach (var key in NonGlobalPlugins.Where(p => p.Value.Metadata.ID == plugin.ID).Select(p => p.Key))
                 {
                     NonGlobalPlugins.Remove(key);

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -701,7 +701,8 @@ namespace Flow.Launcher.Core.Plugin
                 Settings.RemovePluginSettings(plugin.ID);
                 AllPlugins.RemoveAll(p => p.Metadata.ID == plugin.ID);
                 GlobalPlugins.RemoveWhere(p => p.Metadata.ID == plugin.ID);
-                foreach (var key in NonGlobalPlugins.Where(p => p.Value.Metadata.ID == plugin.ID).Select(p => p.Key))
+                var keysToRemove = NonGlobalPlugins.Where(p => p.Value.Metadata.ID == plugin.ID).Select(p => p.Key).ToList();
+                foreach (var key in keysToRemove)
                 {
                     NonGlobalPlugins.Remove(key);
                 }

--- a/Flow.Launcher.Core/Plugin/PluginManager.cs
+++ b/Flow.Launcher.Core/Plugin/PluginManager.cs
@@ -700,6 +700,14 @@ namespace Flow.Launcher.Core.Plugin
                 }
                 Settings.RemovePluginSettings(plugin.ID);
                 AllPlugins.RemoveAll(p => p.Metadata.ID == plugin.ID);
+                foreach (var globalPlugin in GlobalPlugins.Where(p => p.Metadata.ID == plugin.ID))
+                {
+                    GlobalPlugins.Remove(globalPlugin);
+                }
+                foreach (var key in NonGlobalPlugins.Where(p => p.Value.Metadata.ID == plugin.ID).Select(p => p.Key))
+                {
+                    NonGlobalPlugins.Remove(key);
+                }
             }
 
             // Marked for deletion. Will be deleted on next start up


### PR DESCRIPTION
# Remove plugins from global & non-global plugins when they are removed from settings

This can resolve the issue from @jjw24:

```
Store uninstall plugin with option set to no restart, when using the plugin's action keyword, query window seems unresponsive, e.g. remove bookmark plugin and use b balabala
pm uninstall plugin with option set to no restart, when using the plugin's action keyword, query window seems unresponsive, e.g. remove bookmark plugin and use b balabala
```