### PR TITLE
Generate documents for NuGet package

### DIFF
--- a/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
+++ b/Flow.Launcher.Plugin/Flow.Launcher.Plugin.csproj
@@ -27,6 +27,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(APPVEYOR)' == 'True'">


### PR DESCRIPTION
# Generate documents for NuGet package

Currently, FLow.Launcher.Plugin NuGet package does not have documents when referring to its classes, etc.

This attribution is for enabling the documents in NuGet package so that developers can use it more effectively.

# Test

Use the NuGet package in CI:

![image](https://github.com/user-attachments/assets/bfbe36d3-a03f-49d1-badb-893d9d019f8b)