### PR TITLE
Update home page when language changes

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -284,6 +284,10 @@ namespace Flow.Launcher
                         break;
                     case nameof(Settings.Language):
                         UpdateNotifyIconText();
+                        if (_settings.ShowHomePage && _viewModel.QueryResultsSelected() && string.IsNullOrEmpty(_viewModel.QueryText))
+                        {
+                            _viewModel.QueryResults();
+                        }
                         break;
                     case nameof(Settings.Hotkey):
                         UpdateNotifyIconText();


### PR DESCRIPTION
# Changes

- When search is empty and Home Page feature is enabled, if the language is changed, the home page will not be updated by its translation until next non-empty query. So we should check if home page is shown and update the translations

# Test

- Enable Home Page and change language, the search window results will be updated