### PR TITLE
Fix Home Page Update Issue

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -323,12 +323,6 @@ namespace Flow.Launcher
                     case nameof(Settings.ShowAtTopmost):
                         Topmost = _settings.ShowAtTopmost;
                         break;
-                    case nameof(Settings.OpenResultModifiers):
-                        if (_viewModel.QueryResultsSelected() && string.IsNullOrEmpty(_viewModel.QueryText))
-                        {
-                            _viewModel.QueryResults();
-                        }
-                        break;
                 }
             };
 

--- a/Flow.Launcher/ResultListBox.xaml
+++ b/Flow.Launcher/ResultListBox.xaml
@@ -80,7 +80,7 @@
                                     Style="{DynamicResource ItemHotkeyStyle}">
                                     <TextBlock.Text>
                                         <MultiBinding StringFormat="{}{0}+{1}">
-                                            <Binding Path="OpenResultModifiers" />
+                                            <Binding Mode="OneWay" Path="Settings.OpenResultModifiers" />
                                             <Binding Converter="{StaticResource ResourceKey=OrdinalConverter}" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=ListBoxItem}" />
                                         </MultiBinding>
                                     </TextBlock.Text>

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -149,8 +149,6 @@ namespace Flow.Launcher.ViewModel
 
         private bool PreviewImageAvailable => !string.IsNullOrEmpty(Result.Preview.PreviewImagePath) || Result.Preview.PreviewDelegate != null;
 
-        public string OpenResultModifiers => Settings.OpenResultModifiers;
-
         public string ShowTitleToolTip => string.IsNullOrEmpty(Result.TitleToolTip)
             ? Result.Title
             : Result.TitleToolTip;


### PR DESCRIPTION
# Changes

* When we edit these two options, home page should be updated now
   * Change hotkey & modifier binding to one way binding so that the visibility of result hotkey and hotkey modifier string will be changed once the settings are updated.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/12fe2e58-7f60-4f63-ab62-4ffa18c5c339" />
