### PR TITLE
Add Support for Automatically Checking Plugin Updates

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginInstaller.cs
+++ b/Flow.Launcher.Core/Plugin/PluginInstaller.cs
@@ -284,7 +284,7 @@ public static class PluginInstaller
     /// <param name="usePrimaryUrlOnly">If true, only use the primary URL for updates.</param>
     /// <param name="token">Cancellation token to cancel the update operation.</param>
     /// <returns></returns>
-    public static async Task UpdatePluginAsync(bool silentUpdate = true, bool usePrimaryUrlOnly = false, CancellationToken token = default)
+    public static async Task CheckForPluginUpdatesAsync(bool silentUpdate = true, bool usePrimaryUrlOnly = false, CancellationToken token = default)
     {
         // Update the plugin manifest
         await API.UpdatePluginManifestAsync(usePrimaryUrlOnly, token);

--- a/Flow.Launcher.Core/Plugin/PluginInstaller.cs
+++ b/Flow.Launcher.Core/Plugin/PluginInstaller.cs
@@ -281,7 +281,7 @@ public static class PluginInstaller
     /// <summary>
     /// Updates the plugin to the latest version available from its source.
     /// </summary>
-    /// <param name="silentUpdate">If true, do not show any messages when there is no udpate available.</param>
+    /// <param name="silentUpdate">If true, do not show any messages when there is no update available.</param>
     /// <param name="usePrimaryUrlOnly">If true, only use the primary URL for updates.</param>
     /// <param name="token">Cancellation token to cancel the update operation.</param>
     /// <returns></returns>

--- a/Flow.Launcher.Core/Plugin/PluginInstaller.cs
+++ b/Flow.Launcher.Core/Plugin/PluginInstaller.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -327,17 +328,20 @@ public static class PluginInstaller
             return;
         }
 
-        if (API.ShowMsgBox(
-            string.Format(API.GetTranslation("updateAllPluginsSubtitle"),
-            Environment.NewLine, string.Join(", ", resultsForUpdate.Select(x => x.PluginExistingMetadata.Name))),
+        // Show message box with button to update all plugins
+        API.ShowMsgWithButton(
             API.GetTranslation("updateAllPluginsTitle"),
-            MessageBoxButton.YesNo) == MessageBoxResult.No)
-        {
-            return;
-        }
+            API.GetTranslation("updateAllPluginsButtonContent"),
+            () =>
+            {
+                UpdateAllPlugins(resultsForUpdate);
+            },
+            string.Join(", ", resultsForUpdate.Select(x => x.PluginExistingMetadata.Name)));
+    }
 
-        // Update all plugins
-        await Task.WhenAll(resultsForUpdate.Select(async plugin =>
+    private static void UpdateAllPlugins(IEnumerable<dynamic> resultsForUpdate)
+    {
+        _ = Task.WhenAll(resultsForUpdate.Select(async plugin =>
         {
             var downloadToFilePath = Path.Combine(Path.GetTempPath(), $"{plugin.Name}-{plugin.NewVersion}.zip");
 

--- a/Flow.Launcher.Core/Plugin/PluginInstaller.cs
+++ b/Flow.Launcher.Core/Plugin/PluginInstaller.cs
@@ -300,14 +300,14 @@ public static class PluginInstaller
                   0 // if current version precedes version of the plugin from update source (e.g. PluginsManifest)
                   && !API.PluginModified(existingPlugin.Metadata.ID)
             select
-                new
+                new PluginUpdateInfo()
                 {
-                    existingPlugin.Metadata.ID,
-                    pluginUpdateSource.Name,
-                    pluginUpdateSource.Author,
+                    ID = existingPlugin.Metadata.ID,
+                    Name = existingPlugin.Metadata.Name,
+                    Author = existingPlugin.Metadata.Author,
                     CurrentVersion = existingPlugin.Metadata.Version,
                     NewVersion = pluginUpdateSource.Version,
-                    existingPlugin.Metadata.IcoPath,
+                    IcoPath = existingPlugin.Metadata.IcoPath,
                     PluginExistingMetadata = existingPlugin.Metadata,
                     PluginNewUserPlugin = pluginUpdateSource
                 }).ToList();
@@ -339,7 +339,7 @@ public static class PluginInstaller
             string.Join(", ", resultsForUpdate.Select(x => x.PluginExistingMetadata.Name)));
     }
 
-    private static void UpdateAllPlugins(IEnumerable<dynamic> resultsForUpdate)
+    private static void UpdateAllPlugins(IEnumerable<PluginUpdateInfo> resultsForUpdate)
     {
         _ = Task.WhenAll(resultsForUpdate.Select(async plugin =>
         {
@@ -444,5 +444,17 @@ public static class PluginInstaller
             !string.IsNullOrEmpty(x.Metadata.Website) &&
             x.Metadata.Website.StartsWith(constructedUrlPart)
         );
+    }
+
+    private record PluginUpdateInfo
+    {
+        public string ID { get; init; }
+        public string Name { get; init; }
+        public string Author { get; init; }
+        public string CurrentVersion { get; init; }
+        public string NewVersion { get; init; }
+        public string IcoPath { get; init; }
+        public PluginMetadata PluginExistingMetadata { get; init; }
+        public UserPlugin PluginNewUserPlugin { get; init; }
     }
 }

--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -233,6 +233,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
 
         public bool AutoRestartAfterChanging { get; set; } = false;
         public bool ShowUnknownSourceWarning { get; set; } = true;
+        public bool AutoUpdatePlugins { get; set; } = true;
 
         public int CustomExplorerIndex { get; set; } = 0;
 

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -239,6 +239,7 @@ namespace Flow.Launcher
 
                 AutoStartup();
                 AutoUpdates();
+                AutoPluginUpdates();
 
                 API.SaveAppAllSettings();
                 API.LogInfo(ClassName, "End Flow Launcher startup ----------------------------------------------------");
@@ -285,6 +286,23 @@ namespace Flow.Launcher
                     while (await timer.WaitForNextTickAsync())
                         // check updates on startup
                         await Ioc.Default.GetRequiredService<Updater>().UpdateAppAsync();
+                }
+            });
+        }
+
+        private static void AutoPluginUpdates()
+        {
+            _ = Task.Run(async () =>
+            {
+                if (_settings.AutoUpdatePlugins)
+                {
+                    // check plugin updates every 5 hour
+                    var timer = new PeriodicTimer(TimeSpan.FromHours(5));
+                    await PluginInstaller.UpdatePluginAsync();
+
+                    while (await timer.WaitForNextTickAsync())
+                        // check updates on startup
+                        await PluginInstaller.UpdatePluginAsync();
                 }
             });
         }

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -298,11 +298,11 @@ namespace Flow.Launcher
                 {
                     // check plugin updates every 5 hour
                     var timer = new PeriodicTimer(TimeSpan.FromHours(5));
-                    await PluginInstaller.UpdatePluginAsync();
+                    await PluginInstaller.CheckForPluginUpdatesAsync();
 
                     while (await timer.WaitForNextTickAsync())
                         // check updates on startup
-                        await PluginInstaller.UpdatePluginAsync();
+                        await PluginInstaller.CheckForPluginUpdatesAsync();
                 }
             });
         }

--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -251,7 +251,7 @@ namespace Flow.Launcher
         /// Check startup only for Release
         /// </summary>
         [Conditional("RELEASE")]
-        private void AutoStartup()
+        private static void AutoStartup()
         {
             // we try to enable auto-startup on first launch, or reenable if it was removed
             // but the user still has the setting set
@@ -272,7 +272,7 @@ namespace Flow.Launcher
         }
 
         [Conditional("RELEASE")]
-        private void AutoUpdates()
+        private static void AutoUpdates()
         {
             _ = Task.Run(async () =>
             {

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -237,6 +237,7 @@
     <system:String x:Key="updateNoResultSubtitle">All plugins are up to date</system:String>
     <system:String x:Key="updateAllPluginsTitle">Update all plugins</system:String>
     <system:String x:Key="updateAllPluginsSubtitle">Would you like to update these plugins?{0}{0}{1}</system:String>
+    <system:String x:Key="checkPluginUpdatesTooltip">Check plugin updates</system:String>
 
     <!--  Setting Theme  -->
     <system:String x:Key="theme">Theme</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -117,7 +117,7 @@
     <system:String x:Key="DoublePinyinSchemasXingKongJianDao">Xing Kong Jian Dao</system:String>
     <system:String x:Key="DoublePinyinSchemasDaNiu">Da Niu</system:String>
     <system:String x:Key="DoublePinyinSchemasXiaoLang">Xiao Lang</system:String>
-    
+
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
     <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>
     <system:String x:Key="shadowEffectNotAllowed">Shadow effect is not allowed while current theme has blur effect enabled</system:String>
@@ -150,6 +150,8 @@
     <system:String x:Key="autoRestartAfterChangingToolTip">Restart Flow Launcher automatically after installing/uninstalling/updating plugin via Plugin Store</system:String>
     <system:String x:Key="showUnknownSourceWarning">Show unknown source warning</system:String>
     <system:String x:Key="showUnknownSourceWarningToolTip">Show warning when installing plugins from unknown sources</system:String>
+    <system:String x:Key="autoUpdatePlugins">Auto update plugins</system:String>
+    <system:String x:Key="autoUpdatePluginsToolTip">Automatically check plugin updates every 1 hour and notify if there are any updates available</system:String>
 
     <!--  Setting Plugin  -->
     <system:String x:Key="searchplugin">Search Plugin</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -235,8 +235,8 @@
     <system:String x:Key="installLocalPluginTooltip">Install plugin from local path</system:String>
     <system:String x:Key="updateNoResultTitle">No update available</system:String>
     <system:String x:Key="updateNoResultSubtitle">All plugins are up to date</system:String>
-    <system:String x:Key="updateAllPluginsTitle">Update all plugins</system:String>
-    <system:String x:Key="updateAllPluginsSubtitle">Would you like to update these plugins?{0}{0}{1}</system:String>
+    <system:String x:Key="updateAllPluginsTitle">Plugin updates available</system:String>
+    <system:String x:Key="updateAllPluginsButtonContent">Update all plugins</system:String>
     <system:String x:Key="checkPluginUpdatesTooltip">Check plugin updates</system:String>
 
     <!--  Setting Theme  -->

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -151,7 +151,7 @@
     <system:String x:Key="showUnknownSourceWarning">Show unknown source warning</system:String>
     <system:String x:Key="showUnknownSourceWarningToolTip">Show warning when installing plugins from unknown sources</system:String>
     <system:String x:Key="autoUpdatePlugins">Auto update plugins</system:String>
-    <system:String x:Key="autoUpdatePluginsToolTip">Automatically check plugin updates every 1 hour and notify if there are any updates available</system:String>
+    <system:String x:Key="autoUpdatePluginsToolTip">Automatically check plugin updates and notify if there are any updates available</system:String>
 
     <!--  Setting Plugin  -->
     <system:String x:Key="searchplugin">Search Plugin</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -233,6 +233,10 @@
     <system:String x:Key="ZipFiles">Zip files</system:String>
     <system:String x:Key="SelectZipFile">Please select zip file</system:String>
     <system:String x:Key="installLocalPluginTooltip">Install plugin from local path</system:String>
+    <system:String x:Key="updateNoResultTitle">No update available</system:String>
+    <system:String x:Key="updateNoResultSubtitle">All plugins are up to date</system:String>
+    <system:String x:Key="updateAllPluginsTitle">Update all plugins</system:String>
+    <system:String x:Key="updateAllPluginsSubtitle">Would you like to update these plugins?{0}{0}{1}</system:String>
 
     <!--  Setting Theme  -->
     <system:String x:Key="theme">Theme</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -93,6 +93,7 @@
     <system:String x:Key="typingStartEn">Always Start Typing in English Mode</system:String>
     <system:String x:Key="typingStartEnTooltip">Temporarily change your input method to English mode when activating Flow.</system:String>
     <system:String x:Key="autoUpdates">Auto Update</system:String>
+    <system:String x:Key="autoUpdatesTooltip">Automatically check app updates and notify if there are any updates available</system:String>
     <system:String x:Key="select">Select</system:String>
     <system:String x:Key="hideOnStartup">Hide Flow Launcher on startup</system:String>
     <system:String x:Key="hideOnStartupToolTip">Flow Launcher search window is hidden in the tray after starting up.</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -93,7 +93,7 @@
     <system:String x:Key="typingStartEn">Always Start Typing in English Mode</system:String>
     <system:String x:Key="typingStartEnTooltip">Temporarily change your input method to English mode when activating Flow.</system:String>
     <system:String x:Key="autoUpdates">Auto Update</system:String>
-    <system:String x:Key="autoUpdatesTooltip">Automatically check app updates and notify if there are any updates available</system:String>
+    <system:String x:Key="autoUpdatesTooltip">Automatically check and update the app when available</system:String>
     <system:String x:Key="select">Select</system:String>
     <system:String x:Key="hideOnStartup">Hide Flow Launcher on startup</system:String>
     <system:String x:Key="hideOnStartupToolTip">Flow Launcher search window is hidden in the tray after starting up.</system:String>

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
@@ -112,7 +112,7 @@ public partial class SettingsPanePluginStoreViewModel : BaseModel
     [RelayCommand]
     private async Task CheckPluginUpdatesAsync()
     {
-        await PluginInstaller.UpdatePluginAsync(silentUpdate: false);
+        await PluginInstaller.CheckForPluginUpdatesAsync(silentUpdate: false);
     }
 
     private static string GetFileFromDialog(string title, string filter = "")

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
@@ -109,6 +109,12 @@ public partial class SettingsPanePluginStoreViewModel : BaseModel
             await PluginInstaller.InstallPluginAndCheckRestartAsync(file);
     }
 
+    [RelayCommand]
+    private async Task CheckPluginUpdatesAsync()
+    {
+        await PluginInstaller.UpdatePluginAsync(silentUpdate: false);
+    }
+
     private static string GetFileFromDialog(string title, string filter = "")
     {
         var dlg = new Microsoft.Win32.OpenFileDialog

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
@@ -241,9 +241,20 @@
                     Title="{DynamicResource showUnknownSourceWarning}"
                     Icon="&#xE7BA;"
                     Sub="{DynamicResource showUnknownSourceWarningToolTip}"
-                    Type="Last">
+                    Type="Middle">
                     <ui:ToggleSwitch
                         IsOn="{Binding Settings.ShowUnknownSourceWarning}"
+                        OffContent="{DynamicResource disable}"
+                        OnContent="{DynamicResource enable}" />
+                </cc:Card>
+
+                <cc:Card
+                    Title="{DynamicResource autoUpdatePlugins}"
+                    Icon="&#xecc5;"
+                    Sub="{DynamicResource autoUpdatePluginsToolTip}"
+                    Type="Last">
+                    <ui:ToggleSwitch
+                        IsOn="{Binding Settings.AutoUpdatePlugins}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}" />
                 </cc:Card>
@@ -372,7 +383,7 @@
             </cc:Card>
 
             <cc:CardGroup Margin="0 4 0 0">
-                <cc:Card                
+                <cc:Card
                     Title="{DynamicResource ShouldUsePinyin}"
                     Icon="&#xe98a;"
                     Sub="{DynamicResource ShouldUsePinyinToolTip}"
@@ -384,12 +395,12 @@
                         ToolTip="{DynamicResource ShouldUsePinyinToolTip}" />
                 </cc:Card>
                 <cc:Card
-                    Visibility="{ext:VisibleWhen {Binding ShouldUsePinyin},
-                                    IsEqualToBool=True}"
                     Title="{DynamicResource ShouldUseDoublePinyin}"
                     Icon="&#xf085;"
                     Sub="{DynamicResource ShouldUseDoublePinyinToolTip}"
-                    Type="Middle">
+                    Type="Middle"
+                    Visibility="{ext:VisibleWhen {Binding ShouldUsePinyin},
+                                                 IsEqualToBool=True}">
                     <ui:ToggleSwitch
                         IsOn="{Binding UseDoublePinyin}"
                         OffContent="{DynamicResource disable}"
@@ -397,11 +408,11 @@
                         ToolTip="{DynamicResource ShouldUseDoublePinyinToolTip}" />
                 </cc:Card>
                 <cc:Card
-                    Visibility="{ext:VisibleWhen {Binding UseDoublePinyin},
-                                                        IsEqualToBool=True}"
                     Title="{DynamicResource DoublePinyinSchema}"
                     Sub="{DynamicResource DoublePinyinSchemaToolTip}"
-                    Type="Last">
+                    Type="Last"
+                    Visibility="{ext:VisibleWhen {Binding UseDoublePinyin},
+                                                 IsEqualToBool=True}">
                     <ComboBox
                         DisplayMemberPath="Display"
                         ItemsSource="{Binding DoublePinyinSchemas}"

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
@@ -182,7 +182,8 @@
             <cc:Card
                 Title="{DynamicResource autoUpdates}"
                 Margin="0 14 0 0"
-                Icon="&#xecc5;">
+                Icon="&#xecc5;"
+                Sub="{DynamicResource autoUpdatesTooltip}">
                 <ui:ToggleSwitch
                     IsOn="{Binding AutoUpdates}"
                     OffContent="{DynamicResource disable}"

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml
@@ -99,6 +99,13 @@
                     ToolTip="{DynamicResource installLocalPluginTooltip}">
                     <ui:FontIcon FontSize="14" Glyph="&#xE8DA;" />
                 </Button>
+                <Button
+                    Height="34"
+                    Margin="0 0 10 0"
+                    Command="{Binding CheckPluginUpdatesCommand}"
+                    ToolTip="{DynamicResource checkPluginUpdatesTooltip}">
+                    <ui:FontIcon FontSize="14" Glyph="&#xecc5;" />
+                </Button>
                 <TextBox
                     Name="PluginStoreFilterTextbox"
                     Width="150"


### PR DESCRIPTION
# Changes

* Add Auto Update description

<img width="500" alt="image" src="https://github.com/user-attachments/assets/695d81cf-376c-4269-acc5-80746a3da8eb" />

* Add Auto Update Plugins option which can automatically check plugin updates in the background every 5 hours

<img width="500" alt="Screenshot 2025-07-14 163214" src="https://github.com/user-attachments/assets/1f43e483-d1cc-4f82-9ead-6abd5bb80559" />

* Add an option to check plugin updates in plugin store page

<img width="500" alt="Screenshot 2025-07-14 163239" src="https://github.com/user-attachments/assets/2cebc020-97bb-4b7e-b1b5-dddea2fa3408" />

# Test

<img width="350" alt="Screenshot 2025-07-14 163145" src="https://github.com/user-attachments/assets/5d3270e6-7bc3-4268-ac18-55947c9f6555" />

<img width="350" height="196" alt="Screenshot 2025-07-14 163424" src="https://github.com/user-attachments/assets/5a3a6406-cc0a-40b3-980d-1f076179e3b1" />

# One more thing

Since the plugin update message is implemented with message instead of message box which I do not think it will annoy users, I use default True value for Auto Update Plugins.