### PR TITLE
Change double pinyin panel design

### DIFF
--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
@@ -371,44 +371,37 @@
                     OnContent="{DynamicResource enable}" />
             </cc:Card>
 
-            <cc:CardGroup Margin="0 4 0 0">
-                <cc:Card                
-                    Title="{DynamicResource ShouldUsePinyin}"
-                    Icon="&#xe98a;"
-                    Sub="{DynamicResource ShouldUsePinyinToolTip}"
-                    Type="First">
-                    <ui:ToggleSwitch
-                        IsOn="{Binding ShouldUsePinyin}"
-                        OffContent="{DynamicResource disable}"
-                        OnContent="{DynamicResource enable}"
-                        ToolTip="{DynamicResource ShouldUsePinyinToolTip}" />
-                </cc:Card>
-                <cc:Card
-                    Visibility="{ext:VisibleWhen {Binding ShouldUsePinyin},
-                                    IsEqualToBool=True}"
-                    Title="{DynamicResource ShouldUseDoublePinyin}"
-                    Icon="&#xf085;"
-                    Sub="{DynamicResource ShouldUseDoublePinyinToolTip}"
-                    Type="Middle">
+            <cc:Card
+                Title="{DynamicResource ShouldUsePinyin}"
+                Margin="0 4 0 0"
+                Icon="&#xe98a;"
+                Sub="{DynamicResource ShouldUsePinyinToolTip}">
+                <ui:ToggleSwitch
+                    IsOn="{Binding ShouldUsePinyin}"
+                    OffContent="{DynamicResource disable}"
+                    OnContent="{DynamicResource enable}"
+                    ToolTip="{DynamicResource ShouldUsePinyinToolTip}" />
+            </cc:Card>
+
+            <cc:ExCard
+                Title="{DynamicResource ShouldUseDoublePinyin}"
+                Icon="&#xf085;"
+                Sub="{DynamicResource ShouldUseDoublePinyinToolTip}">
+                <cc:ExCard.SideContent>
                     <ui:ToggleSwitch
                         IsOn="{Binding UseDoublePinyin}"
                         OffContent="{DynamicResource disable}"
                         OnContent="{DynamicResource enable}"
                         ToolTip="{DynamicResource ShouldUseDoublePinyinToolTip}" />
-                </cc:Card>
-                <cc:Card
-                    Visibility="{ext:VisibleWhen {Binding UseDoublePinyin},
-                                                        IsEqualToBool=True}"
-                    Title="{DynamicResource DoublePinyinSchema}"
-                    Sub="{DynamicResource DoublePinyinSchemaToolTip}"
-                    Type="Last">
+                </cc:ExCard.SideContent>
+                <cc:Card Title="{DynamicResource DoublePinyinSchema}" Type="InsideFit">
                     <ComboBox
                         DisplayMemberPath="Display"
                         ItemsSource="{Binding DoublePinyinSchemas}"
                         SelectedValue="{Binding Settings.DoublePinyinSchema}"
                         SelectedValuePath="Value" />
                 </cc:Card>
-            </cc:CardGroup>
+            </cc:ExCard>
 
             <cc:Card
                 Title="{DynamicResource language}"


### PR DESCRIPTION
# Change double pinyin panel design

<img width="600" alt="image" src="https://github.com/user-attachments/assets/2c43e19c-e841-4b47-a363-1825a03e2bc8" />

Reason for this changing:
* Originally, we use visibility to organize the relationship of these options, but it looks little strange since all elements in setting window do not use this in its design.
* Now I change it to expand card & card design to make it look more unified with others.

Follows on from https://github.com/Flow-Launcher/Flow.Launcher/pull/2427