### PR TITLE
Add Empty Query Returning & Change ThemeSelector Keyword with ActionKeyword for Sys Plugin

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
@@ -72,7 +72,7 @@ namespace Flow.Launcher.Plugin.Sys
 
             var commands = Commands(query);
             var results = new List<Result>();
-            var isEmptyQuery = string.IsNullOrEmpty(query.Search) || string.IsNullOrWhiteSpace(query.Search);
+            var isEmptyQuery = string.IsNullOrWhiteSpace(query.Search);
             foreach (var c in commands)
             {
                 var command = _settings.Commands.First(x => x.Key == c.Title);

--- a/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
@@ -497,7 +497,15 @@ namespace Flow.Launcher.Plugin.Sys
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\ue790"),
                     Action = c =>
                     {
-                        _context.API.ChangeQuery($"{query.ActionKeyword}{ (string.IsNullOrEmpty(query.ActionKeyword) ? string.Empty : Plugin.Query.ActionKeywordSeparator)}{ThemeSelector.Keyword}{Plugin.Query.ActionKeywordSeparator}");
+                        if (string.IsNullOrEmpty(query.ActionKeyword))
+                        {
+                            _context.API.ChangeQuery($"{ThemeSelector.Keyword}{Plugin.Query.ActionKeywordSeparator}");
+                        }
+                        else
+                        {
+                            _context.API.ChangeQuery($"{query.ActionKeyword}{Plugin.Query.ActionKeywordSeparator}{ThemeSelector.Keyword}{Plugin.Query.ActionKeywordSeparator}");
+
+                        }
                         return false;
                     }
                 }

--- a/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
@@ -70,13 +70,19 @@ namespace Flow.Launcher.Plugin.Sys
                 return _themeSelector.Query(query);
             }
 
-            var commands = Commands();
+            var commands = Commands(query);
             var results = new List<Result>();
+            var isEmptyQuery = string.IsNullOrEmpty(query.Search) || string.IsNullOrWhiteSpace(query.Search);
             foreach (var c in commands)
             {
                 var command = _settings.Commands.First(x => x.Key == c.Title);
                 c.Title = command.Name;
                 c.SubTitle = command.Description;
+                if (isEmptyQuery)
+                {
+                    results.Add(c);
+                    continue;
+                }
 
                 // Match from localized title & localized subtitle & keyword
                 var titleMatch = _context.API.FuzzySearch(query.Search, c.Title);
@@ -188,7 +194,7 @@ namespace Flow.Launcher.Plugin.Sys
             }
         }
 
-        private List<Result> Commands()
+        private List<Result> Commands(Query query)
         {
             var results = new List<Result>();
             var recycleBinFolder = "shell:RecycleBinFolder";
@@ -491,7 +497,7 @@ namespace Flow.Launcher.Plugin.Sys
                     Glyph = new GlyphInfo (FontFamily:"/Resources/#Segoe Fluent Icons", Glyph:"\ue790"),
                     Action = c =>
                     {
-                        _context.API.ChangeQuery($"{ThemeSelector.Keyword} ");
+                        _context.API.ChangeQuery($"{query.ActionKeyword}{ (string.IsNullOrEmpty(query.ActionKeyword) ? string.Empty : Plugin.Query.ActionKeywordSeparator)}{ThemeSelector.Keyword}{Plugin.Query.ActionKeywordSeparator}");
                         return false;
                     }
                 }


### PR DESCRIPTION
1. Support returning all usable commands while query is empty. 
#2040 
2. ChangeQuery by ThemeSelector Action with ActionKeyword  at the front as well
