### PR TITLE
Fix message box vertically center issue when message type is not OK

### DIFF
--- a/Flow.Launcher/MessageBoxEx.xaml.cs
+++ b/Flow.Launcher/MessageBoxEx.xaml.cs
@@ -37,8 +37,9 @@ namespace Flow.Launcher
             try
             {
                 msgBox = new MessageBoxEx(button);
-                if (caption == string.Empty && button == MessageBoxButton.OK && icon == MessageBoxImage.None)
+                if (caption == string.Empty && icon == MessageBoxImage.None)
                 {
+                    // If there is no caption and no icon, use DescOnlyTextBlock for vertically centered text
                     msgBox.Title = messageBoxText;
                     msgBox.DescOnlyTextBlock.Visibility = Visibility.Visible;
                     msgBox.DescOnlyTextBlock.Text = messageBoxText;


### PR DESCRIPTION
If message box ex type is not OK and it has no caption and icon, it will not set description to vertically center. This PR is for resolving this issue.

Test:

WebSearch delete dialog:

Orig:
<img width="300" alt="Screenshot 2025-07-17 113429" src="https://github.com/user-attachments/assets/323579f1-8451-437f-8bb4-e3d1bd8342eb" />

After:
<img width="300" alt="Screenshot 2025-07-17 114946" src="https://github.com/user-attachments/assets/b51bbb5e-a9a7-49d1-b3ec-a51631c2c169" />

