### PR TITLE
Fix dialog jump issue when result will not be execueted under empty query option

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -501,15 +501,14 @@ namespace Flow.Launcher.ViewModel
             // For Dialog Jump and left click mode, we need to navigate to the path
             if (_isDialogJump && Settings.DialogJumpResultBehaviour == DialogJumpResultBehaviours.LeftClick)
             {
-                Hide();
-
-                if (SelectedResults.SelectedItem != null && DialogWindowHandle != nint.Zero)
+                if (result is DialogJumpResult dialogJumpResult)
                 {
-                    if (result is DialogJumpResult dialogJumpResult)
-                    {
-                        Win32Helper.SetForegroundWindow(DialogWindowHandle);
-                        _ = Task.Run(() => DialogJump.JumpToPathAsync(DialogWindowHandle, dialogJumpResult.DialogJumpPath));
-                    }
+                    Win32Helper.SetForegroundWindow(DialogWindowHandle);
+                    _ = Task.Run(() => DialogJump.JumpToPathAsync(DialogWindowHandle, dialogJumpResult.DialogJumpPath));
+                }
+                else
+                {
+                    App.API.LogError(ClassName, "DialogJumpResult expected but got a different result type.");
                 }
             }
             // For query mode, we execute the result


### PR DESCRIPTION
# CHANGES

Originally, if users select empty query option, Flow will call `Hide()` before checking result `SelectedResults.SelectedItem != null` which can cause that `SelectedResults.SelectedItem` is cleared to null, leading to result check failure.

So I have applied these two changes to make it work and work better:

- Remove `SelectedResults.SelectedItem != null` check since we have already gotten the selected item `result`
- Remove `DialogWindowHandle != nint.Zero` check since we have already checked `_isDialogJump` flag
- Do not hide search window when clicking results since right clicking to open will not hide search window, so we should keep their behaviour in consistence.

Resolve #3861.