### PR TITLE
Do not create customized preview panel when preview is off

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -534,8 +534,6 @@
                             MinHeight="380"
                             MaxHeight="{Binding ElementName=ResultListBox, Path=ActualHeight}"
                             Padding="0 0 10 10"
-
-
                             Visibility="{Binding ShowCustomizedPreview}">
                             <ContentControl Content="{Binding CustomizedPreviewControl}" />
                         </Border>

--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -534,10 +534,10 @@
                             MinHeight="380"
                             MaxHeight="{Binding ElementName=ResultListBox, Path=ActualHeight}"
                             Padding="0 0 10 10"
-                            d:DataContext="{d:DesignInstance vm:ResultViewModel}"
-                            DataContext="{Binding PreviewSelectedItem, Mode=OneWay}"
+
+
                             Visibility="{Binding ShowCustomizedPreview}">
-                            <ContentControl Content="{Binding Result.PreviewPanel.Value}" />
+                            <ContentControl Content="{Binding CustomizedPreviewControl}" />
                         </Border>
                     </Grid>
                 </Grid>

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -9,6 +9,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.DependencyInjection;
@@ -882,6 +883,12 @@ namespace Flow.Launcher.ViewModel
                 }
             }
         }
+
+        public Visibility ShowCustomizedPreview
+            => InternalPreviewVisible && PreviewSelectedItem?.Result.PreviewPanel != null ? Visibility.Visible : Visibility.Collapsed;
+
+        public UserControl CustomizedPreviewControl
+            => ShowCustomizedPreview == Visibility.Visible ? PreviewSelectedItem?.Result.PreviewPanel.Value : null;
 
         public Visibility ProgressBarVisibility { get; set; }
         public Visibility MainWindowVisibility { get; set; }

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -66,8 +66,6 @@ namespace Flow.Launcher.ViewModel
 
         public Visibility ShowDefaultPreview => Result.PreviewPanel == null ? Visibility.Visible : Visibility.Collapsed;
 
-        public Visibility ShowCustomizedPreview => Result.PreviewPanel == null ? Visibility.Collapsed : Visibility.Visible;
-
         public Visibility ShowIcon
         {
             get


### PR DESCRIPTION
# Do not create customized preview panel when preview is off

From https://github.com/TBM13/Flow.Launcher/commit/4db994c2a137c7313c3e66ae04a4006fdf357997. Thanks @TBM13!

# Test

- Toggle Always preview to off
- Search for some files (Use Explorer plugin results)
- PreviewPanel is not created if preview control is invisible