### PR TITLE
Clear plugin list selection to make sure all items can be mouse hovered

### DIFF
--- a/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml
@@ -122,6 +122,7 @@
                 FontSize="14"
                 ItemContainerStyle="{StaticResource PluginList}"
                 ItemsSource="{Binding Source={StaticResource PluginCollectionView}}"
+                Loaded="PluginListBox_Loaded"
                 ScrollViewer.CanContentScroll="False"
                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                 SnapsToDevicePixels="True"

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Navigation;
@@ -31,6 +33,14 @@ public partial class SettingsPanePlugins
         }
         _viewModel.PropertyChanged += ViewModel_PropertyChanged;
         base.OnNavigatedTo(e);
+    }
+
+    private void PluginListBox_Loaded(object sender, RoutedEventArgs e)
+    {
+        // After list is loaded, we need to clear selection to make sure all items can be mouse hovered
+        // because the selected item cannot be hovered.
+        if (sender is not ListBox listBox) return;
+        listBox.SelectedIndex = -1;
     }
 
     private void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
# CHANGES

Clear selection to make sure all items can be mouse hovered.

# TEST

Hover your mouse on the first item of the plugin list.

Original:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/55058485-a037-4061-bff3-5264aac893b6" />

After:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/d1b31f6b-9185-44d6-99dd-0b0d1082ed2b" />