### PR TITLE
Fix property binding in WebSearch plugin

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Settings.cs
@@ -7,6 +7,8 @@ namespace Flow.Launcher.Plugin.WebSearch
 {
     public class Settings : BaseModel
     {
+        private bool enableSuggestion;
+
         public Settings()
         {
             SelectedSuggestion = Suggestions[0];
@@ -191,7 +193,15 @@ namespace Flow.Launcher.Plugin.WebSearch
         [JsonIgnore]
         public SearchSource SelectedSearchSource { get; set; }
 
-        public bool EnableSuggestion { get; set; }
+        public bool EnableSuggestion
+        {
+            get => enableSuggestion;
+            set
+            {
+                enableSuggestion = value;
+                OnPropertyChanged(nameof(EnableSuggestion));
+            }
+        }
 
         [JsonIgnore]
         public SuggestionSource[] Suggestions { get; set; } = {

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Settings.cs
@@ -231,9 +231,5 @@ namespace Flow.Launcher.Plugin.WebSearch
                 }
             }
         }
-
-        public string BrowserPath { get; set; }
-
-        public bool OpenInNewBrowser { get; set; } = true;
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
@@ -11,10 +11,6 @@
     mc:Ignorable="d">
 
     <UserControl.Resources>
-        <Style x:Key="BrowserPathBoxStyle" TargetType="TextBox">
-            <Setter Property="Height" Value="28" />
-            <Setter Property="VerticalContentAlignment" Value="Center" />
-        </Style>
         <DataTemplate x:Key="HeaderTemplateArrowUp">
             <DockPanel>
                 <TextBlock HorizontalAlignment="Center" Text="{Binding}" />

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
@@ -138,7 +138,7 @@
                     Margin="{StaticResource SettingPanelItemLeftMargin}"
                     VerticalAlignment="Center"
                     FontSize="11"
-                    IsEnabled="{Binding ElementName=EnableSuggestion, Path=IsChecked}"
+                    IsEnabled="{Binding Settings.EnableSuggestion}"
                     ItemsSource="{Binding Settings.Suggestions}"
                     SelectedItem="{Binding Settings.SelectedSuggestion}" />
                 <CheckBox
@@ -149,7 +149,6 @@
                     Content="{DynamicResource flowlauncher_plugin_websearch_enable_suggestion}"
                     IsChecked="{Binding Settings.EnableSuggestion}" />
             </StackPanel>
-            <!--  Not sure why binding IsEnabled directly to Settings.EnableWebSearchSuggestion is not working  -->
         </DockPanel>
     </Grid>
 </UserControl>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml.cs
@@ -94,7 +94,8 @@ namespace Flow.Launcher.Plugin.WebSearch
             var columnBinding = headerClicked.Column.DisplayMemberBinding as Binding;
             var sortBy = columnBinding?.Path.Path ?? headerClicked.Column.Header as string;
 
-            if(sortBy != null) { 
+            if (sortBy != null)
+            {
                 Sort(sortBy, direction);
 
                 if (direction == ListSortDirection.Ascending)

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/setting.json
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/setting.json
@@ -141,6 +141,6 @@
       "Enabled": true
     }
   ],
-  "EnableWebSearchSuggestion": false,
-  "WebSearchSuggestionSource": "Google"
+  "EnableSuggestion": false,
+  "Suggestion": "Google"
 }


### PR DESCRIPTION
The `OnPropertyChanged` was not triggered, that is why there was a workaround for binding Settings.EnableSuggestion in the WebSearch plugin.