### PR TITLE
Add private mode option to WebSearch plugin items

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/ar.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/ar.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">تعديل</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">إضافة</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">مفعل</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">مفعل</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">مُعطّل</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">تأكيد</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/cs.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/cs.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Editovat</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Přidat</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Povoleno</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Povoleno</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Deaktivován</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Potvrdit</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/da.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/da.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Rediger</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Tilføj</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Enabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirm</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/de.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/de.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Bearbeiten</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Hinzufügen</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Aktiviert</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Aktiviert</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Deaktiviert</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Bestätigen</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/en.xaml
@@ -13,6 +13,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Edit</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Add</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Enabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirm</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/es-419.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/es-419.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Editar</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Añadir</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Enabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirmar</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/es.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/es.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Editar</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Añadir</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Activado</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Activado</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Desactivado</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirmar</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/fr.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/fr.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Modifier</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Ajouter</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Activé</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Activé</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Désactivé</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirmer</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/he.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/he.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">ערו</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">הוסף</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">מופעל</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">מופעל</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">מושבת</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">אישו</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/it.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/it.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Modifica</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Aggiungi</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Abilitato</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Abilitato</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabilitato</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Conferma</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/ja.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/ja.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">編集</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">追加</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Enabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirm</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/ko.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/ko.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">편집</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">추가</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">켬</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">켬</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">확인</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/nb.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/nb.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Rediger</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Legg til</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Aktivert</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Aktivert</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Deaktivert</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Bekreft</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/nl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/nl.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Bewerken</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Toevoegen</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Enabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirm</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/pl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/pl.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Edytuj</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Dodaj</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Aktywny</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Aktywny</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Wyłączony</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Potwierdź</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/pt-br.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/pt-br.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Editar</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Adicionar</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Enabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirm</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/pt-pt.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/pt-pt.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Editar</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Adicionar</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Ativo</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Ativo</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Inativo</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirmar</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/ru.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/ru.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Редактировать</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Добавить</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Enabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Отключён</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirm</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/sk.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/sk.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Upraviť</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Pridať</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Povolené</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Zapnuté</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Vypnuté</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Potvrdiť</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/sr.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/sr.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Izmeni</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Dodaj</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Enabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Confirm</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/tr.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/tr.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Düzenle</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Ekle</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Enabled</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Enabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Onayla</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/uk-UA.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/uk-UA.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Редагувати</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Додати</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Увімкнено</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Увімкнено</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Вимкнено</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Підтвердити</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/vi.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/vi.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">Sửa</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">Thêm</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">Đã bật</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">Đã bật</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Vô hiệu hóa</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">Xác nhận</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/zh-cn.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/zh-cn.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">编辑</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">添加</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">启用</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">已启用</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">已禁用</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">确认</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/zh-tw.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Languages/zh-tw.xaml
@@ -11,6 +11,7 @@
     <system:String x:Key="flowlauncher_plugin_websearch_edit">編輯</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_add">新增</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_enabled_label">已啟用</system:String>
+    <system:String x:Key="flowlauncher_plugin_websearch_private_mode_label">Private mode</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_true">已啟用</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_false">Disabled</system:String>
     <system:String x:Key="flowlauncher_plugin_websearch_confirm">確定</system:String>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Main.cs
@@ -71,7 +71,7 @@ namespace Flow.Launcher.Plugin.WebSearch
                         Score = score,
                         Action = c =>
                         {
-                            _context.API.OpenWebUrl(searchSource.Url.Replace("{q}", Uri.EscapeDataString(keyword)));
+                            _context.API.OpenWebUrl(searchSource.Url.Replace("{q}", Uri.EscapeDataString(keyword)), searchSource.IsPrivateMode);
 
                             return true;
                         },
@@ -135,7 +135,7 @@ namespace Flow.Launcher.Plugin.WebSearch
                 ActionKeywordAssigned = searchSource.ActionKeyword == SearchSourceGlobalPluginWildCardSign ? string.Empty : searchSource.ActionKeyword,
                 Action = c =>
                 {
-                    _context.API.OpenWebUrl(searchSource.Url.Replace("{q}", Uri.EscapeDataString(o)));
+                    _context.API.OpenWebUrl(searchSource.Url.Replace("{q}", Uri.EscapeDataString(o)), searchSource.IsPrivateMode);
 
                     return true;
                 },

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSource.cs
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSource.cs
@@ -7,6 +7,7 @@ namespace Flow.Launcher.Plugin.WebSearch
     public class SearchSource : BaseModel
     {
         public string Title { get; set; }
+
         public string ActionKeyword { get; set; }
 
         [NotNull]
@@ -19,21 +20,17 @@ namespace Flow.Launcher.Plugin.WebSearch
         /// Custom icons are placed in the user data directory
         /// </summary>
         [JsonIgnore]
-        public string IconPath 
-        {
-            get
-            {
-                if (CustomIcon)
-                    return Path.Combine(Main.CustomImagesDirectory, Icon);
-
-                return Path.Combine(Main.DefaultImagesDirectory, Icon);
-            }
-        }
+        public string IconPath => CustomIcon 
+            ? Path.Combine(Main.CustomImagesDirectory, Icon) 
+            : Path.Combine(Main.DefaultImagesDirectory, Icon);
 
         public string Url { get; set; }
 
         [JsonIgnore]
         public bool Status => Enabled;
+
+        public bool IsPrivateMode { get; set; }
+
         public bool Enabled { get; set; }
 
         public SearchSource DeepCopy()
@@ -45,8 +42,10 @@ namespace Flow.Launcher.Plugin.WebSearch
                 Url = Url,
                 Icon = Icon,
                 CustomIcon = CustomIcon,
+                IsPrivateMode = IsPrivateMode,
                 Enabled = Enabled
             };
+
             return webSearch;
         }
     }

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
@@ -101,6 +101,7 @@
                                     <RowDefinition />
                                     <RowDefinition />
                                     <RowDefinition />
+                                    <RowDefinition />
                                 </Grid.RowDefinitions>
                                 <TextBlock
                                     Grid.Row="0"
@@ -181,11 +182,25 @@
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
                                     FontSize="14"
-                                    Text="{DynamicResource flowlauncher_plugin_websearch_enabled_label}" />
+                                    Text="{DynamicResource flowlauncher_plugin_websearch_private_mode_label}" />
                                 <CheckBox
                                     Grid.Row="4"
                                     Grid.Column="1"
                                     Margin="10 10 10 15"
+                                    VerticalAlignment="Center"
+                                    IsChecked="{Binding SearchSource.IsPrivateMode}" />
+                                <TextBlock
+                                    Grid.Row="5"
+                                    Grid.Column="0"
+                                    Margin="10 0 10 10"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    FontSize="14"
+                                    Text="{DynamicResource flowlauncher_plugin_websearch_enabled_label}" />
+                                <CheckBox
+                                    Grid.Row="5"
+                                    Grid.Column="1"
+                                    Margin="10 0 10 10"
                                     VerticalAlignment="Center"
                                     IsChecked="{Binding SearchSource.Enabled}" />
                             </Grid>

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SettingsControl.xaml
@@ -96,6 +96,20 @@
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
+                    <GridViewColumn
+                        Width="120"
+                        Header="{DynamicResource flowlauncher_plugin_websearch_private_mode_label}">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <CheckBox
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    IsChecked="{Binding IsPrivateMode}"
+                                    IsEnabled="False"
+                                    />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
                 </GridView>
             </ListView.View>
         </ListView>


### PR DESCRIPTION
This PR adds a "Private mode" option to individual setting items in the WebSearch plugin.
When enabled, and if Private mode is also configured in
`Flow Launcher → General → Default Web Browser`, links from these
items will open in a private browsing window — independently of other items’ settings.

This allows finer control over which links open in private mode,
without requiring all links to follow the same browser privacy
setting.

I'm not sure if I need to add the placeholders for the localization files or not.

**Some screenshots:**

<img width="1217" height="551" alt="image" src="https://github.com/user-attachments/assets/22ecd2e9-e547-44e8-aa18-354cedd84767" />

<img width="1225" height="914" alt="image" src="https://github.com/user-attachments/assets/e07f9770-611e-4e52-85b2-e5d9bfd18920" />
