### PR TITLE
Fix possible image recursive loading

### DIFF
--- a/Flow.Launcher/ViewModel/PluginViewModel.cs
+++ b/Flow.Launcher/ViewModel/PluginViewModel.cs
@@ -37,12 +37,17 @@ namespace Flow.Launcher.ViewModel
             OnPropertyChanged(nameof(Image));
         }
 
+        private bool _imageLoaded = false;
+
         public ImageSource Image
         {
             get
             {
-                if (_image == ImageLoader.MissingImage)
+                if (!_imageLoaded)
+                {
+                    _imageLoaded = true;
                     _ = LoadIconAsync();
+                }
 
                 return _image;
             }


### PR DESCRIPTION
# Fix possible image recursive loading

If this image is missing, `_image == ImageLoader.MissingImage` will always be true, which can cause recursive loading. So we should use loaded flag to indicate this