### PR TITLE
Use ShowMsgError API Function & Handle E_ABORT COMException

### DIFF
--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -382,21 +382,17 @@ namespace Flow.Launcher
             catch (Win32Exception ex) when (ex.NativeErrorCode == 2)
             {
                 LogError(ClassName, "File Manager not found");
-                ShowMsgBox(
+                ShowMsgError(
                     string.Format(GetTranslation("fileManagerNotFound"), ex.Message),
-                    GetTranslation("fileManagerNotFoundTitle"),
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Error
+                    GetTranslation("fileManagerNotFoundTitle")
                 );
             }
             catch (Exception ex)
             {
                 LogException(ClassName, "Failed to open folder", ex);
-                ShowMsgBox(
+                ShowMsgError(
                     string.Format(GetTranslation("folderOpenError"), ex.Message),
-                    GetTranslation("errorTitle"),
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Error
+                    GetTranslation("errorTitle")
                 );
             }
         }
@@ -424,11 +420,9 @@ namespace Flow.Launcher
                 {
                     var tabOrWindow = browserInfo.OpenInTab ? "tab" : "window";
                     LogException(ClassName, $"Failed to open URL in browser {tabOrWindow}: {path}, {inPrivate ?? browserInfo.EnablePrivate}, {browserInfo.PrivateArg}", e);
-                    ShowMsgBox(
+                    ShowMsgError(
                         GetTranslation("browserOpenError"),
-                        GetTranslation("errorTitle"),
-                        MessageBoxButton.OK,
-                        MessageBoxImage.Error
+                        GetTranslation("errorTitle")
                     );
                 }
             }


### PR DESCRIPTION
# Use ShowMsgError API Function

Use `ShowMsgError` instead of `ShowMsgBox` so that Flow will not bother users a lot.

# Handle E_ABORT COMException

Handle E_ABORT COMException in `OpenDirectory` so that Flow will not try to open folder when users cancel the action.

Resolve #3893.