### PR TITLE
Clean orphan files, temp fix

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
@@ -36,6 +36,26 @@ public class Main : ISettingProvider, IPlugin, IReloadable, IPluginI18n, IContex
         _faviconCacheDir = Path.Combine(
             context.CurrentPluginMetadata.PluginCacheDirectoryPath,
             "FaviconCache");
+        
+        try
+        {
+            if (Directory.Exists(_faviconCacheDir))
+            {
+                var files = Directory.GetFiles(_faviconCacheDir);
+                foreach (var file in files)
+                {
+                    var extension = Path.GetExtension(file);
+                    if (extension is ".db-shm" or ".db-wal" or ".sqlite-shm" or ".sqlite-wal")
+                    {
+                        File.Delete(file);
+                    }
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Context.API.LogException(ClassName, "Failed to clean up orphaned cache files.", e);
+        }
 
         LoadBookmarksIfEnabled();
     }


### PR DESCRIPTION
Clean orphan SQLite files on start-up that are being created by BrowserBookmark plugin.  This is a temporary solution to prevent users' cache accumulating very large numbers of files / MB.

Will be addressed properly with new version of plugin (complete rewrite for Flow Launcher V2).