### PR TITLE
Fix Explorer preview panel issue

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
@@ -5,9 +5,9 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:sys="clr-namespace:System;assembly=System.Runtime"
-    DataContext="{Binding RelativeSource={RelativeSource Self}}"
     d:DesignHeight="300"
     d:DesignWidth="300"
+    DataContext="{Binding RelativeSource={RelativeSource Self}}"
     mc:Ignorable="d">
     <Grid x:Name="PreviewGrid" VerticalAlignment="Stretch">
         <Grid.RowDefinitions>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:sys="clr-namespace:System;assembly=System.Runtime"
+    DataContext="{Binding RelativeSource={RelativeSource Self}}"
     d:DesignHeight="300"
     d:DesignWidth="300"
     mc:Ignorable="d">

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
@@ -56,7 +56,7 @@
             <TextBlock
                 Margin="5 8 8 8"
                 Style="{DynamicResource PreviewItemSubTitleStyle}"
-                Text="{Binding Result.SubTitle}" />
+                Text="{Binding FilePath}" />
             <Rectangle
                 Width="Auto"
                 Height="1"

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
@@ -37,15 +37,6 @@
             </Grid>
         </Grid>
         <StackPanel Grid.Row="1">
-            <StackPanel.Style>
-                <Style TargetType="StackPanel">
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding Result.SubTitle.Length}" Value="0">
-                            <Setter Property="Visibility" Value="Collapsed" />
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </StackPanel.Style>
             <Rectangle
                 x:Name="PreviewSep"
                 Width="Auto"

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
@@ -24,14 +24,14 @@
                 MaxWidth="96"
                 MaxHeight="96"
                 Margin="5 12 8 0"
-                Source="{Binding PreviewImage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" />
+                Source="{Binding PreviewImage, IsAsync=True, Mode=OneWay}" />
             <Grid Grid.Row="1">
                 <TextBlock
                     Margin="5 6 5 16"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Top"
                     Style="{DynamicResource PreviewItemTitleStyle}"
-                    Text="{Binding FileName}"
+                    Text="{Binding FileName, Mode=OneTime}"
                     TextAlignment="Center"
                     TextWrapping="Wrap" />
             </Grid>
@@ -47,7 +47,7 @@
             <TextBlock
                 Margin="5 8 8 8"
                 Style="{DynamicResource PreviewItemSubTitleStyle}"
-                Text="{Binding FilePath}" />
+                Text="{Binding FilePath, Mode=OneTime}" />
             <Rectangle
                 Width="Auto"
                 Height="1"
@@ -60,9 +60,9 @@
                         <Style.Triggers>
                             <MultiDataTrigger>
                                 <MultiDataTrigger.Conditions>
-                                    <Condition Binding="{Binding FileSizeVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" Value="Collapsed" />
-                                    <Condition Binding="{Binding CreatedAtVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" Value="Collapsed" />
-                                    <Condition Binding="{Binding LastModifiedAtVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" Value="Collapsed" />
+                                    <Condition Binding="{Binding FileSizeVisibility}" Value="Collapsed" />
+                                    <Condition Binding="{Binding CreatedAtVisibility}" Value="Collapsed" />
+                                    <Condition Binding="{Binding LastModifiedAtVisibility}" Value="Collapsed" />
                                 </MultiDataTrigger.Conditions>
                                 <Setter Property="Visibility" Value="Collapsed" />
                             </MultiDataTrigger>
@@ -70,7 +70,7 @@
                     </Style>
                 </Rectangle.Style>
             </Rectangle>
-            <Grid Margin="0 10 0 0" Visibility="{Binding FileInfoVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}">
+            <Grid Margin="0 10 0 0" Visibility="{Binding FileInfoVisibility, Mode=OneTime}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="100" />
                     <ColumnDefinition Width="*" />
@@ -88,7 +88,7 @@
                     Style="{DynamicResource PreviewItemSubTitleStyle}"
                     Text="{DynamicResource FileSize}"
                     TextWrapping="Wrap"
-                    Visibility="{Binding FileSizeVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" />
+                    Visibility="{Binding FileSizeVisibility, Mode=OneTime}" />
                 <TextBlock
                     Grid.Row="0"
                     Grid.Column="1"
@@ -96,9 +96,9 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top"
                     Style="{DynamicResource PreviewItemSubTitleStyle}"
-                    Text="{Binding FileSize, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}, Mode=OneWay}"
+                    Text="{Binding FileSize, Mode=OneWay}"
                     TextWrapping="Wrap"
-                    Visibility="{Binding FileSizeVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" />
+                    Visibility="{Binding FileSizeVisibility, Mode=OneTime}" />
 
                 <TextBlock
                     Grid.Row="1"
@@ -108,7 +108,7 @@
                     Style="{DynamicResource PreviewItemSubTitleStyle}"
                     Text="{DynamicResource Created}"
                     TextWrapping="Wrap"
-                    Visibility="{Binding CreatedAtVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" />
+                    Visibility="{Binding CreatedAtVisibility, Mode=OneTime}" />
                 <TextBlock
                     Grid.Row="1"
                     Grid.Column="1"
@@ -116,9 +116,9 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top"
                     Style="{DynamicResource PreviewItemSubTitleStyle}"
-                    Text="{Binding CreatedAt, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}"
+                    Text="{Binding CreatedAt, Mode=OneWay}"
                     TextWrapping="Wrap"
-                    Visibility="{Binding CreatedAtVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" />
+                    Visibility="{Binding CreatedAtVisibility, Mode=OneTime}" />
 
                 <TextBlock
                     Grid.Row="2"
@@ -128,7 +128,7 @@
                     Style="{DynamicResource PreviewItemSubTitleStyle}"
                     Text="{DynamicResource LastModified}"
                     TextWrapping="Wrap"
-                    Visibility="{Binding LastModifiedAtVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" />
+                    Visibility="{Binding LastModifiedAtVisibility, Mode=OneTime}" />
                 <TextBlock
                     Grid.Row="2"
                     Grid.Column="1"
@@ -136,9 +136,9 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top"
                     Style="{DynamicResource PreviewItemSubTitleStyle}"
-                    Text="{Binding LastModifiedAt, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}"
+                    Text="{Binding LastModifiedAt, Mode=OneWay}"
                     TextWrapping="Wrap"
-                    Visibility="{Binding LastModifiedAtVisibility, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" />
+                    Visibility="{Binding LastModifiedAtVisibility, Mode=OneTime}" />
             </Grid>
         </StackPanel>
     </Grid>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
@@ -21,19 +21,10 @@
             </Grid.RowDefinitions>
             <Image
                 Grid.Row="0"
+                MaxWidth="96"
+                MaxHeight="96"
                 Margin="5 12 8 0"
-                Source="{Binding PreviewImage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}">
-                <Image.Style>
-                    <Style TargetType="Image">
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding UseBigThumbnail}" Value="False">
-                                <Setter Property="MaxWidth" Value="96" />
-                                <Setter Property="MaxHeight" Value="96" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Image.Style>
-            </Image>
+                Source="{Binding PreviewImage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=UserControl}}" />
             <Grid Grid.Row="1">
                 <TextBlock
                     Margin="5 6 5 16"

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml
@@ -31,7 +31,7 @@
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Top"
                     Style="{DynamicResource PreviewItemTitleStyle}"
-                    Text="{Binding Result.Title}"
+                    Text="{Binding FileName}"
                     TextAlignment="Center"
                     TextWrapping="Wrap" />
             </Grid>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
@@ -21,7 +21,8 @@ public partial class PreviewPanel : UserControl
 {
     private static readonly string ClassName = nameof(PreviewPanel);
 
-    private string FilePath { get; }
+    public string FilePath { get; }
+    public string FileName { get; }
     public string FileSize { get; private set; } = Main.Context.API.GetTranslation("plugin_explorer_plugin_tooltip_more_info_unknown");
     public string CreatedAt { get; } = "";
     public string LastModifiedAt { get; } = "";
@@ -57,11 +58,11 @@ public partial class PreviewPanel : UserControl
 
     public PreviewPanel(Settings settings, string filePath, ResultType type)
     {
-        InitializeComponent();
-
         Settings = settings;
-
         FilePath = filePath;
+        FileName = Path.GetFileName(filePath);
+
+        InitializeComponent();
 
         if (Settings.ShowFileSizeInPreviewPanel)
         {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/PreviewPanel.xaml.cs
@@ -23,21 +23,20 @@ public partial class PreviewPanel : UserControl
 
     public string FilePath { get; }
     public string FileName { get; }
-    public string FileSize { get; private set; } = Main.Context.API.GetTranslation("plugin_explorer_plugin_tooltip_more_info_unknown");
-    public string CreatedAt { get; } = "";
-    public string LastModifiedAt { get; } = "";
-    private ImageSource _previewImage = new BitmapImage();
-    private Settings Settings { get; }
 
-    public ImageSource PreviewImage
-    {
-        get => _previewImage;
-        private set
-        {
-            _previewImage = value;
-            OnPropertyChanged();
-        }
-    }
+    [ObservableProperty]
+    private string _fileSize = Main.Context.API.GetTranslation("plugin_explorer_plugin_tooltip_more_info_unknown");
+    
+    [ObservableProperty]
+    private string _createdAt = "";
+    
+    [ObservableProperty]
+    private string _lastModifiedAt = "";
+
+    [ObservableProperty]
+    private ImageSource _previewImage = new BitmapImage();
+
+    private Settings Settings { get; }
 
     public Visibility FileSizeVisibility => Settings.ShowFileSizeInPreviewPanel
         ? Visibility.Visible


### PR DESCRIPTION
# Fix Explorer preview panel issue

- Fix many preview panel binding issue in Explorer plugin.
- Add file name & file path in preview panel of Explorer plugin.
- Use DataContext instead of RelativeResource for code quality.
- Use `ObservableProperty` to generate dependency properties.

# Test

Original:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/5569ee17-ef00-45a6-80ee-19a3aa6d4f16" />

with many binding issues

<img width="600" alt="image" src="https://github.com/user-attachments/assets/51190f62-5155-4510-a590-2e741eb27c7d" />

After:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/03fa97e6-db53-495b-9489-127e4e8226ec" />