### PR TITLE
Check plugin updates only for Release

### DIFF
--- a/Flow.Launcher/App.xaml.cs
+++ b/Flow.Launcher/App.xaml.cs
@@ -297,6 +297,7 @@ namespace Flow.Launcher
             });
         }
 
+        [Conditional("RELEASE")]
         private static void AutoPluginUpdates()
         {
             _ = Task.Run(async () =>


### PR DESCRIPTION
# Check plugin updates only for Release

Follow on with #3827.

When we start Flow on Debug configuration, Flow will pop up this message every time it starts since all pre-released plugins are in version 1.0.0. So let us check plugin updates only for release to remove that annoying message to improve development experience.

<img width="377" height="263" alt="image" src="https://github.com/user-attachments/assets/ee7da4aa-a14e-4363-b384-3ae94cbb73e4" />