### PR TITLE
Allow setting of minimum app version plugin requirement

### DIFF
--- a/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
@@ -45,16 +45,16 @@ namespace Flow.Launcher.Core.ExternalPlugins
 
                     lastFetchedAt = DateTime.Now;
 
-                    var updatedPluginResult = new List<UserPlugin>();
+                    var updatedPluginResults = new List<UserPlugin>();
                     var appVersion = SemanticVersioning.Version.Parse(Constant.Version);
                     
                     for (int i = 0; i < results.Count; i++)
                     {
                         if (IsMinimumAppVersionSatisfied(results[i], appVersion))
-                            updatedPluginResult.Add(results[i]);
+                            updatedPluginResults.Add(results[i]);
                     }
 
-                    UserPlugins = updatedPluginResult;
+                    UserPlugins = updatedPluginResults;
 
                     return true;
                 }

--- a/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Plugin;
+using Flow.Launcher.Infrastructure;
 
 namespace Flow.Launcher.Core.ExternalPlugins
 {
@@ -39,13 +40,23 @@ namespace Flow.Launcher.Core.ExternalPlugins
                     var results = await mainPluginStore.FetchAsync(token, usePrimaryUrlOnly).ConfigureAwait(false);
 
                     // If the results are empty, we shouldn't update the manifest because the results are invalid.
-                    if (results.Count != 0)
-                    {
-                        UserPlugins = results;
-                        lastFetchedAt = DateTime.Now;
+                    if (results.Count == 0)
+                        return false;
 
-                        return true;
+                    lastFetchedAt = DateTime.Now;
+
+                    var updatedPluginResult = new List<UserPlugin>();
+                    var appVersion = SemanticVersioning.Version.Parse(Constant.Version);
+                    
+                    for (int i = 0; i < results.Count; i++)
+                    {
+                        if (IsMinimumAppVersionSatisfied(results[i], appVersion))
+                            updatedPluginResult.Add(results[i]);
                     }
+
+                    UserPlugins = updatedPluginResult;
+
+                    return true;
                 }
             }
             catch (Exception e)
@@ -56,6 +67,17 @@ namespace Flow.Launcher.Core.ExternalPlugins
             {
                 manifestUpdateLock.Release();
             }
+
+            return false;
+        }
+
+        private static bool IsMinimumAppVersionSatisfied(UserPlugin plugin, SemanticVersioning.Version appVersion)
+        {
+            if (string.IsNullOrEmpty(plugin.MinimumAppVersion) || appVersion >= SemanticVersioning.Version.Parse(plugin.MinimumAppVersion))
+                return true;
+
+            API.LogDebug(ClassName, $"Plugin {plugin.Name} requires minimum Flow Launcher version {plugin.MinimumAppVersion}, "
+                    + $"but current version is {Constant.Version}. Plugin excluded from manifest.");
 
             return false;
         }

--- a/Flow.Launcher.Plugin/UserPlugin.cs
+++ b/Flow.Launcher.Plugin/UserPlugin.cs
@@ -76,5 +76,10 @@ namespace Flow.Launcher.Plugin
         /// Indicates whether the plugin is installed from a local path
         /// </summary>
         public bool IsFromLocalInstallPath => !string.IsNullOrEmpty(LocalInstallPath);
+
+        /// <summary>
+        /// The minimum Flow Launcher version required for this plugin. Default is "".
+        /// </summary>
+        public string MinimumAppVersion { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
Allows plugin to specify in the their plugin manifest, a new optional property 'MinimumAppVersion', e.g. `"MinimumAppVersion": "2.0.0"`. When the user's is running flow v1.20.2 or below, the plugin will not show up in the Store or the PluginsManager install command results. 

The goal is to prevent users from downloading a plugin version that uses an API method not available in their older flow version, or trying to upgrade to the latest plugin version that is not compatible with their existing outdated flow installation.

Tested:
- plugin excluded from manifest after sync if current user's app version does not meet the minimum requirement.
-  plugin included where app version meets the minimum required version or if the MinimumAppVersion is undefined
- MinimumAppVersion specified in plugin.json file does not have any impact 