### PR TITLE
Switch plugins manifest file download URL to be from main branch

### DIFF
--- a/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
@@ -13,10 +13,10 @@ namespace Flow.Launcher.Core.ExternalPlugins
         private static readonly string ClassName = nameof(PluginsManifest);
 
         private static readonly CommunityPluginStore mainPluginStore =
-            new("https://raw.githubusercontent.com/Flow-Launcher/Flow.Launcher.PluginsManifest/plugin_api_v2/plugins.json",
-                "https://fastly.jsdelivr.net/gh/Flow-Launcher/Flow.Launcher.PluginsManifest@plugin_api_v2/plugins.json",
-                "https://gcore.jsdelivr.net/gh/Flow-Launcher/Flow.Launcher.PluginsManifest@plugin_api_v2/plugins.json",
-                "https://cdn.jsdelivr.net/gh/Flow-Launcher/Flow.Launcher.PluginsManifest@plugin_api_v2/plugins.json");
+            new("https://raw.githubusercontent.com/Flow-Launcher/Flow.Launcher.PluginsManifest/main/plugins.json",
+                "https://fastly.jsdelivr.net/gh/Flow-Launcher/Flow.Launcher.PluginsManifest@main/plugins.json",
+                "https://gcore.jsdelivr.net/gh/Flow-Launcher/Flow.Launcher.PluginsManifest@main/plugins.json",
+                "https://cdn.jsdelivr.net/gh/Flow-Launcher/Flow.Launcher.PluginsManifest@main/plugins.json");
 
         private static readonly SemaphoreSlim manifestUpdateLock = new(1);
 


### PR DESCRIPTION
For v2.0.0 flow, we switch the manifest file plugins.json back to the main branch. This is due to .NET 9 upgrade, we need to prevent older flow versions from updating to plugins in this release. Default plugins are now on .NET 9 and will not work with older versions.

Follows on from #3286 

Todos:
- [ ] PluginsManifest
- [ ] Website