### PR TITLE
Add maximum results shown warning when always preview is on

### DIFF
--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -327,6 +327,7 @@
     <system:String x:Key="PlaceholderTextTip">Change placeholder text. Input empty will use: {0}</system:String>
     <system:String x:Key="KeepMaxResults">Fixed Window Size</system:String>
     <system:String x:Key="KeepMaxResultsToolTip">The window size is not adjustable by dragging.</system:String>
+    <system:String x:Key="MaxShowResultsCannotWorkWithAlwaysPreview">Since Always Preview is on, maximum results shown may not take effect because preview panel requires a certain minimum height</system:String>
 
     <!--  Setting Hotkey  -->
     <system:String x:Key="hotkey">Hotkey</system:String>

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneTheme.xaml
@@ -545,6 +545,15 @@
                         SelectedItem="{Binding Settings.MaxResultsToShow}" />
                 </cc:Card>
             </cc:ExCard>
+            <cc:InfoBar
+                Title=""
+                Margin="0 4 0 0"
+                Closable="False"
+                IsIconVisible="True"
+                Length="Long"
+                Message="{DynamicResource MaxShowResultsCannotWorkWithAlwaysPreview}"
+                Type="Warning"
+                Visibility="{Binding Settings.AlwaysPreview, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
 
             <!--  Time and date  -->
             <cc:CardGroup Margin="0 14 0 0">


### PR DESCRIPTION
# Add maximum results shown warning when always preview is on

Since preview panel requires a certain minimum height, maximum results shown may not take effect. So we need to add a warning to notify users for that. (I even thought this is a bug originally😢)

<img width="600" alt="image" src="https://github.com/user-attachments/assets/d2866fc9-dea8-4b01-ba1b-0518727c635b" />

# Test

When we enable the Always Preview and set a small number for maximum results shown, it will not take effect since preview panel requires a minimum height.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/ed099682-817c-41a3-b3c3-34d7c4ae561a" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/d00fff92-e6f7-41fb-9b03-7c08d9314f80" />
