### PR TITLE
Handle MinimumAppVersion parse fail and reorder last manifest fetch date

### DIFF
--- a/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
@@ -88,7 +88,7 @@ namespace Flow.Launcher.Core.ExternalPlugins
                 return false;
             }
 
-            API.LogDebug(ClassName, $"Plugin {plugin.Name} requires minimum Flow Launcher version {plugin.MinimumAppVersion}, "
+            API.LogInfo(ClassName, $"Plugin {plugin.Name} requires minimum Flow Launcher version {plugin.MinimumAppVersion}, "
                     + $"but current version is {Constant.Version}. Plugin excluded from manifest.");
 
             return false;


### PR DESCRIPTION
Handle MinimumAppVersion parse fail and reorder last manifest fetch date

Follows on from https://github.com/Flow-Launcher/Flow.Launcher/pull/3932