### PR TITLE
Added ISO 8601 date to the SettingsPaneThemeViewModel

### DIFF
--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneThemeViewModel.cs
@@ -172,7 +172,8 @@ public partial class SettingsPaneThemeViewModel : BaseModel
         "dd', 'MMMM",
         "dd.MM.yy",
         "dd.MM.yyyy",
-        "dd MMMM yyyy"
+        "dd MMMM yyyy",
+        "yyyy-MM-dd"
     };
 
     public string TimeFormat


### PR DESCRIPTION
Since the ISO 8601 date format was missing as an option in settings, I added it to the list of options.