### PR TITLE
Use DialogJump to get explorer path

### DIFF
--- a/Flow.Launcher.Infrastructure/FileExplorerHelper.cs
+++ b/Flow.Launcher.Infrastructure/FileExplorerHelper.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using Windows.Win32;
 
 namespace Flow.Launcher.Infrastructure
 {
@@ -13,9 +9,10 @@ namespace Flow.Launcher.Infrastructure
         /// </summary>
         public static string GetActiveExplorerPath()
         {
-            var explorerWindow = GetActiveExplorer();
-            string locationUrl = explorerWindow?.LocationURL;
-            return !string.IsNullOrEmpty(locationUrl) ? GetDirectoryPath(new Uri(locationUrl).LocalPath) : null;
+            var explorerPath = DialogJump.DialogJump.GetActiveExplorerPath();
+            return !string.IsNullOrEmpty(explorerPath) ?
+                GetDirectoryPath(new Uri(explorerPath).LocalPath) :
+                null;
         }
 
         /// <summary>
@@ -23,74 +20,12 @@ namespace Flow.Launcher.Infrastructure
         /// </summary>
         private static string GetDirectoryPath(string path)
         {
-            if (!path.EndsWith("\\"))
+            if (!path.EndsWith('\\'))
             {
                 return path + "\\";
             }
 
             return path;
-        }
-
-        /// <summary>
-        /// Gets the file explorer that is currently in the foreground
-        /// </summary>
-        private static dynamic GetActiveExplorer()
-        {
-            Type type = Type.GetTypeFromProgID("Shell.Application");
-            if (type == null) return null;
-            dynamic shell = Activator.CreateInstance(type);
-            if (shell == null)
-            {
-                return null;
-            }
-
-            var explorerWindows = new List<dynamic>();
-            var openWindows = shell.Windows();
-            for (int i = 0; i < openWindows.Count; i++)
-            {
-                var window = openWindows.Item(i);
-                if (window == null) continue;
-
-                // find the desired window and make sure that it is indeed a file explorer
-                // we don't want the Internet Explorer or the classic control panel
-                // ToLower() is needed, because Windows can report the path as "C:\\Windows\\Explorer.EXE"
-                if (Path.GetFileName((string)window.FullName)?.ToLower() == "explorer.exe")
-                {
-                    explorerWindows.Add(window);
-                }
-            }
-
-            if (explorerWindows.Count == 0) return null;
-
-            var zOrders = GetZOrder(explorerWindows);
-
-            return explorerWindows.Zip(zOrders).MinBy(x => x.Second).First;
-        }
-
-        /// <summary>
-        /// Gets the z-order for one or more windows atomically with respect to each other. In Windows, smaller z-order is higher. If the window is not top level, the z order is returned as -1. 
-        /// </summary>
-        private static IEnumerable<int> GetZOrder(List<dynamic> hWnds)
-        {
-            var z = new int[hWnds.Count];
-            for (var i = 0; i < hWnds.Count; i++) z[i] = -1;
-
-            var index = 0;
-            var numRemaining = hWnds.Count;
-            PInvoke.EnumWindows((wnd, _) =>
-            {
-                var searchIndex = hWnds.FindIndex(x => new IntPtr(x.HWND) == wnd);
-                if (searchIndex != -1)
-                {
-                    z[searchIndex] = index;
-                    numRemaining--;
-                    if (numRemaining == 0) return false;
-                }
-                index++;
-                return true;
-            }, IntPtr.Zero);
-
-            return z;
         }
     }
 }


### PR DESCRIPTION
# Use DialogJump to get explorer path

Follow on with #1018.

If we use `DialogJump` to get explorer path, it can use the third-party explorer plugins and also support to get the path from the most recent tab.