### PR TITLE
Support non action keyword for plugins

### DIFF
--- a/Flow.Launcher.Core/Plugin/PluginConfig.cs
+++ b/Flow.Launcher.Core/Plugin/PluginConfig.cs
@@ -119,7 +119,7 @@ namespace Flow.Launcher.Core.Plugin
                 // for plugins which doesn't has ActionKeywords key
                 metadata.ActionKeywords ??= new List<string> { metadata.ActionKeyword };
                 // for plugin still use old ActionKeyword
-                metadata.ActionKeyword = metadata.ActionKeywords?.Count == 0 ? string.Empty : metadata.ActionKeywords?[0];
+                metadata.ActionKeyword = metadata.ActionKeywords?.FirstOrDefault() ?? string.Empty;
             }
             catch (Exception e)
             {

--- a/Flow.Launcher.Core/Plugin/PluginConfig.cs
+++ b/Flow.Launcher.Core/Plugin/PluginConfig.cs
@@ -119,7 +119,7 @@ namespace Flow.Launcher.Core.Plugin
                 // for plugins which doesn't has ActionKeywords key
                 metadata.ActionKeywords ??= new List<string> { metadata.ActionKeyword };
                 // for plugin still use old ActionKeyword
-                metadata.ActionKeyword = metadata.ActionKeywords.Count == 0 ? string.Empty : metadata.ActionKeywords?[0];
+                metadata.ActionKeyword = metadata.ActionKeywords?.Count == 0 ? string.Empty : metadata.ActionKeywords?[0];
             }
             catch (Exception e)
             {

--- a/Flow.Launcher.Core/Plugin/PluginConfig.cs
+++ b/Flow.Launcher.Core/Plugin/PluginConfig.cs
@@ -119,7 +119,7 @@ namespace Flow.Launcher.Core.Plugin
                 // for plugins which doesn't has ActionKeywords key
                 metadata.ActionKeywords ??= new List<string> { metadata.ActionKeyword };
                 // for plugin still use old ActionKeyword
-                metadata.ActionKeyword = metadata.ActionKeywords?[0];
+                metadata.ActionKeyword = metadata.ActionKeywords.Count == 0 ? string.Empty : metadata.ActionKeywords?[0];
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Some plugins do not need any action keywords. And we should support that so that Flow will not add this plugin into action keyword dictionary.

Currently, `"ActionKeyword": ""` is supported, but `"ActionKeywords": []` is not. This PR enables support for that.

Related:
https://github.com/Flow-Launcher/Flow.Launcher.Plugin.QuickLook/pull/10
https://github.com/Flow-Launcher/Flow.Launcher.Plugin.QuickLook/pull/13