### PR TITLE
Bookmark plugin - catch an exception for empty / broken favicons

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Helper/FaviconHelper.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Helper/FaviconHelper.cs
@@ -106,12 +106,13 @@ public static class FaviconHelper
         {
             try
             {
-                using (var image = SKImage.FromBitmap(bitmap))
-                using (var webp = image.Encode(SKEncodedImageFormat.Webp, 65))
-                {
-                    if (webp != null)
-                        return webp.ToArray();
-                }
+                using var image = SKImage.FromBitmap(bitmap);
+                if (image is null)
+                    return null;
+
+                using var webp = image.Encode(SKEncodedImageFormat.Webp, 65);
+                if (webp != null)
+                    return webp.ToArray();
             }
             finally
             {


### PR DESCRIPTION
Catch an exception for empty / corrupted favicons.

This is just a quick fix until I complete a rewrite of this plugin which will properly fix this issue.