### PR TITLE
Catch scary exception, print friendly log

### DIFF
--- a/Flow.Launcher.Core/ExternalPlugins/CommunityPluginSource.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/CommunityPluginSource.cs
@@ -73,6 +73,11 @@ namespace Flow.Launcher.Core.ExternalPlugins
                     return null;
                 }
             }
+            catch (OperationCanceledException)
+            {
+                API.LogInfo(ClassName, $"Fetching from {ManifestFileUrl} was cancelled. That is most likely OK.");
+                return null;
+            }
             catch (Exception e)
             {
                 if (e is HttpRequestException or WebException or SocketException || e.InnerException is TimeoutException)

--- a/Flow.Launcher.Core/ExternalPlugins/CommunityPluginSource.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/CommunityPluginSource.cs
@@ -73,9 +73,15 @@ namespace Flow.Launcher.Core.ExternalPlugins
                     return null;
                 }
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
             {
-                API.LogInfo(ClassName, $"Fetching from {ManifestFileUrl} was cancelled. That is most likely OK.");
+                API.LogInfo(ClassName, $"Fetching from {ManifestFileUrl} was cancelled by caller.");
+                return null;
+            }
+            catch (TaskCanceledException)
+            {
+                // Likely an HttpClient timeout or external cancellation not requested by our token
+                API.LogWarn(ClassName, $"Fetching from {ManifestFileUrl} timed out.");
                 return null;
             }
             catch (Exception e)


### PR DESCRIPTION
Rather than showing the user `EXCEPTION OCCURS: System.Threading.Tasks.TaskCanceledException...`, print not scary log msg