### PR TITLE
Improve JsonRPC Plugin Setting Panel

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -519,9 +519,6 @@ namespace Flow.Launcher.Core.Plugin
             {
                 if (child is FrameworkElement element && Grid.GetColumn(element) == 0 && Grid.GetColumnSpan(element) == 1)
                 {
-                    if (element.MaxWidth < constrainedWidth)
-                        continue;
-
                     element.MaxWidth = constrainedWidth;
                 }
             }

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -161,8 +161,7 @@ namespace Flow.Launcher.Core.Plugin
             var mainPanel = new Grid { Margin = SettingPanelMargin, VerticalAlignment = VerticalAlignment.Center };
             mainPanel.ColumnDefinitions.Add(new ColumnDefinition()
             {
-                Width = new GridLength(0, GridUnitType.Auto),
-                MaxWidth = MainGridColumn0MaxWidthRatio * 560 // 560 is the default available width
+                Width = new GridLength(0, GridUnitType.Auto)
             });
             mainPanel.ColumnDefinitions.Add(new ColumnDefinition()
             {

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -202,7 +202,7 @@ namespace Flow.Launcher.Core.Plugin
                     {
                         Text = attributes.Label,
                         VerticalAlignment = VerticalAlignment.Center,
-                        TextWrapping = TextWrapping.WrapWithOverflow
+                        TextWrapping = TextWrapping.Wrap
                     };
 
                     // Create a text block for description
@@ -213,7 +213,7 @@ namespace Flow.Launcher.Core.Plugin
                         {
                             Text = attributes.Description,
                             VerticalAlignment = VerticalAlignment.Center,
-                            TextWrapping = TextWrapping.WrapWithOverflow
+                            TextWrapping = TextWrapping.Wrap
                         };
 
                         desc.SetResourceReference(TextBlock.StyleProperty, "SettingPanelTextBlockDescriptionStyle"); // for theme change
@@ -249,7 +249,8 @@ namespace Flow.Launcher.Core.Plugin
                                 VerticalAlignment = VerticalAlignment.Center,
                                 Margin = SettingPanelItemLeftTopBottomMargin,
                                 Text = Settings[attributes.Name] as string ?? string.Empty,
-                                ToolTip = attributes.Description
+                                ToolTip = attributes.Description,
+                                TextWrapping = TextWrapping.Wrap
                             };
 
                             textBox.TextChanged += (_, _) =>
@@ -271,7 +272,8 @@ namespace Flow.Launcher.Core.Plugin
                                 VerticalAlignment = VerticalAlignment.Center,
                                 Margin = SettingPanelItemLeftMargin,
                                 Text = Settings[attributes.Name] as string ?? string.Empty,
-                                ToolTip = attributes.Description
+                                ToolTip = attributes.Description,
+                                TextWrapping = TextWrapping.Wrap
                             };
 
                             textBox.TextChanged += (_, _) =>
@@ -335,7 +337,7 @@ namespace Flow.Launcher.Core.Plugin
                                 HorizontalAlignment = HorizontalAlignment.Stretch,
                                 VerticalAlignment = VerticalAlignment.Center,
                                 Margin = SettingPanelItemLeftTopBottomMargin,
-                                TextWrapping = TextWrapping.WrapWithOverflow,
+                                TextWrapping = TextWrapping.Wrap,
                                 AcceptsReturn = true,
                                 Text = Settings[attributes.Name] as string ?? string.Empty,
                                 ToolTip = attributes.Description
@@ -508,7 +510,21 @@ namespace Flow.Launcher.Core.Plugin
 
             if (workingWidth <= 0) return;
 
-            grid.ColumnDefinitions[0].MaxWidth = MainGridColumn0MaxWidthRatio * workingWidth;
+            var constrainedWidth = MainGridColumn0MaxWidthRatio * workingWidth;
+
+            // Set MaxWidth of column 0 and its childrens
+            // We must set MaxWidth of its childrens to make text wrapping work correctly
+            grid.ColumnDefinitions[0].MaxWidth = constrainedWidth;
+            foreach (var child in grid.Children)
+            {
+                if (child is FrameworkElement element && Grid.GetColumn(element) == 0 && Grid.GetColumnSpan(element) == 1)
+                {
+                    if (element.MaxWidth < constrainedWidth)
+                        continue;
+
+                    element.MaxWidth = constrainedWidth;
+                }
+            }
         }
 
         private static bool NeedSaveInSettings(string type)

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -504,8 +504,7 @@ namespace Flow.Launcher.Core.Plugin
         {
             if (sender is not Grid grid) return;
 
-            var workingWidth =
-                (int)(grid.ActualWidth - SystemParameters.VerticalScrollBarWidth); // take into account vertical scrollbar
+            var workingWidth = grid.ActualWidth;
 
             if (workingWidth <= 0) return;
 

--- a/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCPluginSettings.cs
@@ -27,6 +27,7 @@ namespace Flow.Launcher.Core.Plugin
 
         private JsonStorage<ConcurrentDictionary<string, object?>> _storage = null!;
 
+        private static readonly double MainGridColumn0MaxWidthRatio = 0.6;
         private static readonly Thickness SettingPanelMargin = (Thickness)Application.Current.FindResource("SettingPanelMargin");
         private static readonly Thickness SettingPanelItemLeftMargin = (Thickness)Application.Current.FindResource("SettingPanelItemLeftMargin");
         private static readonly Thickness SettingPanelItemTopBottomMargin = (Thickness)Application.Current.FindResource("SettingPanelItemTopBottomMargin");
@@ -156,11 +157,12 @@ namespace Flow.Launcher.Core.Plugin
         {
             if (!NeedCreateSettingPanel()) return null!;
 
-            // Create main grid with two columns (Column 1: Auto, Column 2: *)
+            // Create main grid with two columns (Column 0: Auto, Column 1: *)
             var mainPanel = new Grid { Margin = SettingPanelMargin, VerticalAlignment = VerticalAlignment.Center };
             mainPanel.ColumnDefinitions.Add(new ColumnDefinition()
             {
-                Width = new GridLength(0, GridUnitType.Auto)
+                Width = new GridLength(0, GridUnitType.Auto),
+                MaxWidth = MainGridColumn0MaxWidthRatio * 560 // 560 is the default available width
             });
             mainPanel.ColumnDefinitions.Add(new ColumnDefinition()
             {
@@ -488,11 +490,25 @@ namespace Flow.Launcher.Core.Plugin
                 rowCount++;
             }
 
+            mainPanel.SizeChanged += MainPanel_SizeChanged;
+
             // Wrap the main grid in a user control
             return new UserControl()
             {
                 Content = mainPanel
             };
+        }
+
+        private void MainPanel_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (sender is not Grid grid) return;
+
+            var workingWidth =
+                (int)(grid.ActualWidth - SystemParameters.VerticalScrollBarWidth); // take into account vertical scrollbar
+
+            if (workingWidth <= 0) return;
+
+            grid.ColumnDefinitions[0].MaxWidth = MainGridColumn0MaxWidthRatio * workingWidth;
         }
 
         private static bool NeedSaveInSettings(string type)


### PR DESCRIPTION
# Improve JsonRPC Plugin Setting Panel

* Constrain column 0 to 60% of the max width of the grid.
* Use wrap as default text wrapping option.

# Test

<img width="400" alt="image" src="https://github.com/user-attachments/assets/a742f75f-4c87-4a5b-b4e8-fc56b8178701" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6c48e2d7-2d03-4d25-ab41-9a846adeff6a" />