### PR TITLE
Fix Wallpaper File Lock

### DIFF
--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -22,7 +22,7 @@ namespace Flow.Launcher.Infrastructure.Image
         private static Lock storageLock { get; } = new();
         private static BinaryStorage<List<(string, bool)>> _storage;
         private static readonly ConcurrentDictionary<string, string> GuidToKey = new();
-        private static IImageHashGenerator _hashGenerator;
+        private static ImageHashGenerator _hashGenerator;
         private static readonly bool EnableImageHash = true;
         public static ImageSource Image => ImageCache[Constant.ImageIcon, false];
         public static ImageSource MissingImage => ImageCache[Constant.MissingImgIcon, false];
@@ -31,7 +31,7 @@ namespace Flow.Launcher.Infrastructure.Image
         public const int FullIconSize = 256;
         public const int FullImageSize = 320;
 
-        private static readonly string[] ImageExtensions = { ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".ico" };
+        private static readonly string[] ImageExtensions = [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".ico"];
         private static readonly string SvgExtension = ".svg";
 
         public static async Task InitializeAsync()
@@ -327,7 +327,7 @@ namespace Flow.Launcher.Infrastructure.Image
             return img;
         }
 
-        private static ImageSource LoadFullImage(string path)
+        private static BitmapImage LoadFullImage(string path)
         {
             BitmapImage image = new BitmapImage();
             image.BeginInit();
@@ -364,7 +364,7 @@ namespace Flow.Launcher.Infrastructure.Image
             return image;
         }
 
-        private static ImageSource LoadSvgImage(string path, bool loadFullImage = false)
+        private static RenderTargetBitmap LoadSvgImage(string path, bool loadFullImage = false)
         {
             // Set up drawing settings
             var desiredHeight = loadFullImage ? FullImageSize : SmallIconSize;

--- a/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
+++ b/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
@@ -75,7 +75,9 @@ public static class WallpaperPathRetrieval
             // Set DecodePixelWidth and DecodePixelHeight to resize the image while preserving aspect ratio
             var bitmap = new BitmapImage();
             bitmap.BeginInit();
+            bitmap.CacheOption = BitmapCacheOption.OnLoad;  // Use OnLoaded to ensure the wallpaper file is not locked
             bitmap.UriSource = new Uri(wallpaperPath);
+            bitmap.CreateOptions = BitmapCreateOptions.IgnoreColorProfile;
             bitmap.DecodePixelWidth = decodedPixelWidth;
             bitmap.DecodePixelHeight = decodedPixelHeight;
             bitmap.EndInit();

--- a/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
+++ b/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
@@ -32,7 +32,7 @@ public static class WallpaperPathRetrieval
             var wallpaperPath = Win32Helper.GetWallpaperPath();
             if (string.IsNullOrEmpty(wallpaperPath) || !File.Exists(wallpaperPath))
             {
-                App.API.LogInfo(ClassName, $"Wallpaper path is invalid: {wallpaperPath}");
+                App.API.LogError(ClassName, $"Wallpaper path is invalid: {wallpaperPath}");
                 var wallpaperColor = GetWallpaperColor();
                 return new SolidColorBrush(wallpaperColor);
             }
@@ -61,7 +61,8 @@ public static class WallpaperPathRetrieval
             if (originalWidth == 0 || originalHeight == 0)
             {
                 App.API.LogError(ClassName, $"Failed to load bitmap: Width={originalWidth}, Height={originalHeight}");
-                return new SolidColorBrush(Colors.Transparent);
+                var wallpaperColor = GetWallpaperColor();
+                return new SolidColorBrush(wallpaperColor);
             }
 
             // Calculate the scaling factor to fit the image within 800x600 while preserving aspect ratio

--- a/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
+++ b/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
@@ -50,6 +50,7 @@ public static class WallpaperPathRetrieval
             }
 
             int originalWidth, originalHeight;
+            // Use `using ()` instead of `using var` sentence here to ensure the wallpaper file is not locked
             using (var fileStream = File.OpenRead(wallpaperPath))
             {
                 var decoder = BitmapDecoder.Create(fileStream, BitmapCreateOptions.DelayCreation, BitmapCacheOption.None);

--- a/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
+++ b/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
@@ -15,9 +15,8 @@ public static class WallpaperPathRetrieval
 {
     private static readonly string ClassName = nameof(WallpaperPathRetrieval);
 
-    // Disable cache feature because some wallpaper applications (like Wallpaper Engine) may change wallpaper frequently
-    private const int MaxCacheSize = 0;//3;
-    private static readonly Dictionary<(string, DateTime), ImageBrush> WallpaperCache = [];
+    private const int MaxCacheSize = 3;
+    private static readonly Dictionary<(string, DateTime), ImageBrush> WallpaperCache = new();
     private static readonly Lock CacheLock = new();
 
     public static Brush GetWallpaperBrush()

--- a/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
+++ b/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
@@ -15,8 +15,9 @@ public static class WallpaperPathRetrieval
 {
     private static readonly string ClassName = nameof(WallpaperPathRetrieval);
 
-    private const int MaxCacheSize = 3;
-    private static readonly Dictionary<(string, DateTime), ImageBrush> WallpaperCache = new();
+    // Disable cache feature because some wallpaper applications (like Wallpaper Engine) may change wallpaper frequently
+    private const int MaxCacheSize = 0;//3;
+    private static readonly Dictionary<(string, DateTime), ImageBrush> WallpaperCache = [];
     private static readonly Lock CacheLock = new();
 
     public static Brush GetWallpaperBrush()

--- a/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
+++ b/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
@@ -48,12 +48,15 @@ public static class WallpaperPathRetrieval
                     return cachedWallpaper;
                 }
             }
-            
-            using var fileStream = File.OpenRead(wallpaperPath);
-            var decoder = BitmapDecoder.Create(fileStream, BitmapCreateOptions.DelayCreation, BitmapCacheOption.None);
-            var frame = decoder.Frames[0];
-            var originalWidth = frame.PixelWidth;
-            var originalHeight = frame.PixelHeight;
+
+            int originalWidth, originalHeight;
+            using (var fileStream = File.OpenRead(wallpaperPath))
+            {
+                var decoder = BitmapDecoder.Create(fileStream, BitmapCreateOptions.DelayCreation, BitmapCacheOption.None);
+                var frame = decoder.Frames[0];
+                originalWidth = frame.PixelWidth;
+                originalHeight = frame.PixelHeight;
+            }
 
             if (originalWidth == 0 || originalHeight == 0)
             {

--- a/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
+++ b/Flow.Launcher/Helper/WallpaperPathRetrieval.cs
@@ -76,7 +76,7 @@ public static class WallpaperPathRetrieval
             // Set DecodePixelWidth and DecodePixelHeight to resize the image while preserving aspect ratio
             var bitmap = new BitmapImage();
             bitmap.BeginInit();
-            bitmap.CacheOption = BitmapCacheOption.OnLoad;  // Use OnLoaded to ensure the wallpaper file is not locked
+            bitmap.CacheOption = BitmapCacheOption.OnLoad;  // Use OnLoad to ensure the wallpaper file is not locked
             bitmap.UriSource = new Uri(wallpaperPath);
             bitmap.CreateOptions = BitmapCreateOptions.IgnoreColorProfile;
             bitmap.DecodePixelWidth = decodedPixelWidth;


### PR DESCRIPTION
# Fix Wallpaper File Lock

* Use `Lock` for `CacheLock`
* Use `LogError` instead of `LogInfo`
* Use `using ()` sentence so that file is not locked
* Use `OnLoaded` to ensure the wallpaper file is not locked
* Use `using` sentence for registry key to fix possible memory leak

Fix #3983

# Test

Open Flow Launcher -> Open setting window -> Navigate to appearance page -> Wallpaper file is not locked