### PR TITLE
Fix DirectoryNotFoundException when deleting cache twice

### DIFF
--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -231,36 +231,41 @@ public partial class SettingsPaneAboutViewModel : BaseModel
             }
         });
 
-        // Firstly, delete plugin cache directories
-        pluginCacheDirectory.EnumerateDirectories("*", SearchOption.TopDirectoryOnly)
-            .ToList()
-            .ForEach(dir =>
+        // Check if plugin cache directory exists before attempting to delete
+        // Or it will throw DirectoryNotFoundException in `pluginCacheDirectory.EnumerateDirectories`
+        if (pluginCacheDirectory.Exists)
+        {
+            // Firstly, delete plugin cache directories
+            pluginCacheDirectory.EnumerateDirectories("*", SearchOption.TopDirectoryOnly)
+                .ToList()
+                .ForEach(dir =>
+                {
+                    try
+                    {
+                        // Plugin may create directories in its cache directory
+                        dir.Delete(recursive: true);
+                    }
+                    catch (Exception e)
+                    {
+                        App.API.LogException(ClassName, $"Failed to delete cache directory: {dir.Name}", e);
+                        success = false;
+                    }
+                });
+
+            // Then, delete plugin directory
+            var dir = pluginCacheDirectory;
+            try
             {
-                try
-                {
-                    // Plugin may create directories in its cache directory
-                    dir.Delete(recursive: true);
-                }
-                catch (Exception e)
-                {
-                    App.API.LogException(ClassName, $"Failed to delete cache directory: {dir.Name}", e);
-                    success = false;
-                }
-            });
+                dir.Delete(recursive: false);
+            }
+            catch (Exception e)
+            {
+                App.API.LogException(ClassName, $"Failed to delete cache directory: {dir.Name}", e);
+                success = false;
+            }
 
-        // Then, delete plugin directory
-        var dir = GetPluginCacheDir();
-        try
-        {
-            dir.Delete(recursive: false);
+            OnPropertyChanged(nameof(CacheFolderSize));
         }
-        catch (Exception e)
-        {
-            App.API.LogException(ClassName, $"Failed to delete cache directory: {dir.Name}", e);
-            success = false;
-        }
-
-        OnPropertyChanged(nameof(CacheFolderSize));
 
         return success;
     }


### PR DESCRIPTION
# CHANGES

If we click `Clean cache` button, it will throw `DirectoryNotFoundException` in `pluginCacheDirectory.EnumerateDirectories`. We should check if `pluginCacheDirectory` exists before calling `EnumerateDirectories` function.

# TEST

Click `Clean cache` button twice.