### PR TITLE
Fix PortableMode Check Issue

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/DataLocation.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/DataLocation.cs
@@ -7,8 +7,8 @@ namespace Flow.Launcher.Infrastructure.UserSettings
     {
         public const string PortableFolderName = "UserData";
         public const string DeletionIndicatorFile = ".dead";
-        public static string PortableDataPath = Path.Combine(Constant.ProgramDirectory, PortableFolderName);
-        public static string RoamingDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FlowLauncher");
+        public static readonly string PortableDataPath = Path.Combine(Constant.ProgramDirectory, PortableFolderName);
+        public static readonly string RoamingDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FlowLauncher");
         public static string DataDirectory()
         {
             if (PortableDataLocationInUse())
@@ -19,7 +19,8 @@ namespace Flow.Launcher.Infrastructure.UserSettings
 
         public static bool PortableDataLocationInUse()
         {
-            if (Directory.Exists(PortableDataPath) && !File.Exists(DeletionIndicatorFile))
+            if (Directory.Exists(PortableDataPath) &&
+                !File.Exists(Path.Combine(PortableDataPath, DeletionIndicatorFile)))
                 return true;
 
             return false;

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneGeneralViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneGeneralViewModel.cs
@@ -123,7 +123,7 @@ public partial class SettingsPaneGeneralViewModel : BaseModel
     }
 
     // This is only required to set at startup. When portable mode enabled/disabled a restart is always required
-    private static bool _portableMode = DataLocation.PortableDataLocationInUse();
+    private static readonly bool _portableMode = DataLocation.PortableDataLocationInUse();
 
     public bool PortableMode
     {


### PR DESCRIPTION
From #3982.

Use `!File.Exists(Path.Combine(PortableDataPath, DeletionIndicatorFile)))` instead of `!File.Exists(DeletionIndicatorFile))` so that we can check if deletion indicator file exists.