### PR TITLE
Build script fixed + enhanced

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,10 +5,10 @@
 			Condition="'$(OutputType)' == 'Library' and '$(CopyLocalLockFileAssemblies)' == 'true' and $(AssemblyName.EndsWith('Tests')) == 'false' ">
 	  <ItemGroup>
 		<ProjectReferenceWithConfiguration Update="@(ProjectReferenceWithConfiguration)" >
-		  <Private>false</Private>
+		  <Private>true</Private>
 		</ProjectReferenceWithConfiguration>
 		<ProjectReference Update="@(ProjectReference)" >
-		  <Private>false</Private>
+		  <Private>true</Private>
 		</ProjectReference>
 	  </ItemGroup>
 	</Target>

--- a/Scripts/flowlauncher.nuspec
+++ b/Scripts/flowlauncher.nuspec
@@ -7,6 +7,7 @@
     <authors>Flow-Launcher Team</authors>
     <projectUrl>https://github.com/Flow-Launcher/Flow.Launcher</projectUrl>
     <icon>images\app.png</icon>
+    <iconUrl>https://raw.githubusercontent.com/Flow-Launcher/Flow.Launcher/master/Flow.Launcher/Resources/app.ico</iconUrl>
     <readme>README.md</readme>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Flow Launcher - Quick file search and app launcher for Windows with community-made plugins</description>

--- a/Scripts/flowlauncher.nuspec
+++ b/Scripts/flowlauncher.nuspec
@@ -6,11 +6,17 @@
     <version>$version$</version>
     <authors>Flow-Launcher Team</authors>
     <projectUrl>https://github.com/Flow-Launcher/Flow.Launcher</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/Flow-Launcher/Flow.Launcher/master/Flow.Launcher/Images/app.png</iconUrl>
+    <icon>images\app.png</icon>
+    <readme>README.md</readme>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Flow Launcher - Quick file search and app launcher for Windows with community-made plugins</description>
+    <dependencies>
+      <group targetFramework="net9.0" />
+    </dependencies>
   </metadata>
   <files>
     <file src="**\*.*" target="lib\net9.0\" exclude="Flow.Launcher.vshost.exe;Flow.Launcher.vshost.exe.config;Flow.Launcher.vshost.exe.manifest;*.nupkg;Setup.exe;RELEASES"/>
+    <file src="images\app.png" target="images\"/>
+    <file src="..\..\README.md" target="\"/>
   </files>
 </package>


### PR DESCRIPTION
Main issues: redundant 95MB file removed from portable zip; fixed plugin build logic so that we always get the latest version and not an obsolete DLL.

---

1.  **Fixed Portable Package Creation**

    * The portable build process was including the temporary `packages` directory in the final archive. This added `FlowLauncher-x.x.x-full.nupkg` file, increasing zip size by ~95MB. We now explicitly remove this directory before compression.
    * We now use a staging directory to assemble the portable version by running a silent install which ensures package structure is correct and contains no unnecessary build artifacts.

2.  **Enhanced Build Process Reliability**

    * **Dynamic Squirrel Path:** The script no longer uses a hardcoded path to `squirrel.windows`.
    * **Improved Dependency Handling:** By changing `<Private>` from `false` to `true` in `Directory.Build.targets`, project-to-project dependencies are now correctly copied to the output directory. This prevents "missing assembly" errors, especially for plugins.
    * **Safer File Deletion:** The `Remove-UnusedFiles` function now includes a safety check to prevent accidentally deleting a plugin's main DLL if it shares a name with a common dependency.
    * **Structured Build Flow:** The main build logic has been restructured to follow a sequence of building the solution, publishing to a temporary directory, and then merging into the final release folder, which prevents interference from old build artifacts.
    * **More Reliable Version Retrieval:** The `Build-Version` function was updated to use `(Get-Item).VersionInfo.ProductVersion` instead of `Get-Command`. This is more reliable for retrieving file version in PowerShell and aligns with `AssemblyInformationalVersion`.

3.  **Modernized NuGet Package**

    * The `.nuspec` file has been updated to use the modern `<icon>` and `<readme>` tags (note - I failed to get rid of the deprecated `<iconUrl>` due to Squirrel).

---

> [!NOTE]
> I've been playing with https://github.com/velopack/velopack for https://github.com/dcog989/Cliptoo - would there be interest in converting Flow to use this given that Squirrel was abandoned long ago? (Velopack originates from a fork of Squirrel).