### PR TITLE
Save settings before shutdown/restart to prevent data loss

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Sys/Main.cs
@@ -211,6 +211,9 @@ namespace Flow.Launcher.Plugin.Sys
                             Localize.flowlauncher_plugin_sys_shutdown_computer(),
                             MessageBoxButton.YesNo, MessageBoxImage.Warning);
 
+                        // Save settings before shutdown to avoid data loss
+                        Context.API.SaveAppAllSettings();
+
                         if (result == MessageBoxResult.Yes)
                             if (EnableShutdownPrivilege())
                                 PInvoke.ExitWindowsEx(EXIT_WINDOWS_FLAGS.EWX_SHUTDOWN | EXIT_WINDOWS_FLAGS.EWX_POWEROFF, REASON);
@@ -232,6 +235,9 @@ namespace Flow.Launcher.Plugin.Sys
                             Localize.flowlauncher_plugin_sys_restart_computer(),
                             MessageBoxButton.YesNo, MessageBoxImage.Warning);
 
+                        // Save settings before restart to avoid data loss
+                        Context.API.SaveAppAllSettings();
+
                         if (result == MessageBoxResult.Yes)
                             if (EnableShutdownPrivilege())
                                 PInvoke.ExitWindowsEx(EXIT_WINDOWS_FLAGS.EWX_REBOOT, REASON);
@@ -252,6 +258,9 @@ namespace Flow.Launcher.Plugin.Sys
                             Localize.flowlauncher_plugin_sys_dlgtext_restart_computer_advanced(),
                             Localize.flowlauncher_plugin_sys_restart_computer(),
                             MessageBoxButton.YesNo, MessageBoxImage.Warning);
+
+                        // Save settings before restart to avoid data loss
+                        Context.API.SaveAppAllSettings();
 
                         if (result == MessageBoxResult.Yes)
                             if (EnableShutdownPrivilege())


### PR DESCRIPTION
Added a call to `Context.API.SaveAppAllSettings()` before executing system shutdown, restart, or advanced restart operations. This ensures that any unsaved settings are persisted, reducing the risk of data loss during these actions.