### PR TITLE
Fix DialogJump UriFormatException when navigating to root directories

### DIFF
--- a/Flow.Launcher.Infrastructure/DialogJump/DialogJump.cs
+++ b/Flow.Launcher.Infrastructure/DialogJump/DialogJump.cs
@@ -828,9 +828,25 @@ namespace Flow.Launcher.Infrastructure.DialogJump
                     return true;
                 }
                 // file: URI paths
-                var localPath = path.StartsWith("file:", StringComparison.OrdinalIgnoreCase)
-                    ? new Uri(path).LocalPath
-                    : path;
+                string localPath;
+                if (path.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Try to create a URI from the path
+                    if (Uri.TryCreate(path, UriKind.Absolute, out var uri))
+                    {
+                        localPath = uri.LocalPath;
+                    }
+                    else
+                    {
+                        // If URI creation fails, treat it as a regular path
+                        // by removing the "file:" prefix
+                        localPath = path.Substring(5);
+                    }
+                }
+                else
+                {
+                    localPath = path;
+                }
                 // Is folder?
                 var isFolder = Directory.Exists(localPath);
                 // Is file?


### PR DESCRIPTION
## Problem

The DialogJump function fails when attempting to navigate to root directories (e.g., `C:\`), throwing a `UriFormatException` with the message:
```
Invalid URI: A Dos path must be rooted, for example, 'c:\\'.
```

This occurs when paths are passed with a `file:` prefix but without proper URI formatting, such as `file:C:` (missing the trailing slash).

## Root Cause

The `CheckPath` method in `DialogJump.cs` was using the `Uri` constructor directly:

```csharp
var localPath = path.StartsWith("file:", StringComparison.OrdinalIgnoreCase)
    ? new Uri(path).LocalPath
    : path;
```

The `Uri` constructor throws `UriFormatException` when given malformed file URIs like `file:C:` (without trailing slash), causing DialogJump to fail for root directories.

## Solution

Replaced the direct `Uri` constructor call with `Uri.TryCreate()` to gracefully handle malformed URIs:

```csharp
string localPath;
if (path.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
{
    // Try to create a URI from the path
    if (Uri.TryCreate(path, UriKind.Absolute, out var uri))
    {
        localPath = uri.LocalPath;
    }
    else
    {
        // If URI creation fails, treat it as a regular path
        // by removing the "file:" prefix
        localPath = path.Substring(5);
    }
}
else
{
    localPath = path;
}
```

This approach:
- ✅ Handles properly formatted file URIs using the standard `Uri.LocalPath` property
- ✅ Gracefully degrades for malformed URIs by stripping the `file:` prefix
- ✅ Allows the subsequent `Directory.Exists()` and `File.Exists()` checks to determine if the path is valid
- ✅ Maintains full backward compatibility with existing functionality

## Testing

Verified the fix handles various path formats correctly:
- Root directories: `file:C:`, `file:D:` no longer throw exceptions
- Properly formatted URIs: `file:///C:/`, `file://C:/` continue to work
- Regular paths: `C:\`, `D:\` work as expected
- Shell paths: `shell:MyComputerFolder` continue to work

Fixes #4048