### PR TITLE
Fix Possible OperationCancelException for WaitAsync Operations

### DIFF
--- a/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/PluginsManifest.cs
@@ -26,9 +26,11 @@ namespace Flow.Launcher.Core.ExternalPlugins
 
         public static async Task<bool> UpdateManifestAsync(bool usePrimaryUrlOnly = false, CancellationToken token = default)
         {
+            bool lockAcquired = false;
             try
             {
                 await manifestUpdateLock.WaitAsync(token).ConfigureAwait(false);
+                lockAcquired = true;
 
                 if (UserPlugins == null || usePrimaryUrlOnly || DateTime.Now.Subtract(lastFetchedAt) >= fetchTimeout)
                 {
@@ -64,7 +66,8 @@ namespace Flow.Launcher.Core.ExternalPlugins
             }
             finally
             {
-                manifestUpdateLock.Release();
+                // Only release the lock if it was acquired
+                if (lockAcquired) manifestUpdateLock.Release();
             }
 
             return false;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingAPI.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingAPI.cs
@@ -133,8 +133,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                     EverythingApiDllImport.Everything_SetRequestFlags(EVERYTHING_REQUEST_FULL_PATH_AND_FILE_NAME);
                 }
 
-
-
                 if (token.IsCancellationRequested) yield break;
 
                 if (!EverythingApiDllImport.Everything_QueryW(true))

--- a/Plugins/Flow.Launcher.Plugin.Program/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Main.cs
@@ -86,29 +86,41 @@ namespace Flow.Launcher.Plugin.Program
                 {
                     // Preparing win32 programs
                     List<Win32> win32s;
+                    bool win32LockAcquired = false;
                     try
                     {
                         await _win32sLock.WaitAsync(token);
+                        win32LockAcquired = true;
                         win32s = [.. _win32s];
                     }
                     catch (OperationCanceledException)
                     {
                         return emptyResults;
                     }
-                    _win32sLock.Release();
+                    finally
+                    {
+                        // Only release the lock if it was acquired
+                        if (win32LockAcquired) _win32sLock.Release();
+                    }
 
                     // Preparing UWP programs
                     List<UWPApp> uwps;
+                    bool uwpsLockAcquired = false;
                     try
                     {
                         await _uwpsLock.WaitAsync(token);
+                        uwpsLockAcquired = true;
                         uwps = [.. _uwps];
                     }
                     catch (OperationCanceledException)
                     {
                         return emptyResults;
                     }
-                    _uwpsLock.Release();
+                    finally
+                    {
+                        // Only release the lock if it was acquired
+                        if (uwpsLockAcquired) _uwpsLock.Release();
+                    }
 
                     // Start querying programs
                     try


### PR DESCRIPTION
Catch exception for `OperationCanceledException` when calling `WaitAsync(CancellationToken)`, so that all `SemaphoreSlim` will be released correctly.

Fix #3962

Confirmed by nuo27