### PR TITLE
Fix: Result.Preview.Description Does not Display in Preview Panel

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -526,7 +526,7 @@
                                     <TextBlock
                                         x:Name="PreviewSubTitle"
                                         Style="{DynamicResource PreviewItemSubTitleStyle}"
-                                        Text="{Binding DefaultPreviewCustomDescription}" />
+                                        Text="{Binding PreviewDescription}" />
                                 </StackPanel>
                             </Grid>
                         </Border>

--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -288,7 +288,7 @@ namespace Flow.Launcher.ViewModel
             }
         }
 
-        public string DefaultPreviewCustomDescription => Result.Preview?.Description ?? Result.SubTitle;
+        public string PreviewDescription => Result.Preview?.Description ?? Result.SubTitle;
 
         public Result Result { get; }
         public int ResultProgress


### PR DESCRIPTION
According to the `Result.Preview.Description` ([`PreviewInfo.Description`](https://github.com/Flow-Launcher/Flow.Launcher/blob/20930617bb714638cbdfdfae57c4d16e66906176/Flow.Launcher.Plugin/Result.cs#L350)) documentation
```
/// <summary>
/// Result description text that is shown at the bottom of the preview panel.
/// </summary>
/// <remarks>
/// When a value is not set, the <see cref="SubTitle"/> will be used.
/// </remarks>
```

However, it actually doesn't do anything.
This PR fixes this, so the `Description` does what it is documented to do.
I left the related `TextBlock` control name as `PreviewSubTitle`, because although this is confusing, changing it could break user themes.