### PR TITLE
Fix an issue that custom query hotkey cannot work with context menu page

### DIFF
--- a/Flow.Launcher/Helper/HotKeyMapper.cs
+++ b/Flow.Launcher/Helper/HotKeyMapper.cs
@@ -143,6 +143,8 @@ internal static class HotKeyMapper
                 return;
 
             App.API.ShowMainWindow();
+            // Make sure to go back to the query results page first since it can cause issues if current page is context menu
+            App.API.BackToQueryResults();
             App.API.ChangeQuery(hotkey.ActionKeyword, true);
         });
     }


### PR DESCRIPTION
This pull request introduces a small but important update to the hotkey handling logic. Now, when a custom query hotkey is triggered, the application will always return to the query results page before changing the query. This ensures that if the user is currently on a context menu page, switching queries will not cause any issues.

- Hotkey behavior improvement:
  * In `HotKeyMapper.cs`, added a call to `App.API.BackToQueryResults()` before changing the query to prevent issues when the current page is a context menu.