### PR TITLE
Update UrlPattern in URL plugin to include private addresses and update test cases

### DIFF
--- a/Flow.Launcher.Test/Plugins/UrlPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/UrlPluginTest.cs
@@ -1,61 +1,84 @@
-﻿using NUnit.Framework;
-using NUnit.Framework.Legacy;
+﻿using System;
+using System.Reflection;
 using Flow.Launcher.Plugin.Url;
+using NUnit.Framework;
 
 namespace Flow.Launcher.Test.Plugins
 {
     [TestFixture]
     public class UrlPluginTest
     {
-        [Test]
-        public void URLMatchTest()
+        private Settings _settings = new()
         {
-            var plugin = new Main();
-            ClassicAssert.IsTrue(plugin.IsURL("http://www.google.com"));
-            ClassicAssert.IsTrue(plugin.IsURL("https://www.google.com"));
-            ClassicAssert.IsTrue(plugin.IsURL("http://google.com"));
-            ClassicAssert.IsTrue(plugin.IsURL("ftp://google.com"));
-            ClassicAssert.IsTrue(plugin.IsURL("www.google.com"));
-            ClassicAssert.IsTrue(plugin.IsURL("google.com"));
-            ClassicAssert.IsTrue(plugin.IsURL("http://localhost"));
-            ClassicAssert.IsTrue(plugin.IsURL("https://localhost"));
-            ClassicAssert.IsTrue(plugin.IsURL("http://localhost:80"));
-            ClassicAssert.IsTrue(plugin.IsURL("https://localhost:80"));
-            ClassicAssert.IsTrue(plugin.IsURL("localhost"));
-            ClassicAssert.IsTrue(plugin.IsURL("localhost:8080"));
-            ClassicAssert.IsTrue(plugin.IsURL("http://110.10.10.10"));
-            ClassicAssert.IsTrue(plugin.IsURL("110.10.10.10"));
-            ClassicAssert.IsTrue(plugin.IsURL("110.10.10.10:8080"));
-            ClassicAssert.IsTrue(plugin.IsURL("192.168.1.1"));
-            ClassicAssert.IsTrue(plugin.IsURL("192.168.1.1:3000"));
-            ClassicAssert.IsTrue(plugin.IsURL("ftp://110.10.10.10"));
-            ClassicAssert.IsTrue(plugin.IsURL("[2001:db8::1]"));
-            ClassicAssert.IsTrue(plugin.IsURL("[2001:db8::1]:8080"));
-            ClassicAssert.IsTrue(plugin.IsURL("http://[2001:db8::1]"));
-            ClassicAssert.IsTrue(plugin.IsURL("https://[2001:db8::1]:8080"));
-            ClassicAssert.IsTrue(plugin.IsURL("[::1]"));
-            ClassicAssert.IsTrue(plugin.IsURL("[::1]:8080"));
-            ClassicAssert.IsTrue(plugin.IsURL("2001:db8::1"));
-            ClassicAssert.IsTrue(plugin.IsURL("fe80:1:2::3:4"));
-            ClassicAssert.IsTrue(plugin.IsURL("::1"));
-            ClassicAssert.IsTrue(plugin.IsURL("HTTP://EXAMPLE.COM"));
-            ClassicAssert.IsTrue(plugin.IsURL("HTTPS://EXAMPLE.COM"));
-            ClassicAssert.IsTrue(plugin.IsURL("EXAMPLE.COM"));
-            ClassicAssert.IsTrue(plugin.IsURL("LOCALHOST"));
+            AlwaysOpenWithHttps = false
+        };
 
+        private readonly Main _plugin = new();
 
-            ClassicAssert.IsFalse(plugin.IsURL("wwww"));
-            ClassicAssert.IsFalse(plugin.IsURL("wwww.c"));
-            ClassicAssert.IsFalse(plugin.IsURL("wwww.c"));
-            ClassicAssert.IsFalse(plugin.IsURL("not a url"));
-            ClassicAssert.IsFalse(plugin.IsURL("just text"));
-            ClassicAssert.IsFalse(plugin.IsURL("http://"));
-            ClassicAssert.IsFalse(plugin.IsURL("://example.com"));
-            ClassicAssert.IsFalse(plugin.IsURL("0.0.0.0")); // Pattern excludes 0.0.0.0
-            ClassicAssert.IsFalse(plugin.IsURL("256.1.1.1")); // Invalid IPv4
-            ClassicAssert.IsFalse(plugin.IsURL("example")); // No TLD
-            ClassicAssert.IsFalse(plugin.IsURL(".com"));
-            ClassicAssert.IsFalse(plugin.IsURL("http://.com"));
+        public UrlPluginTest()
+        {
+            // Set the static Settings property before running tests
+            var settingProperty = typeof(Main).GetProperty("Settings", BindingFlags.NonPublic | BindingFlags.Static);
+            if (settingProperty == null)
+                Assert.Fail("Could not find property 'Settings' on Flow.Launcher.Plugin.Url.Main");
+            settingProperty.SetValue(null, _settings);
+        }
+
+        [TestCase("http://www.google.com")]
+        [TestCase("https://www.google.com")]
+        [TestCase("http://google.com")]
+        [TestCase("ftp://google.com")]
+        [TestCase("www.google.com")]
+        [TestCase("google.com")]
+        [TestCase("http://localhost")]
+        [TestCase("https://localhost")]
+        [TestCase("http://localhost:80")]
+        [TestCase("https://localhost:80")]
+        [TestCase("localhost")]
+        [TestCase("localhost:8080")]
+        [TestCase("http://110.10.10.10")]
+        [TestCase("110.10.10.10")]
+        [TestCase("110.10.10.10:8080")]
+        [TestCase("192.168.1.1")]
+        [TestCase("root@192.168.1.1")]
+        [TestCase("root@192.168.1.1:1080")]
+        [TestCase("root:password@127.0.0.1:1080")]
+        [TestCase("192.168.1.1:3000")]
+        [TestCase("ftp://110.10.10.10")]
+        [TestCase("[2001:db8::1]")]
+        [TestCase("[2001:db8::1]:8080")]
+        [TestCase("http://[2001:db8::1]")]
+        [TestCase("https://[2001:db8::1]:8080")]
+        [TestCase("[::1]")]
+        [TestCase("[::1]:8080")]
+        [TestCase("2001:db8::1")]
+        [TestCase("fe80:1:2::3:4")]
+        [TestCase("::1")]
+        [TestCase("HTTP://EXAMPLE.COM")]
+        [TestCase("HTTPS://EXAMPLE.COM")]
+        [TestCase("EXAMPLE.COM")]
+        [TestCase("EXAMPLE.COM/index.html")]
+        [TestCase("LOCALHOST")]
+        public void WhenValidUrlThenIsUrlReturnsTrue(string url)
+        {
+
+            Assert.That(_plugin.IsURL(url), Is.True);
+        }
+
+        [TestCase("wwww")]
+        [TestCase("wwww.c")]
+        [TestCase("not a url")]
+        [TestCase("just text")]
+        [TestCase("http://")]
+        [TestCase("://example.com")]
+        [TestCase("0.0.0.0")] // Pattern excludes 0.0.0.0
+        [TestCase("256.1.1.1")] // Invalid IPv4
+        [TestCase("example")] // No TLD
+        [TestCase(".com")]
+        [TestCase("http://.com")]
+        public void WhenInvalidUrlThenIsUrlReturnsFalse(string url)
+        {
+            Assert.That(_plugin.IsURL(url), Is.False);
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Url/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Url/Main.cs
@@ -9,48 +9,33 @@ namespace Flow.Launcher.Plugin.Url
 {
     public class Main : IPlugin, IPluginI18n, ISettingProvider
     {
-        //based on https://gist.github.com/dperini/729294
+        // Simplified pattern to quickly reject obviously invalid inputs
+        // Actual validation is done by Uri.TryCreate which properly handles all URL formats
         private const string UrlPattern = "^" +
-            // protocol identifier
-            "(?:(?:https?|ftp)://|)" +
-            // user:pass authentication
-            "(?:\\S+(?::\\S*)?@)?" +
+            // Optional protocol
+            "(?:(?:https?|ftp)://)?" +
+            // Optional user authentication
+            "(?:[^@\\s]+@)?" +
+            // Must contain at least one of:
             "(?:" +
-            // IPv6 address with optional brackets (brackets required if followed by port)
-            // IPv6 with brackets
-            "(?:\\[(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\\]|" + // standard IPv6
-            "\\[(?:[0-9a-fA-F]{1,4}:){1,7}:\\]|" + // IPv6 with trailing ::
-            "\\[(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}\\]|" + // IPv6 compressed
-            "\\[::(?:[0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4}\\]|" + // IPv6 with leading ::
-            "\\[(?:(?:[0-9a-fA-F]{1,4}:){1,6}|:):(?:[0-9a-fA-F]{1,4}:){0,5}[0-9a-fA-F]{1,4}\\]|" + // IPv6 with :: in the middle
-            "\\[::1\\])" + // IPv6 loopback
+            // - protocol with something after it
+            "(?:(?:https?|ftp)://).+" +
             "|" +
-            // IPv6 without brackets (only when no port follows)
-            "(?:(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|" + // standard IPv6
-            "(?:[0-9a-fA-F]{1,4}:){1,7}:|" + // IPv6 with trailing ::
-            "(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|" + // IPv6 compressed
-            "::(?:[0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4}|" + // IPv6 with leading ::
-            "(?:(?:[0-9a-fA-F]{1,4}:){1,6}|:):(?:[0-9a-fA-F]{1,4}:){0,5}[0-9a-fA-F]{1,4}|" + // IPv6 with :: in the middle
-            "::1)(?!:[0-9])" + // IPv6 loopback (not followed by port)
+            // - IPv6 address (simplified detection - just look for colons in brackets or multiple colons)
+            "(?:\\[[0-9a-fA-F:]+\\]|[0-9a-fA-F]*:[0-9a-fA-F:]+)" +
             "|" +
-            // IPv4 address - all valid addresses including private networks (excluding 0.0.0.0)
-            "(?:(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|[1-9])\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d))" +
+            // - IPv4 address (basic pattern)
+            "(?:[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})" +
             "|" +
-            // localhost
+            // - localhost
             "localhost" +
             "|" +
-            // host name
-            "(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)" +
-            // domain name
-            "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*" +
-            // TLD identifier
-            "(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))" +
+            // - domain with TLD (at least one dot with valid characters)
+            "(?:[a-z0-9-]+\\.)+[a-z]{2,}" +
             ")" +
-            // port number
-            "(?::\\d{1,5})?" +
-            // resource path
-            "(?:/\\S*)?" +
-            "$";
+            // Optional port and path
+            "(?::[0-9]{1,5})?(?:/.*)?$";
+            
         private readonly Regex UrlRegex = new(UrlPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
         internal static PluginInitContext Context { get; private set; }
         internal static Settings Settings { get; private set; }
@@ -110,18 +95,75 @@ namespace Flow.Launcher.Plugin.Url
                 ];
         }
 
-        private static string GetHttpPreference()
+        private string GetHttpPreference()
         {
             return Settings.AlwaysOpenWithHttps ? "https" : "http";
         }
 
         public bool IsURL(string raw)
         {
-            raw = raw.ToLower();
+            if (string.IsNullOrWhiteSpace(raw))
+                return false;
 
-            if (UrlRegex.Match(raw).Value == raw) return true;
+            var input = raw.Trim();
+            
+            // Quick pre-filter with regex to reject obviously invalid inputs
+            if (!UrlRegex.IsMatch(input))
+                return false;
 
-            return false;
+            // Pre-validate IPv4 addresses (Uri accepts invalid octets like 256)
+            // Match pattern: optional scheme/auth + IPv4 + optional port/path
+            var ipv4Match = Regex.Match(input, @"(?:(?:https?|ftp)://)?(?:[^@/]+@)?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(?:[:/]|$)");
+            if (ipv4Match.Success)
+            {
+                var octets = ipv4Match.Groups[1].Value.Split('.');
+                foreach (var octet in octets)
+                {
+                    if (!byte.TryParse(octet, out _))
+                        return false;
+                }
+                
+                if (ipv4Match.Groups[1].Value == "0.0.0.0")
+                    return false;
+            }
+
+            // Prepare URL for Uri.TryCreate validation
+            var urlToValidate = input;
+            
+            // Add scheme if missing
+            if (!UrlSchemes.Any(s => input.StartsWith(s, StringComparison.OrdinalIgnoreCase)))
+            {
+                // Handle bare IPv6 addresses (multiple colons, no @ for auth, no :// for scheme)
+                if (input.Count(c => c == ':') > 1 && !input.Contains("://") && !input.Contains('@'))
+                {
+                    // Add brackets if not already present
+                    if (!input.StartsWith('['))
+                    {
+                        // Check if there's a port at the end (]:port pattern)
+                        var portMatch = Regex.Match(input, @"\]:(\d{1,5})$");
+                        if (!portMatch.Success)
+                        {
+                            urlToValidate = $"{GetHttpPreference()}://[{input}]";
+                        }
+                        else
+                        {
+                            urlToValidate = GetHttpPreference() + "://" + input;
+                        }
+                    }
+                    else
+                    {
+                        urlToValidate = GetHttpPreference() + "://" + input;
+                    }
+                }
+                else
+                {
+                    urlToValidate = GetHttpPreference() + "://" + input;
+                }
+            }
+
+            // Use Uri.TryCreate for comprehensive validation
+            return Uri.TryCreate(urlToValidate, UriKind.Absolute, out var uri)
+                   && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps || uri.Scheme == Uri.UriSchemeFtp);
         }
 
         public void Init(PluginInitContext context)


### PR DESCRIPTION
Update the regex that determines if a string is URL in the URL plugin, so private addresses are no longer filtered. Fixes #4184.