### PR TITLE
Fix ShellPath directory for shell path selection

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -532,7 +532,7 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
         [RelayCommand]
         private void OpenShellPath()
         {
-            var path = PromptUserSelectPath(ResultType.File, Settings.EditorPath != null ? Path.GetDirectoryName(Settings.EditorPath) : null);
+            var path = PromptUserSelectPath(ResultType.File, Settings.ShellPath != null ? Path.GetDirectoryName(Settings.ShellPath) : null);
             if (path is null)
                 return;
 


### PR DESCRIPTION
Updated OpenShellPath to use Settings.ShellPath directory when prompting for a file path, ensuring the dialog opens in the relevant location instead of the editor path directory.

From TBM13:
<img width="1800" height="1178" alt="image" src="https://github.com/user-attachments/assets/7f0930a3-9129-474d-95e8-c90e33b43f63" />