### PR TITLE
Fix translation issue

### DIFF
--- a/Flow.Launcher.Core/ExternalPlugins/Environments/AbstractPluginEnvironment.cs
+++ b/Flow.Launcher.Core/ExternalPlugins/Environments/AbstractPluginEnvironment.cs
@@ -43,9 +43,10 @@ namespace Flow.Launcher.Core.ExternalPlugins.Environments
         internal IEnumerable<PluginPair> Setup()
         {
             // If no plugin is using the language, return empty list
-            if (!PluginMetadataList.Any(o => o.Language.Equals(Language, StringComparison.OrdinalIgnoreCase)))
+            var pluginCount = PluginMetadataList.Count(o => o.Language.Equals(Language, StringComparison.OrdinalIgnoreCase));
+            if (pluginCount == 0)
             {
-                return new List<PluginPair>();
+                return [];
             }
 
             if (!string.IsNullOrEmpty(PluginsSettingsFilePath) && FilesFolders.FileExists(PluginsSettingsFilePath))
@@ -57,7 +58,7 @@ namespace Flow.Launcher.Core.ExternalPlugins.Environments
                 return SetPathForPluginPairs(PluginsSettingsFilePath, Language);
             }
 
-            var noRuntimeMessage = Localize.runtimePluginInstalledChooseRuntimePrompt(Language, EnvName, Environment.NewLine);
+            var noRuntimeMessage = Localize.runtimePluginInstalledChooseRuntimePrompt(pluginCount, EnvName, Environment.NewLine);
             if (API.ShowMsgBox(noRuntimeMessage, string.Empty, MessageBoxButton.YesNo) == MessageBoxResult.No)
             {
                 var msg = Localize.runtimePluginChooseRuntimeExecutable(EnvName);
@@ -114,7 +115,7 @@ namespace Flow.Launcher.Core.ExternalPlugins.Environments
                     $"Not able to successfully set {EnvName} path, setting's plugin executable path variable is still an empty string.",
                     $"{Language}Environment");
 
-                return new List<PluginPair>();
+                return [];
             }
         }
 
@@ -131,7 +132,7 @@ namespace Flow.Launcher.Core.ExternalPlugins.Environments
 
         internal abstract PluginPair CreatePluginPair(string filePath, PluginMetadata metadata);
 
-        private IEnumerable<PluginPair> SetPathForPluginPairs(string filePath, string languageToSet)
+        private List<PluginPair> SetPathForPluginPairs(string filePath, string languageToSet)
         {
             var pluginPairs = new List<PluginPair>();
 


### PR DESCRIPTION
Use the number for translation:

```
/// <remarks>
/// e.g.: <code>
/// 
/// Flow detected you have installed {0} plugins, which will require {1} to run. Would you like to download {1}?
/// {2}{2}
/// Click no if it's already installed, and you will be prompted to select the folder that contains the {1} executable
/// 
/// </code>
/// </remarks>
public static string runtimePluginInstalledChooseRuntimePrompt(object? arg0, object? arg1, object? arg2) => string.Format(Flow.Launcher.Core.PublicApi.Instance.GetTranslation("runtimePluginInstalledChooseRuntimePrompt"), arg0, arg1, arg2);
```

Resolve #4255

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the runtime prompt translation and improves setup by counting how many plugins use each language, then showing that count in the message. Skips setup when none need the environment.

- **Bug Fixes**
  - Count plugins per language; return [] if none.
  - Update localized prompt to use numeric placeholders and include plugin count.
  - Use [] for empty returns; change SetPathForPluginPairs to return List<PluginPair>.

<sup>Written for commit 517293a567324431b5576fcc66a2d0b32060c28a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

