### PR TITLE
Downgrade iNKORE.UI.WPF.Modern to 0.10.1 for WebSearch Plugin

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.WebSearch/Flow.Launcher.Plugin.WebSearch.csproj
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/Flow.Launcher.Plugin.WebSearch.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iNKORE.UI.WPF.Modern" Version="0.10.2.1" />
+    <PackageReference Include="iNKORE.UI.WPF.Modern" Version="0.10.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The package reference for iNKORE.UI.WPF.Modern in Flow.Launcher.Plugin.WebSearch.csproj was changed from version 0.10.2.1 to 0.10.1.

Follow on with #4198 

<img width="1410" height="900" alt="image" src="https://github.com/user-attachments/assets/727acc09-702e-49cd-85c4-89516b8583c9" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgrades iNKORE.UI.WPF.Modern in the WebSearch plugin from 0.10.2.1 to 0.10.1 to restore compatibility and unblock the WebSearch UI. Context: this follows up on #4198 and closes the WebSearch plugin issue introduced by 0.10.2.1.

<sup>Written for commit cb604926577c2e572b93a073fdd70273b3d9a035. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

