### PR TITLE
Revert SkiaSharp version bump & remove unnecessary runtimes

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Flow.Launcher.Plugin.BrowserBookmark.csproj
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Flow.Launcher.Plugin.BrowserBookmark.csproj
@@ -87,20 +87,6 @@
                             $(PublishDir)runtimes\win-arm64;"/>
   </Target>
 
-  <!-- Workaround for https://github.com/mono/SkiaSharp/issues/3519 -->
-  <Target Name="RemoveUnnecessaryPdbFilesAfterBuild" AfterTargets="Build">
-    <ItemGroup>
-      <PdbFilesToRemoveBuild Include="$(OutputPath)runtimes\**\*.pdb" />
-    </ItemGroup>
-    <Delete Files="@(PdbFilesToRemoveBuild)" />
-  </Target>
-  <Target Name="RemoveUnnecessaryPdbFilesAfterPublish" AfterTargets="Publish">
-    <ItemGroup>
-      <PdbFilesToRemovePublish Include="$(PublishDir)runtimes\**\*.pdb" />
-    </ItemGroup>
-    <Delete Files="@(PdbFilesToRemovePublish)" />
-  </Target>
-
   <ItemGroup>
     <None Include="plugin.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -125,7 +111,7 @@
     <PackageReference Include="Flow.Launcher.Localization" Version="0.0.6" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.3" />
     <PackageReference Include="Svg.Skia" Version="3.4.1" />
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Revert Skia Sharp version bump and remove unnecessary runtimes from packages.

Follow on with #4260.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim unnecessary SkiaSharp runtimes in the BrowserBookmark plugin to reduce package size and clean outputs.

- **Refactors**
  - Filter out linux-musl-riscv64 and linux-riscv64 in OutputPath and PublishDir.
  - Revert SkiaSharp to 3.119.1 for compatibility.

<sup>Written for commit 9e66f717746b98d6a97f659159773c4c128e6479. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

