### PR TITLE
Fix process priority for logon startup task set to BelowNormal by default

### DIFF
--- a/Flow.Launcher/Helper/AutoStartup.cs
+++ b/Flow.Launcher/Helper/AutoStartup.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Security.Principal;
 using Flow.Launcher.Infrastructure;
@@ -65,7 +66,7 @@ public class AutoStartup
                 {
                     var action = taskAction.ToString().Trim();
                     var needsRecreation = !action.Equals(Constant.ExecutablePath, StringComparison.OrdinalIgnoreCase)
-                        || task.Definition.Settings.Priority != System.Diagnostics.ProcessPriorityClass.Normal;
+                        || task.Definition.Settings.Priority != ProcessPriorityClass.Normal;
                     if (needsRecreation)
                     {
                         UnscheduleLogonTask();
@@ -186,7 +187,7 @@ public class AutoStartup
         td.Settings.StopIfGoingOnBatteries = false;
         td.Settings.DisallowStartIfOnBatteries = false;
         td.Settings.ExecutionTimeLimit = TimeSpan.Zero;
-        td.Settings.Priority = System.Diagnostics.ProcessPriorityClass.Normal;
+        td.Settings.Priority = ProcessPriorityClass.Normal;
 
         try
         {


### PR DESCRIPTION
Follow on with #3218,

The default value of `task.Definition.Settings.Priority` seems to be `BelowNormal` which is used for background services.

Now we use normal for it.

Fix #4281.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sluggish responsiveness when Flow Launcher starts via the Windows logon task by setting the task’s process priority to Normal and auto-recreating it if the priority is wrong. This addresses Task Scheduler’s default BelowNormal/Low priority, fixes existing installs on next start, and closes #4281 (follow-up to #3218).

<sup>Written for commit fc3860cca46d3876b36f40e157edf4deb974beb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

