### PR TITLE
Move progress bar animation init to Loaded event to fix possible null exception of ProgressBar

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -342,6 +342,7 @@
                     Margin="12 0 12 0"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Bottom"
+                    Loaded="ProgressBar_Loaded"
                     StrokeThickness="2"
                     Visibility="{Binding ProgressBarVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                     X1="-100"

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -199,9 +199,6 @@ namespace Flow.Launcher
                 ThemeManager.Current.ApplicationTheme = ApplicationTheme.Dark;
             }
 
-            // Initialize position
-            InitProgressbarAnimation();
-
             // Force update position
             UpdatePosition();
 
@@ -352,6 +349,11 @@ namespace Flow.Launcher
             {
                 _viewModel.QueryResults();
             }
+        }
+
+        private void ProgressBar_Loaded(object sender, RoutedEventArgs e)
+        {
+            InitProgressbarAnimation();
         }
 
         private async void OnClosing(object sender, CancelEventArgs e)


### PR DESCRIPTION
InitProgressbarAnimation is now triggered by the progress bar's Loaded event instead of during main window initialization. This ensures the animation starts only after the progress bar is fully loaded, improving reliability and preventing potential UI timing issues.

Resolve #4311

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the progress bar animation init from window load to the ProgressBar Loaded event. This prevents null reference exceptions and ensures the animation starts only after the control is ready.

- **Summary of changes**
  - Changed: Removed InitProgressbarAnimation() call from MainWindow.OnLoaded; animation now depends on the ProgressBar’s lifecycle.
  - Added: ProgressBar_Loaded event handler in code-behind that calls InitProgressbarAnimation(); wired up in XAML via Loaded="ProgressBar_Loaded".
  - Removed: Early initialization of the progress bar animation during main window initialization.
  - Tests: No unit tests added (UI timing change).
  - Security: No security impact; UI-only change.

<sup>Written for commit a2f224225e33d4401992423ced546f74544f51f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

