### PR TITLE
Freeze SolidColorBrush to improve performance

### DIFF
--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -674,16 +674,12 @@ namespace Flow.Launcher.Core.Resource
                 if (backdropType == BackdropTypes.Mica || backdropType == BackdropTypes.MicaAlt)
                 {
                     windowBorderStyle.Setters.Remove(windowBorderStyle.Setters.OfType<Setter>().FirstOrDefault(x => x.Property == Control.BackgroundProperty));
-                    var brush = new SolidColorBrush(Color.FromArgb(1, 0, 0, 0));
-                    brush.Freeze();
-                    windowBorderStyle.Setters.Add(new Setter(Border.BackgroundProperty, brush));
+                    windowBorderStyle.Setters.Add(new Setter(Border.BackgroundProperty, ThemeHelper.GetFreezeSolidColorBrush(Color.FromArgb(1, 0, 0, 0))));
                 }
                 else if (backdropType == BackdropTypes.Acrylic)
                 {
                     windowBorderStyle.Setters.Remove(windowBorderStyle.Setters.OfType<Setter>().FirstOrDefault(x => x.Property == Control.BackgroundProperty));
-                    var brush = new SolidColorBrush(Colors.Transparent);
-                    brush.Freeze();
-                    windowBorderStyle.Setters.Add(new Setter(Border.BackgroundProperty, brush));
+                    windowBorderStyle.Setters.Add(new Setter(Border.BackgroundProperty, Brushes.Transparent));
                 }
                 
                 // For themes with blur enabled, the window border is rendered by the system, so it's treated as a simple rectangle regardless of thickness.
@@ -806,10 +802,8 @@ namespace Flow.Launcher.Core.Resource
             }
 
             // Apply background color (remove transparency in color)
-            Color backgroundColor = Color.FromRgb(bgColor.Value.R, bgColor.Value.G, bgColor.Value.B);
-            var brush = new SolidColorBrush(backgroundColor);
-            brush.Freeze();
-            previewStyle.Setters.Add(new Setter(Border.BackgroundProperty, brush));
+            var backgroundColor = Color.FromRgb(bgColor.Value.R, bgColor.Value.G, bgColor.Value.B);
+            previewStyle.Setters.Add(new Setter(Border.BackgroundProperty, ThemeHelper.GetFreezeSolidColorBrush(backgroundColor)));
 
             // The blur theme keeps the corner round fixed (applying DWM code to modify it causes rendering issues).
             // The non-blur theme retains the previously set WindowBorderStyle.
@@ -923,15 +917,11 @@ namespace Flow.Launcher.Core.Resource
                 // Only set the background to transparent if the theme supports blur
                 if (backdropType == BackdropTypes.Mica || backdropType == BackdropTypes.MicaAlt)
                 {
-                    var backgroundBrush = new SolidColorBrush(Color.FromArgb(1, 0, 0, 0));
-                    backgroundBrush.Freeze();
-                    mainWindow.Background = backgroundBrush;
+                    mainWindow.Background = ThemeHelper.GetFreezeSolidColorBrush(Color.FromArgb(1, 0, 0, 0));
                 }
                 else
                 {
-                    var backgroundBrush = new SolidColorBrush(selectedBG);
-                    backgroundBrush.Freeze();
-                    mainWindow.Background = backgroundBrush;
+                    mainWindow.Background = ThemeHelper.GetFreezeSolidColorBrush(selectedBG);
                 }
             }
         }

--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -673,13 +673,17 @@ namespace Flow.Launcher.Core.Resource
                 // If the BackdropType is Mica or MicaAlt, set the windowborderstyle's background to transparent
                 if (backdropType == BackdropTypes.Mica || backdropType == BackdropTypes.MicaAlt)
                 {
-                    windowBorderStyle.Setters.Remove(windowBorderStyle.Setters.OfType<Setter>().FirstOrDefault(x => x.Property.Name == "Background"));
-                    windowBorderStyle.Setters.Add(new Setter(Border.BackgroundProperty, new SolidColorBrush(Color.FromArgb(1, 0, 0, 0))));
+                    windowBorderStyle.Setters.Remove(windowBorderStyle.Setters.OfType<Setter>().FirstOrDefault(x => x.Property == Control.BackgroundProperty));
+                    var brush = new SolidColorBrush(Color.FromArgb(1, 0, 0, 0));
+                    brush.Freeze();
+                    windowBorderStyle.Setters.Add(new Setter(Border.BackgroundProperty, brush));
                 }
                 else if (backdropType == BackdropTypes.Acrylic)
                 {
-                    windowBorderStyle.Setters.Remove(windowBorderStyle.Setters.OfType<Setter>().FirstOrDefault(x => x.Property.Name == "Background"));
-                    windowBorderStyle.Setters.Add(new Setter(Border.BackgroundProperty, new SolidColorBrush(Colors.Transparent)));
+                    windowBorderStyle.Setters.Remove(windowBorderStyle.Setters.OfType<Setter>().FirstOrDefault(x => x.Property == Control.BackgroundProperty));
+                    var brush = new SolidColorBrush(Colors.Transparent);
+                    brush.Freeze();
+                    windowBorderStyle.Setters.Add(new Setter(Border.BackgroundProperty, brush));
                 }
                 
                 // For themes with blur enabled, the window border is rendered by the system, so it's treated as a simple rectangle regardless of thickness.
@@ -803,7 +807,9 @@ namespace Flow.Launcher.Core.Resource
 
             // Apply background color (remove transparency in color)
             Color backgroundColor = Color.FromRgb(bgColor.Value.R, bgColor.Value.G, bgColor.Value.B);
-            previewStyle.Setters.Add(new Setter(Border.BackgroundProperty, new SolidColorBrush(backgroundColor)));
+            var brush = new SolidColorBrush(backgroundColor);
+            brush.Freeze();
+            previewStyle.Setters.Add(new Setter(Border.BackgroundProperty, brush));
 
             // The blur theme keeps the corner round fixed (applying DWM code to modify it causes rendering issues).
             // The non-blur theme retains the previously set WindowBorderStyle.
@@ -917,11 +923,15 @@ namespace Flow.Launcher.Core.Resource
                 // Only set the background to transparent if the theme supports blur
                 if (backdropType == BackdropTypes.Mica || backdropType == BackdropTypes.MicaAlt)
                 {
-                    mainWindow.Background = new SolidColorBrush(Color.FromArgb(1, 0, 0, 0));
+                    var backgroundBrush = new SolidColorBrush(Color.FromArgb(1, 0, 0, 0));
+                    backgroundBrush.Freeze();
+                    mainWindow.Background = backgroundBrush;
                 }
                 else
                 {
-                    mainWindow.Background = new SolidColorBrush(selectedBG);
+                    var backgroundBrush = new SolidColorBrush(selectedBG);
+                    backgroundBrush.Freeze();
+                    mainWindow.Background = backgroundBrush;
                 }
             }
         }

--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -674,7 +674,7 @@ namespace Flow.Launcher.Core.Resource
                 if (backdropType == BackdropTypes.Mica || backdropType == BackdropTypes.MicaAlt)
                 {
                     windowBorderStyle.Setters.Remove(windowBorderStyle.Setters.OfType<Setter>().FirstOrDefault(x => x.Property == Control.BackgroundProperty));
-                    windowBorderStyle.Setters.Add(new Setter(Border.BackgroundProperty, ThemeHelper.GetFreezeSolidColorBrush(Color.FromArgb(1, 0, 0, 0))));
+                    windowBorderStyle.Setters.Add(new Setter(Border.BackgroundProperty, ThemeHelper.GetFrozenSolidColorBrush(Color.FromArgb(1, 0, 0, 0))));
                 }
                 else if (backdropType == BackdropTypes.Acrylic)
                 {
@@ -803,7 +803,7 @@ namespace Flow.Launcher.Core.Resource
 
             // Apply background color (remove transparency in color)
             var backgroundColor = Color.FromRgb(bgColor.Value.R, bgColor.Value.G, bgColor.Value.B);
-            previewStyle.Setters.Add(new Setter(Border.BackgroundProperty, ThemeHelper.GetFreezeSolidColorBrush(backgroundColor)));
+            previewStyle.Setters.Add(new Setter(Border.BackgroundProperty, ThemeHelper.GetFrozenSolidColorBrush(backgroundColor)));
 
             // The blur theme keeps the corner round fixed (applying DWM code to modify it causes rendering issues).
             // The non-blur theme retains the previously set WindowBorderStyle.
@@ -902,11 +902,11 @@ namespace Flow.Launcher.Core.Resource
                 // Only set the background to transparent if the theme supports blur
                 if (backdropType == BackdropTypes.Mica || backdropType == BackdropTypes.MicaAlt)
                 {
-                    mainWindow.Background = ThemeHelper.GetFreezeSolidColorBrush(Color.FromArgb(1, 0, 0, 0));
+                    mainWindow.Background = ThemeHelper.GetFrozenSolidColorBrush(Color.FromArgb(1, 0, 0, 0));
                 }
                 else
                 {
-                    mainWindow.Background = ThemeHelper.GetFreezeSolidColorBrush(selectedBG);
+                    mainWindow.Background = ThemeHelper.GetFrozenSolidColorBrush(selectedBG);
                 }
             }
         }

--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -798,7 +798,7 @@ namespace Flow.Launcher.Core.Resource
                 Application.Current.Resources["WindowBorderStyle"] is Style originalStyle)
             {
                 // Copy the original style, including the base style if it exists
-                CopyStyle(originalStyle, previewStyle);
+                ThemeHelper.CopyStyle(originalStyle, previewStyle);
             }
 
             // Apply background color (remove transparency in color)
@@ -815,21 +815,6 @@ namespace Flow.Launcher.Core.Resource
 
             // Set the new style to the resource
             Application.Current.Resources["PreviewWindowBorderStyle"] = previewStyle;
-        }
-
-        private void CopyStyle(Style originalStyle, Style targetStyle)
-        {
-            // If the style is based on another style, copy the base style first
-            if (originalStyle.BasedOn != null)
-            {
-                CopyStyle(originalStyle.BasedOn, targetStyle);
-            }
-
-            // Copy the setters from the original style
-            foreach (var setter in originalStyle.Setters.OfType<Setter>())
-            {
-                targetStyle.Setters.Add(new Setter(setter.Property, setter.Value));
-            }
         }
 
         private void ColorizeWindow(string theme, BackdropTypes backdropType)

--- a/Flow.Launcher.Core/Resource/ThemeHelper.cs
+++ b/Flow.Launcher.Core/Resource/ThemeHelper.cs
@@ -1,0 +1,13 @@
+﻿using System.Windows.Media;
+
+namespace Flow.Launcher.Core.Resource;
+
+public static class ThemeHelper
+{
+    public static SolidColorBrush GetFreezeSolidColorBrush(Color color)
+    {
+        var brush = new SolidColorBrush(color);
+        brush.Freeze();
+        return brush;
+    }
+}

--- a/Flow.Launcher.Core/Resource/ThemeHelper.cs
+++ b/Flow.Launcher.Core/Resource/ThemeHelper.cs
@@ -1,9 +1,26 @@
-﻿using System.Windows.Media;
+﻿using System.Linq;
+using System.Windows;
+using System.Windows.Media;
 
 namespace Flow.Launcher.Core.Resource;
 
 public static class ThemeHelper
 {
+    public static void CopyStyle(Style originalStyle, Style targetStyle)
+    {
+        // If the style is based on another style, copy the base style first
+        if (originalStyle.BasedOn != null)
+        {
+            CopyStyle(originalStyle.BasedOn, targetStyle);
+        }
+
+        // Copy the setters from the original style
+        foreach (var setter in originalStyle.Setters.OfType<Setter>())
+        {
+            targetStyle.Setters.Add(new Setter(setter.Property, setter.Value));
+        }
+    }
+
     public static SolidColorBrush GetFreezeSolidColorBrush(Color color)
     {
         var brush = new SolidColorBrush(color);

--- a/Flow.Launcher.Core/Resource/ThemeHelper.cs
+++ b/Flow.Launcher.Core/Resource/ThemeHelper.cs
@@ -21,7 +21,7 @@ public static class ThemeHelper
         }
     }
 
-    public static SolidColorBrush GetFreezeSolidColorBrush(Color color)
+    public static SolidColorBrush GetFrozenSolidColorBrush(Color color)
     {
         var brush = new SolidColorBrush(color);
         brush.Freeze();


### PR DESCRIPTION
Refactor background brush creation to assign, freeze, and reuse SolidColorBrush instances for better WPF performance.

Separated from #4302

Test: All types of themes work as expected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freezes SolidColorBrush instances, switches to type‑safe Background property checks, and moves style‑copy logic to ThemeHelper to cut allocations and improve WPF rendering. Uses Brushes.Transparent where clearer.

- **Summary of changes**
  - Changed: Replace string-based setter lookup with Control.BackgroundProperty in SetBlurForWindow.
  - Changed: Use ThemeHelper.GetFrozenSolidColorBrush in SetBlurForWindow, ApplyPreviewBackground, and ColorizeWindow.
  - Changed: Call ThemeHelper.CopyStyle instead of a local method in ApplyPreviewBackground.
  - Changed: Use Brushes.Transparent for the Acrylic path.
  - Added: ThemeHelper utility with GetFrozenSolidColorBrush and CopyStyle.
  - Removed: Theme.CopyStyle method, inline unfrozen SolidColorBrush allocations, and reliance on property name strings.
  - Memory: Slight reduction in allocations and change tracking.
  - Security: No new risks.
  - Tests: No unit tests; verified via UI rendering.

<sup>Written for commit 7766d7053da399ec1dabeb752566dd6a86066592. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

