### PR TITLE
Use DynamicResource for TextBox SelectionBrush

### DIFF
--- a/Flow.Launcher/Themes/Win11Light.xaml
+++ b/Flow.Launcher/Themes/Win11Light.xaml
@@ -52,7 +52,7 @@
         <Setter Property="Padding" Value="0 0 50 0" />
         <Setter Property="Foreground" Value="{DynamicResource Color05B}" />
         <Setter Property="CaretBrush" Value="{DynamicResource Color05B}" />
-        <Setter Property="SelectionBrush" Value="{StaticResource SystemAccentColorLight1Brush}" />
+        <Setter Property="SelectionBrush" Value="{DynamicResource SystemAccentColorLight1Brush}" />
         <Setter Property="FontSize" Value="16" />
         <Setter Property="Height" Value="42" />
     </Style>


### PR DESCRIPTION
Changed SelectionBrush in TextBox style from StaticResource to DynamicResource for SystemAccentColorLight1Brush.

Resolve #4298. Tested by participants in #4298

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the TextBox SelectionBrush from StaticResource to DynamicResource so the selection color updates live with the system accent. Improves theme responsiveness and fixes #4298.

- **Summary of changes**
  - Changed: SelectionBrush in Win11Light TextBox style now uses DynamicResource for SystemAccentColorLight1Brush, enabling runtime updates when the accent color changes.
  - Added: Live resource lookup for the selection highlight to reflect system/theme changes without restart.
  - Removed: Dependency on a static resource lookup that froze the selection color at load.
  - Memory: No meaningful impact; DynamicResource adds negligible lookup overhead but no measurable memory growth.
  - Security: No risk; XAML style-only change.
  - Tests: No unit tests added; verified manually by participants in #4298.

<sup>Written for commit 71944ab6cdc638b128f214703d07e6dd16c1405f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

