### PR TITLE
Refactor AutoDropShadow logic for clarity and correctness

### DIFF
--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -706,30 +706,27 @@ namespace Flow.Launcher.Core.Resource
 
         private void AutoDropShadow(bool useDropShadowEffect)
         {
-            SetWindowCornerPreference("Default");
-            RemoveDropShadowEffectFromCurrentTheme();
             if (useDropShadowEffect)
             {
                 if (BlurEnabled && Win32Helper.IsBackdropSupported())
                 {
+                    // For themes with blur enabled, the window border is rendered by the system,
+                    // so we set corner preference to round and remove drop shadow effect to avoid rendering issues.
                     SetWindowCornerPreference("Round");
+                    RemoveDropShadowEffectFromCurrentTheme();
                 }
                 else
                 {
+                    // For themes without blur, we set corner preference to default and add drop shadow effect.
                     SetWindowCornerPreference("Default");
                     AddDropShadowEffectToCurrentTheme();
                 }
             }
             else
             {
-                if (BlurEnabled && Win32Helper.IsBackdropSupported())
-                {
-                    SetWindowCornerPreference("Default");
-                }
-                else
-                {
-                    RemoveDropShadowEffectFromCurrentTheme();
-                }
+                // When drop shadow effect is disabled, we set corner preference to default and remove drop shadow effect.
+                SetWindowCornerPreference("Default");
+                RemoveDropShadowEffectFromCurrentTheme();
             }
         }
 


### PR DESCRIPTION
Separated from #4302.

# TEST

* Query window shadow effect still works.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
**Summary of changes**

Refactors AutoDropShadow to remove redundant calls and make the blur/backdrop vs. shadow behavior explicit and correct. Improves readability and avoids rendering glitches when blur is enabled.

- Changed
  - Reworked branching so corner preference and shadow effect are set only within the relevant paths.
  - Behavior mapping:
    - Blur enabled + backdrop supported + shadow enabled → Set corners to Round; remove drop shadow.
    - Blur disabled (or backdrop unsupported) + shadow enabled → Set corners to Default; add drop shadow.
    - Shadow disabled → Set corners to Default; remove drop shadow.
- Added
  - Clear inline comments explaining each case to prevent future regressions.
- Removed
  - Unconditional SetWindowCornerPreference("Default") and RemoveDropShadowEffectFromCurrentTheme() at method start.
  - Convoluted branching that duplicated operations.
- Memory impact
  - None. Fewer calls; no allocations added.
- Security risks
  - None. UI-only refactor; no new inputs or surfaces.
- Unit tests
  - No new unit tests. UI behavior validated via manual testing paths.

<sup>Written for commit b5d372ed4b9369019674551330920e71ab92ff8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

