### PR TITLE
Refactor theme resource dictionary retrieval logic

### DIFF
--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -418,11 +418,6 @@ namespace Flow.Launcher.Core.Resource
                 if (string.IsNullOrEmpty(path))
                     throw new DirectoryNotFoundException($"Theme path can't be found <{path}>");
 
-                // Retrieve theme resource – always use the resource with font settings applied.
-                var resourceDict = GetResourceDictionary(theme);
-
-                UpdateResourceDictionary(resourceDict);
-
                 _settings.Theme = theme;
 
                 // Always allow re-loading default theme, in case of failure of switching to a new theme from default theme
@@ -432,7 +427,8 @@ namespace Flow.Launcher.Core.Resource
                 }
 
                 // Check if blur is enabled
-                BlurEnabled = Win32Helper.IsBackdropSupported() && IsThemeBlurEnabled(resourceDict);
+                var dict = GetThemeResourceDictionary(theme);
+                BlurEnabled = Win32Helper.IsBackdropSupported() && IsThemeBlurEnabled(dict);
 
                 // Apply blur and drop shadow effect so that we do not need to call it again
                 _ = RefreshFrameAsync();


### PR DESCRIPTION
# CHANGES

No need to update the resource dictionary in this place. Since it will be updated later in this function.

Separated from #4302.

# TEST

* Changing themes still works.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors theme resource dictionary handling in `Theme.ChangeTheme` to use a single `GetThemeResourceDictionary` call. Simplifies blur enablement logic without changing user-visible behavior.

- **Summary of changes**
  - Changed: Blur enablement now uses the dictionary from `GetThemeResourceDictionary(theme)`. Dictionary retrieval happens once and is used directly for `IsThemeBlurEnabled`.
  - Added: Use of `GetThemeResourceDictionary(theme)` to centralize getting the font-applied theme resources used during theme change.
  - Removed: Explicit calls to `GetResourceDictionary(theme)` and `UpdateResourceDictionary(...)`.
  - Memory: No impact. Only a local variable is introduced; no long-lived allocations.
  - Security: No new risks. No I/O, deserialization, or permission changes.
  - Tests: No new unit tests. Manually verified that changing themes still works.

<sup>Written for commit c0134d56921f994f3578edaf03dfc10c9437d47a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

