### PR TITLE
Fix ReportWindow crash when log directory is empty or missing

### DIFF
--- a/Flow.Launcher/ReportWindow.xaml.cs
+++ b/Flow.Launcher/ReportWindow.xaml.cs
@@ -50,7 +50,7 @@ namespace Flow.Launcher
             }
             catch (Exception)
             {
-                // Ignore IO errors when trying to find the log file
+                // Intentionally ignore all errors when trying to find the log file to avoid secondary crashes
             }
 
             var websiteUrl = exception switch

--- a/Flow.Launcher/ReportWindow.xaml.cs
+++ b/Flow.Launcher/ReportWindow.xaml.cs
@@ -38,9 +38,20 @@ namespace Flow.Launcher
 
         private void SetException(Exception exception)
         {
-            var path = DataLocation.VersionLogDirectory;
-            var directory = new DirectoryInfo(path);
-            var log = directory.GetFiles().OrderByDescending(f => f.LastWriteTime).First();
+            FileInfo log = null;
+            try
+            {
+                var path = DataLocation.VersionLogDirectory;
+                var directory = new DirectoryInfo(path);
+                if (directory.Exists)
+                {
+                    log = directory.GetFiles().OrderByDescending(f => f.LastWriteTime).FirstOrDefault();
+                }
+            }
+            catch (Exception)
+            {
+                // Ignore IO errors when trying to find the log file
+            }
 
             var websiteUrl = exception switch
             {
@@ -49,8 +60,11 @@ namespace Flow.Launcher
             };
 
             var paragraph = Hyperlink(Localize.reportWindow_please_open_issue(), websiteUrl);
-            paragraph.Inlines.Add(Localize.reportWindow_upload_log(log.FullName));
-            paragraph.Inlines.Add("\n");
+            if (log is not null)
+            {
+                paragraph.Inlines.Add(Localize.reportWindow_upload_log(log.FullName));
+                paragraph.Inlines.Add("\n");
+            }
             paragraph.Inlines.Add(Localize.reportWindow_copy_below());
             ErrorTextbox.Document.Blocks.Add(paragraph);
 


### PR DESCRIPTION
Resolve #4326

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
**Summary of changes**
Fixes a crash in ReportWindow when the log directory is missing, empty, or unreadable by safely handling IO errors and absent log files. The UI only prompts to upload a log when a log file exists.

**Bug Fixes**
- Changed: `SetException` now verifies directory existence and uses `FirstOrDefault()` for the latest log.
- Added: Try/catch around log discovery, a null-check before adding the “upload log” hint, and clearer code comments explaining the defensive handling.
- Removed: The assumption that a log directory and at least one log file always exist.
- Memory: No meaningful impact.
- Security: No new risks; avoids exposing paths unless a log is present and intended to be shown.
- Tests: No unit tests added.

<sup>Written for commit b1d98f60dd1d4c60bc848a8131e787244a8e0cfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

