### PR TITLE
Fix ArgumentException when editing a disabled Explorer action keyword

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -230,7 +230,7 @@ namespace Flow.Launcher.Plugin.Explorer
         internal Dictionary<ActionKeyword, string> GetActiveActionKeywords(string actionKeywordStr)
         {
             var result = new Dictionary<ActionKeyword, string>();
-            if (string.IsNullOrEmpty(actionKeywordStr)) return null;
+            if (string.IsNullOrEmpty(actionKeywordStr)) return result;
             foreach (var action in Enum.GetValues<ActionKeyword>())
             {
                 var keywordStr = GetActionKeyword(action);

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ViewModels/SettingsViewModel.cs
@@ -321,8 +321,9 @@ namespace Flow.Launcher.Plugin.Explorer.ViewModels
                     Context.API.AddActionKeyword(Context.CurrentPluginMetadata.ID, actionKeywordWindow.ActionKeyword);
                     break;
                 case (false, false):
-                    throw new ArgumentException(
-                        $"Both false in {nameof(actionKeyword)}.{nameof(actionKeyword.Enabled)} and {nameof(actionKeywordWindow)}.{nameof(actionKeywordWindow.KeywordEnabled)} should suggest that the ShowDialog() result is false");
+                    // Keyword was disabled and remains disabled, but the keyword text was changed.
+                    // No action keyword registration changes needed; the model will be updated below.
+                    break;
             }
 
             (actionKeyword.Keyword, actionKeyword.Enabled) = (actionKeywordWindow.ActionKeyword, actionKeywordWindow.KeywordEnabled);

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml
@@ -82,7 +82,7 @@
                         VerticalAlignment="Center"
                         DataObject.Pasting="TextBox_Pasting"
                         PreviewKeyDown="TxtCurrentActionKeyword_OnKeyDown"
-                        Text="{Binding ActionKeyword}" />
+                        Text="{Binding ActionKeyword, UpdateSourceTrigger=PropertyChanged}" />
                 </StackPanel>
                 <StackPanel Margin="0 10 0 15" Orientation="Horizontal">
                     <TextBlock

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ActionKeywordSetting.xaml.cs
@@ -16,9 +16,9 @@ namespace Flow.Launcher.Plugin.Explorer.Views
             get => actionKeyword;
             set
             {
-                // Set Enable to be true if user change ActionKeyword
-                KeywordEnabled = true;
-                _ = SetProperty(ref actionKeyword, value);
+                // Set Enable to be true only when the ActionKeyword value actually changes
+                if (SetProperty(ref actionKeyword, value))
+                    KeywordEnabled = true;
             }
         }
 
@@ -34,8 +34,9 @@ namespace Flow.Launcher.Plugin.Explorer.Views
         public ActionKeywordSetting(ActionKeywordModel selectedActionKeyword)
         {
             CurrentActionKeyword = selectedActionKeyword;
-            ActionKeyword = selectedActionKeyword.Keyword;
-            KeywordEnabled = selectedActionKeyword.Enabled;
+            // Initialize backing fields directly to avoid triggering the auto-enable side-effect
+            actionKeyword = selectedActionKeyword.Keyword;
+            _keywordEnabled = selectedActionKeyword.Enabled;
 
             InitializeComponent();
 


### PR DESCRIPTION
Resolve #4289

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
**Summary of changes**

Fixes an ArgumentException when editing a disabled action keyword in `Flow.Launcher.Plugin.Explorer` and prevents a potential NullReferenceException. The Action Keyword dialog now updates as you type and only auto-enables when the keyword actually changes.

- Changed logic/behavior:
  - In SettingsViewModel.EditActionKeyword: handle the (disabled → disabled) case by doing nothing instead of throwing, allowing text edits on a disabled keyword without re-registering it.
  - In Settings.GetActiveActionKeywords: return an empty dictionary when the input string is null/empty (was returning null), avoiding null checks and NullReferenceException risks.
  - In ActionKeywordSetting.ActionKeyword setter: only set KeywordEnabled = true when the value actually changes, preventing unintended auto-enable during no-op sets.
  - In ActionKeywordSetting constructor: initialize backing fields directly to avoid triggering auto-enable during dialog initialization.
  - In ActionKeywordSetting.xaml: TextBox binding uses UpdateSourceTrigger=PropertyChanged so the model updates as the user types, making the enable checkbox reflect changes immediately.

- New logic/behavior added:
  - Live text updates in the dialog with immediate checkbox feedback while typing.
  - Graceful no-op when editing the text of a disabled keyword that remains disabled.

- Removed logic/behavior:
  - Throwing ArgumentException for the (false, false) edit case.
  - Returning null from GetActiveActionKeywords on empty input.

- Memory usage impact:
  - Negligible. Returning an empty dictionary instead of null adds a tiny allocation only when the input is empty; no sustained memory growth.

- Security risks:
  - None. Changes are confined to UI logic and in-memory state handling.

- Unit tests:
  - No new unit tests added.

<sup>Written for commit 531b45210ae2c5d8b68db3e0770b0fa8d00f14df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

