### PR TITLE
Fix settings window is minimized when re-opened.

### DIFF
--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -169,7 +169,9 @@ public partial class SettingWindow
             SetWindowPosition(top, left);
         }
 
-        WindowState = _settings.SettingWindowState;
+        WindowState = _settings.SettingWindowState == WindowState.Minimized
+            ? WindowState.Normal
+            : _settings.SettingWindowState;
     }
 
     private void SetWindowPosition(double top, double left)

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -96,7 +96,7 @@ public partial class SettingWindow
     private void Window_StateChanged(object sender, EventArgs e)
     {
         RefreshMaximizeRestoreButton();
-        if (IsLoaded)
+        if (IsLoaded && WindowState != WindowState.Minimized)
         {
             _settings.SettingWindowState = WindowState;
         }


### PR DESCRIPTION
Currently if settings window is closed when minimized, it stays minimized the next time you open it. It's a bad UX design.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Settings window from reopening minimized. We stop saving the minimized state and normalize it to Normal on reopen for better UX.

- **Summary of changes**
  - Changed: `Window_StateChanged` no longer saves `WindowState.Minimized` to `_settings.SettingWindowState`.
  - Added: `UpdatePositionAndState` converts a saved `Minimized` state to `Normal` when reopening.
  - Removed: Behavior where the Settings window could persist and restore a minimized state.
  - Memory: No impact. Only conditional logic changes; no new allocations.
  - Security: No risks. UI state logic only.
  - Tests: No unit tests added. Verified manually by reopening after minimize/close.

<sup>Written for commit 121084f4c1db0d4346a307a308fbb9760c297774. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

