### PR TITLE
Fix Quick Access Links of type File ignoring custom name in search results

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/QuickAccessLinks/QuickAccess.cs
@@ -21,7 +21,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
                     {
                         ResultType.Volume => ResultManager.CreateDriveSpaceDisplayResult(l.Path, query.ActionKeyword, QuickAccessResultScore),
                         ResultType.Folder => ResultManager.CreateFolderResult(l.Name, l.Path, l.Path, query, QuickAccessResultScore),
-                        ResultType.File => ResultManager.CreateFileResult(l.Path, query, QuickAccessResultScore),
+                        ResultType.File => ResultManager.CreateFileResult(l.Path, query, QuickAccessResultScore, name: l.Name),
                         _ => throw new ArgumentOutOfRangeException()
                     })
                 .ToList();
@@ -35,7 +35,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.QuickAccessLinks
                 {
                     ResultType.Volume => ResultManager.CreateDriveSpaceDisplayResult(l.Path, query.ActionKeyword, QuickAccessResultScore),
                     ResultType.Folder => ResultManager.CreateFolderResult(l.Name, l.Path, l.Path, query, QuickAccessResultScore),
-                    ResultType.File => ResultManager.CreateFileResult(l.Path, query, QuickAccessResultScore),
+                    ResultType.File => ResultManager.CreateFileResult(l.Path, query, QuickAccessResultScore, name: l.Name),
                     _ => throw new ArgumentOutOfRangeException()
                 }).ToList();
     }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -282,10 +282,10 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             };
         }
 
-        internal static Result CreateFileResult(string filePath, Query query, int score = 0, bool windowsIndexed = false)
+        internal static Result CreateFileResult(string filePath, Query query, int score = 0, bool windowsIndexed = false, string name = null)
         {
             var isMedia = IsMedia(Path.GetExtension(filePath));
-            var title = Path.GetFileName(filePath) ?? string.Empty;
+            var title = name ?? Path.GetFileName(filePath) ?? string.Empty;
             var directory = Path.GetDirectoryName(filePath) ?? string.Empty;
 
             /* Preview Detail */


### PR DESCRIPTION
Fixes #3772 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Summary of changes
Fixes file-type Quick Access Links ignoring custom names by passing the saved link name into `ResultManager.CreateFileResult`, so search results display the custom title.

- Changed: `QuickAccess.AccessLinkListMatched` and `AccessLinkListAll` now call `CreateFileResult(..., name: l.Name)` for `ResultType.File`.
- Changed: `ResultManager.CreateFileResult` accepts an optional `string name` and uses it for the result title; falls back to `Path.GetFileName(filePath)` when not provided.
- Added: Support for displaying custom names for file-type Quick Access Links in results.
- Removed: Nothing; filename fallback remains.
- Memory impact: None noticeable. Only an extra optional string parameter; no new persistent allocations.
- Security: No new risks. Only the display title changes; file paths and execution behavior are unchanged.
- Tests: No new unit tests included.

<sup>Written for commit d0c30dfcb5721f62cc3e8a1ea19b591acd3bb7b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

