### PR TITLE
Ensure plugin manifest is non-nullable

### DIFF
--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -535,9 +535,6 @@ namespace Flow.Launcher.Plugin
         /// <summary>
         /// Get the plugin manifest.
         /// </summary>
-        /// <remarks>
-        /// If Flow cannot get manifest data, this could be null
-        /// </remarks>
         /// <returns></returns>
         public IReadOnlyList<UserPlugin> GetPluginManifest();
 

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -533,9 +533,12 @@ namespace Flow.Launcher.Plugin
         public Task<bool> UpdatePluginManifestAsync(bool usePrimaryUrlOnly = false, CancellationToken token = default);
 
         /// <summary>
-        /// Get the plugin manifest.
+        /// Get the current plugin manifest entries known to Flow Launcher.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>
+        /// A non-null read-only list of <see cref="UserPlugin"/> entries. The list may be empty if the
+        /// manifest has not been loaded/updated yet, or if the most recent manifest fetch failed.
+        /// </returns>
         public IReadOnlyList<UserPlugin> GetPluginManifest();
 
         /// <summary>

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -537,7 +537,7 @@ namespace Flow.Launcher.Plugin
         /// </summary>
         /// <returns>
         /// A non-null read-only list of <see cref="UserPlugin"/> entries. The list may be empty if the
-        /// manifest has not been loaded/updated yet, or if the most recent manifest fetch failed.
+        /// manifest has not been loaded yet, or if no successful manifest fetch has completed in the current session.
         /// </returns>
         public IReadOnlyList<UserPlugin> GetPluginManifest();
 

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -583,7 +583,7 @@ namespace Flow.Launcher
         public Task<bool> UpdatePluginManifestAsync(bool usePrimaryUrlOnly = false, CancellationToken token = default) =>
             PluginsManifest.UpdateManifestAsync(usePrimaryUrlOnly, token);
 
-        public IReadOnlyList<UserPlugin> GetPluginManifest() => PluginsManifest.UserPlugins;
+        public IReadOnlyList<UserPlugin> GetPluginManifest() => PluginsManifest.UserPlugins ?? [];
 
         public bool PluginModified(string id) => PluginManager.PluginModified(id);
 

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
@@ -82,7 +82,7 @@ public partial class SettingsPanePluginStoreViewModel : BaseModel
         }
     }
 
-    public IList<PluginStoreItemViewModel> ExternalPlugins => App.API.GetPluginManifest()?
+    public IList<PluginStoreItemViewModel> ExternalPlugins => App.API.GetPluginManifest()
         .Select(p => new PluginStoreItemViewModel(p))
         .OrderByDescending(p => p.Category == PluginStoreItemViewModel.NewRelease)
         .ThenByDescending(p => p.Category == PluginStoreItemViewModel.RecentlyUpdated)


### PR DESCRIPTION
Resolve #4251

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures `GetPluginManifest` always returns a non-null list. Simplifies callers, clarifies docs/comments, and removes null checks in the plugin store view.

- **Summary of changes**
  - Changed: `IPublicAPI.GetPluginManifest` is non-nullable and documented to return a list that may be empty. `SettingsPanePluginStoreViewModel.ExternalPlugins` now enumerates and sorts without null checks. Improved XML docs and inline comments for clarity.
  - Added: Empty-list fallback (`[]`) in `PublicAPIInstance.GetPluginManifest` when `PluginsManifest.UserPlugins` is null.
  - Removed: Prior remark suggesting `GetPluginManifest` could be null; null-conditional operator in `ExternalPlugins`.
  - Memory: Negligible. Returning an empty list instead of null adds minimal overhead.
  - Security: No new risks. Improves null-safety and contract clarity only.
  - Tests: No new unit tests. Follow-up tests can validate the empty-list contract.

<sup>Written for commit 015c32ed9c113b714307a72a36ca0a9b7df3506b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

