### PR TITLE
Boost score for Windows home folder in Explorer results

### DIFF
--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -438,5 +438,56 @@ namespace Flow.Launcher.Test.Plugins
             // Then
             ClassicAssert.AreEqual(result, expectedResult);
         }
+
+        [Test]
+        public void GivenHomeFolderPaths_WhenCheckedWithIsHomeFolderPath_ThenShouldReturnTrue()
+        {
+            // Given
+            var homeFolders = new[]
+            {
+                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
+                Environment.GetFolderPath(Environment.SpecialFolder.MyMusic),
+                Environment.GetFolderPath(Environment.SpecialFolder.MyVideos),
+                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads"),
+            };
+
+            // When, Then
+            foreach (var folder in homeFolders)
+            {
+                if (string.IsNullOrEmpty(folder))
+                    continue;
+
+                ClassicAssert.IsTrue(ResultManager.IsHomeFolderPath(folder),
+                    $"Expected '{folder}' to be recognized as a home folder");
+                ClassicAssert.IsTrue(ResultManager.IsHomeFolderPath(folder + Path.DirectorySeparatorChar),
+                    $"Expected '{folder}\\' (with trailing separator) to be recognized as a home folder");
+            }
+        }
+
+        [Test]
+        public void GivenNonHomeFolderPaths_WhenCheckedWithIsHomeFolderPath_ThenShouldReturnFalse()
+        {
+            // Given
+            var nonHomeFolders = new[]
+            {
+                @"C:\SomeRandomFolder",
+                @"C:\Windows\System32",
+                @"C:\Program Files",
+                // Subfolders of home directories should not be recognized as home folders
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "SubFolder"),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "SubFolder"),
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads", "SubFolder"),
+            };
+
+            // When, Then
+            foreach (var folder in nonHomeFolders)
+            {
+                ClassicAssert.IsFalse(ResultManager.IsHomeFolderPath(folder),
+                    $"Expected '{folder}' to NOT be recognized as a home folder");
+            }
+        }
     }
 }

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -471,7 +471,6 @@ namespace Flow.Launcher.Test.Plugins
             var homeFolderVariants = new[]
             {
                 Path.Combine(desktopPath, "dummy_desktop_file"),
-                Path.Combine(desktopPath, "dummy_desktop_folder"),
                 Path.Combine(desktopPath, "dummy_desktop_folder") + "\\\\",
                 desktopPath + "\\\\dummy_desktop_folder\\\\",
                 Path.Combine(desktopPath, "dummy_desktop_file", "dummy_file"),

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -473,7 +473,7 @@ namespace Flow.Launcher.Test.Plugins
                 Path.Combine(desktopPath, "dummy_desktop_file"),
                 Path.Combine(desktopPath, "dummy_desktop_folder") + "\\\\",
                 desktopPath + "\\\\dummy_desktop_folder\\\\",
-                Path.Combine(desktopPath, "dummy_desktop_folder", "dummy_file"),
+                Path.Combine(desktopPath, "dummy_desktop_folder", "dummy_desktop_file"),
             };
 
             foreach (var path in homeFolderVariants)

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -473,7 +473,7 @@ namespace Flow.Launcher.Test.Plugins
                 Path.Combine(desktopPath, "dummy_desktop_file"),
                 Path.Combine(desktopPath, "dummy_desktop_folder") + "\\\\",
                 desktopPath + "\\\\dummy_desktop_folder\\\\",
-                Path.Combine(desktopPath, "dummy_desktop_file", "dummy_file"),
+                Path.Combine(desktopPath, "dummy_desktop_folder", "dummy_file"),
             };
 
             foreach (var path in homeFolderVariants)

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -448,10 +448,6 @@ namespace Flow.Launcher.Test.Plugins
                 @"C:\SomeRandomFolder",
                 @"C:\Windows\System32",
                 @"C:\Program Files",
-                // Subfolders of home directories should not be recognized as home folders
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "SubFolder"),
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "SubFolder"),
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads", "SubFolder"),
             };
 
             // When, Then
@@ -459,6 +455,28 @@ namespace Flow.Launcher.Test.Plugins
             {
                 ClassicAssert.IsFalse(ResultManager.IsHomeFolderPath(folder),
                     $"Expected '{folder}' to NOT be recognized as a home folder");
+            }
+        }
+
+        [Test]
+        public void GivenPathsInsideHomeDirectories_WhenCheckedWithIsHomeFolderPath_ThenShouldReturnTrue()
+        {
+            // Given
+            var desktopPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+            var homeSubPaths = new[]
+            {
+                Path.Combine(desktopPath, "dummy_desktop_file"),
+                Path.Combine(desktopPath, "dummy_desktop_folder"),
+                Path.Combine(desktopPath, "dummy_desktop_folder"),
+                Path.Combine(desktopPath, "dummy_desktop_folder"),
+                Path.Combine(desktopPath, "dummy_desktop_file", "dummy_file"),
+            };
+
+            // When, Then
+            foreach (var path in homeSubPaths)
+            {
+                ClassicAssert.IsTrue(ResultManager.IsHomeFolderPath(path),
+                    $"Expected '{path}' to be recognized as inside a home folder");
             }
         }
     }

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -440,34 +440,6 @@ namespace Flow.Launcher.Test.Plugins
         }
 
         [Test]
-        public void GivenHomeFolderPaths_WhenCheckedWithIsHomeFolderPath_ThenShouldReturnTrue()
-        {
-            // Given
-            var homeFolders = new[]
-            {
-                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
-                Environment.GetFolderPath(Environment.SpecialFolder.MyMusic),
-                Environment.GetFolderPath(Environment.SpecialFolder.MyVideos),
-                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads"),
-            };
-
-            // When, Then
-            foreach (var folder in homeFolders)
-            {
-                if (string.IsNullOrEmpty(folder))
-                    continue;
-
-                ClassicAssert.IsTrue(ResultManager.IsHomeFolderPath(folder),
-                    $"Expected '{folder}' to be recognized as a home folder");
-                ClassicAssert.IsTrue(ResultManager.IsHomeFolderPath(folder + Path.DirectorySeparatorChar),
-                    $"Expected '{folder}\\' (with trailing separator) to be recognized as a home folder");
-            }
-        }
-
-        [Test]
         public void GivenNonHomeFolderPaths_WhenCheckedWithIsHomeFolderPath_ThenShouldReturnFalse()
         {
             // Given

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -460,20 +460,24 @@ namespace Flow.Launcher.Test.Plugins
 
         [Test]
         public void GivenPathsInsideHomeDirectories_WhenCheckedWithIsHomeFolderPath_ThenShouldReturnTrue()
-        {
-            // Given
+{
             var desktopPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
-            var homeSubPaths = new[]
+            
+            if (string.IsNullOrEmpty(desktopPath))
+            {
+                Assert.Ignore("Desktop special folder path is unavailable in this environment.");
+            }
+
+            var homeFolderVariants = new[]
             {
                 Path.Combine(desktopPath, "dummy_desktop_file"),
                 Path.Combine(desktopPath, "dummy_desktop_folder"),
-                Path.Combine(desktopPath, "dummy_desktop_folder"),
-                Path.Combine(desktopPath, "dummy_desktop_folder"),
+                Path.Combine(desktopPath, "dummy_desktop_folder") + "\\\\",
+                desktopPath + "\\\\dummy_desktop_folder\\\\",
                 Path.Combine(desktopPath, "dummy_desktop_file", "dummy_file"),
             };
 
-            // When, Then
-            foreach (var path in homeSubPaths)
+            foreach (var path in homeFolderVariants)
             {
                 ClassicAssert.IsTrue(ResultManager.IsHomeFolderPath(path),
                     $"Expected '{path}' to be recognized as inside a home folder");

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -51,7 +51,7 @@
     <system:String x:Key="plugin_explorer_use_location_as_working_dir">Use search result's location as the working directory of the executable</system:String>
     <system:String x:Key="plugin_explorer_display_more_info_in_tooltip">Display more information like size and age in tooltips</system:String>
     <system:String x:Key="plugin_explorer_default_open_in_file_manager">Hit Enter to open folder in Default File Manager</system:String>
-    <system:String x:Key="plugin_explorer_boost_home_folder_score">Boost score for home folders (Documents, Desktop, Downloads, etc.)</system:String>
+    <system:String x:Key="plugin_explorer_boost_home_folder_score">Place results of home folders (Documents, Desktop, Downloads, etc.) higher</system:String>
     <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch">Use Index Search For Path Search</system:String>
     <system:String x:Key="plugin_explorer_manageindexoptions">Indexing Options</system:String>
     <system:String x:Key="plugin_explorer_actionkeywordview_search">Search:</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -51,7 +51,7 @@
     <system:String x:Key="plugin_explorer_use_location_as_working_dir">Use search result's location as the working directory of the executable</system:String>
     <system:String x:Key="plugin_explorer_display_more_info_in_tooltip">Display more information like size and age in tooltips</system:String>
     <system:String x:Key="plugin_explorer_default_open_in_file_manager">Hit Enter to open folder in Default File Manager</system:String>
-    <system:String x:Key="plugin_explorer_boost_home_folder_score">Place results of home folders (Documents, Desktop, Downloads, etc.) higher</system:String>
+    <system:String x:Key="plugin_explorer_boost_home_folder_score">Prioritize home folders (Documents, Desktop, Downloads, etc.) in search results</system:String>
     <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch">Use Index Search For Path Search</system:String>
     <system:String x:Key="plugin_explorer_manageindexoptions">Indexing Options</system:String>
     <system:String x:Key="plugin_explorer_actionkeywordview_search">Search:</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -51,6 +51,7 @@
     <system:String x:Key="plugin_explorer_use_location_as_working_dir">Use search result's location as the working directory of the executable</system:String>
     <system:String x:Key="plugin_explorer_display_more_info_in_tooltip">Display more information like size and age in tooltips</system:String>
     <system:String x:Key="plugin_explorer_default_open_in_file_manager">Hit Enter to open folder in Default File Manager</system:String>
+    <system:String x:Key="plugin_explorer_boost_home_folder_score">Boost score for home folders (Documents, Desktop, Downloads, etc.)</system:String>
     <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch">Use Index Search For Path Search</system:String>
     <system:String x:Key="plugin_explorer_manageindexoptions">Indexing Options</system:String>
     <system:String x:Key="plugin_explorer_actionkeywordview_search">Search:</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Properties/AssemblyInfo.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Flow.Launcher.Test")]

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Properties/AssemblyInfo.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Flow.Launcher.Test")]

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -130,7 +130,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
         internal static Result CreateFolderResult(string title, string subtitle, string path, Query query, int score = 0, bool windowsIndexed = false)
         {
-            if (IsHomeFolderPath(path))
+            if (IsHomeFolderPath(path) && score > 0)
                 score += HomeFolderScoreBoost;
 
             return new Result

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -130,7 +130,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
         internal static Result CreateFolderResult(string title, string subtitle, string path, Query query, int score = 0, bool windowsIndexed = false)
         {
-            if (IsHomeFolderPath(path) && score > 0)
+            if (IsHomeFolderPath(path))
                 score += HomeFolderScoreBoost;
 
             return new Result

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -20,6 +21,41 @@ namespace Flow.Launcher.Plugin.Explorer.Search
         private static readonly string[] SizeUnits = { "B", "KB", "MB", "GB", "TB" };
         private static PluginInitContext Context;
         private static Settings Settings { get; set; }
+
+        private const int HomeFolderScoreBoost = 50;
+
+        private static readonly Lazy<HashSet<string>> HomeFolderPaths = new(() =>
+        {
+            var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            var specialFolders = new[]
+            {
+                Environment.SpecialFolder.MyDocuments,
+                Environment.SpecialFolder.MyPictures,
+                Environment.SpecialFolder.MyMusic,
+                Environment.SpecialFolder.MyVideos,
+                Environment.SpecialFolder.Desktop,
+                Environment.SpecialFolder.UserProfile,
+            };
+
+            foreach (var folder in specialFolders)
+            {
+                var path = Environment.GetFolderPath(folder);
+                if (!string.IsNullOrEmpty(path))
+                    paths.Add(path);
+            }
+
+            // Downloads has no dedicated SpecialFolder enum value
+            var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (!string.IsNullOrEmpty(userProfile))
+                paths.Add(Path.Combine(userProfile, "Downloads"));
+
+            return paths;
+        });
+
+        internal static bool IsHomeFolderPath(string path) =>
+            !string.IsNullOrEmpty(path) &&
+            HomeFolderPaths.Value.Contains(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
 
         public static void Init(PluginInitContext context, Settings settings)
         {
@@ -94,6 +130,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
         internal static Result CreateFolderResult(string title, string subtitle, string path, Query query, int score = 0, bool windowsIndexed = false)
         {
+            if (IsHomeFolderPath(path))
+                score += HomeFolderScoreBoost;
+
             return new Result
             {
                 Title = title,

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -53,7 +53,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             return paths;
         });
 
-        internal static bool IsHomeFolderPath(string path) =>
+        public static bool IsHomeFolderPath(string path) =>
             !string.IsNullOrEmpty(path) &&
             HomeFolderPaths.Value.Contains(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -53,9 +53,15 @@ namespace Flow.Launcher.Plugin.Explorer.Search
             return paths;
         });
 
-        public static bool IsHomeFolderPath(string path) =>
-            !string.IsNullOrEmpty(path) &&
-            HomeFolderPaths.Value.Contains(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        public static bool IsHomeFolderPath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return false;
+
+            var normalizedPath = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return HomeFolderPaths.Value.Any(homeFolderPath =>
+                FilesFolders.PathContains(homeFolderPath, normalizedPath, allowEqual: true));
+        }
 
         public static void Init(PluginInitContext context, Settings settings)
         {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -130,7 +130,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search
 
         internal static Result CreateFolderResult(string title, string subtitle, string path, Query query, int score = 0, bool windowsIndexed = false)
         {
-            if (IsHomeFolderPath(path))
+            if (Settings.BoostHomeFolderScore && IsHomeFolderPath(path))
                 score += HomeFolderScoreBoost;
 
             return new Result

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -39,6 +39,8 @@ namespace Flow.Launcher.Plugin.Explorer
 
         public bool DisplayMoreInformationInToolTip { get; set; } = false;
 
+        public bool BoostHomeFolderScore { get; set; } = true;
+
         public string SearchActionKeyword { get; set; } = Query.GlobalPluginWildcardSign;
 
         public bool SearchActionKeywordEnabled { get; set; } = true;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -202,6 +202,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -234,8 +235,17 @@
                     Content="{DynamicResource plugin_explorer_display_more_info_in_tooltip}"
                     IsChecked="{Binding Settings.DisplayMoreInformationInToolTip}" />
 
-                <TextBlock
+                <CheckBox
                     Grid.Row="3"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    Margin="{StaticResource SettingPanelItemTopBottomMargin}"
+                    HorizontalAlignment="Left"
+                    Content="{DynamicResource plugin_explorer_boost_home_folder_score}"
+                    IsChecked="{Binding Settings.BoostHomeFolderScore}" />
+
+                <TextBlock
+                    Grid.Row="4"
                     Grid.Column="0"
                     Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                     HorizontalAlignment="Left"
@@ -243,7 +253,7 @@
                     Foreground="{DynamicResource Color05B}"
                     Text="{DynamicResource plugin_explorer_file_editor_path}" />
                 <StackPanel
-                    Grid.Row="3"
+                    Grid.Row="4"
                     Grid.Column="1"
                     Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                     Orientation="Horizontal">
@@ -262,7 +272,7 @@
                 </StackPanel>
 
                 <TextBlock
-                    Grid.Row="4"
+                    Grid.Row="5"
                     Grid.Column="0"
                     Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                     HorizontalAlignment="Left"
@@ -270,7 +280,7 @@
                     Foreground="{DynamicResource Color05B}"
                     Text="{DynamicResource plugin_explorer_folder_editor_path}" />
                 <StackPanel
-                    Grid.Row="4"
+                    Grid.Row="5"
                     Grid.Column="1"
                     Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                     Orientation="Horizontal">
@@ -289,7 +299,7 @@
                 </StackPanel>
 
                 <TextBlock
-                    Grid.Row="5"
+                    Grid.Row="6"
                     Grid.Column="0"
                     Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                     HorizontalAlignment="Left"
@@ -297,7 +307,7 @@
                     Foreground="{DynamicResource Color05B}"
                     Text="{DynamicResource plugin_explorer_shell_path}" />
                 <StackPanel
-                    Grid.Row="5"
+                    Grid.Row="6"
                     Grid.Column="1"
                     Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                     Orientation="Horizontal">
@@ -316,14 +326,14 @@
                 </StackPanel>
 
                 <TextBlock
-                    Grid.Row="6"
+                    Grid.Row="7"
                     Grid.Column="0"
                     Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                     VerticalAlignment="Center"
                     Foreground="{DynamicResource Color05B}"
                     Text="{DynamicResource plugin_explorer_Index_Search_Engine}" />
                 <ComboBox
-                    Grid.Row="6"
+                    Grid.Row="7"
                     Grid.Column="1"
                     Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                     HorizontalAlignment="Left"
@@ -333,14 +343,14 @@
                     SelectedItem="{Binding SelectedIndexSearchEngine}" />
 
                 <TextBlock
-                    Grid.Row="7"
+                    Grid.Row="8"
                     Grid.Column="0"
                     Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                     VerticalAlignment="Center"
                     Foreground="{DynamicResource Color05B}"
                     Text="{DynamicResource plugin_explorer_Content_Search_Engine}" />
                 <ComboBox
-                    Grid.Row="7"
+                    Grid.Row="8"
                     Grid.Column="1"
                     Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                     HorizontalAlignment="Left"
@@ -350,14 +360,14 @@
                     SelectedItem="{Binding SelectedContentSearchEngine}" />
 
                 <TextBlock
-                    Grid.Row="8"
+                    Grid.Row="9"
                     Grid.Column="0"
                     Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                     VerticalAlignment="Center"
                     Foreground="{DynamicResource Color05B}"
                     Text="{DynamicResource plugin_explorer_Directory_Recursive_Search_Engine}" />
                 <ComboBox
-                    Grid.Row="8"
+                    Grid.Row="9"
                     Grid.Column="1"
                     Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
                     HorizontalAlignment="Left"
@@ -367,14 +377,14 @@
                     SelectedItem="{Binding SelectedPathEnumerationEngine}" />
 
                 <TextBlock
-                    Grid.Row="9"
+                    Grid.Row="10"
                     Grid.Column="0"
                     Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                     VerticalAlignment="Center"
                     Foreground="{DynamicResource Color05B}"
                     Text="{DynamicResource plugin_explorer_Excluded_File_Types}" />
                 <TextBox
-                    Grid.Row="9"
+                    Grid.Row="10"
                     Grid.Column="1"
                     MinWidth="{StaticResource SettingPanelTextBoxMinWidth}"
                     Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
@@ -383,14 +393,14 @@
                     ToolTip="{DynamicResource plugin_explorer_Excluded_File_Types_Tooltip}" />
 
                 <TextBlock
-                    Grid.Row="10"
+                    Grid.Row="11"
                     Grid.Column="0"
                     Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                     VerticalAlignment="Center"
                     Foreground="{DynamicResource Color05B}"
                     Text="{DynamicResource plugin_explorer_Maximum_Results}" />
                 <TextBox
-                    Grid.Row="10"
+                    Grid.Row="11"
                     Grid.Column="1"
                     MinWidth="{StaticResource SettingPanelTextBoxMinWidth}"
                     Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
@@ -402,7 +412,7 @@
                     ToolTip="{DynamicResource plugin_explorer_Maximum_Results_Tooltip}" />
 
                 <Button
-                    Grid.Row="11"
+                    Grid.Row="12"
                     Grid.Column="0"
                     Grid.ColumnSpan="2"
                     Margin="{StaticResource SettingPanelItemTopBottomMargin}"


### PR DESCRIPTION
Fix #4304.

<img width="611" height="365" alt="image" src="https://github.com/user-attachments/assets/f0ad20f3-f967-4cbb-952f-819e268473c6" />

<img width="705" height="446" alt="image" src="https://github.com/user-attachments/assets/ba21af4f-43b6-4b9f-865c-ce60434cfb9e" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Boosts Windows home folders in Explorer search results by +50 so Documents, Desktop, Downloads, etc., rank higher. Adds a setting to toggle this and improves detection to include subfolders and path variants.

- **Summary of changes**
  - Changed: In `ResultManager.CreateFolderResult`, add +50 to score when `Settings.BoostHomeFolderScore` and `IsHomeFolderPath(path)` are true; made `ResultManager.IsHomeFolderPath` public; `IsHomeFolderPath` now trims trailing separators and uses `FilesFolders.PathContains(..., allowEqual: true)` for exact-or-subpath matches; clarified the setting label text in `en.xaml` and Explorer settings UI.
  - Added: `Settings.BoostHomeFolderScore` (default true) with a checkbox in Explorer settings; lazy `HashSet<string>` of home folder roots from `Environment.SpecialFolder` plus `Downloads`.
  - Removed: `InternalsVisibleTo` test allowance; an obsolete test path variant.
  - Memory: One lazy `HashSet<string>` with a few paths per process; negligible impact.
  - Security: No new risks. Only reads known system folder locations; no extra I/O or permissions.
  - Tests: Added negative checks for non-home folders and positive checks for Desktop subpaths; guard when Desktop path is unavailable; include extra backslash variants; cleaned up an obsolete test path; minor test updates for robustness.

<sup>Written for commit 98ea412cb7f6591661bae2e5753e302bc380d016. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



