### PR TITLE
Fix incorrect Everything dll import name

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiDllImport.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiDllImport.cs
@@ -126,7 +126,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
         public static extern uint Everything_GetRequestFlags();
         [DllImport(DLL)]
         public static extern uint Everything_GetResultListRequestFlags();
-        [DllImport("Everything64.dll", CharSet = CharSet.Unicode)]
+        [DllImport(DLL, CharSet = CharSet.Unicode)]
         public static extern IntPtr Everything_GetResultExtension(uint nIndex);
         [DllImport(DLL)]
         public static extern bool Everything_GetResultSize(uint nIndex, out long lpFileSize);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a mismatched P/Invoke by replacing a hard-coded import with the shared DLL constant, ensuring the correct Everything DLL loads across architectures and preventing runtime load errors.

**Summary of changes**
- Changed: Swapped [DllImport("Everything64.dll"...)] for [DllImport(DLL,...)] on Everything_GetResultExtension to use the centralized DLL name.
- Added: No new logic or behavior.
- Removed: The hard-coded DLL name for this API entry point.
- Memory impact: None.
- Security risks: None; using a centralized DLL reference reduces risk of loading the wrong architecture.
- Unit tests: No new tests added. Existing behavior covered by integration/runtime verification.

<sup>Written for commit 56c32ad4406fe44c9b18798b975389bdb9d4272a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

