### PR TITLE
Bump Microsoft.CsWin32 in other projects

### DIFF
--- a/Flow.Launcher.Infrastructure/Flow.Launcher.Infrastructure.csproj
+++ b/Flow.Launcher.Infrastructure/Flow.Launcher.Infrastructure.csproj
@@ -66,7 +66,7 @@
     <PackageReference Include="InputSimulator" Version="1.0.4" />
     <PackageReference Include="MemoryPack" Version="1.21.4" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.14.15" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.205">
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -849,10 +849,10 @@ namespace Flow.Launcher.Infrastructure
 
             try
             {
-                var hrFolder = PInvoke.SHParseDisplayName(folderPath, null, out pidlFolder, 0, null);
+                var hrFolder = PInvoke.SHParseDisplayName(folderPath, null, out pidlFolder, 0, out _);
                 if (hrFolder.Failed) throw new COMException("Failed to parse folder path", hrFolder);
 
-                var hrFile = PInvoke.SHParseDisplayName(filePath, null, out pidlFile, 0, null);
+                var hrFile = PInvoke.SHParseDisplayName(filePath, null, out pidlFile, 0, out _);
                 if (hrFile.Failed) throw new COMException("Failed to parse file path", hrFile);
 
                 var hrSelect = PInvoke.SHOpenFolderAndSelectItems(pidlFolder, 1, &pidlFile, 0);

--- a/Flow.Launcher.Infrastructure/packages.lock.json
+++ b/Flow.Launcher.Infrastructure/packages.lock.json
@@ -70,13 +70,13 @@
       },
       "Microsoft.Windows.CsWin32": {
         "type": "Direct",
-        "requested": "[0.3.205, )",
-        "resolved": "0.3.205",
-        "contentHash": "U5wGAnyKd7/I2YMd43nogm81VMtjiKzZ9dsLMVI4eAB7jtv5IEj0gprj0q/F3iRmAIaGv5omOf8iSYx2+nE6BQ==",
+        "requested": "[0.3.269, )",
+        "resolved": "0.3.269",
+        "contentHash": "O4GVJ0ymxcoFRGS07VcoEClj7A9PIciHIjWDrPymzonhYlOfM7V0ZqGBUK19cUH3BPca9MfSOH0KLK/9JzQ8+Q==",
         "dependencies": {
           "Microsoft.Windows.SDK.Win32Docs": "0.1.42-alpha",
-          "Microsoft.Windows.SDK.Win32Metadata": "61.0.15-preview",
-          "Microsoft.Windows.WDK.Win32Metadata": "0.12.8-experimental"
+          "Microsoft.Windows.SDK.Win32Metadata": "69.0.7-preview",
+          "Microsoft.Windows.WDK.Win32Metadata": "0.13.25-experimental"
         }
       },
       "NHotkey.Wpf": {
@@ -178,15 +178,15 @@
       },
       "Microsoft.Windows.SDK.Win32Metadata": {
         "type": "Transitive",
-        "resolved": "61.0.15-preview",
-        "contentHash": "cysex3dazKtCPALCluC2XX3f5Aedy9H2pw5jb+TW5uas2rkem1Z7FRnbUrg2vKx0pk0Qz+4EJNr37HdYTEcvEQ=="
+        "resolved": "69.0.7-preview",
+        "contentHash": "RJoNjQJVCIDNLPbvYuaygCFknTyAxOUE45of1voj0jjOgJa9MB2m1/G8L8F3IYc+2EFG5aqa/9y8PEx7Tk2tLQ=="
       },
       "Microsoft.Windows.WDK.Win32Metadata": {
         "type": "Transitive",
-        "resolved": "0.12.8-experimental",
-        "contentHash": "3n8R44/Z96Ly+ty4eYVJfESqbzvpw96lRLs3zOzyDmr1x1Kw7FNn5CyE416q+bZQV3e1HRuMUvyegMeRE/WedA==",
+        "resolved": "0.13.25-experimental",
+        "contentHash": "IM50tb/+UIwBr9FMr6ZKcZjCMW+Axo6NjGqKxgjUfyCY8dRnYUfrJEXxAaXoWtYP4X8EmASmC1Jtwh4XucseZg==",
         "dependencies": {
-          "Microsoft.Windows.SDK.Win32Metadata": "61.0.15-preview"
+          "Microsoft.Windows.SDK.Win32Metadata": "63.0.31-preview"
         }
       },
       "NHotkey": {

--- a/Plugins/Flow.Launcher.Plugin.Program/Flow.Launcher.Plugin.Program.csproj
+++ b/Plugins/Flow.Launcher.Plugin.Program/Flow.Launcher.Plugin.Program.csproj
@@ -65,7 +65,7 @@
     <PackageReference Include="ini-parser" Version="2.5.2" />
     <PackageReference Include="MemoryPack" Version="1.21.4" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.205">
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Bump Microsoft.CsWin32 in other projects

Amending #4252 which brings inconsistent Microsoft.CsWin32 versions across the whole solution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Summary of changes

Bumped `Microsoft.Windows.CsWin32` to 0.3.269 in Infrastructure and Program plugin, and updated `SHParseDisplayName` calls to match the new generated signature. Regenerates Win32 P/Invoke bindings; no behavior change expected.

- **Details**
  - Changed: Updated `Microsoft.Windows.CsWin32` in two `.csproj` files; lockfile now pins newer `Microsoft.Windows.SDK.Win32Metadata` and `Microsoft.Windows.WDK.Win32Metadata`. In `Win32Helper.OpenFolderAndSelectFile`, replaced the last `SHParseDisplayName` arg from `null` to `out _` to align with the new P/Invoke signature.
  - Added: No new runtime logic. Generator may surface additional Win32 APIs/constants at compile time.
  - Removed: No logic removed.
  - Memory: No runtime memory impact expected. Minor binary size changes possible from regenerated interop.
  - Security: Low risk. Using `out _` avoids passing null pointers; watch for rare marshaling/signature regressions.
  - Tests: No new tests. Existing tests and CI cover build and runtime behavior.

<sup>Written for commit f8416d7ec6410470999a1482785e2accbbfd25af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

