### PR TITLE
Fix last opened result not showing in 'Empty Last Query' mode

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -550,7 +550,7 @@ namespace Flow.Launcher.ViewModel
                 lastHistoryIndex = 1;
             }
 
-            // Only hide for query results (not Dialog Jump)
+            // Only hide for query results (not Dialog Jump left-click mode)
             if (!isDialogJumpLeftClick && hideWindow)
             {
                 Hide();

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -515,8 +515,11 @@ namespace Flow.Launcher.ViewModel
                 return;
             }
 
+            var hideWindow = false;
+            var isDialogJumpLeftClick = _isDialogJump && Settings.DialogJumpResultBehaviour == DialogJumpResultBehaviours.LeftClick;
+
             // For Dialog Jump and left click mode, we need to navigate to the path
-            if (_isDialogJump && Settings.DialogJumpResultBehaviour == DialogJumpResultBehaviours.LeftClick)
+            if (isDialogJumpLeftClick)
             {
                 if (result is DialogJumpResult dialogJumpResult)
                 {
@@ -531,26 +534,30 @@ namespace Flow.Launcher.ViewModel
             // For query mode, we execute the result
             else
             {
-                var hideWindow = await result.ExecuteAsync(new ActionContext
+                hideWindow = await result.ExecuteAsync(new ActionContext
                 {
                     // not null means pressing modifier key + number, should ignore the modifier key
                     SpecialKeyState = index is not null ? SpecialKeyState.Default : GlobalHotkey.CheckModifiers()
                 }).ConfigureAwait(false);
-
-                if (hideWindow)
-                {
-                    Hide();
-                }
             }
 
-            // Record user selected result for result ranking
-            _userSelectedRecord.Add(result);
-            // Add item to history only if it is from results but not context menu or history
+            // New history result must be recorded before Hide() is called, otherwise when in 'Empty Last Query' query style mode
+            // the QueryAsync call will reconstuct the result list without the new item.
+            // Also, add item to history only if it is from results but not context menu or history.
             if (queryResultsSelected)
             {
                 _history.Add(result);
                 lastHistoryIndex = 1;
             }
+
+            // Only hide for query results (not Dialog Jump)
+            if (!isDialogJumpLeftClick && hideWindow)
+            {
+                Hide();
+            }
+
+            // Record user selected result for result ranking
+            _userSelectedRecord.Add(result);
         }
 
         private static IReadOnlyList<Result> DeepCloneResults(IReadOnlyList<Result> results, bool isDialogJump, CancellationToken token = default)

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -542,7 +542,7 @@ namespace Flow.Launcher.ViewModel
             }
 
             // New history result must be recorded before Hide() is called, otherwise when in 'Empty Last Query' query style mode
-            // the QueryAsync call will reconstuct the result list without the new item.
+            // the QueryAsync call will reconstruct the result list without the new item.
             // Also, add item to history only if it is from results but not context menu or history.
             if (queryResultsSelected)
             {


### PR DESCRIPTION
From https://github.com/Flow-Launcher/Flow.Launcher/pull/4042

Fix last opened result not showing in 'Empty Last Query' query style mode after result is selected, and would only show when re-queried or clearing of a new query.

The cause is the Hide() call after result is actioned triggers a `QueryResultsAsync` which constructs the result list before the result is added to the last opened history items. 

Closing #4374


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bug where the last opened result didn’t appear in history in “Empty Last Query” mode by recording history before hiding the window. Keeps the window visible for Dialog Jump left-click to keep navigation smooth.

**Summary of changes**
- Changed: Write history before any Hide(); consolidated Dialog Jump left-click check into isDialogJumpLeftClick; reuse a local hideWindow flag; move user-ranking record after the conditional Hide().
- Added: Conditional Hide() executed only after history write and only for normal query results (not Dialog Jump left-click).
- Removed: Immediate Hide() after ExecuteAsync; hiding is now deferred and conditional.
- Misc: Clarified inline comments; fixed a minor typo.
- Memory impact: None; only simple locals added.
- Security risks: None; control flow only with no new I/O or privileges.
- Unit tests: No new tests; manual checks for “Empty Last Query” and Dialog Jump left-click paths.

<sup>Written for commit 654026e66308bf833b0a152abc0ebe3527f963c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



