### PR TITLE
Remove Segoe UI font-family style for CJK Character Rendering

### DIFF
--- a/Flow.Launcher/MessageBoxEx.xaml
+++ b/Flow.Launcher/MessageBoxEx.xaml
@@ -88,7 +88,6 @@
                     MaxWidth="400"
                     Margin="0 0 26 0"
                     VerticalAlignment="Center"
-                    FontFamily="Segoe UI"
                     FontSize="20"
                     FontWeight="SemiBold"
                     TextAlignment="Left"

--- a/Flow.Launcher/ProgressBoxEx.xaml
+++ b/Flow.Launcher/ProgressBoxEx.xaml
@@ -95,7 +95,6 @@
                 MaxWidth="400"
                 Margin="0 0 26 12"
                 VerticalAlignment="Center"
-                FontFamily="Segoe UI"
                 FontSize="20"
                 FontWeight="SemiBold"
                 TextAlignment="Left"

--- a/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.WebSearch/SearchSourceSetting.xaml
@@ -246,7 +246,6 @@
                         <TextBlock
                             Grid.Column="0"
                             Margin="0,0,0,0"
-                            FontFamily="Segoe UI"
                             FontSize="20"
                             FontWeight="SemiBold"
                             Text="{DynamicResource flowlauncher_plugin_websearch_window_title}"


### PR DESCRIPTION
Removed FontFamily, FontSize, and FontWeight properties from TitleTextBlock/TextBlock in MessageBoxEx.xaml, ProgressBoxEx.xaml, and SearchSourceSetting.xaml to use default font styling for correct CJK character rendering.

Used the same solution as #1427. No need to test.

Resolve #4373. Follow on with #1427.