### PR TITLE
[FEATURE] Plugin settings window & context menu option

### DIFF
--- a/Flow.Launcher.Core/Plugin/JsonRPCV2Models/JsonRPCPublicAPI.cs
+++ b/Flow.Launcher.Core/Plugin/JsonRPCV2Models/JsonRPCPublicAPI.cs
@@ -94,6 +94,11 @@ namespace Flow.Launcher.Core.Plugin.JsonRPCV2Models
             _api.OpenSettingDialog();
         }
 
+        public bool OpenPluginSettingsWindow(string pluginId)
+        {
+            return _api.OpenPluginSettingsWindow(pluginId);
+        }
+
         public string GetTranslation(string key)
         {
             return _api.GetTranslation(key);

--- a/Flow.Launcher.Infrastructure/Constant.cs
+++ b/Flow.Launcher.Infrastructure/Constant.cs
@@ -33,6 +33,7 @@ namespace Flow.Launcher.Infrastructure
         public static readonly string LoadingImgIcon = Path.Combine(ImagesDirectory, "loading.png");
         public static readonly string ImageIcon = Path.Combine(ImagesDirectory, "image.png");
         public static readonly string HistoryIcon = Path.Combine(ImagesDirectory, "history.png");
+        public static readonly string SettingsIcon = Path.Combine(ImagesDirectory, "settings.png");
 
         public static string PythonPath;
         public static string NodePath;

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -164,10 +164,11 @@ namespace Flow.Launcher.Plugin
 
 
         /// <summary>
-        /// Open plugin setting window for a specific plugin
+        /// Open plugin setting window for a specific plugin.
+        /// Reuses the existing window when that plugin's settings window is already open.
         /// </summary>
         /// <param name="pluginId">ID of the plugin whose settings window should be opened</param>
-        /// <returns>True if the plugin settings window was successfully opened; false otherwise</returns>
+        /// <returns>True if the plugin settings window was successfully opened or reused; false otherwise</returns>
         bool OpenPluginSettingsWindow(string pluginId);
 
         /// <summary>

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -162,6 +162,13 @@ namespace Flow.Launcher.Plugin
         /// </summary>
         void OpenSettingDialog();
 
+
+        /// <summary>
+        /// Open plugin setting window for a specific plugin
+        /// </summary>
+        /// <param name="pluginId">ID of the plugin whose settings window should be opened</param>
+        void OpenPluginSettingsWindow(string pluginId);
+
         /// <summary>
         /// Get translation of current language
         /// You need to implement IPluginI18n if you want to support multiple languages for your plugin

--- a/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
+++ b/Flow.Launcher.Plugin/Interfaces/IPublicAPI.cs
@@ -167,7 +167,8 @@ namespace Flow.Launcher.Plugin
         /// Open plugin setting window for a specific plugin
         /// </summary>
         /// <param name="pluginId">ID of the plugin whose settings window should be opened</param>
-        void OpenPluginSettingsWindow(string pluginId);
+        /// <returns>True if the plugin settings window was successfully opened; false otherwise</returns>
+        bool OpenPluginSettingsWindow(string pluginId);
 
         /// <summary>
         /// Get translation of current language

--- a/Flow.Launcher/Helper/SingletonWindowOpener.cs
+++ b/Flow.Launcher/Helper/SingletonWindowOpener.cs
@@ -11,30 +11,6 @@ public static class SingletonWindowOpener
         var window = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.GetType() == typeof(T))
                      ?? (T)Activator.CreateInstance(typeof(T), args);
 
-        // Fix UI bug
-        // Add `window.WindowState = WindowState.Normal`
-        // If only use `window.Show()`, Settings-window doesn't show when minimized in taskbar 
-        // Not sure why this works tho
-        // Probably because, when `.Show()` fails, `window.WindowState == Minimized` (not `Normal`) 
-        // https://stackoverflow.com/a/59719760/4230390
-        // Ensure the window is not minimized before showing it
-        if (window.WindowState == WindowState.Minimized)
-        {
-            window.WindowState = WindowState.Normal;
-        }
-
-        // Ensure the window is visible
-        if (!window.IsVisible)
-        {
-            window.Show();
-        }
-        else
-        {
-            window.Activate(); // Bring the window to the foreground if already open
-        }
-
-        window.Focus();
-
-        return (T)window;
+        return WindowVisibilityHelper.ShowOrActivate((T)window);
     }
 }

--- a/Flow.Launcher/Helper/WindowVisibilityHelper.cs
+++ b/Flow.Launcher/Helper/WindowVisibilityHelper.cs
@@ -1,0 +1,35 @@
+using System.Windows;
+
+namespace Flow.Launcher.Helper;
+
+public static class WindowVisibilityHelper
+{
+    public static T ShowOrActivate<T>(T window) where T : Window
+    {
+        // Fix UI bug
+        // Add `window.WindowState = WindowState.Normal`
+        // If only use `window.Show()`, Settings-window doesn't show when minimized in taskbar 
+        // Not sure why this works tho
+        // Probably because, when `.Show()` fails, `window.WindowState == Minimized` (not `Normal`) 
+        // https://stackoverflow.com/a/59719760/4230390
+        // Ensure the window is not minimized before showing it
+        if (window.WindowState == WindowState.Minimized)
+        {
+            window.WindowState = WindowState.Normal;
+        }
+
+        // Ensure the window is visible
+        if (!window.IsVisible)
+        {
+            window.Show();
+        }
+        else
+        {
+            window.Activate(); // Bring the window to the foreground if already open
+        }
+
+        window.Focus();
+
+        return (T)window;
+    }
+}

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -46,7 +46,6 @@
     <system:String x:Key="invalidFlowLauncherPluginFileFormat">Invalid Flow Launcher plugin file format</system:String>
     <system:String x:Key="setAsTopMostInThisQuery">Set as topmost in this query</system:String>
     <system:String x:Key="cancelTopMostInThisQuery">Cancel topmost in this query</system:String>
-    <system:String x:Key="contextMenuPluginSettingsTitle">Plugin Settings</system:String>
     <system:String x:Key="executeQuery">Execute query: {0}</system:String>
     <system:String x:Key="lastExecuteTime">Last execution time: {0}</system:String>
     <system:String x:Key="iconTrayOpen">Open</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -487,6 +487,7 @@
 
     <!--  Plugin Settings Window  -->
     <system:String x:Key="pluginSettingsWindowTitle">Settings: {0}</system:String>
+    <system:String x:Key="pluginSettingsWindowOpenFailed">Failed to open plugin settings window</system:String>
 
     <!--  Release Notes Window  -->
     <system:String x:Key="seeMoreReleaseNotes">See more release notes on GitHub</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -46,6 +46,7 @@
     <system:String x:Key="invalidFlowLauncherPluginFileFormat">Invalid Flow Launcher plugin file format</system:String>
     <system:String x:Key="setAsTopMostInThisQuery">Set as topmost in this query</system:String>
     <system:String x:Key="cancelTopMostInThisQuery">Cancel topmost in this query</system:String>
+    <system:String x:Key="contextMenuPluginSettingsTitle">Plugin Settings</system:String>
     <system:String x:Key="executeQuery">Execute query: {0}</system:String>
     <system:String x:Key="lastExecuteTime">Last execution time: {0}</system:String>
     <system:String x:Key="iconTrayOpen">Open</system:String>
@@ -483,6 +484,9 @@
     <system:String x:Key="LogLevelINFO">Info</system:String>
     <system:String x:Key="LogLevelDEBUG">Debug</system:String>
     <system:String x:Key="settingWindowFontTitle">Setting Window Font</system:String>
+
+    <!--  Plugin Settings Window  -->
+    <system:String x:Key="pluginSettingsWindowTitle">Settings: {0}</system:String>
 
     <!--  Release Notes Window  -->
     <system:String x:Key="seeMoreReleaseNotes">See more release notes on GitHub</system:String>

--- a/Flow.Launcher/PluginSettingsWindow.xaml
+++ b/Flow.Launcher/PluginSettingsWindow.xaml
@@ -3,10 +3,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
-    Width="920"
-    Height="320"
-    MinWidth="720"
-    MinHeight="230"
+    Width="800"
+    Height="Auto"
+    MinWidth="600"
+    MinHeight="300"
     ResizeMode="CanResize"
     SnapsToDevicePixels="True"
     Loaded="OnLoaded"
@@ -47,9 +47,8 @@
         </Style>
     </Window.Resources>
 
-    <Grid>
-        <Border Style="{StaticResource WindowMainPanelStyle}">
-            <Grid Background="{DynamicResource Color01B}">
+    <Border Style="{StaticResource WindowMainPanelStyle}">
+        <Grid Background="{DynamicResource Color01B}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
@@ -171,23 +170,18 @@
                     </Path>
                 </Button>
 
-                <Border
+                <ScrollViewer
                     Grid.Row="1"
                     Grid.Column="0"
                     Grid.ColumnSpan="5"
-                    Margin="20 8 20 16">
-                    <ScrollViewer
-                        FontSize="14"
-                        HorizontalScrollBarVisibility="Disabled"
-                        VerticalScrollBarVisibility="Auto">
-                        <StackPanel Margin="8 0 32 0">
+                    FontSize="14"
+                    HorizontalScrollBarVisibility="Disabled"
+                    VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="32 8 32 16">
                             <!--  Plugin header  -->
-                            <Border
-                                Margin="0"
-                                Padding="0 12">
-                                <Grid Margin="16 12 18 12">
+                            <Grid Margin="16 16 18 24">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="36" MinWidth="36" />
+                                        <ColumnDefinition Width="36" />
                                         <ColumnDefinition Width="*" />
                                     </Grid.ColumnDefinitions>
                                     <Image
@@ -214,23 +208,19 @@
                                             Text="{Binding PluginPair.Metadata.Description}"
                                             TextWrapping="WrapWithOverflow" />
                                     </StackPanel>
-                                </Grid>
-                            </Border>
+                            </Grid>
 
-                            <Border
-                                Margin="0"
-                                Padding="0"
-                                CornerRadius="5 5 0 0">
-                                <Border.Style>
-                                    <Style BasedOn="{StaticResource SettingGroupBox}" TargetType="Border">
-                                        <Setter Property="BorderThickness" Value="0" />
-                                        <Setter Property="Padding" Value="0" />
-                                        <Setter Property="Margin" Value="0" />
-                                    </Style>
-                                </Border.Style>
+                            <Border 
+                                Margin="0" 
+                                Padding="0" 
+                                CornerRadius="5 5 0 0"
+                                BorderThickness="0"
+                                Style="{StaticResource SettingGroupBox}">
                                 <StackPanel>
                                     <!--  Enabled row  -->
-                                    <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
+                                    <Border
+                                        BorderThickness="0"
+                                        Style="{StaticResource PluginSettingsRowBorderStyle}">
                                         <DockPanel Margin="{StaticResource SettingPanelMargin}" LastChildFill="False">
                                             <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
                                                 &#xe7e8;
@@ -317,7 +307,6 @@
                                                 Text="{DynamicResource searchDelay}" />
                                             <ui:NumberBox
                                                 Width="120"
-                                                MinWidth="120"
                                                 Margin="0 -4.5 0 -4.5"
                                                 HorizontalAlignment="Right"
                                                 IsEnabled="{Binding SearchDelayEnabled}"
@@ -373,10 +362,8 @@
                                                         
                             <!-- Plugin Footer -->
                             <ContentControl Content="{Binding BottomPart2}" />
-                        </StackPanel>
-                    </ScrollViewer>
-                </Border>
-            </Grid>
-        </Border>
-    </Grid>
+                    </StackPanel>
+                </ScrollViewer>
+        </Grid>
+    </Border>
 </Window>

--- a/Flow.Launcher/PluginSettingsWindow.xaml
+++ b/Flow.Launcher/PluginSettingsWindow.xaml
@@ -2,7 +2,7 @@
     x:Class="Flow.Launcher.PluginSettingsWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:cc="clr-namespace:Flow.Launcher.Resources.Controls"
+    xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
     Width="920"
     Height="320"
     MinWidth="720"
@@ -22,6 +22,30 @@
     <Window.CommandBindings>
         <CommandBinding Command="Close" Executed="OnCloseExecuted" />
     </Window.CommandBindings>
+    <Window.Resources>
+        <Style x:Key="PluginSettingsRowBorderStyle" TargetType="Border">
+            <Setter Property="BorderBrush" Value="{DynamicResource Color03B}" />
+            <Setter Property="BorderThickness" Value="0 1 0 0" />
+        </Style>
+        <Style
+            x:Key="PluginSettingsRowLabelStyle"
+            BasedOn="{StaticResource SettingTitleLabel}"
+            TargetType="TextBlock">
+            <Setter Property="Margin" Value="{StaticResource SettingPanelItemRightMargin}" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="DockPanel.Dock" Value="Left" />
+        </Style>
+        <Style
+            x:Key="PluginSettingsRowGlyphStyle"
+            BasedOn="{StaticResource Glyph}"
+            TargetType="TextBlock">
+            <Setter Property="Margin" Value="{StaticResource SettingPanelItemRightMargin}" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="DockPanel.Dock" Value="Left" />
+        </Style>
+    </Window.Resources>
 
     <Grid>
         <Border Style="{StaticResource WindowMainPanelStyle}">
@@ -151,26 +175,180 @@
                     Grid.Row="1"
                     Grid.Column="0"
                     Grid.ColumnSpan="5"
-                    Margin="20 8 20 16"
-                    Background="{DynamicResource Color01B}">
-                    <ListBox
-                        x:Name="PluginListBox"
-                        Padding="0 0 7 0"
-                        Background="{DynamicResource Color01B}"
+                    Margin="20 8 20 16">
+                    <ScrollViewer
                         FontSize="14"
-                        ItemContainerStyle="{DynamicResource PluginList}"
-                        ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                        SnapsToDevicePixels="True"
-                        Style="{DynamicResource PluginListStyle}"
-                        VirtualizingPanel.ScrollUnit="Pixel"
-                        VirtualizingStackPanel.IsVirtualizing="True"
-                        VirtualizingStackPanel.VirtualizationMode="Recycling">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <cc:InstalledPluginDisplay />
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
+                        HorizontalScrollBarVisibility="Disabled"
+                        VerticalScrollBarVisibility="Auto">
+                        <StackPanel Margin="8 0 32 0">
+                            <!--  Plugin header  -->
+                            <Border
+                                Margin="0"
+                                Padding="0 12">
+                                <Grid Margin="16 12 18 12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="36" MinWidth="36" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Image
+                                        Grid.Column="0"
+                                        Width="32"
+                                        Height="32"
+                                        VerticalAlignment="Center"
+                                        Source="{Binding Image, Mode=OneWay, IsAsync=True}" />
+                                    <StackPanel
+                                        Grid.Column="1"
+                                        Margin="16 0 0 0"
+                                        VerticalAlignment="Center">
+                                        <TextBlock
+                                            FontSize="15"
+                                            FontWeight="SemiBold"
+                                            Foreground="{DynamicResource Color05B}"
+                                            Text="{Binding PluginPair.Metadata.Name}"
+                                            TextWrapping="Wrap"
+                                            ToolTip="{Binding PluginPair.Metadata.Version}" />
+                                        <TextBlock
+                                            Margin="0 2 0 0"
+                                            FontSize="12"
+                                            Foreground="{DynamicResource Color04B}"
+                                            Text="{Binding PluginPair.Metadata.Description}"
+                                            TextWrapping="WrapWithOverflow" />
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+
+                            <Border
+                                Margin="0"
+                                Padding="0"
+                                CornerRadius="5 5 0 0">
+                                <Border.Style>
+                                    <Style BasedOn="{StaticResource SettingGroupBox}" TargetType="Border">
+                                        <Setter Property="BorderThickness" Value="0" />
+                                        <Setter Property="Padding" Value="0" />
+                                        <Setter Property="Margin" Value="0" />
+                                    </Style>
+                                </Border.Style>
+                                <StackPanel>
+                                    <!--  Enabled row  -->
+                                    <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
+                                        <DockPanel Margin="{StaticResource SettingPanelMargin}" LastChildFill="False">
+                                            <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
+                                                &#xe7e8;
+                                            </TextBlock>
+                                            <TextBlock
+                                                Style="{StaticResource PluginSettingsRowLabelStyle}"
+                                                Text="{DynamicResource DisplayModeOnOff}" />
+                                            <ui:ToggleSwitch
+                                                DockPanel.Dock="Right"
+                                                Margin="0 -8.5 0 -8.5"
+                                                IsOn="{Binding PluginState}"
+                                                OffContent="{DynamicResource disable}"
+                                                OnContent="{DynamicResource enable}" />
+                                        </DockPanel>
+                                    </Border>
+
+                                    <!--  Home row  -->
+                                    <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
+                                        <DockPanel Margin="{StaticResource SettingPanelMargin}" LastChildFill="False">
+                                            <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
+                                                &#xE80F;
+                                            </TextBlock>
+                                            <TextBlock
+                                                Style="{StaticResource PluginSettingsRowLabelStyle}"
+                                                Text="{DynamicResource homeTitle}" />
+                                            <ui:ToggleSwitch
+                                                DockPanel.Dock="Right"
+                                                Margin="0 -8.5 0 -8.5"
+                                                IsEnabled="{Binding HomeEnabled}"
+                                                IsOn="{Binding PluginHomeState}"
+                                                OffContent="{DynamicResource disable}"
+                                                OnContent="{DynamicResource enable}"
+                                                ToolTip="{DynamicResource homeToggleBoxToolTip}" />
+                                        </DockPanel>
+                                    </Border>
+
+                                    <!--  Priority row  -->
+                                    <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
+                                        <DockPanel Margin="{StaticResource SettingPanelMargin}">
+                                            <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
+                                                &#xE74A;
+                                            </TextBlock>
+                                            <TextBlock
+                                                Style="{StaticResource PluginSettingsRowLabelStyle}"
+                                                Text="{DynamicResource priority}"
+                                                ToolTip="{DynamicResource priorityToolTip}" />
+                                            <ui:NumberBox
+                                                MinWidth="120"
+                                                Margin="0 -4.5 0 -4.5"
+                                                HorizontalAlignment="Right"
+                                                Maximum="999"
+                                                Minimum="-999"
+                                                SpinButtonPlacementMode="Inline"
+                                                ToolTip="{DynamicResource priorityToolTip}"
+                                                Value="{Binding Priority, Mode=TwoWay}"
+                                                ValueChanged="NumberBox_OnValueChanged" />
+                                        </DockPanel>
+                                    </Border>
+
+                                    <!--  Search Delay row  -->
+                                    <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
+                                        <DockPanel Margin="{StaticResource SettingPanelMargin}">
+                                            <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
+                                                &#xE961;
+                                            </TextBlock>
+                                            <TextBlock
+                                                Style="{StaticResource PluginSettingsRowLabelStyle}"
+                                                Text="{DynamicResource searchDelay}"
+                                                ToolTip="{DynamicResource searchDelayToolTip}" />
+                                            <ui:NumberBox
+                                                Width="120"
+                                                MinWidth="120"
+                                                Margin="0 -4.5 0 -4.5"
+                                                HorizontalAlignment="Right"
+                                                IsEnabled="{Binding SearchDelayEnabled}"
+                                                Maximum="1000"
+                                                Minimum="0"
+                                                PlaceholderText="{Binding DefaultSearchDelay}"
+                                                SmallChange="10"
+                                                SpinButtonPlacementMode="Compact"
+                                                ToolTip="{DynamicResource searchDelayNumberBoxToolTip}"
+                                                ToolTipService.InitialShowDelay="0"
+                                                ToolTipService.ShowOnDisabled="True"
+                                                Value="{Binding PluginSearchDelayTime, Mode=TwoWay}" />
+                                        </DockPanel>
+                                    </Border>
+                                </StackPanel>
+                            </Border>
+
+                            <!-- Action keyword row -->
+                            <ContentControl Content="{Binding BottomPart1}" />
+
+                            <!-- Plugin's own settings panel, if it has one -->
+                            <Border
+                                Margin="0"
+                                Padding="0"
+                                BorderThickness="0 1 0 0"
+                                CornerRadius="0">
+                                <Border.Style>
+                                    <Style BasedOn="{StaticResource SettingGroupBox}" TargetType="Border">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding HasSettingControl}" Value="False">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                                <ContentControl
+                                    Margin="0"
+                                    Padding="1"
+                                    VerticalAlignment="Stretch"
+                                    Content="{Binding SettingControl}" />
+                            </Border>
+                                                        
+                            <!-- Plugin Footer -->
+                            <ContentControl Content="{Binding BottomPart2}" />
+                        </StackPanel>
+                    </ScrollViewer>
                 </Border>
             </Grid>
         </Border>

--- a/Flow.Launcher/PluginSettingsWindow.xaml
+++ b/Flow.Launcher/PluginSettingsWindow.xaml
@@ -1,0 +1,178 @@
+<Window
+    x:Class="Flow.Launcher.PluginSettingsWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:cc="clr-namespace:Flow.Launcher.Resources.Controls"
+    Width="920"
+    Height="320"
+    MinWidth="720"
+    MinHeight="230"
+    ResizeMode="CanResize"
+    SnapsToDevicePixels="True"
+    Loaded="OnLoaded"
+    StateChanged="Window_StateChanged"
+    UseLayoutRounding="True"
+    WindowStartupLocation="CenterScreen">
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="32" ResizeBorderThickness="{x:Static SystemParameters.WindowResizeBorderThickness}" />
+    </WindowChrome.WindowChrome>
+    <Window.InputBindings>
+        <KeyBinding Key="Escape" Command="Close" />
+    </Window.InputBindings>
+    <Window.CommandBindings>
+        <CommandBinding Command="Close" Executed="OnCloseExecuted" />
+    </Window.CommandBindings>
+
+    <Grid>
+        <Border Style="{StaticResource WindowMainPanelStyle}">
+            <Grid Background="{DynamicResource Color01B}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="32" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <Image
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    Width="16"
+                    Height="16"
+                    Margin="10 4 4 4"
+                    RenderOptions.BitmapScalingMode="HighQuality"
+                    Source="/Images/app.png" />
+                <TextBlock
+                    Grid.Row="0"
+                    Grid.Column="1"
+                    Margin="4 0 0 0"
+                    VerticalAlignment="Center"
+                    FontSize="12"
+                    Foreground="{DynamicResource Color05B}"
+                    Text="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}, Path=Title}" />
+
+                <Button
+                    Grid.Row="0"
+                    Grid.Column="2"
+                    Click="OnMinimizeButtonClick"
+                    RenderOptions.EdgeMode="Aliased"
+                    Style="{DynamicResource TitleBarButtonStyle}">
+                    <Path
+                        Width="46"
+                        Height="32"
+                        Data="M 18,15 H 28"
+                        Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                        StrokeThickness="1">
+                        <Path.Style>
+                            <Style TargetType="Path">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                        <Setter Property="Opacity" Value="0.5" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Path.Style>
+                    </Path>
+                </Button>
+                <Button
+                    Name="MaximizeButton"
+                    Grid.Row="0"
+                    Grid.Column="3"
+                    Click="OnMaximizeRestoreButtonClick"
+                    Style="{StaticResource TitleBarButtonStyle}">
+                    <Path
+                        Width="46"
+                        Height="32"
+                        Data="M 18.5,10.5 H 27.5 V 19.5 H 18.5 Z"
+                        Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                        StrokeThickness="1">
+                        <Path.Style>
+                            <Style TargetType="Path">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                        <Setter Property="Opacity" Value="0.5" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Path.Style>
+                    </Path>
+                </Button>
+                <Button
+                    Grid.Row="0"
+                    Name="RestoreButton"
+                    Grid.Column="3"
+                    Click="OnMaximizeRestoreButtonClick"
+                    Style="{StaticResource TitleBarButtonStyle}">
+                    <Path
+                        Width="46"
+                        Height="32"
+                        Data="M 18.5,12.5 H 25.5 V 19.5 H 18.5 Z M 20.5,12.5 V 10.5 H 27.5 V 17.5 H 25.5"
+                        Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                        StrokeThickness="1">
+                        <Path.Style>
+                            <Style TargetType="Path">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                        <Setter Property="Opacity" Value="0.5" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Path.Style>
+                    </Path>
+                </Button>
+                <Button
+                    Grid.Row="0"
+                    Grid.Column="4"
+                    Click="OnCloseButtonClick"
+                    Style="{StaticResource TitleBarCloseButtonStyle}">
+                    <Path
+                        Width="46"
+                        Height="32"
+                        Data="M 18,11 27,20 M 18,20 27,11"
+                        Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                        StrokeThickness="1">
+                        <Path.Style>
+                            <Style TargetType="Path">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                        <Setter Property="Opacity" Value="0.5" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Path.Style>
+                    </Path>
+                </Button>
+
+                <Border
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="5"
+                    Margin="20 8 20 16"
+                    Background="{DynamicResource Color01B}">
+                    <ListBox
+                        x:Name="PluginListBox"
+                        Padding="0 0 7 0"
+                        Background="{DynamicResource Color01B}"
+                        FontSize="14"
+                        ItemContainerStyle="{DynamicResource PluginList}"
+                        ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                        SnapsToDevicePixels="True"
+                        Style="{DynamicResource PluginListStyle}"
+                        VirtualizingPanel.ScrollUnit="Pixel"
+                        VirtualizingStackPanel.IsVirtualizing="True"
+                        VirtualizingStackPanel.VirtualizationMode="Recycling">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <cc:InstalledPluginDisplay />
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </Border>
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/Flow.Launcher/PluginSettingsWindow.xaml
+++ b/Flow.Launcher/PluginSettingsWindow.xaml
@@ -7,9 +7,9 @@
     Height="Auto"
     MinWidth="600"
     MinHeight="300"
+    Loaded="OnLoaded"
     ResizeMode="CanResize"
     SnapsToDevicePixels="True"
-    Loaded="OnLoaded"
     StateChanged="Window_StateChanged"
     UseLayoutRounding="True"
     WindowStartupLocation="CenterScreen">
@@ -49,321 +49,303 @@
 
     <Border Style="{StaticResource WindowMainPanelStyle}">
         <Grid Background="{DynamicResource Color01B}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="32" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="32" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
-                <Image
-                    Grid.Row="0"
-                    Grid.Column="0"
-                    Width="16"
-                    Height="16"
-                    Margin="10 4 4 4"
-                    RenderOptions.BitmapScalingMode="HighQuality"
-                    Source="/Images/app.png" />
-                <TextBlock
-                    Grid.Row="0"
-                    Grid.Column="1"
-                    Margin="4 0 0 0"
-                    VerticalAlignment="Center"
-                    FontSize="12"
-                    Foreground="{DynamicResource Color05B}"
-                    Text="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}, Path=Title}" />
+            <Image
+                Grid.Row="0"
+                Grid.Column="0"
+                Width="16"
+                Height="16"
+                Margin="10 4 4 4"
+                RenderOptions.BitmapScalingMode="HighQuality"
+                Source="/Images/app.png" />
+            <TextBlock
+                Grid.Row="0"
+                Grid.Column="1"
+                Margin="4 0 0 0"
+                VerticalAlignment="Center"
+                FontSize="12"
+                Foreground="{DynamicResource Color05B}"
+                Text="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}, Path=Title}" />
 
-                <Button
-                    Grid.Row="0"
-                    Grid.Column="2"
-                    Click="OnMinimizeButtonClick"
-                    RenderOptions.EdgeMode="Aliased"
-                    Style="{DynamicResource TitleBarButtonStyle}">
-                    <Path
-                        Width="46"
-                        Height="32"
-                        Data="M 18,15 H 28"
-                        Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
-                        StrokeThickness="1">
-                        <Path.Style>
-                            <Style TargetType="Path">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
-                                        <Setter Property="Opacity" Value="0.5" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Path.Style>
-                    </Path>
-                </Button>
-                <Button
-                    Name="MaximizeButton"
-                    Grid.Row="0"
-                    Grid.Column="3"
-                    Click="OnMaximizeRestoreButtonClick"
-                    Style="{StaticResource TitleBarButtonStyle}">
-                    <Path
-                        Width="46"
-                        Height="32"
-                        Data="M 18.5,10.5 H 27.5 V 19.5 H 18.5 Z"
-                        Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
-                        StrokeThickness="1">
-                        <Path.Style>
-                            <Style TargetType="Path">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
-                                        <Setter Property="Opacity" Value="0.5" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Path.Style>
-                    </Path>
-                </Button>
-                <Button
-                    Grid.Row="0"
-                    Name="RestoreButton"
-                    Grid.Column="3"
-                    Click="OnMaximizeRestoreButtonClick"
-                    Style="{StaticResource TitleBarButtonStyle}">
-                    <Path
-                        Width="46"
-                        Height="32"
-                        Data="M 18.5,12.5 H 25.5 V 19.5 H 18.5 Z M 20.5,12.5 V 10.5 H 27.5 V 17.5 H 25.5"
-                        Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
-                        StrokeThickness="1">
-                        <Path.Style>
-                            <Style TargetType="Path">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
-                                        <Setter Property="Opacity" Value="0.5" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Path.Style>
-                    </Path>
-                </Button>
-                <Button
-                    Grid.Row="0"
-                    Grid.Column="4"
-                    Click="OnCloseButtonClick"
-                    Style="{StaticResource TitleBarCloseButtonStyle}">
-                    <Path
-                        Width="46"
-                        Height="32"
-                        Data="M 18,11 27,20 M 18,20 27,11"
-                        Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
-                        StrokeThickness="1">
-                        <Path.Style>
-                            <Style TargetType="Path">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
-                                        <Setter Property="Opacity" Value="0.5" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Path.Style>
-                    </Path>
-                </Button>
+            <Button
+                Grid.Row="0"
+                Grid.Column="2"
+                Click="OnMinimizeButtonClick"
+                RenderOptions.EdgeMode="Aliased"
+                Style="{DynamicResource TitleBarButtonStyle}">
+                <Path
+                    Width="46"
+                    Height="32"
+                    Data="M 18,15 H 28"
+                    Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                    StrokeThickness="1">
+                    <Path.Style>
+                        <Style TargetType="Path">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                    <Setter Property="Opacity" Value="0.5" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Path.Style>
+                </Path>
+            </Button>
+            <Button
+                Name="MaximizeButton"
+                Grid.Row="0"
+                Grid.Column="3"
+                Click="OnMaximizeRestoreButtonClick"
+                Style="{StaticResource TitleBarButtonStyle}">
+                <Path
+                    Width="46"
+                    Height="32"
+                    Data="M 18.5,10.5 H 27.5 V 19.5 H 18.5 Z"
+                    Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                    StrokeThickness="1">
+                    <Path.Style>
+                        <Style TargetType="Path">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                    <Setter Property="Opacity" Value="0.5" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Path.Style>
+                </Path>
+            </Button>
+            <Button
+                Name="RestoreButton"
+                Grid.Row="0"
+                Grid.Column="3"
+                Click="OnMaximizeRestoreButtonClick"
+                Style="{StaticResource TitleBarButtonStyle}">
+                <Path
+                    Width="46"
+                    Height="32"
+                    Data="M 18.5,12.5 H 25.5 V 19.5 H 18.5 Z M 20.5,12.5 V 10.5 H 27.5 V 17.5 H 25.5"
+                    Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                    StrokeThickness="1">
+                    <Path.Style>
+                        <Style TargetType="Path">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                    <Setter Property="Opacity" Value="0.5" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Path.Style>
+                </Path>
+            </Button>
+            <Button
+                Grid.Row="0"
+                Grid.Column="4"
+                Click="OnCloseButtonClick"
+                Style="{StaticResource TitleBarCloseButtonStyle}">
+                <Path
+                    Width="46"
+                    Height="32"
+                    Data="M 18,11 27,20 M 18,20 27,11"
+                    Stroke="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                    StrokeThickness="1">
+                    <Path.Style>
+                        <Style TargetType="Path">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Path=IsActive, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}}" Value="False">
+                                    <Setter Property="Opacity" Value="0.5" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Path.Style>
+                </Path>
+            </Button>
 
-                <ScrollViewer
-                    Grid.Row="1"
-                    Grid.Column="0"
-                    Grid.ColumnSpan="5"
-                    FontSize="14"
-                    HorizontalScrollBarVisibility="Disabled"
-                    VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="32 8 32 16">
-                            <!--  Plugin header  -->
-                            <Grid Margin="16 16 18 24">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="36" />
-                                        <ColumnDefinition Width="*" />
-                                    </Grid.ColumnDefinitions>
-                                    <Image
-                                        Grid.Column="0"
-                                        Width="32"
-                                        Height="32"
-                                        VerticalAlignment="Center"
-                                        Source="{Binding Image, Mode=OneWay, IsAsync=True}" />
-                                    <StackPanel
-                                        Grid.Column="1"
-                                        Margin="16 0 0 0"
-                                        VerticalAlignment="Center">
-                                        <TextBlock
-                                            FontSize="15"
-                                            FontWeight="SemiBold"
-                                            Foreground="{DynamicResource Color05B}"
-                                            Text="{Binding PluginPair.Metadata.Name}"
-                                            TextWrapping="Wrap"
-                                            ToolTip="{Binding PluginPair.Metadata.Version}" />
-                                        <TextBlock
-                                            Margin="0 2 0 0"
-                                            FontSize="12"
-                                            Foreground="{DynamicResource Color04B}"
-                                            Text="{Binding PluginPair.Metadata.Description}"
-                                            TextWrapping="WrapWithOverflow" />
-                                    </StackPanel>
-                            </Grid>
+            <ScrollViewer
+                Grid.Row="1"
+                Grid.Column="0"
+                Grid.ColumnSpan="5"
+                FontSize="14"
+                HorizontalScrollBarVisibility="Disabled"
+                VerticalScrollBarVisibility="Auto">
+                <StackPanel Margin="32 8 32 16">
+                    <!--  Plugin header  -->
+                    <Grid Margin="16 16 18 24">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="36" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Image
+                            Grid.Column="0"
+                            Width="32"
+                            Height="32"
+                            VerticalAlignment="Center"
+                            Source="{Binding Image, Mode=OneWay, IsAsync=True}" />
+                        <StackPanel
+                            Grid.Column="1"
+                            Margin="16 0 0 0"
+                            VerticalAlignment="Center">
+                            <TextBlock
+                                FontSize="15"
+                                FontWeight="SemiBold"
+                                Foreground="{DynamicResource Color05B}"
+                                Text="{Binding PluginPair.Metadata.Name}"
+                                TextWrapping="Wrap"
+                                ToolTip="{Binding PluginPair.Metadata.Version}" />
+                            <TextBlock
+                                Margin="0 2 0 0"
+                                FontSize="12"
+                                Foreground="{DynamicResource Color04B}"
+                                Text="{Binding PluginPair.Metadata.Description}"
+                                TextWrapping="WrapWithOverflow" />
+                        </StackPanel>
+                    </Grid>
 
-                            <Border 
-                                Margin="0" 
-                                Padding="0" 
-                                CornerRadius="5 5 0 0"
-                                BorderThickness="0"
-                                Style="{StaticResource SettingGroupBox}">
-                                <StackPanel>
-                                    <!--  Enabled row  -->
-                                    <Border
-                                        BorderThickness="0"
-                                        Style="{StaticResource PluginSettingsRowBorderStyle}">
-                                        <DockPanel Margin="{StaticResource SettingPanelMargin}" LastChildFill="False">
-                                            <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
-                                                &#xe7e8;
-                                            </TextBlock>
-                                            <TextBlock
-                                                Style="{StaticResource PluginSettingsRowLabelStyle}"
-                                                Text="{DynamicResource DisplayModeOnOff}" />
-                                            <ui:ToggleSwitch
-                                                DockPanel.Dock="Right"
-                                                Margin="0 -8.5 0 -8.5"
-                                                IsOn="{Binding PluginState}"
-                                                OffContent="{DynamicResource disable}"
-                                                OnContent="{DynamicResource enable}" />
-                                        </DockPanel>
-                                    </Border>
-
-                                    <!--  Home row  -->
-                                    <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
-                                        <DockPanel
-                                            Margin="{StaticResource SettingPanelMargin}"
-                                            LastChildFill="False">
-                                            <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
-                                                &#xE80F;
-                                            </TextBlock>
-                                            <TextBlock
-                                                Style="{StaticResource PluginSettingsRowLabelStyle}"
-                                                Text="{DynamicResource homeTitle}" />
-                                            <ui:ToggleSwitch
-                                                DockPanel.Dock="Right"
-                                                Margin="0 -8.5 0 -8.5"
-                                                IsEnabled="{Binding HomeEnabled}"
-                                                IsOn="{Binding PluginHomeState}"
-                                                OffContent="{DynamicResource disable}"
-                                                OnContent="{DynamicResource enable}"
-                                                ToolTip="{DynamicResource homeToggleBoxToolTip}"
-                                                ToolTipService.ShowOnDisabled="True">
-                                                <ui:ToggleSwitch.Style>
-                                                    <Style
-                                                        BasedOn="{StaticResource {x:Type ui:ToggleSwitch}}"
-                                                        TargetType="ui:ToggleSwitch">
-                                                        <Style.Triggers>
-                                                            <Trigger Property="IsEnabled" Value="False">
-                                                                <Setter Property="ToolTipService.InitialShowDelay" Value="0" />
-                                                            </Trigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </ui:ToggleSwitch.Style>
-                                            </ui:ToggleSwitch>
-                                        </DockPanel>
-                                    </Border>
-
-                                    <!--  Priority row  -->
-                                    <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
-                                        <DockPanel
-                                            Margin="{StaticResource SettingPanelMargin}">
-                                            <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
-                                                &#xE74A;
-                                            </TextBlock>
-                                            <TextBlock
-                                                Style="{StaticResource PluginSettingsRowLabelStyle}"
-                                                Text="{DynamicResource priority}" />
-                                            <ui:NumberBox
-                                                MinWidth="120"
-                                                Margin="0 -4.5 0 -4.5"
-                                                HorizontalAlignment="Right"
-                                                Maximum="999"
-                                                Minimum="-999"
-                                                SpinButtonPlacementMode="Inline"
-                                                ToolTip="{DynamicResource priorityToolTip}"
-                                                Value="{Binding Priority, Mode=TwoWay}"
-                                                ValueChanged="NumberBox_OnValueChanged" />
-                                        </DockPanel>
-                                    </Border>
-
-                                    <!--  Search Delay row  -->
-                                    <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
-                                        <DockPanel
-                                            Margin="{StaticResource SettingPanelMargin}">
-                                            <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
-                                                &#xE961;
-                                            </TextBlock>
-                                            <TextBlock
-                                                Style="{StaticResource PluginSettingsRowLabelStyle}"
-                                                Text="{DynamicResource searchDelay}" />
-                                            <ui:NumberBox
-                                                Width="120"
-                                                Margin="0 -4.5 0 -4.5"
-                                                HorizontalAlignment="Right"
-                                                IsEnabled="{Binding SearchDelayEnabled}"
-                                                Maximum="1000"
-                                                Minimum="0"
-                                                PlaceholderText="{Binding DefaultSearchDelay}"
-                                                SmallChange="10"
-                                                SpinButtonPlacementMode="Compact"
-                                                ToolTip="{DynamicResource searchDelayNumberBoxToolTip}"
-                                                ToolTipService.ShowOnDisabled="True"
-                                                Value="{Binding PluginSearchDelayTime, Mode=TwoWay}">
-                                                <ui:NumberBox.Style>
-                                                    <Style
-                                                        BasedOn="{StaticResource {x:Type ui:NumberBox}}"
-                                                        TargetType="ui:NumberBox">
-                                                        <Style.Triggers>
-                                                            <Trigger Property="IsEnabled" Value="False">
-                                                                <Setter Property="ToolTipService.InitialShowDelay" Value="0" />
-                                                            </Trigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </ui:NumberBox.Style>
-                                            </ui:NumberBox>
-                                        </DockPanel>
-                                    </Border>
-                                </StackPanel>
+                    <Border
+                        Margin="0"
+                        Padding="0"
+                        BorderThickness="0"
+                        CornerRadius="5 5 0 0"
+                        Style="{StaticResource SettingGroupBox}">
+                        <StackPanel>
+                            <!--  Enabled row  -->
+                            <Border BorderThickness="0" Style="{StaticResource PluginSettingsRowBorderStyle}">
+                                <DockPanel Margin="{StaticResource SettingPanelMargin}" LastChildFill="False">
+                                    <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
+                                        &#xe7e8;
+                                    </TextBlock>
+                                    <TextBlock Style="{StaticResource PluginSettingsRowLabelStyle}" Text="{DynamicResource DisplayModeOnOff}" />
+                                    <ui:ToggleSwitch
+                                        Margin="0 -8.5 0 -8.5"
+                                        DockPanel.Dock="Right"
+                                        IsOn="{Binding PluginState}"
+                                        OffContent="{DynamicResource disable}"
+                                        OnContent="{DynamicResource enable}" />
+                                </DockPanel>
                             </Border>
 
-                            <!-- Action keyword row -->
-                            <ContentControl Content="{Binding BottomPart1}" />
-
-                            <!-- Plugin's own settings panel, if it has one -->
-                            <Border
-                                Margin="0"
-                                Padding="0"
-                                BorderThickness="0 1 0 0"
-                                CornerRadius="0">
-                                <Border.Style>
-                                    <Style BasedOn="{StaticResource SettingGroupBox}" TargetType="Border">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding HasSettingControl}" Value="False">
-                                                <Setter Property="Visibility" Value="Collapsed" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Border.Style>
-                                <ContentControl
-                                    Margin="0"
-                                    Padding="1"
-                                    VerticalAlignment="Stretch"
-                                    Content="{Binding SettingControl}" />
+                            <!--  Home row  -->
+                            <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
+                                <DockPanel Margin="{StaticResource SettingPanelMargin}" LastChildFill="False">
+                                    <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
+                                        &#xE80F;
+                                    </TextBlock>
+                                    <TextBlock Style="{StaticResource PluginSettingsRowLabelStyle}" Text="{DynamicResource homeTitle}" />
+                                    <ui:ToggleSwitch
+                                        Margin="0 -8.5 0 -8.5"
+                                        DockPanel.Dock="Right"
+                                        IsEnabled="{Binding HomeEnabled}"
+                                        IsOn="{Binding PluginHomeState}"
+                                        OffContent="{DynamicResource disable}"
+                                        OnContent="{DynamicResource enable}"
+                                        ToolTip="{DynamicResource homeToggleBoxToolTip}"
+                                        ToolTipService.ShowOnDisabled="True">
+                                        <ui:ToggleSwitch.Style>
+                                            <Style BasedOn="{StaticResource {x:Type ui:ToggleSwitch}}" TargetType="ui:ToggleSwitch">
+                                                <Style.Triggers>
+                                                    <Trigger Property="IsEnabled" Value="False">
+                                                        <Setter Property="ToolTipService.InitialShowDelay" Value="0" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ui:ToggleSwitch.Style>
+                                    </ui:ToggleSwitch>
+                                </DockPanel>
                             </Border>
-                                                        
-                            <!-- Plugin Footer -->
-                            <ContentControl Content="{Binding BottomPart2}" />
-                    </StackPanel>
-                </ScrollViewer>
+
+                            <!--  Priority row  -->
+                            <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
+                                <DockPanel Margin="{StaticResource SettingPanelMargin}">
+                                    <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
+                                        &#xE74A;
+                                    </TextBlock>
+                                    <TextBlock Style="{StaticResource PluginSettingsRowLabelStyle}" Text="{DynamicResource priority}" />
+                                    <ui:NumberBox
+                                        MinWidth="120"
+                                        Margin="0 -4.5 0 -4.5"
+                                        HorizontalAlignment="Right"
+                                        Maximum="999"
+                                        Minimum="-999"
+                                        SpinButtonPlacementMode="Inline"
+                                        ToolTip="{DynamicResource priorityToolTip}"
+                                        ValueChanged="NumberBox_OnValueChanged"
+                                        Value="{Binding Priority, Mode=TwoWay}" />
+                                </DockPanel>
+                            </Border>
+
+                            <!--  Search Delay row  -->
+                            <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
+                                <DockPanel Margin="{StaticResource SettingPanelMargin}">
+                                    <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
+                                        &#xE961;
+                                    </TextBlock>
+                                    <TextBlock Style="{StaticResource PluginSettingsRowLabelStyle}" Text="{DynamicResource searchDelay}" />
+                                    <ui:NumberBox
+                                        Width="120"
+                                        Margin="0 -4.5 0 -4.5"
+                                        HorizontalAlignment="Right"
+                                        IsEnabled="{Binding SearchDelayEnabled}"
+                                        Maximum="1000"
+                                        Minimum="0"
+                                        PlaceholderText="{Binding DefaultSearchDelay}"
+                                        SmallChange="10"
+                                        SpinButtonPlacementMode="Compact"
+                                        ToolTip="{DynamicResource searchDelayNumberBoxToolTip}"
+                                        ToolTipService.ShowOnDisabled="True"
+                                        Value="{Binding PluginSearchDelayTime, Mode=TwoWay}">
+                                        <ui:NumberBox.Style>
+                                            <Style BasedOn="{StaticResource {x:Type ui:NumberBox}}" TargetType="ui:NumberBox">
+                                                <Style.Triggers>
+                                                    <Trigger Property="IsEnabled" Value="False">
+                                                        <Setter Property="ToolTipService.InitialShowDelay" Value="0" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ui:NumberBox.Style>
+                                    </ui:NumberBox>
+                                </DockPanel>
+                            </Border>
+                        </StackPanel>
+                    </Border>
+
+                    <!--  Action keyword row  -->
+                    <ContentControl Content="{Binding BottomPart1}" />
+
+                    <!--  Plugin's own settings panel, if it has one  -->
+                    <Border
+                        Margin="0"
+                        Padding="0"
+                        BorderThickness="0 1 0 0"
+                        CornerRadius="0">
+                        <Border.Style>
+                            <Style BasedOn="{StaticResource SettingGroupBox}" TargetType="Border">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasSettingControl}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <ContentControl
+                            Margin="0"
+                            Padding="1"
+                            VerticalAlignment="Stretch"
+                            Content="{Binding SettingControl}" />
+                    </Border>
+
+                    <!--  Plugin Footer  -->
+                    <ContentControl Content="{Binding BottomPart2}" />
+                </StackPanel>
+            </ScrollViewer>
         </Grid>
     </Border>
 </Window>

--- a/Flow.Launcher/PluginSettingsWindow.xaml
+++ b/Flow.Launcher/PluginSettingsWindow.xaml
@@ -249,7 +249,9 @@
 
                                     <!--  Home row  -->
                                     <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
-                                        <DockPanel Margin="{StaticResource SettingPanelMargin}" LastChildFill="False">
+                                        <DockPanel
+                                            Margin="{StaticResource SettingPanelMargin}"
+                                            LastChildFill="False">
                                             <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
                                                 &#xE80F;
                                             </TextBlock>
@@ -263,20 +265,33 @@
                                                 IsOn="{Binding PluginHomeState}"
                                                 OffContent="{DynamicResource disable}"
                                                 OnContent="{DynamicResource enable}"
-                                                ToolTip="{DynamicResource homeToggleBoxToolTip}" />
+                                                ToolTip="{DynamicResource homeToggleBoxToolTip}"
+                                                ToolTipService.ShowOnDisabled="True">
+                                                <ui:ToggleSwitch.Style>
+                                                    <Style
+                                                        BasedOn="{StaticResource {x:Type ui:ToggleSwitch}}"
+                                                        TargetType="ui:ToggleSwitch">
+                                                        <Style.Triggers>
+                                                            <Trigger Property="IsEnabled" Value="False">
+                                                                <Setter Property="ToolTipService.InitialShowDelay" Value="0" />
+                                                            </Trigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </ui:ToggleSwitch.Style>
+                                            </ui:ToggleSwitch>
                                         </DockPanel>
                                     </Border>
 
                                     <!--  Priority row  -->
                                     <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
-                                        <DockPanel Margin="{StaticResource SettingPanelMargin}">
+                                        <DockPanel
+                                            Margin="{StaticResource SettingPanelMargin}">
                                             <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
                                                 &#xE74A;
                                             </TextBlock>
                                             <TextBlock
                                                 Style="{StaticResource PluginSettingsRowLabelStyle}"
-                                                Text="{DynamicResource priority}"
-                                                ToolTip="{DynamicResource priorityToolTip}" />
+                                                Text="{DynamicResource priority}" />
                                             <ui:NumberBox
                                                 MinWidth="120"
                                                 Margin="0 -4.5 0 -4.5"
@@ -292,14 +307,14 @@
 
                                     <!--  Search Delay row  -->
                                     <Border Style="{StaticResource PluginSettingsRowBorderStyle}">
-                                        <DockPanel Margin="{StaticResource SettingPanelMargin}">
+                                        <DockPanel
+                                            Margin="{StaticResource SettingPanelMargin}">
                                             <TextBlock Style="{StaticResource PluginSettingsRowGlyphStyle}">
                                                 &#xE961;
                                             </TextBlock>
                                             <TextBlock
                                                 Style="{StaticResource PluginSettingsRowLabelStyle}"
-                                                Text="{DynamicResource searchDelay}"
-                                                ToolTip="{DynamicResource searchDelayToolTip}" />
+                                                Text="{DynamicResource searchDelay}" />
                                             <ui:NumberBox
                                                 Width="120"
                                                 MinWidth="120"
@@ -312,9 +327,20 @@
                                                 SmallChange="10"
                                                 SpinButtonPlacementMode="Compact"
                                                 ToolTip="{DynamicResource searchDelayNumberBoxToolTip}"
-                                                ToolTipService.InitialShowDelay="0"
                                                 ToolTipService.ShowOnDisabled="True"
-                                                Value="{Binding PluginSearchDelayTime, Mode=TwoWay}" />
+                                                Value="{Binding PluginSearchDelayTime, Mode=TwoWay}">
+                                                <ui:NumberBox.Style>
+                                                    <Style
+                                                        BasedOn="{StaticResource {x:Type ui:NumberBox}}"
+                                                        TargetType="ui:NumberBox">
+                                                        <Style.Triggers>
+                                                            <Trigger Property="IsEnabled" Value="False">
+                                                                <Setter Property="ToolTipService.InitialShowDelay" Value="0" />
+                                                            </Trigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </ui:NumberBox.Style>
+                                            </ui:NumberBox>
                                         </DockPanel>
                                     </Border>
                                 </StackPanel>

--- a/Flow.Launcher/PluginSettingsWindow.xaml.cs
+++ b/Flow.Launcher/PluginSettingsWindow.xaml.cs
@@ -1,24 +1,22 @@
 using System;
-using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Infrastructure.UserSettings;
 using Flow.Launcher.ViewModel;
+using iNKORE.UI.WPF.Modern.Controls;
 
 namespace Flow.Launcher;
 
 public partial class PluginSettingsWindow
 {
     private readonly Settings _settings;
-    private readonly PluginDisplayModes _displayModes = new();
 
     public PluginSettingsWindow()
     {
         _settings = Ioc.Default.GetRequiredService<Settings>();
         InitializeComponent();
-        PluginListBox.DataContext = _displayModes;
     }
 
     public PluginSettingsWindow(string pluginId)
@@ -56,9 +54,17 @@ public partial class PluginSettingsWindow
             IsExpanded = true,
         };
 
-        PluginListBox.ItemsSource = new List<PluginViewModel> { pluginViewModel };
-        PluginListBox.SelectedIndex = -1;
+        DataContext = pluginViewModel;
         Title = $"{pluginPair.Metadata.Name} Settings";
+    }
+
+    // This is used for Priority control to force its value to be 0 when the user clears the value.
+    private void NumberBox_OnValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+    {
+        if (double.IsNaN(args.NewValue))
+        {
+            sender.Value = 0;
+        }
     }
 
     private void OnMinimizeButtonClick(object sender, RoutedEventArgs e)
@@ -118,13 +124,5 @@ public partial class PluginSettingsWindow
         }
 
         base.OnClosed(e);
-    }
-
-    private sealed class PluginDisplayModes
-    {
-        public bool IsOnOffSelected => true;
-        public bool IsPrioritySelected => false;
-        public bool IsSearchDelaySelected => false;
-        public bool IsHomeOnOffSelected => false;
     }
 }

--- a/Flow.Launcher/PluginSettingsWindow.xaml.cs
+++ b/Flow.Launcher/PluginSettingsWindow.xaml.cs
@@ -13,6 +13,8 @@ public partial class PluginSettingsWindow
 {
     private readonly Settings _settings;
 
+    public string PluginId { get; }
+
     public PluginSettingsWindow(string pluginId)
     {
         _settings = Ioc.Default.GetRequiredService<Settings>();
@@ -20,6 +22,8 @@ public partial class PluginSettingsWindow
         if (string.IsNullOrWhiteSpace(pluginId)){
             throw new ArgumentException("Plugin ID cannot be null or whitespace.", nameof(pluginId));
         }
+
+        PluginId = pluginId;
 
         var pluginPair = PluginManager.GetPluginForId(pluginId);
         if (pluginPair == null)

--- a/Flow.Launcher/PluginSettingsWindow.xaml.cs
+++ b/Flow.Launcher/PluginSettingsWindow.xaml.cs
@@ -45,8 +45,7 @@ public partial class PluginSettingsWindow
         };
 
         DataContext = pluginViewModel;
-        Title = $"{pluginPair.Metadata.Name} Settings";
-
+        Title = Localize.pluginSettingsWindowTitle(pluginPair.Metadata.Name);
         InitializeComponent();
     }
 

--- a/Flow.Launcher/PluginSettingsWindow.xaml.cs
+++ b/Flow.Launcher/PluginSettingsWindow.xaml.cs
@@ -17,24 +17,20 @@ public partial class PluginSettingsWindow
     {
         _settings = Ioc.Default.GetRequiredService<Settings>();
 
-        if (string.IsNullOrWhiteSpace(pluginId))
-        {
-            App.API.ShowMsgError("Plugin settings", "Invalid plugin id.");
-            return;
+        if (string.IsNullOrWhiteSpace(pluginId)){
+            throw new ArgumentException("Plugin ID cannot be null or whitespace.", nameof(pluginId));
         }
 
         var pluginPair = PluginManager.GetPluginForId(pluginId);
         if (pluginPair == null)
         {
-            App.API.ShowMsgError("Plugin settings", $"Unable to find plugin: {pluginId}");
-            return;
+            throw new InvalidOperationException($"Unable to find plugin: {pluginId}");
         }
 
         var pluginSettings = _settings.PluginSettings.GetPluginSettings(pluginId);
         if (pluginSettings == null)
         {
-            App.API.ShowMsgError("Plugin settings", $"Unable to load settings for plugin: {pluginPair.Metadata.Name}");
-            return;
+            throw new InvalidOperationException($"Unable to load settings for plugin: {pluginPair.Metadata.Name}");
         }
 
         var pluginViewModel = new PluginViewModel

--- a/Flow.Launcher/PluginSettingsWindow.xaml.cs
+++ b/Flow.Launcher/PluginSettingsWindow.xaml.cs
@@ -13,20 +13,10 @@ public partial class PluginSettingsWindow
 {
     private readonly Settings _settings;
 
-    public PluginSettingsWindow()
+    public PluginSettingsWindow(string pluginId)
     {
         _settings = Ioc.Default.GetRequiredService<Settings>();
-        InitializeComponent();
-    }
 
-    public PluginSettingsWindow(string pluginId)
-        : this()
-    {
-        LoadPlugin(pluginId);
-    }
-
-    private void LoadPlugin(string pluginId)
-    {
         if (string.IsNullOrWhiteSpace(pluginId))
         {
             App.API.ShowMsgError("Plugin settings", "Invalid plugin id.");
@@ -56,6 +46,8 @@ public partial class PluginSettingsWindow
 
         DataContext = pluginViewModel;
         Title = $"{pluginPair.Metadata.Name} Settings";
+
+        InitializeComponent();
     }
 
     // This is used for Priority control to force its value to be 0 when the user clears the value.

--- a/Flow.Launcher/PluginSettingsWindow.xaml.cs
+++ b/Flow.Launcher/PluginSettingsWindow.xaml.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Flow.Launcher.Core.Plugin;
+using Flow.Launcher.Infrastructure.UserSettings;
+using Flow.Launcher.ViewModel;
+
+namespace Flow.Launcher;
+
+public partial class PluginSettingsWindow
+{
+    private readonly Settings _settings;
+    private readonly PluginDisplayModes _displayModes = new();
+
+    public PluginSettingsWindow()
+    {
+        _settings = Ioc.Default.GetRequiredService<Settings>();
+        InitializeComponent();
+        PluginListBox.DataContext = _displayModes;
+    }
+
+    public PluginSettingsWindow(string pluginId)
+        : this()
+    {
+        LoadPlugin(pluginId);
+    }
+
+    private void LoadPlugin(string pluginId)
+    {
+        if (string.IsNullOrWhiteSpace(pluginId))
+        {
+            App.API.ShowMsgError("Plugin settings", "Invalid plugin id.");
+            return;
+        }
+
+        var pluginPair = PluginManager.GetPluginForId(pluginId);
+        if (pluginPair == null)
+        {
+            App.API.ShowMsgError("Plugin settings", $"Unable to find plugin: {pluginId}");
+            return;
+        }
+
+        var pluginSettings = _settings.PluginSettings.GetPluginSettings(pluginId);
+        if (pluginSettings == null)
+        {
+            App.API.ShowMsgError("Plugin settings", $"Unable to load settings for plugin: {pluginPair.Metadata.Name}");
+            return;
+        }
+
+        var pluginViewModel = new PluginViewModel
+        {
+            PluginPair = pluginPair,
+            PluginSettingsObject = pluginSettings,
+            IsExpanded = true,
+        };
+
+        PluginListBox.ItemsSource = new List<PluginViewModel> { pluginViewModel };
+        PluginListBox.SelectedIndex = -1;
+        Title = $"{pluginPair.Metadata.Name} Settings";
+    }
+
+    private void OnMinimizeButtonClick(object sender, RoutedEventArgs e)
+    {
+        WindowState = WindowState.Minimized;
+    }
+
+    private void OnMaximizeRestoreButtonClick(object sender, RoutedEventArgs e)
+    {
+        WindowState = WindowState switch
+        {
+            WindowState.Maximized => WindowState.Normal,
+            _ => WindowState.Maximized
+        };
+    }
+
+    private void OnCloseButtonClick(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    private void OnCloseExecuted(object sender, ExecutedRoutedEventArgs e)
+    {
+        Close();
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        RefreshMaximizeRestoreButton();
+    }
+
+    private void Window_StateChanged(object sender, EventArgs e)
+    {
+        RefreshMaximizeRestoreButton();
+    }
+
+    private void RefreshMaximizeRestoreButton()
+    {
+        if (WindowState == WindowState.Maximized)
+        {
+            MaximizeButton.Visibility = Visibility.Hidden;
+            RestoreButton.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            MaximizeButton.Visibility = Visibility.Visible;
+            RestoreButton.Visibility = Visibility.Hidden;
+        }
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        if (!App.LoadingOrExiting)
+        {
+            _settings.Save();
+            App.API.SavePluginSettings();
+        }
+
+        base.OnClosed(e);
+    }
+
+    private sealed class PluginDisplayModes
+    {
+        public bool IsOnOffSelected => true;
+        public bool IsPrioritySelected => false;
+        public bool IsSearchDelaySelected => false;
+        public bool IsHomeOnOffSelected => false;
+    }
+}

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -147,6 +147,15 @@ namespace Flow.Launcher
             });
         }
 
+        public void OpenPluginSettingsWindow(string pluginId)
+        {
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                var window = new PluginSettingsWindow(pluginId);
+                window.Show();
+            });
+        }
+
         public void ShellRun(string cmd, string filename = "cmd.exe")
         {
             var args = filename == "cmd.exe" ? $"/C {cmd}" : $"{cmd}";

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -153,8 +154,27 @@ namespace Flow.Launcher
             {
                 try
                 {
-                    var window = new PluginSettingsWindow(pluginId);
-                    window.Show();
+                    // get existing settings window for this plugin, or else create a new one
+                    var window = Application.Current.Windows
+                        .OfType<PluginSettingsWindow>()
+                        .FirstOrDefault(existing => existing.PluginId == pluginId)
+                        ?? new PluginSettingsWindow(pluginId);
+
+                    if (window.WindowState == WindowState.Minimized)
+                    {
+                        window.WindowState = WindowState.Normal;
+                    }
+
+                    if (!window.IsVisible)
+                    {
+                        window.Show();
+                    }
+                    else
+                    {
+                        window.Activate();
+                    }
+
+                    window.Focus();
                     return true;
                 }
                 catch (Exception e)

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -160,21 +160,7 @@ namespace Flow.Launcher
                         .FirstOrDefault(existing => existing.PluginId == pluginId)
                         ?? new PluginSettingsWindow(pluginId);
 
-                    if (window.WindowState == WindowState.Minimized)
-                    {
-                        window.WindowState = WindowState.Normal;
-                    }
-
-                    if (!window.IsVisible)
-                    {
-                        window.Show();
-                    }
-                    else
-                    {
-                        window.Activate();
-                    }
-
-                    window.Focus();
+                    WindowVisibilityHelper.ShowOrActivate(window);
                     return true;
                 }
                 catch (Exception e)

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -147,12 +147,22 @@ namespace Flow.Launcher
             });
         }
 
-        public void OpenPluginSettingsWindow(string pluginId)
+        public bool OpenPluginSettingsWindow(string pluginId)
         {
-            Application.Current.Dispatcher.Invoke(() =>
+            return Application.Current.Dispatcher.Invoke(() =>
             {
-                var window = new PluginSettingsWindow(pluginId);
-                window.Show();
+                try
+                {
+                    var window = new PluginSettingsWindow(pluginId);
+                    window.Show();
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    LogException(ClassName, $"Failed to open plugin settings window for plugin id '{pluginId}'", e);
+                    ShowMsgError(Localize.pluginSettingsWindowOpenFailed());
+                    return false;
+                }
             });
         }
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1841,8 +1841,7 @@ namespace Flow.Launcher.ViewModel
                 PluginDirectory = Constant.ProgramDirectory,
                 Action = _ =>
                 {
-                    App.API.OpenPluginSettingsWindow(id);
-                    return true;
+                    return App.API.OpenPluginSettingsWindow(id);
                 },
                 OriginQuery = result.OriginQuery
             };

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1275,6 +1275,7 @@ namespace Flow.Launcher.ViewModel
             {
                 List<Result> results = PluginManager.GetContextMenusForPlugin(selected);
                 results.Add(ContextMenuTopMost(selected));
+                results.Add(ContextMenuPluginSettings(selected));
                 results.Add(ContextMenuPluginInfo(selected));
 
                 if (!string.IsNullOrEmpty(query))
@@ -1824,6 +1825,28 @@ namespace Flow.Launcher.ViewModel
                 };
             }
 
+            return menu;
+        }
+
+        private static Result ContextMenuPluginSettings(Result result)
+        {
+            var id = result.PluginID;
+
+            var settings = Localize.iconTraySettings();  // Todo: replace with dedicated translation
+            var title = $"{settings}";
+
+            var menu = new Result
+            {
+                Title = title,
+                Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\uE713"),
+                PluginDirectory = Constant.ProgramDirectory,
+                Action = _ =>
+                {
+                    App.API.OpenPluginSettingsWindow(id);
+                    return true;
+                },
+                OriginQuery = result.OriginQuery
+            };
             return menu;
         }
 

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1832,8 +1832,7 @@ namespace Flow.Launcher.ViewModel
         {
             var id = result.PluginID;
 
-            var settings = Localize.iconTraySettings();  // Todo: replace with dedicated translation
-            var title = $"{settings}";
+            var title = Localize.contextMenuPluginSettingsTitle();
 
             var menu = new Result
             {

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -1831,12 +1831,12 @@ namespace Flow.Launcher.ViewModel
         private static Result ContextMenuPluginSettings(Result result)
         {
             var id = result.PluginID;
-
-            var title = Localize.contextMenuPluginSettingsTitle();
+            var metadata = PluginManager.GetPluginForId(id).Metadata;
 
             var menu = new Result
             {
-                Title = title,
+                Title = Localize.pluginSettingsWindowTitle(metadata.Name),
+                IcoPath = Constant.SettingsIcon,
                 Glyph = new GlyphInfo(FontFamily: "/Resources/#Segoe Fluent Icons", Glyph: "\uE713"),
                 PluginDirectory = Constant.ProgramDirectory,
                 Action = _ =>


### PR DESCRIPTION
Add a context menu option for all plugins, which calls a new api method, which opens a new plugin settings window for that plugin.

Closes #4262

## UI Changes
<img width="774" height="381" alt="Screenshot 2026-03-29 182405" src="https://github.com/user-attachments/assets/2284265d-06f7-4962-8513-0d3d455ebc0c" />
<img width="1200" height="708" alt="Screenshot 2026-03-29 182410" src="https://github.com/user-attachments/assets/bad47d40-7b02-41bc-b490-12bd3ad1ad99" />
<img width="1200" height="708" alt="image" src="https://github.com/user-attachments/assets/e8a8dc61-92ca-4de7-9f12-92d2c00b0436" />

I tried to match the style of the existing plugin settings ui in InstalledPluginDisplay, reusing components from it where possible.