### PR TITLE
Fix highlight data 0 length

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/ResultManager.cs
@@ -145,7 +145,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                 IcoPath = path,
                 SubTitle = subtitle,
                 AutoCompleteText = GetAutoCompleteText(title, query, path, ResultType.Folder),
-                TitleHighlightData = highlightData ?? Context.API.FuzzySearch(query.Search, title).MatchData,
+                TitleHighlightData = (highlightData == null || highlightData.Count == 0) ?
+                                        Context.API.FuzzySearch(query.Search, title).MatchData :
+                                        highlightData,
                 CopyText = path,
                 Preview = new Result.PreviewInfo
                 {
@@ -347,7 +349,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search
                     FilePath = filePath,
                 },
                 AutoCompleteText = GetAutoCompleteText(title, query, filePath, ResultType.File),
-                TitleHighlightData = highlightData ?? Context.API.FuzzySearch(query.Search, title).MatchData,
+                TitleHighlightData = (highlightData == null || highlightData.Count == 0) ? 
+                                        Context.API.FuzzySearch(query.Search, title).MatchData :
+                                        highlightData,
                 Score = score,
                 CopyText = filePath,
                 PreviewPanel = new Lazy<UserControl>(() => new PreviewPanel(Settings, filePath, ResultType.File)),


### PR DESCRIPTION
Follow #4196

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing title highlights when an empty highlight data list is passed by falling back to fuzzy search match data. Applies to both folder and file results to keep highlighting consistent.

- **Summary of changes**
  - Changed: `TitleHighlightData` now falls back to `Context.API.FuzzySearch(query.Search, title).MatchData` when `highlightData` is null or has length 0 in `CreateFolderResult` and `CreateFileResult`.
  - Added: Explicit zero-length check for `highlightData` to trigger the fallback.
  - Removed: Passing through empty `highlightData`, which produced no highlights.
  - Memory: Negligible impact; only allocates match data when `highlightData` is empty.
  - Security: No risks; UI-only change affecting result highlighting.
  - Tests: No unit tests added; consider tests for null and empty `highlightData`.

<sup>Written for commit d03b6981c741f3e0a8bee62cc06b9d59f1d5c512. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

