### PR TITLE
Add Crowdin translation links to settings pages

### DIFF
--- a/Flow.Launcher.Infrastructure/Constant.cs
+++ b/Flow.Launcher.Infrastructure/Constant.cs
@@ -24,6 +24,7 @@ namespace Flow.Launcher.Infrastructure
         public static readonly string Version = FileVersionInfo.GetVersionInfo(Assembly.Location.NonNull()).ProductVersion;
         public static readonly string Dev = "Dev";
         public const string Documentation = "https://flowlauncher.com/docs/#/usage-tips";
+        public const string CrowdinProjectUrl = "https://crowdin.com/project/flow-launcher";
 
         public static readonly int ThumbnailSize = 64;
         private static readonly string ImagesDirectory = Path.Combine(ProgramDirectory, "Images");

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -144,6 +144,7 @@
     <system:String x:Key="DoublePinyinSchemasXingKongJianDao">Xing Kong Jian Dao</system:String>
     <system:String x:Key="DoublePinyinSchemasDaNiu">Da Niu</system:String>
     <system:String x:Key="DoublePinyinSchemasXiaoLang">Xiao Lang</system:String>
+    <system:String x:Key="HelpUsTranslateFlow">Help us translate Flow</system:String>
 
     <system:String x:Key="AlwaysPreview">Always Preview</system:String>
     <system:String x:Key="AlwaysPreviewToolTip">Always open preview panel when Flow activates. Press {0} to toggle preview.</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -451,6 +451,7 @@
     <system:String x:Key="website">Website</system:String>
     <system:String x:Key="github">GitHub</system:String>
     <system:String x:Key="docs">Docs</system:String>
+    <system:String x:Key="crowdin">Crowdin</system:String>
     <system:String x:Key="version">Version</system:String>
     <system:String x:Key="icons">Icons</system:String>
     <system:String x:Key="about_activate_times">You have activated Flow Launcher {0} times</system:String>

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -44,6 +44,7 @@ public partial class SettingsPaneAboutViewModel : BaseModel
     public string Documentation => Constant.Documentation;
     public string Docs => Constant.Docs;
     public string Github => Constant.GitHub;
+    public string Crowdin => Constant.CrowdinProjectUrl;
 
     public string Version => Constant.Version switch
     {

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneGeneralViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneGeneralViewModel.cs
@@ -226,6 +226,8 @@ public partial class SettingsPaneGeneralViewModel : BaseModel
         Settings.CustomBrowser.OnDisplayNameChanged();
     }
 
+    public string Crowdin => Constant.CrowdinProjectUrl;
+
     public string Language
     {
         get => Settings.Language;

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -77,6 +77,7 @@
                     <ui:HyperlinkButton Content="{DynamicResource website}" NavigateUri="{Binding Website}" />
                     <ui:HyperlinkButton Content="{DynamicResource documentation}" NavigateUri="{Binding Documentation}" />
                     <ui:HyperlinkButton Content="{DynamicResource github}" NavigateUri="{Binding Github}" />
+                    <ui:HyperlinkButton Content="Crowdin" NavigateUri="{Binding Crowdin}" />
                 </StackPanel>
             </ui:SettingsCard>
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -77,7 +77,7 @@
                     <ui:HyperlinkButton Content="{DynamicResource website}" NavigateUri="{Binding Website}" />
                     <ui:HyperlinkButton Content="{DynamicResource documentation}" NavigateUri="{Binding Documentation}" />
                     <ui:HyperlinkButton Content="{DynamicResource github}" NavigateUri="{Binding Github}" />
-                    <ui:HyperlinkButton Content="Crowdin" NavigateUri="{Binding Crowdin}" />
+                    <ui:HyperlinkButton Content="{DynamicResource crowdin}" NavigateUri="{Binding Crowdin}" />
                 </StackPanel>
             </ui:SettingsCard>
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneGeneral.xaml
@@ -565,13 +565,16 @@
                     <ui:FontIcon Glyph="&#xf2b7;" />
                 </ui:SettingsCard.HeaderIcon>
 
-                <ComboBox
-                    MaxWidth="200"
-                    Margin="10 0 0 0"
-                    DisplayMemberPath="Display"
-                    ItemsSource="{Binding Languages}"
-                    SelectedValue="{Binding Language}"
-                    SelectedValuePath="LanguageCode" />
+                <StackPanel Orientation="Horizontal">
+                    <ui:HyperlinkButton Content="{DynamicResource HelpUsTranslateFlow}" NavigateUri="{Binding Crowdin}" />
+                    <ComboBox
+                        MaxWidth="200"
+                        Margin="10 0 0 0"
+                        DisplayMemberPath="Display"
+                        ItemsSource="{Binding Languages}"
+                        SelectedValue="{Binding Language}"
+                        SelectedValuePath="LanguageCode" />
+                </StackPanel>
             </ui:SettingsCard>
             <Border Visibility="{Binding KoreanIMERegistryKeyExists, Converter={StaticResource BoolToVisibilityConverter}}">
                 <ui:InfoBar


### PR DESCRIPTION
Added Crowdin project URL constant and resource string. Exposed Crowdin link in About and General settings via new properties and hyperlink buttons, encouraging users to help translate Flow.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/0052ba9f-940f-4cd6-adad-c9211b7c7999" />

<img width="800" alt="image" src="https://github.com/user-attachments/assets/aa191564-c27b-492e-88cd-167878929da0" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Crowdin translation links to About and General settings so users can help translate Flow. Introduces a shared Crowdin URL constant and localized labels for both pages.

- **Summary of changes**
  - Changed: General settings language row now includes a “Help us translate Flow” hyperlink next to the language selector; About settings Crowdin link label is now localized via the `crowdin` resource (no hardcoded text).
  - Added: `Constant.CrowdinProjectUrl`; `HelpUsTranslateFlow` and `crowdin` resource strings; `Crowdin` properties in About and General view models; hyperlink buttons in About and General settings.
  - Removed: No existing logic or UI removed.
  - Memory: Negligible. Adds two localized strings, one string constant, and two lightweight hyperlink buttons.
  - Security: Low risk. Links open a fixed, hardcoded Crowdin URL; no user input involved.
  - Tests: No unit tests added (UI-only change).

<sup>Written for commit b06680b4ef0636076c38f5264d9aed8fe3f94f6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

