### PR TITLE
[FEATURE] Add sorting modes to the plugin store

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -108,3 +108,7 @@ Msix
 dummyprofile
 browserbookmark
 copyurl
+uninstaller
+taskbar
+taskbars
+ikw

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -242,6 +242,11 @@
     <system:String x:Key="pluginStore_RecentlyUpdated">Recently Updated</system:String>
     <system:String x:Key="pluginStore_None">Plugins</system:String>
     <system:String x:Key="pluginStore_Installed">Installed</system:String>
+    <system:String x:Key="PluginStoreSortModeDefault">Default</system:String>
+    <system:String x:Key="PluginStoreSortModeName">Name</system:String>
+    <system:String x:Key="PluginStoreSortModeReleaseDate">Release Date</system:String>
+    <system:String x:Key="PluginStoreSortModeUpdatedDate">Updated Date</system:String>
+    <system:String x:Key="PluginStoreSortingModeComboboxLabel">Sorting Mode:</system:String>
     <system:String x:Key="refresh">Refresh</system:String>
     <system:String x:Key="installbtn">Install</system:String>
     <system:String x:Key="uninstallbtn">Uninstall</system:String>

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
@@ -32,6 +32,7 @@ public partial class SettingsPanePluginStoreViewModel : BaseModel
             {
                 _selectedSortMode = value;
                 OnPropertyChanged();
+                OnPropertyChanged(nameof(ExternalPlugins));
             }
         }
     }
@@ -106,13 +107,8 @@ public partial class SettingsPanePluginStoreViewModel : BaseModel
         }
     }
 
-    public IList<PluginStoreItemViewModel> ExternalPlugins => App.API.GetPluginManifest()
-        .Select(p => new PluginStoreItemViewModel(p))
-        .OrderByDescending(p => p.Category == PluginStoreItemViewModel.NewRelease)
-        .ThenByDescending(p => p.Category == PluginStoreItemViewModel.RecentlyUpdated)
-        .ThenByDescending(p => p.Category == PluginStoreItemViewModel.None)
-        .ThenByDescending(p => p.Category == PluginStoreItemViewModel.Installed)
-        .ToList();
+    public IList<PluginStoreItemViewModel> ExternalPlugins => GetSortedPlugins(
+        App.API.GetPluginManifest().Select(p => new PluginStoreItemViewModel(p)));
 
     [RelayCommand]
     private async Task RefreshExternalPluginsAsync()
@@ -196,6 +192,36 @@ public partial class SettingsPanePluginStoreViewModel : BaseModel
     private void UpdateEnumDropdownLocalizations()
     {
         DropdownDataGeneric<PluginStoreSortMode>.UpdateLabels(SortModes);
+    }
+
+    private IList<PluginStoreItemViewModel> GetSortedPlugins(IEnumerable<PluginStoreItemViewModel> plugins)
+    {
+        return SelectedSortMode switch
+        {
+            PluginStoreSortMode.Name => plugins
+                .OrderBy(p => p.LabelInstalled)
+                .ThenBy(p => p.Name)
+                .ToList(),
+
+            PluginStoreSortMode.ReleaseDate => plugins
+                .OrderBy(p => p.LabelInstalled)
+                .ThenByDescending(p => p.DateAdded.HasValue)
+                .ThenByDescending(p => p.DateAdded)
+                .ToList(),
+
+            PluginStoreSortMode.UpdatedDate => plugins
+                .OrderBy(p => p.LabelInstalled)
+                .ThenByDescending(p => p.UpdatedDate.HasValue)
+                .ThenByDescending(p => p.UpdatedDate)
+                .ToList(),
+
+            _ => plugins
+                .OrderByDescending(p => p.DefaultCategory == PluginStoreItemViewModel.NewRelease)
+                .ThenByDescending(p => p.DefaultCategory == PluginStoreItemViewModel.RecentlyUpdated)
+                .ThenByDescending(p => p.DefaultCategory == PluginStoreItemViewModel.None)
+                .ThenByDescending(p => p.DefaultCategory == PluginStoreItemViewModel.Installed)
+                .ToList(),
+        };
     }
 
 }

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPanePluginStoreViewModel.cs
@@ -12,6 +12,30 @@ namespace Flow.Launcher.SettingPages.ViewModels;
 
 public partial class SettingsPanePluginStoreViewModel : BaseModel
 {
+    public class SortModeData : DropdownDataGeneric<PluginStoreSortMode> { }
+
+    public List<SortModeData> SortModes { get; } =
+        DropdownDataGeneric<PluginStoreSortMode>.GetValues<SortModeData>("PluginStoreSortMode");
+
+    public SettingsPanePluginStoreViewModel()
+    {
+        UpdateEnumDropdownLocalizations();
+    }
+
+    private PluginStoreSortMode _selectedSortMode = PluginStoreSortMode.Default;
+    public PluginStoreSortMode SelectedSortMode
+    {
+        get => _selectedSortMode;
+        set
+        {
+            if (_selectedSortMode != value)
+            {
+                _selectedSortMode = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
     private string filterText = string.Empty;
     public string FilterText
     {
@@ -168,4 +192,18 @@ public partial class SettingsPanePluginStoreViewModel : BaseModel
             App.API.FuzzySearch(FilterText, plugin.Name).IsSearchPrecisionScoreMet() ||
             App.API.FuzzySearch(FilterText, plugin.Description).IsSearchPrecisionScoreMet();
     }
+
+    private void UpdateEnumDropdownLocalizations()
+    {
+        DropdownDataGeneric<PluginStoreSortMode>.UpdateLabels(SortModes);
+    }
+
+}
+
+public enum PluginStoreSortMode
+{
+    Default,
+    Name,
+    ReleaseDate,
+    UpdatedDate
 }

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml
@@ -32,7 +32,7 @@
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
-            <RowDefinition Height="72" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Border
@@ -50,77 +50,104 @@
         <DockPanel
             Grid.Row="0"
             Grid.Column="1"
-            Margin="5 24 0 0">
-
+            Margin="5 24 0 8">
             <ikw:SimpleStackPanel
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 DockPanel.Dock="Right"
-                Orientation="Horizontal"
+                Orientation="Vertical"
                 Spacing="8">
-                <Button
-                    Height="34"
-                    Margin="0 5 0 5"
-                    Padding="12 4"
+                <ikw:SimpleStackPanel
                     HorizontalAlignment="Right"
-                    VerticalAlignment="Center"
-                    Command="{Binding RefreshExternalPluginsCommand}"
-                    Content="{DynamicResource refresh}"
-                    FontSize="13" />
-                <Button Height="34">
-                    <ui:FontIcon FontSize="14" Glyph="&#xe71c;" />
-                    <ui:FlyoutService.Flyout>
-                        <ui:MenuFlyout x:Name="FilterFlyout" Placement="Bottom">
-                            <MenuItem
-                                Header=".Net"
-                                IsCheckable="True"
-                                IsChecked="{Binding ShowDotNet, Mode=TwoWay}"
-                                StaysOpenOnClick="True" />
-                            <MenuItem
-                                Header="Python"
-                                IsCheckable="True"
-                                IsChecked="{Binding ShowPython, Mode=TwoWay}"
-                                StaysOpenOnClick="True" />
-                            <MenuItem
-                                Header="Node.js"
-                                IsCheckable="True"
-                                IsChecked="{Binding ShowNodeJs, Mode=TwoWay}"
-                                StaysOpenOnClick="True" />
-                            <MenuItem
-                                Header="Exe"
-                                IsCheckable="True"
-                                IsChecked="{Binding ShowExecutable, Mode=TwoWay}"
-                                StaysOpenOnClick="True" />
-                        </ui:MenuFlyout>
-                    </ui:FlyoutService.Flyout>
-                </Button>
-                <Button
-                    Height="34"
-                    Command="{Binding InstallPluginCommand}"
-                    ToolTip="{DynamicResource installLocalPluginTooltip}">
-                    <ui:FontIcon FontSize="14" Glyph="&#xE8DA;" />
-                </Button>
-                <Button
-                    Height="34"
-                    Command="{Binding CheckPluginUpdatesCommand}"
-                    ToolTip="{DynamicResource checkPluginUpdatesTooltip}">
-                    <ui:FontIcon FontSize="14" Glyph="&#xecc5;" />
-                </Button>
-                <TextBox
-                    Name="PluginStoreFilterTextbox"
-                    Width="150"
-                    Height="34"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Button
+                        Height="34"
+                        Padding="12 4"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
+                        Command="{Binding RefreshExternalPluginsCommand}"
+                        Content="{DynamicResource refresh}"
+                        FontSize="13" />
+                    <Button Height="34">
+                        <ui:FontIcon FontSize="14" Glyph="&#xe71c;" />
+                        <ui:FlyoutService.Flyout>
+                            <ui:MenuFlyout x:Name="FilterFlyout" Placement="Bottom">
+                                <MenuItem
+                                    Header=".Net"
+                                    IsCheckable="True"
+                                    IsChecked="{Binding ShowDotNet, Mode=TwoWay}"
+                                    StaysOpenOnClick="True" />
+                                <MenuItem
+                                    Header="Python"
+                                    IsCheckable="True"
+                                    IsChecked="{Binding ShowPython, Mode=TwoWay}"
+                                    StaysOpenOnClick="True" />
+                                <MenuItem
+                                    Header="Node.js"
+                                    IsCheckable="True"
+                                    IsChecked="{Binding ShowNodeJs, Mode=TwoWay}"
+                                    StaysOpenOnClick="True" />
+                                <MenuItem
+                                    Header="Exe"
+                                    IsCheckable="True"
+                                    IsChecked="{Binding ShowExecutable, Mode=TwoWay}"
+                                    StaysOpenOnClick="True" />
+                            </ui:MenuFlyout>
+                        </ui:FlyoutService.Flyout>
+                    </Button>
+                    <Button
+                        Height="34"
+                        Command="{Binding InstallPluginCommand}"
+                        ToolTip="{DynamicResource installLocalPluginTooltip}">
+                        <ui:FontIcon FontSize="14" Glyph="&#xE8DA;" />
+                    </Button>
+                    <Button
+                        Height="34"
+                        Command="{Binding CheckPluginUpdatesCommand}"
+                        ToolTip="{DynamicResource checkPluginUpdatesTooltip}">
+                        <ui:FontIcon FontSize="14" Glyph="&#xecc5;" />
+                    </Button>
+                    <TextBox
+                        Name="PluginStoreFilterTextbox"
+                        Width="150"
+                        Height="34"
+                        Margin="0 0 26 0"
+                        HorizontalAlignment="Right"
+                        VerticalContentAlignment="Center"
+                        ui:ControlHelper.PlaceholderText="{DynamicResource searchplugin}"
+                        ContextMenu="{StaticResource TextBoxContextMenu}"
+                        DockPanel.Dock="Right"
+                        FontSize="14"
+                        Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                        ToolTip="{DynamicResource searchpluginToolTip}"
+                        ToolTipService.InitialShowDelay="200"
+                        ToolTipService.Placement="Top" />
+                </ikw:SimpleStackPanel>
+
+                <ikw:SimpleStackPanel
+                    HorizontalAlignment="Right"
                     Margin="0 0 26 0"
-                    HorizontalAlignment="Right"
-                    VerticalContentAlignment="Center"
-                    ui:ControlHelper.PlaceholderText="{DynamicResource searchplugin}"
-                    ContextMenu="{StaticResource TextBoxContextMenu}"
-                    DockPanel.Dock="Right"
-                    FontSize="14"
-                    Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
-                    ToolTip="{DynamicResource searchpluginToolTip}"
-                    ToolTipService.InitialShowDelay="200"
-                    ToolTipService.Placement="Top" />
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        FontSize="14"
+                        Foreground="{DynamicResource Color15B}"
+                        Text="{DynamicResource PluginStoreSortingModeComboboxLabel}" />
+                    <ComboBox
+                        x:Name="SortModeComboBox"
+                        Width="Auto"
+                        Height="34"
+                        MinWidth="150"
+                        MaxWidth="150"
+                        HorizontalContentAlignment="Left"
+                        Background="{DynamicResource Color00B}"
+                        ItemsSource="{Binding SortModes}"
+                        DisplayMemberPath="Display"
+                        SelectedValuePath="Value" 
+                        SelectedValue="{Binding SelectedSortMode, Mode=TwoWay}"/>
+                </ikw:SimpleStackPanel>
             </ikw:SimpleStackPanel>
         </DockPanel>
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml
@@ -22,7 +22,7 @@
             Filter="PluginStoreCollectionView_OnFilter"
             Source="{Binding ExternalPlugins}">
             <CollectionViewSource.GroupDescriptions>
-                <PropertyGroupDescription PropertyName="Category" />
+                <PropertyGroupDescription PropertyName="DefaultCategory" />
             </CollectionViewSource.GroupDescriptions>
         </CollectionViewSource>
     </ui:Page.Resources>

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
@@ -29,12 +29,20 @@ public partial class SettingsPanePluginStore
         {
             InitializeComponent();
         }
+        UpdateCategoryGrouping();
         _viewModel.PropertyChanged += ViewModel_PropertyChanged;
         base.OnNavigatedTo(e);
     }
 
     private void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
     {
+        // If SelectedSortMode changed, then we need to update the categories
+        if (e.PropertyName == nameof(SettingsPanePluginStoreViewModel.SelectedSortMode))
+        {
+            UpdateCategoryGrouping();
+        }
+
+        // Check if changed property requires PluginStoreCollectionView refresh
         switch (e.PropertyName)
         {
             case nameof(SettingsPanePluginStoreViewModel.FilterText):
@@ -42,6 +50,7 @@ public partial class SettingsPanePluginStore
             case nameof(SettingsPanePluginStoreViewModel.ShowPython):
             case nameof(SettingsPanePluginStoreViewModel.ShowNodeJs):
             case nameof(SettingsPanePluginStoreViewModel.ShowExecutable):
+            case nameof(SettingsPanePluginStoreViewModel.SelectedSortMode):
                 ((CollectionViewSource)FindResource("PluginStoreCollectionView")).View.Refresh();
                 break;
         }
@@ -74,5 +83,24 @@ public partial class SettingsPanePluginStore
         }
 
         e.Accepted = _viewModel.SatisfiesFilter(plugin);
+    }
+
+    private void UpdateCategoryGrouping()
+    {
+        var collectionView = (CollectionViewSource)FindResource("PluginStoreCollectionView");
+        var groupDescriptions = collectionView.GroupDescriptions;
+
+        groupDescriptions.Clear();
+
+        // For default sorting mode we use the default categories 
+        if (_viewModel.SelectedSortMode == PluginStoreSortMode.Default)
+        {
+            groupDescriptions.Add(new PropertyGroupDescription(nameof(PluginStoreItemViewModel.DefaultCategory)));
+        }
+
+        // Otherwise we only split by installed or not
+        else{
+            groupDescriptions.Add(new PropertyGroupDescription(nameof(PluginStoreItemViewModel.InstallCategory)));
+        }
     }
 }

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
@@ -97,9 +97,9 @@ public partial class SettingsPanePluginStore
         {
             groupDescriptions.Add(new PropertyGroupDescription(nameof(PluginStoreItemViewModel.DefaultCategory)));
         }
-
         // Otherwise we only split by installed or not
-        else{
+        else
+        {
             groupDescriptions.Add(new PropertyGroupDescription(nameof(PluginStoreItemViewModel.InstallCategory)));
         }
     }

--- a/Flow.Launcher/ViewModel/PluginStoreItemViewModel.cs
+++ b/Flow.Launcher/ViewModel/PluginStoreItemViewModel.cs
@@ -28,6 +28,8 @@ namespace Flow.Launcher.ViewModel
         public string UrlDownload => _newPlugin.UrlDownload;
         public string UrlSourceCode => _newPlugin.UrlSourceCode;
         public string IcoPath => _newPlugin.IcoPath;
+        public DateTime? DateAdded => _newPlugin.DateAdded;
+        public DateTime? UpdatedDate => _newPlugin.LatestReleaseDate;
 
         public bool LabelInstalled => _oldPluginPair != null;
         public bool LabelUpdate => LabelInstalled && new Version(_newPlugin.Version) > new Version(_oldPluginPair.Metadata.Version);
@@ -37,7 +39,9 @@ namespace Flow.Launcher.ViewModel
         internal const string NewRelease = "NewRelease";
         internal const string Installed = "Installed";
 
-        public string Category
+        public string InstallCategory => LabelInstalled ? Installed : None;
+
+        public string DefaultCategory
         {
             get
             {


### PR DESCRIPTION
## Summary
Add dropdown with sorting modes to the plugin store panel of the settings window.
Added the following modes:
- Default
- Name
- Release Date
- Updated Date

Default matches the current way it lists plugins, included the recently added / recently updated categories.
The other modes hide those categories as they no longer make sense / are needed, leaving only "Plugins" and "Installed".

Related to this request:
https://www.reddit.com/r/FlowLauncher/comments/1s8gcrm/plugin_sort_by_date_created_or_updated/

Closes #2845

### UI
<img width="2390" height="461" alt="image" src="https://github.com/user-attachments/assets/fa4a2cec-06a1-4dba-8c62-2111aceb5f05" />
(ignore the missing plugin icons - that just always happens in my local debug mode)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds sorting modes to the Plugin Store with a new dropdown (Default, Name, Release Date, Updated Date). Non‑default sorts collapse categories to only “Installed” and “Plugins”.

**Summary of changes**
- Changed
  - External plugin list now sorted via GetSortedPlugins based on SelectedSortMode; view refreshes on change.
  - Grouping: Default uses DefaultCategory; other modes use InstallCategory; grouping updated in code-behind when sort mode changes; header split into two rows to fit the dropdown.
  - Localized labels for enum are loaded at ViewModel init; minor cleanup with no behavior change.
  - Spelling allowlist updated in `.github/actions/spelling/expect.txt` for CI.
- Added
  - Sorting dropdown and `PluginStoreSortMode` enum (Default, Name, ReleaseDate, UpdatedDate) with localized labels and a "Sorting Mode:" label.
  - `DateAdded` and `UpdatedDate` to `PluginStoreItemViewModel` for sorting.
  - `InstallCategory` and `UpdateCategoryGrouping` to switch grouping when sort mode changes.
- Removed
  - Hard‑coded ordering chain in ExternalPlugins.
  - Single `Category` property (replaced by `DefaultCategory` and `InstallCategory`).
- Memory impact
  - Minimal. Same list materialization; small enum dropdown data.
- Security risks
  - None. UI-only sorting and grouping.
- Unit tests
  - No new tests included.

<sup>Written for commit 6f44d0cfff947ca12eae110a5afbb910ff88d449. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



