### PR TITLE
[FEATURE] Add Extra Args option to browser settings

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/CustomBrowserViewModel.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/CustomBrowserViewModel.cs
@@ -10,6 +10,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         public string DisplayName => Name == "Default" ? Localize.defaultBrowser_default() : Name;
         public string Path { get; set; }
         public string PrivateArg { get; set; }
+        public string ExtraArgs { get; set; }
         public bool EnablePrivate { get; set; }
         public bool OpenInTab { get; set; } = true;
         [JsonIgnore]
@@ -24,6 +25,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
                 Path = Path,
                 OpenInTab = OpenInTab,
                 PrivateArg = PrivateArg,
+                ExtraArgs = ExtraArgs,
                 EnablePrivate = EnablePrivate,
                 Editable = Editable
             };

--- a/Flow.Launcher.Plugin/SharedCommands/SearchWeb.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/SearchWeb.cs
@@ -52,7 +52,7 @@ namespace Flow.Launcher.Plugin.SharedCommands
             var browser = string.IsNullOrEmpty(browserExecutableName) ? "chrome" : browserPath;
 
             // Internet Explorer will open url in new browser window, and does not take the --new-window parameter
-            var browserArguements = (browserExecutableName == "iexplore.exe" ? "" : "--new-window ")
+            var browserArguments = (browserExecutableName == "iexplore.exe" ? "" : "--new-window ")
                                    + (inPrivate ? $"{privateArg} " : "")
                                    + (string.IsNullOrWhiteSpace(extraArgs) ? "" : $"{extraArgs} ")
                                    + url;
@@ -60,7 +60,7 @@ namespace Flow.Launcher.Plugin.SharedCommands
             var psi = new ProcessStartInfo
             {
                 FileName = browser,
-                Arguments = browserArguements,
+                Arguments = browserArguments,
                 UseShellExecute = true
             };
 

--- a/Flow.Launcher.Plugin/SharedCommands/SearchWeb.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/SearchWeb.cs
@@ -38,7 +38,7 @@ namespace Flow.Launcher.Plugin.SharedCommands
         /// Opens search in a new browser. If no browser path is passed in then Chrome is used. 
         /// Leave browser path blank to use Chrome.
         /// </summary>
-        public static void OpenInBrowserWindow(this string url, string browserPath = "", bool inPrivate = false, string privateArg = "")
+        public static void OpenInBrowserWindow(this string url, string browserPath = "", bool inPrivate = false, string privateArg = "", string extraArgs = "")
         {
             browserPath = string.IsNullOrEmpty(browserPath) ? GetDefaultBrowserPath() : browserPath;
 
@@ -52,7 +52,10 @@ namespace Flow.Launcher.Plugin.SharedCommands
             var browser = string.IsNullOrEmpty(browserExecutableName) ? "chrome" : browserPath;
 
             // Internet Explorer will open url in new browser window, and does not take the --new-window parameter
-            var browserArguements = (browserExecutableName == "iexplore.exe" ? "" : "--new-window ") + (inPrivate ? $"{privateArg} " : "") + url;
+            var browserArguements = (browserExecutableName == "iexplore.exe" ? "" : "--new-window ")
+                                   + (inPrivate ? $"{privateArg} " : "")
+                                   + (string.IsNullOrWhiteSpace(extraArgs) ? "" : $"{extraArgs} ")
+                                   + url;
 
             var psi = new ProcessStartInfo
             {
@@ -86,7 +89,7 @@ namespace Flow.Launcher.Plugin.SharedCommands
         /// <summary> 
         /// Opens search as a tab in the default browser chosen in Windows settings.
         /// </summary>
-        public static void OpenInBrowserTab(this string url, string browserPath = "", bool inPrivate = false, string privateArg = "")
+        public static void OpenInBrowserTab(this string url, string browserPath = "", bool inPrivate = false, string privateArg = "", string extraArgs = "")
         {
             browserPath = string.IsNullOrEmpty(browserPath) ? GetDefaultBrowserPath() : browserPath;
 
@@ -99,7 +102,9 @@ namespace Flow.Launcher.Plugin.SharedCommands
                 if (!string.IsNullOrEmpty(browserPath))
                 {
                     psi.FileName = browserPath;
-                    psi.Arguments = (inPrivate ? $"{privateArg} " : "") + url;
+                    psi.Arguments = (inPrivate ? $"{privateArg} " : "")
+                                    + (string.IsNullOrWhiteSpace(extraArgs) ? "" : $"{extraArgs} ")
+                                    + url;
                 }
                 else
                 {

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -518,6 +518,7 @@
     <system:String x:Key="defaultBrowser_newWindow">New Window</system:String>
     <system:String x:Key="defaultBrowser_newTab">New Tab</system:String>
     <system:String x:Key="defaultBrowser_parameter">Private Mode</system:String>
+    <system:String x:Key="defaultBrowser_extraArgs">Extra Args</system:String>
     <system:String x:Key="defaultBrowser_default">Default</system:String>
     <system:String x:Key="defaultBrowser_new_profile">New Profile</system:String>
 

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -464,10 +464,9 @@ namespace Flow.Launcher
                 catch (Exception e)
                 {
                     var tabOrWindow = browserInfo.OpenInTab ? "tab" : "window";
-                    string includesExtraArgs = string.IsNullOrWhiteSpace(browserInfo.ExtraArgs) 
+                    var includesExtraArgs = string.IsNullOrWhiteSpace(browserInfo.ExtraArgs) 
                         ? "" 
                         : ", [including omitted Extra Args]";
-                        
                     LogException(ClassName, $"Failed to open URL in browser {tabOrWindow}: {path}, {inPrivate ?? browserInfo.EnablePrivate}, {browserInfo.PrivateArg}{includesExtraArgs}", e);
                     ShowMsgError(
                         Localize.errorTitle(),

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -464,7 +464,11 @@ namespace Flow.Launcher
                 catch (Exception e)
                 {
                     var tabOrWindow = browserInfo.OpenInTab ? "tab" : "window";
-                    LogException(ClassName, $"Failed to open URL in browser {tabOrWindow}: {path}, {inPrivate ?? browserInfo.EnablePrivate}, {browserInfo.PrivateArg}, {browserInfo.ExtraArgs}", e);
+                    string includesExtraArgs = string.IsNullOrWhiteSpace(browserInfo.ExtraArgs) 
+                        ? "" 
+                        : ", [including omitted Extra Args]";
+                        
+                    LogException(ClassName, $"Failed to open URL in browser {tabOrWindow}: {path}, {inPrivate ?? browserInfo.EnablePrivate}, {browserInfo.PrivateArg}{includesExtraArgs}", e);
                     ShowMsgError(
                         Localize.errorTitle(),
                         Localize.browserOpenError()

--- a/Flow.Launcher/PublicAPIInstance.cs
+++ b/Flow.Launcher/PublicAPIInstance.cs
@@ -454,17 +454,17 @@ namespace Flow.Launcher
                 {
                     if (browserInfo.OpenInTab)
                     {
-                        uri.AbsoluteUri.OpenInBrowserTab(path, inPrivate ?? browserInfo.EnablePrivate, browserInfo.PrivateArg);
+                        uri.AbsoluteUri.OpenInBrowserTab(path, inPrivate ?? browserInfo.EnablePrivate, browserInfo.PrivateArg, browserInfo.ExtraArgs);
                     }
                     else
                     {
-                        uri.AbsoluteUri.OpenInBrowserWindow(path, inPrivate ?? browserInfo.EnablePrivate, browserInfo.PrivateArg);
+                        uri.AbsoluteUri.OpenInBrowserWindow(path, inPrivate ?? browserInfo.EnablePrivate, browserInfo.PrivateArg, browserInfo.ExtraArgs);
                     }
                 }
                 catch (Exception e)
                 {
                     var tabOrWindow = browserInfo.OpenInTab ? "tab" : "window";
-                    LogException(ClassName, $"Failed to open URL in browser {tabOrWindow}: {path}, {inPrivate ?? browserInfo.EnablePrivate}, {browserInfo.PrivateArg}", e);
+                    LogException(ClassName, $"Failed to open URL in browser {tabOrWindow}: {path}, {inPrivate ?? browserInfo.EnablePrivate}, {browserInfo.PrivateArg}, {browserInfo.ExtraArgs}", e);
                     ShowMsgError(
                         Localize.errorTitle(),
                         Localize.browserOpenError()

--- a/Flow.Launcher/SelectBrowserWindow.xaml
+++ b/Flow.Launcher/SelectBrowserWindow.xaml
@@ -126,6 +126,7 @@
                             <RowDefinition />
                             <RowDefinition />
                             <RowDefinition />
+                            <RowDefinition />
                         </Grid.RowDefinitions>
                         <TextBlock
                             Grid.Row="0"
@@ -198,7 +199,7 @@
                         <TextBlock
                             Grid.Row="3"
                             Grid.Column="0"
-                            Margin="14 10 0 20"
+                            Margin="14 10 0 0"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             FontSize="14"
@@ -206,7 +207,7 @@
                         <StackPanel
                             Grid.Row="3"
                             Grid.Column="1"
-                            Margin="0 10 0 15"
+                            Margin="0 10 0 0"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Center"
                             Orientation="Horizontal">
@@ -230,6 +231,21 @@
                                 </CheckBox.Style>
                             </CheckBox>
                         </StackPanel>
+                        <TextBlock
+                            Grid.Row="4"
+                            Grid.Column="0"
+                            Margin="14 10 0 20"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            FontSize="14"
+                            Text="{DynamicResource defaultBrowser_extraArgs}" />
+                        <TextBox
+                            Grid.Row="4"
+                            Grid.Column="1"
+                            Margin="10 10 0 15"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Center"
+                            Text="{Binding ExtraArgs}" />
                     </Grid>
                 </StackPanel>
             </StackPanel>


### PR DESCRIPTION
## Summary
- added new prop ExtraArgs to CustomBrowserViewModel
- add new row in SelectBrowserWindow to edit this
- Update OpenInBrowserWindow and OpenInBrowserTab to pass along these extra arguments

Should close #2653
Doesn't explicitly handle profiles but this should allow users to set that up themselves.

## UI Change
<img width="1100" height="1033" alt="image" src="https://github.com/user-attachments/assets/c5a06fd9-1548-47f0-98e5-ed6f38a252b7" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Extra Args field to custom browser settings so users can pass command-line flags when opening URLs. Works for both new window and new tab, and logs now note when Extra Args were provided without recording their contents.

- **Summary of changes**
  - Changed: `OpenInBrowserWindow`/`OpenInBrowserTab` accept optional `extraArgs` and pass them to `ProcessStartInfo.Arguments`; `PublicAPIInstance.OpenUri` forwards `ExtraArgs`; error logs omit `ExtraArgs` and add a notice when present; `SelectBrowserWindow` layout adjusted; minor code quality and typo fixes in `SearchWeb`.
  - Added: `ExtraArgs` to `CustomBrowserViewModel` (and its `Copy()`), TextBox binding in `SelectBrowserWindow.xaml`, and locale key `defaultBrowser_extraArgs`.
  - Removed: None.
  - Memory: Negligible (one extra string per browser config; one locale string).
  - Security: Low risk; args are passed directly to the process. Logging no longer prints `ExtraArgs`, reducing risk of leaking sensitive flags.
  - Tests: No unit tests added.

<sup>Written for commit faf8ab52febc97a9beecca1f97cbde0c6af6edae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



