### PR TITLE
Fix icon binding in Plugin Store Settings Pane

### DIFF
--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml
@@ -333,7 +333,7 @@
                                         Margin="18 24 0 0"
                                         HorizontalAlignment="Left"
                                         RenderOptions.BitmapScalingMode="Fant"
-                                        Source="{Binding IcoPathAbsolute, IsAsync=True}" />
+                                        Source="{Binding IcoPath, IsAsync=True}" />
                                     <Border
                                         x:Name="LabelUpdate"
                                         Height="12"


### PR DESCRIPTION
## Change
Use IcoPath instead of non-existent IcoPathAbsolute

(This seems to be an issue only on the current dev branch, not the latest release)

## UI
### Before
<img width="2403" height="1032" alt="image" src="https://github.com/user-attachments/assets/d1c91aea-3dc5-43de-a13a-cee1d8b9ec50" />


### After
<img width="2409" height="932" alt="image" src="https://github.com/user-attachments/assets/b7943ee9-ec6e-4119-951d-fc96d1f7bb2c" />

Follows on from https://github.com/Flow-Launcher/Flow.Launcher/pull/4057