### PR TITLE
Fix missing last opened result due to race condition from plugins that call hide directly

### DIFF
--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -515,6 +515,17 @@ namespace Flow.Launcher.ViewModel
                 return;
             }
 
+            // New history result must be recorded before ExecuteAsync and Hide() is called, otherwise when in 'Empty Last Query' query style mode
+            // the QueryAsync call will reconstruct the result list without the new item.
+            // This must happen before ExecuteAsync because some plugin actions call HideMainWindow() inside their action,
+            // which triggers a home query that reads history before _history.Add would have been called.
+            // Also, add item to history only if it is from results but not context menu or history.
+            if (queryResultsSelected)
+            {
+                _history.Add(result);
+                lastHistoryIndex = 1;
+            }
+
             var hideWindow = false;
             var isDialogJumpLeftClick = _isDialogJump && Settings.DialogJumpResultBehaviour == DialogJumpResultBehaviours.LeftClick;
 
@@ -539,15 +550,6 @@ namespace Flow.Launcher.ViewModel
                     // not null means pressing modifier key + number, should ignore the modifier key
                     SpecialKeyState = index is not null ? SpecialKeyState.Default : GlobalHotkey.CheckModifiers()
                 }).ConfigureAwait(false);
-            }
-
-            // New history result must be recorded before Hide() is called, otherwise when in 'Empty Last Query' query style mode
-            // the QueryAsync call will reconstruct the result list without the new item.
-            // Also, add item to history only if it is from results but not context menu or history.
-            if (queryResultsSelected)
-            {
-                _history.Add(result);
-                lastHistoryIndex = 1;
             }
 
             // Only hide for query results (not Dialog Jump left-click mode)


### PR DESCRIPTION
Follow on from https://github.com/Flow-Launcher/Flow.Launcher/pull/4375 with issue https://github.com/Flow-Launcher/Flow.Launcher/issues/4374

**Problem:**
Some Sys plugin results (e.g 'Settings') do not show up in 'Empty Last Query' query style mode after they are selected, and would only show when re-queried or clearing of a new query.

**Cause:**
When plugin actions call Context.API.HideMainWindow() directly it does a re-query before the result is added to last history items and consequently the second Hide() call at the end of OpenResultAsync(string) would not trigger a re-query because QueryText is already "", so QueryText != queryText is false. Without a re-query the newly added last history item does not get added to result list display.

**Fix:**
Move _history.Add(result) to immediately after the result == null check, before ExecuteAsync(ActionContext) is called, guaranteeing that history is updated before any possible Hide() invocation — whether triggered from inside the plugin action or from the explicit Hide() call afterward.

**Tested:**
- Results like 'Settings' from Sys plugin show up after selection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race that caused the last selected system plugin result (e.g., “Settings”) to not appear in “Empty Last Query” mode. We now record the history entry before executing the action, so plugin-triggered re-queries don’t drop it.

- **Summary of changes**
  - Changed: In `OpenResultAsync`, add the selected result to history before `ExecuteAsync` and any `Hide()` call; applies only to query results (not context menu/history).
  - Added: Set `lastHistoryIndex = 1` at the time of the early history write to ensure correct positioning in history.
  - Removed: The late `_history.Add` block after `ExecuteAsync`, avoiding missed updates and duplicate logic.
  - Memory usage: No impact; same history size and allocations, only call order changed.
  - Security: No new risks; internal ordering change only, no new I/O or permissions.
  - Tests: No new unit tests; manually verified that Sys plugin entries like “Settings” now appear immediately in “Empty Last Query” mode.

<sup>Written for commit a250e795b10d9e3f0e27063257085007001469f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

