### PR TITLE
Make image hashing deterministic and format/DPI-agnostic

### DIFF
--- a/Flow.Launcher.Infrastructure/Image/ImageHashGenerator.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageHashGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Security.Cryptography;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -35,18 +36,30 @@ namespace Flow.Launcher.Infrastructure.Image
                     normalized = converted;
                 }
 
-                // Prepare final buffer (should be HashSize x HashSize)
-                var bpp = normalized.Format.BitsPerPixel;
-                if (bpp < 1)
+                // Since we forced Pbgra32, we know it is exactly 4 bytes per pixel.
+                const int bytesPerPixel = 4;
+
+                var stride = normalized.PixelWidth * bytesPerPixel;
+                var bufferSize = stride * normalized.PixelHeight;
+
+                if (bufferSize <= 0)
                     return null;
 
-                var bytesPerPixel = (bpp + 7) / 8;
-                var stride = normalized.PixelWidth * bytesPerPixel;
-                var pixels = new byte[stride * normalized.PixelHeight];
-                normalized.CopyPixels(pixels, stride, 0);
+                // Use ArrayPool to prevent Large Object Heap (LOH) allocations for big images
+                var rentedPixelBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
 
-                var hashBytes = SHA1.HashData(pixels);
-                return Convert.ToBase64String(hashBytes);
+                try
+                {
+                    normalized.CopyPixels(rentedPixelBuffer, stride, 0);
+
+                    // Slice the rented array to the exact buffer size (Rented arrays are often larger than the requested size)
+                    var hashBytes = SHA1.HashData(rentedPixelBuffer.AsSpan(0, bufferSize));
+                    return Convert.ToBase64String(hashBytes);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(rentedPixelBuffer);
+                }
             }
             catch
             {

--- a/Flow.Launcher.Infrastructure/Image/ImageHashGenerator.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageHashGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Security.Cryptography;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -10,27 +9,70 @@ namespace Flow.Launcher.Infrastructure.Image
     {
         string GetHashFromImage(ImageSource image);
     }
+
     public class ImageHashGenerator : IImageHashGenerator
     {
+        private const int HashSize = 64; // Deterministic size for hashing to avoid DPI/stride variability
+
         public string GetHashFromImage(ImageSource imageSource)
         {
-            if (imageSource is not BitmapSource image)
+            if (imageSource is not BitmapSource { IsFrozen: true } image)
             {
                 return null;
             }
 
             try
             {
-                using var outStream = new MemoryStream();
-                var enc = new JpegBitmapEncoder();
-                var bitmapFrame = BitmapFrame.Create(image);
-                bitmapFrame.Freeze();
-                enc.Frames.Add(bitmapFrame);
-                enc.Save(outStream);
-                var byteArray = outStream.GetBuffer();
-                using var sha1 = SHA1.Create();
-                var hash = Convert.ToBase64String(sha1.ComputeHash(byteArray));
-                return hash;
+                // Normalize to a deterministic pixel format (32-bit premultiplied BGRA)
+                BitmapSource normalized = image;
+                if (normalized.Format != PixelFormats.Pbgra32)
+                {
+                    var converted = new FormatConvertedBitmap();
+                    converted.BeginInit();
+                    converted.Source = normalized;
+                    converted.DestinationFormat = PixelFormats.Pbgra32;
+                    converted.EndInit();
+                    converted.Freeze();
+
+                    normalized = converted;
+                }
+
+                // Draw into a fixed-size RenderTarget at 96 DPI to ensure deterministic pixel buffer
+                var rtb = new RenderTargetBitmap(HashSize, HashSize, 96, 96, PixelFormats.Pbgra32);
+                var dv = new DrawingVisual();
+
+                using (var dc = dv.RenderOpen())
+                {
+                    // Uniformly scale to fit into HashSize x HashSize
+                    var scale = Math.Min((double)HashSize / normalized.PixelWidth, (double)HashSize / normalized.PixelHeight);
+                    var drawWidth = normalized.PixelWidth * scale;
+                    var drawHeight = normalized.PixelHeight * scale;
+
+                    var offsetX = (HashSize - drawWidth) / 2;
+                    var offsetY = (HashSize - drawHeight) / 2;
+                    dc.DrawImage(normalized, new System.Windows.Rect(offsetX, offsetY, drawWidth, drawHeight));
+                }
+
+                rtb.Render(dv);
+                rtb.Freeze();
+
+                // Extract raw pixel bytes
+                var bpp = rtb.Format.BitsPerPixel;
+                if (bpp < 1)
+                    return null;
+
+                var bytesPerPixel = (bpp + 7) / 8;
+                var stride = rtb.PixelWidth * bytesPerPixel;
+
+                var bufferSize = stride * rtb.PixelHeight;
+                if (bufferSize < 1)
+                    return null;
+
+                var pixels = new byte[bufferSize];
+                rtb.CopyPixels(pixels, stride, 0);
+
+                var hashBytes = SHA1.HashData(pixels);
+                return Convert.ToBase64String(hashBytes);
             }
             catch
             {

--- a/Flow.Launcher.Infrastructure/Image/ImageHashGenerator.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageHashGenerator.cs
@@ -12,8 +12,6 @@ namespace Flow.Launcher.Infrastructure.Image
 
     public class ImageHashGenerator : IImageHashGenerator
     {
-        private const int HashSize = 64; // Deterministic size for hashing to avoid DPI/stride variability
-
         public string GetHashFromImage(ImageSource imageSource)
         {
             if (imageSource is not BitmapSource { IsFrozen: true } image)
@@ -37,39 +35,15 @@ namespace Flow.Launcher.Infrastructure.Image
                     normalized = converted;
                 }
 
-                // Draw into a fixed-size RenderTarget at 96 DPI to ensure deterministic pixel buffer
-                var rtb = new RenderTargetBitmap(HashSize, HashSize, 96, 96, PixelFormats.Pbgra32);
-                var dv = new DrawingVisual();
-
-                using (var dc = dv.RenderOpen())
-                {
-                    // Uniformly scale to fit into HashSize x HashSize
-                    var scale = Math.Min((double)HashSize / normalized.PixelWidth, (double)HashSize / normalized.PixelHeight);
-                    var drawWidth = normalized.PixelWidth * scale;
-                    var drawHeight = normalized.PixelHeight * scale;
-
-                    var offsetX = (HashSize - drawWidth) / 2;
-                    var offsetY = (HashSize - drawHeight) / 2;
-                    dc.DrawImage(normalized, new System.Windows.Rect(offsetX, offsetY, drawWidth, drawHeight));
-                }
-
-                rtb.Render(dv);
-                rtb.Freeze();
-
-                // Extract raw pixel bytes
-                var bpp = rtb.Format.BitsPerPixel;
+                // Prepare final buffer (should be HashSize x HashSize)
+                var bpp = normalized.Format.BitsPerPixel;
                 if (bpp < 1)
                     return null;
 
                 var bytesPerPixel = (bpp + 7) / 8;
-                var stride = rtb.PixelWidth * bytesPerPixel;
-
-                var bufferSize = stride * rtb.PixelHeight;
-                if (bufferSize < 1)
-                    return null;
-
-                var pixels = new byte[bufferSize];
-                rtb.CopyPixels(pixels, stride, 0);
+                var stride = normalized.PixelWidth * bytesPerPixel;
+                var pixels = new byte[stride * normalized.PixelHeight];
+                normalized.CopyPixels(pixels, stride, 0);
 
                 var hashBytes = SHA1.HashData(pixels);
                 return Convert.ToBase64String(hashBytes);


### PR DESCRIPTION
Closes #4116

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes image hashing deterministic and format/DPI-agnostic by normalizing to `Pbgra32` and hashing raw pixels. Prevents collisions across formats/metadata and reduces allocations.

- **Summary of changes**
  - Changed: Hash raw `Pbgra32` pixels via `SHA1.HashData` instead of JPEG-encoded buffers.
  - Changed: Only accept `BitmapSource` inputs with `IsFrozen`; others return null.
  - Added: Normalize to `Pbgra32`, freeze the converted bitmap, guard zero-size images, and use `ArrayPool<byte>` for pixel storage.
  - Removed: `MemoryStream`, `JpegBitmapEncoder`, `BitmapFrame`, and any reliance on encoder output or metadata (including DPI/EXIF).
  - Memory: Rents a width×height×4 buffer from `ArrayPool<byte>`, returns it after use to avoid LOH allocations and reduce GC pressure.
  - Security: No new risks; SHA‑1 used only for IDs, pooled buffers are returned and not exposed.
  - Tests: No unit tests added.

<sup>Written for commit e436287492da51b8b575f332de53dd80d6ea08a9. Summary will update on new commits. <a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4432?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

