### PR TITLE
Fix Pinyin search's default to false

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -345,7 +345,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         /// <summary>
         /// when false Alphabet static service will always return empty results
         /// </summary>
-        private bool _useAlphabet = true;
+        private bool _useAlphabet = false;
         public bool ShouldUsePinyin
         {
             get => _useAlphabet;


### PR DESCRIPTION
Pinyin search should not default to true.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set Pinyin search to be off by default by flipping the settings flag to false. This prevents Pinyin results from appearing unless users enable the option.

- **Summary of changes**
  - Changed: Default `_useAlphabet` (backing `ShouldUsePinyin`) from `true` to `false`, so the Alphabet service returns no Pinyin results unless enabled.
  - Added: None.
  - Removed: None.
  - Memory impact: None.
  - Security risks: None.
  - Unit tests: None added.

<sup>Written for commit ae275b6f388077fe0ba3aa88c1556ba38d8937bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

