### PR TITLE
Improve sound handling and show title in volume mixer 

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -159,7 +159,19 @@ namespace Flow.Launcher.Infrastructure.UserSettings
         public string ResultSubFontStretch { get; set; }
         public bool UseGlyphIcons { get; set; } = true;
         public bool UseAnimation { get; set; } = true;
-        public bool UseSound { get; set; } = true;
+        private bool _useSound = true;
+        public bool UseSound
+        {
+            get => _useSound;
+            set
+            {
+                if (_useSound != value)
+                {
+                    _useSound = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
         public double SoundVolume { get; set; } = 50;
         public bool ShowBadges { get; set; } = false;
         public bool ShowBadgesGlobalOnly { get; set; } = false;

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -1533,9 +1533,9 @@ namespace Flow.Launcher
                 {
                     _hwndSource?.Dispose();
                     _notifyIcon?.Dispose();
+                    UnregisterSoundEffectsEvent();
                     DisposeSoundEffects();
                     _viewModel.ActualApplicationThemeChanged -= ViewModel_ActualApplicationThemeChanged;
-                    UnregisterSoundEffectsEvent();
                 }
 
                 _disposed = true;

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -710,7 +710,8 @@ namespace Flow.Launcher
             {
                 if (_settings.WMPInstalled)
                 {
-                    if (_animationSoundWMP == null){
+                    if (_animationSoundWMP == null)
+                    {
                         return;
                     }
 
@@ -720,7 +721,8 @@ namespace Flow.Launcher
                 }
                 else
                 {
-                    if (_animationSoundWPF == null){
+                    if (_animationSoundWPF == null)
+                    {
                         return;
                     }
 

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -710,12 +710,20 @@ namespace Flow.Launcher
             {
                 if (_settings.WMPInstalled)
                 {
+                    if (_animationSoundWMP == null){
+                        return;
+                    }
+
                     _animationSoundWMP.Position = TimeSpan.Zero;
                     _animationSoundWMP.Volume = _settings.SoundVolume / 100.0;
                     _animationSoundWMP.Play();
                 }
                 else
                 {
+                    if (_animationSoundWPF == null){
+                        return;
+                    }
+
                     _animationSoundWPF.Play();
                 }
             }

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -95,7 +95,7 @@ namespace Flow.Launcher
             InitializeComponent();
             UpdatePosition();
 
-            InitSoundEffects();
+            SyncSoundEffectsState();
             RegisterSoundEffectsEvent();
             DataObject.AddPastingHandler(QueryTextBox, QueryTextBox_OnPaste);
             _viewModel.ActualApplicationThemeChanged += ViewModel_ActualApplicationThemeChanged;
@@ -327,6 +327,9 @@ namespace Flow.Launcher
                         break;
                     case nameof(Settings.ShowAtTopmost):
                         Topmost = _settings.ShowAtTopmost;
+                        break;
+                    case nameof(Settings.UseSound):
+                        SyncSoundEffectsState();
                         break;
                 }
             };
@@ -718,6 +721,46 @@ namespace Flow.Launcher
             }
         }
 
+        private bool IsSoundEffectsInitialized()
+        {
+            lock (_soundLock)
+            {
+                return _animationSoundWMP != null || _animationSoundWPF != null;
+            }
+        }
+
+        private void DisposeSoundEffects()
+        {
+            lock (_soundLock)
+            {
+                _animationSoundWMP?.Stop();
+                _animationSoundWMP?.Close();
+                _animationSoundWMP = null;
+
+                _animationSoundWPF?.Stop();
+                _animationSoundWPF?.Dispose();
+                _animationSoundWPF = null;
+            }
+        }
+
+        private void SyncSoundEffectsState(bool forceReinitializeWhenEnabled = false)
+        {
+            if (!_settings.UseSound)
+            {
+                if (IsSoundEffectsInitialized())
+                {
+                    DisposeSoundEffects();
+                }
+
+                return;
+            }
+
+            if (forceReinitializeWhenEnabled || !IsSoundEffectsInitialized())
+            {
+                InitSoundEffects();
+            }
+        }
+
         private void RegisterSoundEffectsEvent()
         {
             // Fix for sound not playing after sleep / hibernate for both modern standby and legacy standby
@@ -731,14 +774,14 @@ namespace Flow.Launcher
                         return;
                     }
 
-                    // We must run InitSoundEffects on UI thread because MediaPlayer is a DispatcherObject
+                    // We must run SyncSoundEffectsState on UI thread because MediaPlayer is a DispatcherObject
                     if (!Application.Current.Dispatcher.CheckAccess())
                     {
-                        Application.Current.Dispatcher.Invoke(InitSoundEffects);
+                        Application.Current.Dispatcher.Invoke(() => SyncSoundEffectsState(forceReinitializeWhenEnabled: true));
                         return;
                     }
 
-                    InitSoundEffects();
+                    SyncSoundEffectsState(forceReinitializeWhenEnabled: true);
                 });
             }
             catch (Exception e)
@@ -1480,8 +1523,7 @@ namespace Flow.Launcher
                 {
                     _hwndSource?.Dispose();
                     _notifyIcon?.Dispose();
-                    _animationSoundWMP?.Close();
-                    _animationSoundWPF?.Dispose();
+                    DisposeSoundEffects();
                     _viewModel.ActualApplicationThemeChanged -= ViewModel_ActualApplicationThemeChanged;
                     UnregisterSoundEffectsEvent();
                 }

--- a/SolutionAssemblyInfo.cs
+++ b/SolutionAssemblyInfo.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Release build, https://github.com/Flow-Launcher/Flow.Launcher")]
 #endif
 
+[assembly: AssemblyTitle("Flow Launcher")]
 [assembly: AssemblyCompany("Flow Launcher")]
 [assembly: AssemblyProduct("Flow Launcher")]
 [assembly: AssemblyCopyright("The MIT License (MIT)")]


### PR DESCRIPTION
Mostly fixes #2864

Fixes the blank name issue in the volume mixer by setting AssemblyTitle

Only creates the sound / media players when _settings.UseSounds is set and observes changes to that, disposing and init'ing as needed.

This avoids showing flow in the volume mixer if it is set to false at startup, but unfortunately it doesn't seem possible to remove it from there in runtime.

As far as I can tell this is because the created audio session is tied to the flow launcher process itself in windows, so our only options would be trying some low level API's or using a seperate process for audio.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Summary of changes

Show “Flow Launcher” by name in the Windows volume mixer and make sound effects opt-in with lazy init. The mixer no longer shows Flow if sounds are off at startup (addresses #2864; runtime removal isn’t possible).

- **Details**
  - Changed: `Settings.UseSound` is now observable; we react on startup, on setting changes, and after resume via `SyncSoundEffectsState`. In `Dispose`, we now `UnregisterSoundEffectsEvent` before `DisposeSoundEffects` for safe teardown. `SoundPlay` adds null checks.
  - Added: `[assembly: AssemblyTitle("Flow Launcher")]` for the mixer label. New methods `SyncSoundEffectsState`, `DisposeSoundEffects`, and `IsSoundEffectsInitialized` manage player lifecycle and reinit after resume.
  - Removed: Unconditional media player initialization at startup and direct per-field close/dispose calls.
  - Memory impact: Lower usage when `UseSound` is off (no players created); resources released immediately when toggled off or on dispose.
  - Security: No new risks.
  - Tests: No new unit tests.

<sup>Written for commit c7447ea36af08efa986f262406f6330cbf18c4b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

