### PR TITLE
Fix Publish Default Plugin workflow token declaration

### DIFF
--- a/.github/workflows/default_plugins.yml
+++ b/.github/workflows/default_plugins.yml
@@ -53,8 +53,7 @@ jobs:
           files: "Flow.Launcher.Plugin.BrowserBookmark.zip"
           tag_name: "v${{steps.updated-version-browserbookmark.outputs.prop}}"
           body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+          token: ${{ secrets.PUBLISH_PLUGINS }}
 
 
       - name: Get Calculator Version
@@ -77,8 +76,7 @@ jobs:
           files: "Flow.Launcher.Plugin.Calculator.zip"
           tag_name: "v${{steps.updated-version-calculator.outputs.prop}}"
           body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+          token: ${{ secrets.PUBLISH_PLUGINS }}
 
 
       - name: Get Explorer Version
@@ -101,8 +99,7 @@ jobs:
           files: "Flow.Launcher.Plugin.Explorer.zip"
           tag_name: "v${{steps.updated-version-explorer.outputs.prop}}"
           body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+          token: ${{ secrets.PUBLISH_PLUGINS }}
 
 
       - name: Get PluginIndicator Version
@@ -125,8 +122,7 @@ jobs:
           files: "Flow.Launcher.Plugin.PluginIndicator.zip"
           tag_name: "v${{steps.updated-version-pluginindicator.outputs.prop}}"
           body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+          token: ${{ secrets.PUBLISH_PLUGINS }}
 
 
       - name: Get PluginsManager Version
@@ -149,8 +145,7 @@ jobs:
           files: "Flow.Launcher.Plugin.PluginsManager.zip"
           tag_name: "v${{steps.updated-version-pluginsmanager.outputs.prop}}"
           body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+          token: ${{ secrets.PUBLISH_PLUGINS }}
 
 
       - name: Get ProcessKiller Version
@@ -173,8 +168,7 @@ jobs:
           files: "Flow.Launcher.Plugin.ProcessKiller.zip"
           tag_name: "v${{steps.updated-version-processkiller.outputs.prop}}"
           body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+          token: ${{ secrets.PUBLISH_PLUGINS }}
 
 
       - name: Get Program Version
@@ -197,8 +191,7 @@ jobs:
           files: "Flow.Launcher.Plugin.Program.zip"
           tag_name: "v${{steps.updated-version-program.outputs.prop}}"
           body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+          token: ${{ secrets.PUBLISH_PLUGINS }}
 
 
       - name: Get Shell Version
@@ -221,8 +214,7 @@ jobs:
           files: "Flow.Launcher.Plugin.Shell.zip"
           tag_name: "v${{steps.updated-version-shell.outputs.prop}}"
           body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+          token: ${{ secrets.PUBLISH_PLUGINS }}
 
 
       - name: Get Sys Version
@@ -245,8 +237,7 @@ jobs:
           files: "Flow.Launcher.Plugin.Sys.zip"
           tag_name: "v${{steps.updated-version-sys.outputs.prop}}"
           body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+          token: ${{ secrets.PUBLISH_PLUGINS }}
 
 
       - name: Get Url Version
@@ -269,8 +260,7 @@ jobs:
           files: "Flow.Launcher.Plugin.Url.zip"
           tag_name: "v${{steps.updated-version-url.outputs.prop}}"
           body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+          token: ${{ secrets.PUBLISH_PLUGINS }}
 
 
       - name: Get WebSearch Version
@@ -293,8 +283,7 @@ jobs:
           files: "Flow.Launcher.Plugin.WebSearch.zip"
           tag_name: "v${{steps.updated-version-websearch.outputs.prop}}"
           body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+          token: ${{ secrets.PUBLISH_PLUGINS }}
 
 
       - name: Get WindowsSettings Version
@@ -317,5 +306,4 @@ jobs:
           files: "Flow.Launcher.Plugin.WindowsSettings.zip"
           tag_name: "v${{steps.updated-version-windowssettings.outputs.prop}}"
           body: Visit Flow's [release notes](https://github.com/Flow-Launcher/Flow.Launcher/releases) for changes.
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}
+          token: ${{ secrets.PUBLISH_PLUGINS }}


### PR DESCRIPTION
Recent change of softprops/action-gh-release GitHub action from v2 to v3 seems to require token be explicitly declared instead of via env variable.

Tested:
-  v2.1.2 default plugins are published

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the default plugins publish workflow by passing the token via the `token` input required by `softprops/action-gh-release@v3`. This unblocks publishing after the v3 upgrade.

**Summary of changes**
- Changed: All release steps in `.github/workflows/default_plugins.yml` now use `token: ${{ secrets.PUBLISH_PLUGINS }}` with `softprops/action-gh-release`.
- Added: Explicit token input for each plugin release step to satisfy v3 requirements.
- Removed: `env: GITHUB_TOKEN: ${{ secrets.PUBLISH_PLUGINS }}` from those steps.
- Memory impact: None.
- Security: Token stays masked; passing it as an action input reduces exposure versus env vars; no permission changes.
- Tests: No unit tests for workflows; validated by successfully publishing default plugins (e.g., v2.1.2).

**Release Note**
Fixes an issue that prevented publishing default plugins; updates now publish as expected.

<sup>Written for commit c81176e6a846ce3caf5a81a621123836dc981d02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

