### PR TITLE
Improve ImageLoader thumbnail fallbacks and refactor GetThumbnailResult

### DIFF
--- a/Flow.Launcher.Infrastructure/Constant.cs
+++ b/Flow.Launcher.Infrastructure/Constant.cs
@@ -35,6 +35,7 @@ namespace Flow.Launcher.Infrastructure
         public static readonly string ImageIcon = Path.Combine(ImagesDirectory, "image.png");
         public static readonly string HistoryIcon = Path.Combine(ImagesDirectory, "history.png");
         public static readonly string SettingsIcon = Path.Combine(ImagesDirectory, "settings.png");
+        public static readonly string FolderIcon = Path.Combine(ImagesDirectory, "folder.png");
 
         public static string PythonPath;
         public static string NodePath;

--- a/Flow.Launcher.Infrastructure/Constant.cs
+++ b/Flow.Launcher.Infrastructure/Constant.cs
@@ -32,7 +32,6 @@ namespace Flow.Launcher.Infrastructure
         public static readonly string ErrorIcon = Path.Combine(ImagesDirectory, "app_error.png");
         public static readonly string MissingImgIcon = Path.Combine(ImagesDirectory, "app_missing_img.png");
         public static readonly string LoadingImgIcon = Path.Combine(ImagesDirectory, "loading.png");
-        public static readonly string ImageIcon = Path.Combine(ImagesDirectory, "image.png");
         public static readonly string HistoryIcon = Path.Combine(ImagesDirectory, "history.png");
         public static readonly string SettingsIcon = Path.Combine(ImagesDirectory, "settings.png");
         public static readonly string FolderIcon = Path.Combine(ImagesDirectory, "folder.png");

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -151,14 +151,14 @@ namespace Flow.Launcher.Infrastructure.Image
                     return new ImageResult(imageSource, ImageType.Data);
                 }
 
-                imageResult = await Task.Run(() => GetThumbnailResult(ref path, loadFullImage));
+                imageResult = await Task.Run(() => GetThumbnailResult(path, loadFullImage));
             }
             catch (System.Exception e)
             {
                 try
                 {
                     // Get thumbnail may fail for certain images on the first try, retry again has proven to work
-                    imageResult = GetThumbnailResult(ref path, loadFullImage);
+                    imageResult = GetThumbnailResult(path, loadFullImage);
                 }
                 catch (System.Exception e2)
                 {
@@ -197,23 +197,23 @@ namespace Flow.Launcher.Infrastructure.Image
             return image;
         }
 
-        private static ImageResult GetThumbnailResult(ref string path, bool loadFullImage = false)
+        private static ImageResult GetThumbnailResult(string path, bool loadFullImage = false)
         {
             if (Directory.Exists(path))
-                return GetDirectoryThumbnailResult(ref path);
+                return GetDirectoryThumbnailResult(path);
 
             if (!File.Exists(path))
-                return GetMissingThumbnailResult(ref path);
+                return GetMissingThumbnailResult();
 
             var extension = Path.GetExtension(path).ToLower();
 
             if (ImageExtensions.Contains(extension))
-                return GetImageFileThumbnailResult(ref path, loadFullImage);
+                return GetImageFileThumbnailResult(path, loadFullImage);
 
             if (extension == SvgExtension)
-                return GetSvgFileThumbnailResult(ref path, loadFullImage);
+                return GetSvgFileThumbnailResult(path, loadFullImage);
 
-            return GetFileThumbnailResult(ref path, loadFullImage);
+            return GetFileThumbnailResult(path, loadFullImage);
         }
 
         private static ImageResult CreateImageResult(ImageSource image, ImageType type)
@@ -226,13 +226,12 @@ namespace Flow.Launcher.Infrastructure.Image
             return new ImageResult(image, type);
         }
 
-        private static ImageResult GetMissingThumbnailResult(ref string path)
+        private static ImageResult GetMissingThumbnailResult()
         {
-            path = Constant.MissingImgIcon;
             return CreateImageResult(MissingImage, ImageType.Error);
         }
 
-        private static ImageResult GetDirectoryThumbnailResult(ref string path)
+        private static ImageResult GetDirectoryThumbnailResult(string path)
         {
             try
             {
@@ -247,12 +246,11 @@ namespace Flow.Launcher.Infrastructure.Image
             catch (System.Exception ex)
             {
                 Log.Info(ClassName, $"Failed to get shell thumbnail for folder {path}: {ex.Message}\nUsing default folder image as fallback.");
-                path = Constant.FolderIcon;
                 return CreateImageResult(FolderImage, ImageType.Folder);
             }
         }
 
-        private static ImageResult GetImageFileThumbnailResult(ref string path, bool loadFullImage)
+        private static ImageResult GetImageFileThumbnailResult(string path, bool loadFullImage)
         {
             if (loadFullImage)
             {
@@ -264,7 +262,7 @@ namespace Flow.Launcher.Infrastructure.Image
                 catch (NotSupportedException ex)
                 {
                     Log.Exception(ClassName, $"Failed to load image file from path {path}: {ex.Message}", ex);
-                    return GetMissingThumbnailResult(ref path);
+                    return GetMissingThumbnailResult();
                 }
             }
 
@@ -290,12 +288,12 @@ namespace Flow.Launcher.Infrastructure.Image
                 catch (System.Exception ex2)
                 {
                     Log.Exception(ClassName, $"Failed to load image file from path {path}: {ex2.Message}", ex2);
-                    return GetMissingThumbnailResult(ref path);
+                    return GetMissingThumbnailResult();
                 }
             }
         }
 
-        private static ImageResult GetSvgFileThumbnailResult(ref string path, bool loadFullImage)
+        private static ImageResult GetSvgFileThumbnailResult(string path, bool loadFullImage)
         {
             try
             {
@@ -305,11 +303,11 @@ namespace Flow.Launcher.Infrastructure.Image
             catch (System.Exception ex)
             {
                 Log.Exception(ClassName, $"Failed to load SVG image from path {path}: {ex.Message}", ex);
-                return GetMissingThumbnailResult(ref path);
+                return GetMissingThumbnailResult();
             }
         }
 
-        private static ImageResult GetFileThumbnailResult(ref string path, bool loadFullImage)
+        private static ImageResult GetFileThumbnailResult(string path, bool loadFullImage)
         {
             var size = loadFullImage ? FullIconSize : SmallIconSize;
             try
@@ -326,7 +324,7 @@ namespace Flow.Launcher.Infrastructure.Image
                     return CreateImageResult(image, ImageType.File);
 
                 Log.Info(ClassName, $"ExtractAssociatedIcon returned no icon for {path}. Using missing image.");
-                return GetMissingThumbnailResult(ref path);
+                return GetMissingThumbnailResult();
             }
         }
 

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -35,6 +35,13 @@ namespace Flow.Launcher.Infrastructure.Image
 
         private static readonly string[] ImageExtensions = [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".ico"];
         private static readonly string SvgExtension = ".svg";
+        internal static Func<string, ThumbnailOptions, int, BitmapSource> ThumbnailLoader { get; set; } =
+            (path, option, size) =>
+                WindowsThumbnailProvider.GetThumbnail(
+                    path,
+                    size,
+                    size,
+                    option);
 
         public static async Task InitializeAsync()
         {
@@ -333,11 +340,7 @@ namespace Flow.Launcher.Infrastructure.Image
         private static BitmapSource GetThumbnail(string path, ThumbnailOptions option = ThumbnailOptions.ThumbnailOnly,
             int size = SmallIconSize)
         {
-            return WindowsThumbnailProvider.GetThumbnail(
-                path,
-                size,
-                size,
-                option);
+            return ThumbnailLoader(path, option, size);
         }
 
         private static bool TryExtractAssociatedIcon(string path, int size, out BitmapSource image)

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -234,12 +234,30 @@ namespace Flow.Launcher.Infrastructure.Image
                     }
                     else
                     {
-                        /* Although the documentation for GetImage on MSDN indicates that
-                         * if a thumbnail is available it will return one, this has proved to not
-                         * be the case in many situations while testing.
-                         * - Solution: explicitly pass the ThumbnailOnly flag
-                         */
-                        image = GetThumbnail(path, ThumbnailOptions.ThumbnailOnly);
+                        try
+                        {
+                            /* Although the documentation for GetImage on MSDN indicates that
+                             * if a thumbnail is available it will return one, this has proved to not
+                             * be the case in many situations while testing.
+                             * - Solution: explicitly pass the ThumbnailOnly flag
+                             */
+                            image = GetThumbnail(path, ThumbnailOptions.ThumbnailOnly);
+                        }
+                        catch (System.Exception ex)
+                        {
+                            Log.Info(ClassName, $"Failed to get shell thumbnail for image file {path}: {ex.Message}\nTrying bitmap fallback.");
+
+                            try
+                            {
+                                image = LoadBitmapImageScaleToFitWithin(path, SmallIconSize);
+                            }
+                            catch (System.Exception ex2)
+                            {
+                                image = Image;
+                                type = ImageType.Error;
+                                Log.Exception(ClassName, $"Failed to load image file from path {path}: {ex2.Message}", ex2);
+                            }
+                        }
                     }
                 }
                 else if (extension == SvgExtension)

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -26,7 +26,6 @@ namespace Flow.Launcher.Infrastructure.Image
         private static readonly ConcurrentDictionary<string, string> GuidToKey = new();
         private static ImageHashGenerator _hashGenerator;
         private static readonly bool EnableImageHash = true;
-        public static ImageSource Image => ImageCache[Constant.ImageIcon, false];
         public static ImageSource MissingImage => ImageCache[Constant.MissingImgIcon, false];
         public static ImageSource LoadingImage => ImageCache[Constant.LoadingImgIcon, false];
         public static ImageSource FolderImage => ImageCache[Constant.FolderIcon, false];
@@ -209,10 +208,10 @@ namespace Flow.Launcher.Infrastructure.Image
             var extension = Path.GetExtension(path).ToLower();
 
             if (ImageExtensions.Contains(extension))
-                return GetImageFileThumbnailResult(path, loadFullImage);
+                return GetImageFileThumbnailResult(ref path, loadFullImage);
 
             if (extension == SvgExtension)
-                return GetSvgFileThumbnailResult(path, loadFullImage);
+                return GetSvgFileThumbnailResult(ref path, loadFullImage);
 
             return GetFileThumbnailResult(ref path, loadFullImage);
         }
@@ -252,7 +251,7 @@ namespace Flow.Launcher.Infrastructure.Image
             }
         }
 
-        private static ImageResult GetImageFileThumbnailResult(string path, bool loadFullImage)
+        private static ImageResult GetImageFileThumbnailResult(ref string path, bool loadFullImage)
         {
             if (loadFullImage)
             {
@@ -264,7 +263,7 @@ namespace Flow.Launcher.Infrastructure.Image
                 catch (NotSupportedException ex)
                 {
                     Log.Exception(ClassName, $"Failed to load image file from path {path}: {ex.Message}", ex);
-                    return CreateImageResult(Image, ImageType.Error);
+                    return GetMissingThumbnailResult(ref path);
                 }
             }
 
@@ -290,12 +289,12 @@ namespace Flow.Launcher.Infrastructure.Image
                 catch (System.Exception ex2)
                 {
                     Log.Exception(ClassName, $"Failed to load image file from path {path}: {ex2.Message}", ex2);
-                    return CreateImageResult(Image, ImageType.Error);
+                    return GetMissingThumbnailResult(ref path);
                 }
             }
         }
 
-        private static ImageResult GetSvgFileThumbnailResult(string path, bool loadFullImage)
+        private static ImageResult GetSvgFileThumbnailResult(ref string path, bool loadFullImage)
         {
             try
             {
@@ -305,7 +304,7 @@ namespace Flow.Launcher.Infrastructure.Image
             catch (System.Exception ex)
             {
                 Log.Exception(ClassName, $"Failed to load SVG image from path {path}: {ex.Message}", ex);
-                return CreateImageResult(Image, ImageType.Error);
+                return GetMissingThumbnailResult(ref path);
             }
         }
 

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -48,7 +48,7 @@ namespace Flow.Launcher.Infrastructure.Image
 
                 ImageCache.Initialize(usage);
 
-                foreach (var icon in new[] { Constant.DefaultIcon, Constant.ImageIcon, Constant.MissingImgIcon, Constant.LoadingImgIcon, Constant.FolderIcon })
+                foreach (var icon in new[] { Constant.DefaultIcon, Constant.MissingImgIcon, Constant.LoadingImgIcon, Constant.FolderIcon })
                 {
                     ImageSource img = new BitmapImage(new Uri(icon));
                     img.Freeze();

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Flow.Launcher.Infrastructure.Logger;
@@ -257,7 +259,24 @@ namespace Flow.Launcher.Infrastructure.Image
                 else
                 {
                     type = ImageType.File;
-                    image = GetThumbnail(path, ThumbnailOptions.None, loadFullImage ? FullIconSize : SmallIconSize);
+                    var size = loadFullImage ? FullIconSize : SmallIconSize;
+                    try
+                    {
+                        image = GetThumbnail(path, ThumbnailOptions.None, size);
+                    }
+                    catch (System.Exception ex)
+                    {
+                        Log.Info(ClassName, $"Failed to get shell thumbnail for {path}: {ex.Message}\nTrying ExtractAssociatedIcon fallback.");
+
+                        image = ExtractAssociatedIconOrNull(path, size);
+                        if (image == null)
+                        {
+                            Log.Info(ClassName, $"ExtractAssociatedIcon returned no icon for {path}. Using missing image.");
+                            image = MissingImage;
+                            path = Constant.MissingImgIcon;
+                            type = ImageType.Error;
+                        }
+                    }
                 }
             }
             else
@@ -282,6 +301,29 @@ namespace Flow.Launcher.Infrastructure.Image
                 size,
                 size,
                 option);
+        }
+
+        private static BitmapSource ExtractAssociatedIconOrNull(string path, int size)
+        {
+            try
+            {
+                using var icon = System.Drawing.Icon.ExtractAssociatedIcon(path);
+                if (icon == null)
+                {
+                    return null;
+                }
+
+                var image = Imaging.CreateBitmapSourceFromHIcon(
+                    icon.Handle,
+                    Int32Rect.Empty,
+                    BitmapSizeOptions.FromWidthAndHeight(size, size));
+                image.Freeze();
+                return image;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         public static bool CacheContainImage(string path, bool loadFullImage = false)

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -371,38 +371,43 @@ namespace Flow.Launcher.Infrastructure.Image
 
         private static BitmapImage LoadFullImage(string path)
         {
-            BitmapImage image = new BitmapImage();
-            image.BeginInit();
-            image.CacheOption = BitmapCacheOption.OnLoad;
-            image.UriSource = new Uri(path);
-            image.CreateOptions = BitmapCreateOptions.IgnoreColorProfile;
-            image.EndInit();
+            BitmapImage image = LoadBitmapImage(path);
 
             if (image.PixelWidth > FullImageSize)
             {
-                BitmapImage resizedWidth = new BitmapImage();
-                resizedWidth.BeginInit();
-                resizedWidth.CacheOption = BitmapCacheOption.OnLoad;
-                resizedWidth.UriSource = new Uri(path);
-                resizedWidth.CreateOptions = BitmapCreateOptions.IgnoreColorProfile;
-                resizedWidth.DecodePixelWidth = FullImageSize;
-                resizedWidth.EndInit();
+                BitmapImage resizedWidth = LoadBitmapImage(path, decodePixelWidth: FullImageSize);
 
                 if (resizedWidth.PixelHeight > FullImageSize)
                 {
-                    BitmapImage resizedHeight = new BitmapImage();
-                    resizedHeight.BeginInit();
-                    resizedHeight.CacheOption = BitmapCacheOption.OnLoad;
-                    resizedHeight.UriSource = new Uri(path);
-                    resizedHeight.CreateOptions = BitmapCreateOptions.IgnoreColorProfile;
-                    resizedHeight.DecodePixelHeight = FullImageSize;
-                    resizedHeight.EndInit();
+                    BitmapImage resizedHeight = LoadBitmapImage(path, decodePixelHeight: FullImageSize);
                     return resizedHeight;
                 }
 
                 return resizedWidth;
             }
 
+            return image;
+        }
+
+        private static BitmapImage LoadBitmapImage(string path, int? decodePixelWidth = null, int? decodePixelHeight = null)
+        {
+            BitmapImage image = new BitmapImage();
+            image.BeginInit();
+            image.CacheOption = BitmapCacheOption.OnLoad;
+            image.UriSource = new Uri(path);
+            image.CreateOptions = BitmapCreateOptions.IgnoreColorProfile;
+
+            if (decodePixelWidth.HasValue)
+            {
+                image.DecodePixelWidth = decodePixelWidth.Value;
+            }
+
+            if (decodePixelHeight.HasValue)
+            {
+                image.DecodePixelHeight = decodePixelHeight.Value;
+            }
+
+            image.EndInit();
             return image;
         }
 

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -162,8 +162,8 @@ namespace Flow.Launcher.Infrastructure.Image
                 }
                 catch (System.Exception e2)
                 {
-                    Log.Exception(ClassName, $"Failed to get thumbnail for {path} on first try", e);
-                    Log.Exception(ClassName, $"Failed to get thumbnail for {path} on second try", e2);
+                    Log.Warn(ClassName, $"Failed to get thumbnail for {path} on first try: {e.Message}");
+                    Log.Warn(ClassName, $"Failed to get thumbnail for {path} on second try: {e2.Message}");
 
                     ImageSource image = MissingImage;
                     ImageCache[path, false] = image;
@@ -245,7 +245,7 @@ namespace Flow.Launcher.Infrastructure.Image
             }
             catch (System.Exception ex)
             {
-                Log.Info(ClassName, $"Failed to get shell thumbnail for folder {path}: {ex.Message}\nUsing default folder image as fallback.");
+                Log.Warn(ClassName, $"Failed to get shell thumbnail for folder {path}: {ex.Message}\nUsing default folder image as fallback.");
                 return CreateImageResult(FolderImage, ImageType.Folder);
             }
         }
@@ -261,7 +261,7 @@ namespace Flow.Launcher.Infrastructure.Image
                 }
                 catch (NotSupportedException ex)
                 {
-                    Log.Exception(ClassName, $"Failed to load image file from path {path}: {ex.Message}", ex);
+                    Log.Warn(ClassName, $"Failed to load image file from path {path}: {ex.Message}\nUsing missing icon instead.");
                     return GetMissingThumbnailResult();
                 }
             }
@@ -278,7 +278,7 @@ namespace Flow.Launcher.Infrastructure.Image
             }
             catch (System.Exception ex)
             {
-                Log.Info(ClassName, $"Failed to get shell thumbnail for image file {path}: {ex.Message}\nTrying bitmap fallback.");
+                Log.Debug(ClassName, $"Failed to get shell thumbnail for image file {path}: {ex.Message}\nTrying bitmap fallback.");
 
                 try
                 {
@@ -287,7 +287,7 @@ namespace Flow.Launcher.Infrastructure.Image
                 }
                 catch (System.Exception ex2)
                 {
-                    Log.Exception(ClassName, $"Failed to load image file from path {path}: {ex2.Message}", ex2);
+                    Log.Warn(ClassName, $"Failed to load image file from path {path}: {ex2.Message}\nUsing missing icon instead.");
                     return GetMissingThumbnailResult();
                 }
             }
@@ -302,7 +302,7 @@ namespace Flow.Launcher.Infrastructure.Image
             }
             catch (System.Exception ex)
             {
-                Log.Exception(ClassName, $"Failed to load SVG image from path {path}: {ex.Message}", ex);
+                Log.Warn(ClassName, $"Failed to load SVG image from path {path}: {ex.Message}\nUsing missing icon instead.");
                 return GetMissingThumbnailResult();
             }
         }
@@ -317,13 +317,13 @@ namespace Flow.Launcher.Infrastructure.Image
             }
             catch (System.Exception ex)
             {
-                Log.Info(ClassName, $"Failed to get shell thumbnail for {path}: {ex.Message}\nTrying ExtractAssociatedIcon fallback.");
+                Log.Debug(ClassName, $"Failed to get shell thumbnail for {path}: {ex.Message}\nTrying ExtractAssociatedIcon fallback.");
 
                 var image = ExtractAssociatedIconOrNull(path, size);
                 if (image != null)
                     return CreateImageResult(image, ImageType.File);
 
-                Log.Info(ClassName, $"ExtractAssociatedIcon returned no icon for {path}. Using missing image.");
+                Log.Warn(ClassName, $"ExtractAssociatedIcon returned no icon for path: {path}\nUsing missing icon instead.");
                 return GetMissingThumbnailResult();
             }
         }

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -29,6 +29,7 @@ namespace Flow.Launcher.Infrastructure.Image
         public static ImageSource Image => ImageCache[Constant.ImageIcon, false];
         public static ImageSource MissingImage => ImageCache[Constant.MissingImgIcon, false];
         public static ImageSource LoadingImage => ImageCache[Constant.LoadingImgIcon, false];
+        public static ImageSource FolderImage => ImageCache[Constant.FolderIcon, false];
         public const int SmallIconSize = 64;
         public const int FullIconSize = 256;
         public const int FullImageSize = 320;
@@ -48,7 +49,7 @@ namespace Flow.Launcher.Infrastructure.Image
 
                 ImageCache.Initialize(usage);
 
-                foreach (var icon in new[] { Constant.DefaultIcon, Constant.ImageIcon, Constant.MissingImgIcon, Constant.LoadingImgIcon })
+                foreach (var icon in new[] { Constant.DefaultIcon, Constant.ImageIcon, Constant.MissingImgIcon, Constant.LoadingImgIcon, Constant.FolderIcon })
                 {
                     ImageSource img = new BitmapImage(new Uri(icon));
                     img.Freeze();
@@ -204,13 +205,23 @@ namespace Flow.Launcher.Infrastructure.Image
 
             if (Directory.Exists(path))
             {
-                /* Directories can also have thumbnails instead of shell icons.
-                 * Generating thumbnails for a bunch of folder results while scrolling
-                 * could have a big impact on performance and Flow.Launcher responsibility.
-                 * - Solution: just load the icon
-                 */
-                type = ImageType.Folder;
-                image = GetThumbnail(path, ThumbnailOptions.IconOnly);
+                try
+                {
+                    /* Directories can also have thumbnails instead of shell icons.
+                    * Generating thumbnails for a bunch of folder results while scrolling
+                    * could have a big impact on performance and Flow.Launcher responsibility.
+                    * - Solution: just load the icon
+                    */
+                    type = ImageType.Folder;
+                    image = GetThumbnail(path, ThumbnailOptions.IconOnly);
+                }
+                catch (System.Exception ex)
+                {
+                    Log.Info(ClassName, $"Failed to get shell thumbnail for folder {path}: {ex.Message}\nUsing default folder image as fallback.");
+                    type = ImageType.Folder;
+                    image = FolderImage;
+                }
+                
             }
             else if (File.Exists(path))
             {

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -222,7 +222,7 @@ namespace Flow.Launcher.Infrastructure.Image
                     {
                         try
                         {
-                            image = LoadFullImage(path);
+                            image = LoadBitmapImageScaleToFitWithin(path, FullImageSize);
                             type = ImageType.FullImageFile;
                         }
                         catch (NotSupportedException ex)
@@ -369,17 +369,17 @@ namespace Flow.Launcher.Infrastructure.Image
             return img;
         }
 
-        private static BitmapImage LoadFullImage(string path)
+        private static BitmapImage LoadBitmapImageScaleToFitWithin(string path, int maxSize)
         {
             BitmapImage image = LoadBitmapImage(path);
 
-            if (image.PixelWidth > FullImageSize)
+            if (image.PixelWidth > maxSize)
             {
-                BitmapImage resizedWidth = LoadBitmapImage(path, decodePixelWidth: FullImageSize);
+                BitmapImage resizedWidth = LoadBitmapImage(path, decodePixelWidth: maxSize);
 
-                if (resizedWidth.PixelHeight > FullImageSize)
+                if (resizedWidth.PixelHeight > maxSize)
                 {
-                    BitmapImage resizedHeight = LoadBitmapImage(path, decodePixelHeight: FullImageSize);
+                    BitmapImage resizedHeight = LoadBitmapImage(path, decodePixelHeight: maxSize);
                     return resizedHeight;
                 }
 

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -410,20 +410,20 @@ namespace Flow.Launcher.Infrastructure.Image
         {
             BitmapImage image = LoadBitmapImage(path);
 
-            if (image.PixelWidth > maxSize)
+            if (image.PixelWidth <= maxSize && image.PixelHeight <= maxSize)
+                return image;
+
+            bool widthIsLarger = image.PixelWidth >= image.PixelHeight;
+
+            // LoadBitmapImage will maintain aspect ratio so we only need to scale by the largest dimension
+            if (widthIsLarger)
             {
-                BitmapImage resizedWidth = LoadBitmapImage(path, decodePixelWidth: maxSize);
-
-                if (resizedWidth.PixelHeight > maxSize)
-                {
-                    BitmapImage resizedHeight = LoadBitmapImage(path, decodePixelHeight: maxSize);
-                    return resizedHeight;
-                }
-
-                return resizedWidth;
+                return LoadBitmapImage(path, decodePixelWidth: maxSize);
             }
-
-            return image;
+            else
+            {
+                return LoadBitmapImage(path, decodePixelHeight: maxSize);
+            }
         }
 
         private static BitmapImage LoadBitmapImage(string path, int? decodePixelWidth = null, int? decodePixelHeight = null)

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -320,9 +320,10 @@ namespace Flow.Launcher.Infrastructure.Image
             {
                 Log.Debug(ClassName, $"Failed to get shell thumbnail for {path}: {ex.Message}\nTrying ExtractAssociatedIcon fallback.");
 
-                var image = ExtractAssociatedIconOrNull(path, size);
-                if (image != null)
+                if (TryExtractAssociatedIcon(path, size, out var image))
+                {
                     return CreateImageResult(image, ImageType.File);
+                }
 
                 Log.Warn(ClassName, $"ExtractAssociatedIcon returned no icon for path: {path}\nUsing missing icon instead.");
                 return GetMissingThumbnailResult();
@@ -339,26 +340,29 @@ namespace Flow.Launcher.Infrastructure.Image
                 option);
         }
 
-        private static BitmapSource ExtractAssociatedIconOrNull(string path, int size)
+        private static bool TryExtractAssociatedIcon(string path, int size, out BitmapSource image)
         {
+            image = null;
+
             try
             {
                 using var icon = System.Drawing.Icon.ExtractAssociatedIcon(path);
                 if (icon == null)
                 {
-                    return null;
+                    return false;
                 }
 
-                var image = Imaging.CreateBitmapSourceFromHIcon(
+                image = Imaging.CreateBitmapSourceFromHIcon(
                     icon.Handle,
                     Int32Rect.Empty,
                     BitmapSizeOptions.FromWidthAndHeight(size, size));
                 image.Freeze();
-                return image;
+                return true;
             }
             catch
             {
-                return null;
+                image = null;
+                return false;
             }
         }
 

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -200,7 +200,7 @@ namespace Flow.Launcher.Infrastructure.Image
         private static ImageResult GetThumbnailResult(string path, bool loadFullImage = false)
         {
             if (Directory.Exists(path))
-                return GetDirectoryThumbnailResult(path);
+                return GetDirectoryThumbnailResult(path, loadFullImage);
 
             if (!File.Exists(path))
                 return GetMissingThumbnailResult();
@@ -231,8 +231,9 @@ namespace Flow.Launcher.Infrastructure.Image
             return CreateImageResult(MissingImage, ImageType.Error);
         }
 
-        private static ImageResult GetDirectoryThumbnailResult(string path)
+        private static ImageResult GetDirectoryThumbnailResult(string path, bool loadFullImage)
         {
+            var size = loadFullImage ? FullIconSize : SmallIconSize;
             try
             {
                 /* Directories can also have thumbnails instead of shell icons.
@@ -240,7 +241,7 @@ namespace Flow.Launcher.Infrastructure.Image
                  * could have a big impact on performance and Flow.Launcher responsibility.
                  * - Solution: just load the icon
                  */
-                var image = GetThumbnail(path, ThumbnailOptions.IconOnly);
+                var image = GetThumbnail(path, ThumbnailOptions.IconOnly, size);
                 return CreateImageResult(image, ImageType.Folder);
             }
             catch (System.Exception ex)

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -404,14 +404,56 @@ namespace Flow.Launcher.Infrastructure.Image
             return img;
         }
 
+        private static bool TryGetBitmapImageDimensionsFromMetadata(string path, out int width, out int height)
+        {
+            width = 0;
+            height = 0;
+
+            try
+            {
+                using var stream = File.OpenRead(path);
+                var decoder = BitmapDecoder.Create(
+                    stream,
+                    BitmapCreateOptions.DelayCreation,
+                    BitmapCacheOption.None);
+
+                var frame = decoder.Frames.FirstOrDefault();
+                if (frame is null)
+                    return false;
+
+                width = frame.PixelWidth;
+                height = frame.PixelHeight;
+                return width > 0 && height > 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         private static BitmapImage LoadBitmapImageScaleToFitWithin(string path, int maxSize)
         {
-            BitmapImage image = LoadBitmapImage(path);
+            BitmapImage decodedImage = null;
 
-            if (image.PixelWidth <= maxSize && image.PixelHeight <= maxSize)
-                return image;
+            // try to get the image's dimensions from metadata before fully decoding the image
+            bool metadataReadSucceeded = TryGetBitmapImageDimensionsFromMetadata(path, out var width, out var height);
 
-            bool widthIsLarger = image.PixelWidth >= image.PixelHeight;
+            // if we couldn't read the metadata then fully load the image and get dimensions from that
+            if (!metadataReadSucceeded)
+            {
+                decodedImage = LoadBitmapImage(path);
+                width = decodedImage.PixelWidth;
+                height = decodedImage.PixelHeight;
+            }
+
+            // If resizing is unnecessary, return the original image
+            // (reusing the already decoded image if available).
+            if (width <= maxSize && height <= maxSize)
+            {
+                return decodedImage ?? LoadBitmapImage(path);
+            }
+
+            bool widthIsLarger = width >= height;
 
             // LoadBitmapImage will maintain aspect ratio so we only need to scale by the largest dimension
             if (widthIsLarger)

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -200,126 +200,134 @@ namespace Flow.Launcher.Infrastructure.Image
 
         private static ImageResult GetThumbnailResult(ref string path, bool loadFullImage = false)
         {
-            ImageSource image;
-            ImageType type = ImageType.Error;
-
             if (Directory.Exists(path))
-            {
-                try
-                {
-                    /* Directories can also have thumbnails instead of shell icons.
-                    * Generating thumbnails for a bunch of folder results while scrolling
-                    * could have a big impact on performance and Flow.Launcher responsibility.
-                    * - Solution: just load the icon
-                    */
-                    type = ImageType.Folder;
-                    image = GetThumbnail(path, ThumbnailOptions.IconOnly);
-                }
-                catch (System.Exception ex)
-                {
-                    Log.Info(ClassName, $"Failed to get shell thumbnail for folder {path}: {ex.Message}\nUsing default folder image as fallback.");
-                    type = ImageType.Folder;
-                    image = FolderImage;
-                }
-                
-            }
-            else if (File.Exists(path))
-            {
-                var extension = Path.GetExtension(path).ToLower();
-                if (ImageExtensions.Contains(extension))
-                {
-                    type = ImageType.ImageFile;
-                    if (loadFullImage)
-                    {
-                        try
-                        {
-                            image = LoadBitmapImageScaleToFitWithin(path, FullImageSize);
-                            type = ImageType.FullImageFile;
-                        }
-                        catch (NotSupportedException ex)
-                        {
-                            image = Image;
-                            type = ImageType.Error;
-                            Log.Exception(ClassName, $"Failed to load image file from path {path}: {ex.Message}", ex);
-                        }
-                    }
-                    else
-                    {
-                        try
-                        {
-                            /* Although the documentation for GetImage on MSDN indicates that
-                             * if a thumbnail is available it will return one, this has proved to not
-                             * be the case in many situations while testing.
-                             * - Solution: explicitly pass the ThumbnailOnly flag
-                             */
-                            image = GetThumbnail(path, ThumbnailOptions.ThumbnailOnly);
-                        }
-                        catch (System.Exception ex)
-                        {
-                            Log.Info(ClassName, $"Failed to get shell thumbnail for image file {path}: {ex.Message}\nTrying bitmap fallback.");
+                return GetDirectoryThumbnailResult(path);
 
-                            try
-                            {
-                                image = LoadBitmapImageScaleToFitWithin(path, SmallIconSize);
-                            }
-                            catch (System.Exception ex2)
-                            {
-                                image = Image;
-                                type = ImageType.Error;
-                                Log.Exception(ClassName, $"Failed to load image file from path {path}: {ex2.Message}", ex2);
-                            }
-                        }
-                    }
-                }
-                else if (extension == SvgExtension)
-                {
-                    try
-                    {
-                        image = LoadSvgImage(path, loadFullImage);
-                        type = ImageType.FullImageFile;
-                    }
-                    catch (System.Exception ex)
-                    {
-                        image = Image;
-                        type = ImageType.Error;
-                        Log.Exception(ClassName, $"Failed to load SVG image from path {path}: {ex.Message}", ex);
-                    }
-                }
-                else
-                {
-                    type = ImageType.File;
-                    var size = loadFullImage ? FullIconSize : SmallIconSize;
-                    try
-                    {
-                        image = GetThumbnail(path, ThumbnailOptions.None, size);
-                    }
-                    catch (System.Exception ex)
-                    {
-                        Log.Info(ClassName, $"Failed to get shell thumbnail for {path}: {ex.Message}\nTrying ExtractAssociatedIcon fallback.");
+            if (!File.Exists(path))
+                return GetMissingThumbnailResult(ref path);
 
-                        image = ExtractAssociatedIconOrNull(path, size);
-                        if (image == null)
-                        {
-                            Log.Info(ClassName, $"ExtractAssociatedIcon returned no icon for {path}. Using missing image.");
-                            image = MissingImage;
-                            path = Constant.MissingImgIcon;
-                            type = ImageType.Error;
-                        }
-                    }
-                }
-            }
-            else
-            {
-                image = MissingImage;
-                path = Constant.MissingImgIcon;
-            }
+            var extension = Path.GetExtension(path).ToLower();
 
-            if (type != ImageType.Error)
+            if (ImageExtensions.Contains(extension))
+                return GetImageFileThumbnailResult(path, loadFullImage);
+
+            if (extension == SvgExtension)
+                return GetSvgFileThumbnailResult(path, loadFullImage);
+
+            return GetFileThumbnailResult(ref path, loadFullImage);
+        }
+
+        private static ImageResult CreateImageResult(ImageSource image, ImageType type)
+        {
+            if (type != ImageType.Error && !image.IsFrozen)
             {
                 image.Freeze();
             }
 
             return new ImageResult(image, type);
+        }
+
+        private static ImageResult GetMissingThumbnailResult(ref string path)
+        {
+            path = Constant.MissingImgIcon;
+            return CreateImageResult(MissingImage, ImageType.Error);
+        }
+
+        private static ImageResult GetDirectoryThumbnailResult(string path)
+        {
+            try
+            {
+                /* Directories can also have thumbnails instead of shell icons.
+                 * Generating thumbnails for a bunch of folder results while scrolling
+                 * could have a big impact on performance and Flow.Launcher responsibility.
+                 * - Solution: just load the icon
+                 */
+                var image = GetThumbnail(path, ThumbnailOptions.IconOnly);
+                return CreateImageResult(image, ImageType.Folder);
+            }
+            catch (System.Exception ex)
+            {
+                Log.Info(ClassName, $"Failed to get shell thumbnail for folder {path}: {ex.Message}\nUsing default folder image as fallback.");
+                return CreateImageResult(FolderImage, ImageType.Folder);
+            }
+        }
+
+        private static ImageResult GetImageFileThumbnailResult(string path, bool loadFullImage)
+        {
+            if (loadFullImage)
+            {
+                try
+                {
+                    var image = LoadBitmapImageScaleToFitWithin(path, FullImageSize);
+                    return CreateImageResult(image, ImageType.FullImageFile);
+                }
+                catch (NotSupportedException ex)
+                {
+                    Log.Exception(ClassName, $"Failed to load image file from path {path}: {ex.Message}", ex);
+                    return CreateImageResult(Image, ImageType.Error);
+                }
+            }
+
+            try
+            {
+                /* Although the documentation for GetImage on MSDN indicates that
+                 * if a thumbnail is available it will return one, this has proved to not
+                 * be the case in many situations while testing.
+                 * - Solution: explicitly pass the ThumbnailOnly flag
+                 */
+                var image = GetThumbnail(path, ThumbnailOptions.ThumbnailOnly);
+                return CreateImageResult(image, ImageType.ImageFile);
+            }
+            catch (System.Exception ex)
+            {
+                Log.Info(ClassName, $"Failed to get shell thumbnail for image file {path}: {ex.Message}\nTrying bitmap fallback.");
+
+                try
+                {
+                    var image = LoadBitmapImageScaleToFitWithin(path, SmallIconSize);
+                    return CreateImageResult(image, ImageType.ImageFile);
+                }
+                catch (System.Exception ex2)
+                {
+                    Log.Exception(ClassName, $"Failed to load image file from path {path}: {ex2.Message}", ex2);
+                    return CreateImageResult(Image, ImageType.Error);
+                }
+            }
+        }
+
+        private static ImageResult GetSvgFileThumbnailResult(string path, bool loadFullImage)
+        {
+            try
+            {
+                var image = LoadSvgImage(path, loadFullImage);
+                return CreateImageResult(image, ImageType.FullImageFile);
+            }
+            catch (System.Exception ex)
+            {
+                Log.Exception(ClassName, $"Failed to load SVG image from path {path}: {ex.Message}", ex);
+                return CreateImageResult(Image, ImageType.Error);
+            }
+        }
+
+        private static ImageResult GetFileThumbnailResult(ref string path, bool loadFullImage)
+        {
+            var size = loadFullImage ? FullIconSize : SmallIconSize;
+            try
+            {
+                var image = GetThumbnail(path, ThumbnailOptions.None, size);
+                return CreateImageResult(image, ImageType.File);
+            }
+            catch (System.Exception ex)
+            {
+                Log.Info(ClassName, $"Failed to get shell thumbnail for {path}: {ex.Message}\nTrying ExtractAssociatedIcon fallback.");
+
+                var image = ExtractAssociatedIconOrNull(path, size);
+                if (image != null)
+                    return CreateImageResult(image, ImageType.File);
+
+                Log.Info(ClassName, $"ExtractAssociatedIcon returned no icon for {path}. Using missing image.");
+                return GetMissingThumbnailResult(ref path);
+            }
         }
 
         private static BitmapSource GetThumbnail(string path, ThumbnailOptions option = ThumbnailOptions.ThumbnailOnly,

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -200,7 +200,7 @@ namespace Flow.Launcher.Infrastructure.Image
         private static ImageResult GetThumbnailResult(ref string path, bool loadFullImage = false)
         {
             if (Directory.Exists(path))
-                return GetDirectoryThumbnailResult(path);
+                return GetDirectoryThumbnailResult(ref path);
 
             if (!File.Exists(path))
                 return GetMissingThumbnailResult(ref path);
@@ -232,7 +232,7 @@ namespace Flow.Launcher.Infrastructure.Image
             return CreateImageResult(MissingImage, ImageType.Error);
         }
 
-        private static ImageResult GetDirectoryThumbnailResult(string path)
+        private static ImageResult GetDirectoryThumbnailResult(ref string path)
         {
             try
             {
@@ -247,6 +247,7 @@ namespace Flow.Launcher.Infrastructure.Image
             catch (System.Exception ex)
             {
                 Log.Info(ClassName, $"Failed to get shell thumbnail for folder {path}: {ex.Message}\nUsing default folder image as fallback.");
+                path = Constant.FolderIcon;
                 return CreateImageResult(FolderImage, ImageType.Folder);
             }
         }

--- a/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
+++ b/Flow.Launcher.Infrastructure/Image/ImageLoader.cs
@@ -35,7 +35,7 @@ namespace Flow.Launcher.Infrastructure.Image
 
         private static readonly string[] ImageExtensions = [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".ico"];
         private static readonly string SvgExtension = ".svg";
-        internal static Func<string, ThumbnailOptions, int, BitmapSource> ThumbnailLoader { get; set; } =
+        internal static Func<string, ThumbnailOptions, int, BitmapSource> ShellThumbnailLoader { get; set; } =
             (path, option, size) =>
                 WindowsThumbnailProvider.GetThumbnail(
                     path,
@@ -248,7 +248,7 @@ namespace Flow.Launcher.Infrastructure.Image
                  * could have a big impact on performance and Flow.Launcher responsibility.
                  * - Solution: just load the icon
                  */
-                var image = GetThumbnail(path, ThumbnailOptions.IconOnly, size);
+                var image = GetShellThumbnail(path, ThumbnailOptions.IconOnly, size);
                 return CreateImageResult(image, ImageType.Folder);
             }
             catch (System.Exception ex)
@@ -281,7 +281,7 @@ namespace Flow.Launcher.Infrastructure.Image
                  * be the case in many situations while testing.
                  * - Solution: explicitly pass the ThumbnailOnly flag
                  */
-                var image = GetThumbnail(path, ThumbnailOptions.ThumbnailOnly);
+                var image = GetShellThumbnail(path, ThumbnailOptions.ThumbnailOnly);
                 return CreateImageResult(image, ImageType.ImageFile);
             }
             catch (System.Exception ex)
@@ -320,7 +320,7 @@ namespace Flow.Launcher.Infrastructure.Image
             var size = loadFullImage ? FullIconSize : SmallIconSize;
             try
             {
-                var image = GetThumbnail(path, ThumbnailOptions.None, size);
+                var image = GetShellThumbnail(path, ThumbnailOptions.None, size);
                 return CreateImageResult(image, ImageType.File);
             }
             catch (System.Exception ex)
@@ -337,10 +337,10 @@ namespace Flow.Launcher.Infrastructure.Image
             }
         }
 
-        private static BitmapSource GetThumbnail(string path, ThumbnailOptions option = ThumbnailOptions.ThumbnailOnly,
+        private static BitmapSource GetShellThumbnail(string path, ThumbnailOptions option = ThumbnailOptions.ThumbnailOnly,
             int size = SmallIconSize)
         {
-            return ThumbnailLoader(path, option, size);
+            return ShellThumbnailLoader(path, option, size);
         }
 
         private static bool TryExtractAssociatedIcon(string path, int size, out BitmapSource image)

--- a/Flow.Launcher.Test/Flow.Launcher.Test.csproj
+++ b/Flow.Launcher.Test/Flow.Launcher.Test.csproj
@@ -58,4 +58,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="..\Flow.Launcher\Images\*.*" Link="Images\%(Filename)%(Extension)">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Flow.Launcher.Test/ImageLoaderTests.cs
+++ b/Flow.Launcher.Test/ImageLoaderTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Flow.Launcher.Infrastructure;
+using Flow.Launcher.Infrastructure.Image;
+using NUnit.Framework;
+
+namespace Flow.Launcher.Test
+{
+    [TestFixture]
+    [NonParallelizable]
+    public class ImageLoaderTests
+    {
+        private Func<string, ThumbnailOptions, int, BitmapSource> _originalThumbnailLoader;
+
+        private Func<string, ThumbnailOptions, int, BitmapSource> _failingThumbnailLoader =
+            (_, _, _) => throw new InvalidOperationException("Forced shell thumbnail failure");
+
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUpAsync()
+        {
+            await ImageLoader.InitializeAsync();
+
+            // Explicitly load defaults by constant keys so fallback tests do not depend on cache preload timing.
+            // This should be enough for the current test set, but future tests that depend on cache behavior may need DI/injection.
+            _ = await ImageLoader.LoadAsync(Constant.MissingImgIcon, loadFullImage: false, cacheImage: true);
+            _ = await ImageLoader.LoadAsync(Constant.FolderIcon, loadFullImage: false, cacheImage: true);
+
+            Assert.That(ImageLoader.MissingImage, Is.Not.Null, "ImageLoader initialization must load default missing image.");
+            Assert.That(ImageLoader.FolderImage, Is.Not.Null, "ImageLoader initialization must load default folder image.");
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _originalThumbnailLoader = ImageLoader.ThumbnailLoader;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            ImageLoader.ThumbnailLoader = _originalThumbnailLoader;
+        }
+
+        #region Missing Image Cases
+
+        [Test]
+        public async Task NonExistentPath_ReturnsMissingImageAsync()
+        {
+            var missingPath = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.txt");
+
+            var image = await ImageLoader.LoadAsync(missingPath, loadFullImage: false, cacheImage: false);
+
+            Assert.That(image, Is.SameAs(ImageLoader.MissingImage));
+            Assert.That(image.IsFrozen, Is.True);
+        }
+
+        [Test]
+        public async Task NonExistentFolderPath_ReturnsMissingImageAsync()
+        {
+            var missingFolderPath = Path.Combine(Path.GetTempPath(), $"missing-folder-{Guid.NewGuid():N}");
+
+            var image = await ImageLoader.LoadAsync(missingFolderPath, loadFullImage: false, cacheImage: false);
+
+            Assert.That(image, Is.SameAs(ImageLoader.MissingImage));
+            Assert.That(image.IsFrozen, Is.True);
+        }
+
+        [Test]
+        public async Task InvalidSvg_ReturnsMissingImageAsync()
+        {
+            var tempPath = Path.Combine(Path.GetTempPath(), $"image-loader-{Guid.NewGuid():N}.svg");
+            await File.WriteAllTextAsync(tempPath, "not-a-valid-image");
+
+            try
+            {
+                foreach (var loadFullImage in new[] { false, true })
+                {
+                    var image = await ImageLoader.LoadAsync(tempPath, loadFullImage, cacheImage: false);
+
+                    Assert.That(image, Is.SameAs(ImageLoader.MissingImage));
+                    Assert.That(image.IsFrozen, Is.True);
+                }
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                {
+                    File.Delete(tempPath);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Shell Thumbnail Failure Fallbacks
+
+        [Test]
+        public async Task ShellThumbnailFailure_Directory_ReturnsDefaultFolderImageAsync()
+        {
+            var tempFolder = Path.Combine(Path.GetTempPath(), $"image-loader-test-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempFolder);
+
+            try
+            {
+                ImageLoader.ThumbnailLoader = _failingThumbnailLoader;
+
+                var image = await ImageLoader.LoadAsync(tempFolder, loadFullImage: false, cacheImage: false);
+
+                Assert.That(image, Is.SameAs(ImageLoader.FolderImage));
+                Assert.That(image.IsFrozen, Is.True);
+            }
+            finally
+            {
+                if (Directory.Exists(tempFolder))
+                {
+                    Directory.Delete(tempFolder);
+                }
+            }
+        }
+
+        [Test]
+        public async Task ShellThumbnailFailure_ImageFile_ReturnsNonMissingImageAsync()
+        {
+            var defaultIconExtension = Path.GetExtension(Constant.DefaultIcon);
+            Assert.That(defaultIconExtension, Is.Not.Null.And.Not.Empty, "Default icon must have a file extension.");
+            Assert.That(string.Equals(defaultIconExtension, ".svg", StringComparison.OrdinalIgnoreCase), Is.False,
+                "This test covers the non-SVG image-file branch.");
+
+            var tempImagePath = Path.Combine(Path.GetTempPath(), $"image-loader-{Guid.NewGuid():N}{defaultIconExtension}");
+            File.Copy(Constant.DefaultIcon, tempImagePath);
+
+            try
+            {
+                ImageLoader.ThumbnailLoader = _failingThumbnailLoader;
+
+                var image = await ImageLoader.LoadAsync(tempImagePath, loadFullImage: false, cacheImage: false);
+
+                Assert.That(image, Is.Not.Null);
+                Assert.That(image, Is.Not.SameAs(ImageLoader.MissingImage));
+                Assert.That(image.IsFrozen, Is.True);
+            }
+            finally
+            {
+                if (File.Exists(tempImagePath))
+                {
+                    File.Delete(tempImagePath);
+                }
+            }
+        }
+
+        [Test]
+        public async Task ShellThumbnailFailure_Executable_ReturnsNonMissingImageAsync()
+        {
+            // Use the current process executable as a stable existing generic file input.
+            var executablePath = Environment.ProcessPath;
+            Assert.That(executablePath, Is.Not.Null.And.Not.Empty, "Current process executable path is unavailable.");
+            Assert.That(File.Exists(executablePath), Is.True, $"Current process executable path does not exist: {executablePath}");
+
+            ImageLoader.ThumbnailLoader = _failingThumbnailLoader;
+
+            var image = await ImageLoader.LoadAsync(executablePath, loadFullImage: false, cacheImage: false);
+
+            Assert.That(image, Is.Not.Null);
+            Assert.That(image, Is.Not.SameAs(ImageLoader.MissingImage));
+            Assert.That(image.IsFrozen, Is.True);
+        }
+
+        [Test]
+        public async Task ShellThumbnailFailure_TextFile_ReturnsNonMissingImageAsync()
+        {
+            var tempTextPath = Path.Combine(Path.GetTempPath(), $"image-loader-{Guid.NewGuid():N}.txt");
+            await File.WriteAllTextAsync(tempTextPath, "fallback-test");
+
+            try
+            {
+                ImageLoader.ThumbnailLoader = _failingThumbnailLoader;
+
+                var image = await ImageLoader.LoadAsync(tempTextPath, loadFullImage: false, cacheImage: false);
+
+                Assert.That(image, Is.Not.Null);
+                Assert.That(image, Is.Not.SameAs(ImageLoader.MissingImage));
+                Assert.That(image.IsFrozen, Is.True);
+            }
+            finally
+            {
+                if (File.Exists(tempTextPath))
+                {
+                    File.Delete(tempTextPath);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Flow.Launcher.Test/ImageLoaderTests.cs
+++ b/Flow.Launcher.Test/ImageLoaderTests.cs
@@ -14,9 +14,9 @@ namespace Flow.Launcher.Test
     [NonParallelizable]
     public class ImageLoaderTests
     {
-        private Func<string, ThumbnailOptions, int, BitmapSource> _originalThumbnailLoader;
+        private Func<string, ThumbnailOptions, int, BitmapSource> _originalShellThumbnailLoader;
 
-        private Func<string, ThumbnailOptions, int, BitmapSource> _failingThumbnailLoader =
+        private Func<string, ThumbnailOptions, int, BitmapSource> _failingShellThumbnailLoader =
             (_, _, _) => throw new InvalidOperationException("Forced shell thumbnail failure");
 
 
@@ -37,13 +37,13 @@ namespace Flow.Launcher.Test
         [SetUp]
         public void SetUp()
         {
-            _originalThumbnailLoader = ImageLoader.ThumbnailLoader;
+            _originalShellThumbnailLoader = ImageLoader.ShellThumbnailLoader;
         }
 
         [TearDown]
         public void TearDown()
         {
-            ImageLoader.ThumbnailLoader = _originalThumbnailLoader;
+            ImageLoader.ShellThumbnailLoader = _originalShellThumbnailLoader;
         }
 
         #region Missing Image Cases
@@ -107,7 +107,7 @@ namespace Flow.Launcher.Test
 
             try
             {
-                ImageLoader.ThumbnailLoader = _failingThumbnailLoader;
+                ImageLoader.ShellThumbnailLoader = _failingShellThumbnailLoader;
 
                 var image = await ImageLoader.LoadAsync(tempFolder, loadFullImage: false, cacheImage: false);
 
@@ -136,7 +136,7 @@ namespace Flow.Launcher.Test
 
             try
             {
-                ImageLoader.ThumbnailLoader = _failingThumbnailLoader;
+                ImageLoader.ShellThumbnailLoader = _failingShellThumbnailLoader;
 
                 var image = await ImageLoader.LoadAsync(tempImagePath, loadFullImage: false, cacheImage: false);
 
@@ -161,7 +161,7 @@ namespace Flow.Launcher.Test
             Assert.That(executablePath, Is.Not.Null.And.Not.Empty, "Current process executable path is unavailable.");
             Assert.That(File.Exists(executablePath), Is.True, $"Current process executable path does not exist: {executablePath}");
 
-            ImageLoader.ThumbnailLoader = _failingThumbnailLoader;
+            ImageLoader.ShellThumbnailLoader = _failingShellThumbnailLoader;
 
             var image = await ImageLoader.LoadAsync(executablePath, loadFullImage: false, cacheImage: false);
 
@@ -178,7 +178,7 @@ namespace Flow.Launcher.Test
 
             try
             {
-                ImageLoader.ThumbnailLoader = _failingThumbnailLoader;
+                ImageLoader.ShellThumbnailLoader = _failingShellThumbnailLoader;
 
                 var image = await ImageLoader.LoadAsync(tempTextPath, loadFullImage: false, cacheImage: false);
 


### PR DESCRIPTION
Will resolve #4450, maybe also #4403

## Summary
- Refactored GetThumbnailResult by splitting it into per-type helper methods (GetDirectoryThumbnailResult, GetImageFileThumbnailResult, GetSvgFileThumbnailResult, GetFileThumbnailResult)
- Consistently use MissingImage as the final fallback for all but folders. Removed the now-unused ImageIcon constant that was sometimes used instead.
- Added a number of fallbacks if the usual shell thumbnail method fails (e.g. on ARM as in #4450)
  - Folders fall back to the default folder icon if shell thumbnail fails
  - Image files fall back to loading the bitmap directly
  - Non-image files fall back to ExtractAssociatedIcon
- Replaced LoadFullImage with new seperate methods for loading the bitmap, scaling it, and extracting dimensions from metadata.
- Removed path mutation from GetThumbnailResult as it no longer served any useful purpose and was a confusing side effect.
- Improved logging by using Log.Warn for final fallbacks and Log.Debug for intermediate fallbacks, removing the excessive use of Log.Exception

## Testing
Added ImageLoaderTests, which you can run with `dotnet test Flow.Launcher.Test/Flow.Launcher.Test.csproj --filter ImageLoaderTests`
This simulates invalid paths and also simulates a failing shell thumbnail to test the fallbacks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves thumbnail reliability in `ImageLoader` with per-type fallbacks, no path-mutation side effects, and clearer logging. Adds a size-aware bitmap loader, an injectable `ShellThumbnailLoader`, and tests that cover key failure paths.

**Summary of changes**
- Changed:
  - Split `GetThumbnailResult` into per-type helpers; added `CreateImageResult`; freeze images; never rewrite paths in logs/cache.
  - Renamed `GetThumbnail` to `GetShellThumbnail`; introduced `ShellThumbnailLoader` delegate for injection.
  - Folders: request shell icon-only; size follows `loadFullImage`; fallback to preloaded folder image.
  - Image files: prefer shell thumbnail; fallback to scaled bitmap; full image uses size-aware loader.
  - SVG: load via existing SVG path; on error return missing image.
  - Non-image/svg files: prefer shell thumbnail; fallback to `TryExtractAssociatedIcon`.
  - Logging: `Log.Debug` for intermediate fallbacks; `Log.Warn` for final failures.
- Added:
  - `Constant.FolderIcon` and preloaded `FolderImage`.
  - `LoadBitmapImageScaleToFitWithin`, `LoadBitmapImage`, `TryGetBitmapImageDimensionsFromMetadata`.
  - `TryExtractAssociatedIcon` and injectable `ShellThumbnailLoader` for testability.
  - Unit tests in `Flow.Launcher.Test/ImageLoaderTests.cs`; `.csproj` now copies image assets for test runs.
- Removed:
  - `Constant.ImageIcon` and the `ImageLoader.Image` placeholder.
  - `LoadFullImage` and all path-mutation side effects.
- Memory:
  - Slightly lower due to metadata-first sizing, fewer full decodes, frozen images, and disposing GDI icons.
- Security:
  - No new risks; uses OS and WPF APIs without elevated permissions.
- Tests:
  - New tests cover missing-path handling and shell-thumbnail failure fallbacks for folders, image files, and generic files using `ShellThumbnailLoader` injection.

**Release Note**
Thumbnails and icons now load more reliably with smarter fallbacks, including a default folder image when needed.

<sup>Written for commit 47bfb8618438105dca352438b390b887b4e713bc. Summary will update on new commits. <a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4453?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->









