### PR TITLE
Fix default browser detection by adding support for newer registry key

### DIFF
--- a/Flow.Launcher.Plugin/SharedCommands/SearchWeb.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/SearchWeb.cs
@@ -17,8 +17,16 @@ namespace Flow.Launcher.Plugin.SharedCommands
             var name = string.Empty;
             try
             {
-                using var regDefault = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice", false);
-                var stringDefault = regDefault.GetValue("ProgId");
+                // Updating your default browser in Windows updates the following registry
+                using var regDefaultLatest = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoiceLatest\\ProgId", false);
+                var stringDefault = regDefaultLatest?.GetValue("ProgId");
+
+                if (stringDefault is null)
+                {
+                    // If the above registry key is not found, we will fallback to the older registry key which is used in Windows 10 and earlier versions of Windows 11
+                    using var regDefault = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice", false);
+                    stringDefault = regDefault.GetValue("ProgId");
+                }
 
                 using var regKey = Registry.ClassesRoot.OpenSubKey(stringDefault + "\\shell\\open\\command", false);
                 name = regKey.GetValue(null).ToString().ToLower().Replace("\"", "");


### PR DESCRIPTION
This pull request updates the logic for detecting the default web browser on Windows by adding support for newer registry keys used in recent Windows versions, while maintaining compatibility with older versions.

**Default browser detection improvements:**

* Updated `GetDefaultBrowserPath` in `SearchWeb.cs` to first check the newer `UserChoiceLatest` registry key for the default browser, falling back to the older `UserChoice` key if necessary. This ensures compatibility with both the latest and older Windows versions.*
* 
See Issue #4465 - this resolves that.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves default browser detection on Windows by first checking the newer UserChoiceLatest registry entry and falling back to the older UserChoice key. This restores correct detection on recent Windows while keeping older versions working.

- **Summary of changes**
  - Changed: `GetDefaultBrowserPath` in `SearchWeb.cs` now prefers the newer `UserChoiceLatest` registry value when resolving the default browser.
  - Added: Fallback to the older `UserChoice` registry value when the newer entry is missing or null.
  - Removed: No existing behavior removed; legacy lookup path is retained.
  - Memory impact: None meaningful; a couple of short-lived registry handles with `using` disposal.
  - Security risks: Low. Read-only access under HKCU; no elevation or writes; no expansion of execution surface.
  - Unit tests: No new unit tests included.

- **Release Note**
  Default browser detection now works reliably on newer Windows versions while staying compatible with older ones.

<sup>Written for commit 48c9d85b3b6d6dbfdfe1793d0ebce3deb4c15d65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

