### PR TITLE
Renew secure token in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,7 +81,7 @@ deploy:
       
       Please report any bugs or issues over at the [main repository](https://github.com/Flow-Launcher/Flow.Launcher/issues)'
     auth_token:
-      secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
+      secure: ZSlXMOONaB9prSh1rOaL9zlzhvGpbyeiBydJuTxYJAloaYJghhsUNaUWavHcL9hN
     artifact: Squirrel Installer, Portable Version, Squirrel nupkg, Squirrel RELEASES
     force_update: true
     on:
@@ -90,7 +90,7 @@ deploy:
   - provider: GitHub
     release: v$(flowVersion)
     auth_token:
-      secure: ij4UeXUYQBDJxn2YRAAhUOjklOGVKDB87Hn5J8tKIzj13yatoI7sLM666QDQFEgv
+      secure: ZSlXMOONaB9prSh1rOaL9zlzhvGpbyeiBydJuTxYJAloaYJghhsUNaUWavHcL9hN
     artifact: Squirrel Installer, Portable Version, Squirrel nupkg, Squirrel RELEASES
     draft: true
     force_update: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rotated the encrypted AppVeyor GitHub auth token used for release deployments to restore/maintain deploy access. No changes to build or release behavior.

**Summary of changes**
- Changed: Updated `auth_token.secure` for both AppVeyor deploy steps to the new encrypted token.
- Added: No new logic or steps.
- Removed: Old encrypted token.
- Memory usage: No impact.
- Security: Improves security via token rotation; token remains encrypted in `appveyor.yml`. No secret exposure in logs. Deploys may fail if token scopes/permissions are incorrect.
- Unit tests: Not applicable; CI config only.

**Release Note**
We refreshed our CI release credentials so automated publishing works as expected.

<sup>Written for commit 18bfb0eb74a58de3172159da7fabc7de59dcf44d. Summary will update on new commits. <a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4488?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

