### PR TITLE
Add official channels section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Dedicated to making your workflow more seamless. Search everything from applicat
 
 <img src="https://user-images.githubusercontent.com/6903107/144858082-8b654daf-60fb-4ee6-89b2-6183b73510d1.png" width="100%">
 
-<h4 align="center">
+<h4 align="center">  
+  <a href="#-official-channels">Official Channels</a> •
   <a href="#-getting-started">Getting Started</a> •
   <a href="#-features">Features</a> •
   <a href="#-plugins">Plugins</a> •
@@ -35,6 +36,19 @@ Dedicated to making your workflow more seamless. Search everything from applicat
   <a href="#development">Development</a> •
   <a href="https://flowlauncher.com/docs">Docs</a>
 </h4>
+
+<img src="https://user-images.githubusercontent.com/6903107/144858082-8b654daf-60fb-4ee6-89b2-6183b73510d1.png" width="100%">
+
+## 📣 Official Channels
+
+- Website: [https://flowlauncher.com](https://flowlauncher.com)
+- GitHub Organization: [https://github.com/Flow-Launcher](https://github.com/Flow-Launcher)
+- Discord: [https://discord.gg/AvgAQgh](https://discord.gg/AvgAQgh)
+- Reddit: [https://www.reddit.com/r/FlowLauncher/](https://www.reddit.com/r/FlowLauncher/)
+
+⚠️ Only trust official channels for downloads and announcements, and be careful of similar-looking domains.
+
+For installation, use the official methods listed below.
 
 <img src="https://user-images.githubusercontent.com/6903107/144858082-8b654daf-60fb-4ee6-89b2-6183b73510d1.png" width="100%">
 


### PR DESCRIPTION
In light of discussions regarding flow-launcher.com

Adds a list of official channels and a warning to be careful of similar looking domains and only use official installation methods

<img width="2078" height="582" alt="image" src="https://github.com/user-attachments/assets/e95ac06a-3e00-434b-b355-faaadf41b9a9" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an “Official Channels” section to the README with trusted links (website, GitHub, Discord, Reddit) and a warning about lookalike domains. Also adds a TOC link to the new section. No code changes.

**Summary of changes**
- Changed: Updated the README’s link bar to include “Official Channels.”
- Added: New “Official Channels” section with links to the website, GitHub org, Discord, and Reddit, plus a warning to use only official install methods.
- Removed: Nothing.
- Memory usage: No impact; documentation-only change.
- Security: Lowers phishing risk by directing users to verified channels; no new risks introduced.
- Unit tests: None required; documentation-only change.

**Release Note**
Added a new “Official Channels” section in the README with trusted links so users can find authentic downloads and announcements.

<sup>Written for commit 3c09e767522af55b4e69757e5e82e69bdc2f626a. Summary will update on new commits. <a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4489?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

