### PR TITLE
Refactor InitProgressbarAnimation & avoid style cast issue 

### DIFF
--- a/Flow.Launcher/MainWindow.xaml
+++ b/Flow.Launcher/MainWindow.xaml
@@ -337,6 +337,7 @@
                 </Border>
                 <Line
                     x:Name="ProgressBar"
+                    Style="{DynamicResource PendingLineStyle}"
                     Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Grid}}, Path=ActualWidth}"
                     Height="2"
                     Margin="12 0 12 0"

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -1126,8 +1126,18 @@ namespace Flow.Launcher
             var animationDuration = new Duration(TimeSpan.FromMilliseconds(1600));
             var progressBarLength = ProgressBar.X2 - ProgressBar.X1;
 
-            var lineEndAnimation = new DoubleAnimation(ProgressBar.X2, ActualWidth + progressBarLength, animationDuration);
-            var lineStartAnimation = new DoubleAnimation(ProgressBar.X1, ActualWidth, animationDuration);
+            var lineEndAnimation = new DoubleAnimation
+            {
+                From = ProgressBar.X2,
+                To = ActualWidth + progressBarLength,
+                Duration = animationDuration
+            };
+            var lineStartAnimation = new DoubleAnimation
+            {
+                From = ProgressBar.X1,
+                To = ActualWidth,
+                Duration = animationDuration
+            };
             
             Storyboard.SetTarget(lineEndAnimation, ProgressBar);
             Storyboard.SetTargetProperty(lineEndAnimation, new PropertyPath("(Line.X2)"));

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -1124,7 +1124,7 @@ namespace Flow.Launcher
             _progressBarStoryboard = new Storyboard();
 
             var animationDuration = new Duration(TimeSpan.FromMilliseconds(1600));
-            var progressBarLength = 100;
+            var progressBarLength = ProgressBar.X2 - ProgressBar.X1;
 
             var lineEndAnimation = new DoubleAnimation(ProgressBar.X2, ActualWidth + progressBarLength, animationDuration);
             var lineStartAnimation = new DoubleAnimation(ProgressBar.X1, ActualWidth, animationDuration);

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -1129,13 +1129,13 @@ namespace Flow.Launcher
             var lineEndAnimation = new DoubleAnimation
             {
                 From = ProgressBar.X2,
-                To = ActualWidth + progressBarLength,
+                To = ProgressBar.ActualWidth + progressBarLength,
                 Duration = animationDuration
             };
             var lineStartAnimation = new DoubleAnimation
             {
                 From = ProgressBar.X1,
-                To = ActualWidth,
+                To = ProgressBar.ActualWidth,
                 Duration = animationDuration
             };
             

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -1142,7 +1142,6 @@ namespace Flow.Launcher
             lineEndAnimation.Freeze();
             lineStartAnimation.Freeze();
 
-            ProgressBar.SetResourceReference(StyleProperty, "PendingLineStyle");
             ProgressBar.IsVisibleChanged -= ProgressBar_IsVisibleChanged;
             ProgressBar.IsVisibleChanged += ProgressBar_IsVisibleChanged;
 

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -1123,20 +1123,24 @@ namespace Flow.Launcher
         {
             _progressBarStoryboard = new Storyboard();
 
-            var da = new DoubleAnimation(ProgressBar.X2, ActualWidth + 100,
-                new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
-            var da1 = new DoubleAnimation(ProgressBar.X1, ActualWidth + 0,
-                new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
-            Storyboard.SetTarget(da, ProgressBar);
-            Storyboard.SetTargetProperty(da, new PropertyPath("(Line.X2)"));
-            Storyboard.SetTarget(da1, ProgressBar);
-            Storyboard.SetTargetProperty(da1, new PropertyPath("(Line.X1)"));
-            _progressBarStoryboard.Children.Add(da);
-            _progressBarStoryboard.Children.Add(da1);
+            var animationDuration = new Duration(TimeSpan.FromMilliseconds(1600));
+            var progressBarLength = 100;
+
+            var lineEndAnimation = new DoubleAnimation(ProgressBar.X2, ActualWidth + progressBarLength, animationDuration);
+            var lineStartAnimation = new DoubleAnimation(ProgressBar.X1, ActualWidth, animationDuration);
+            
+            Storyboard.SetTarget(lineEndAnimation, ProgressBar);
+            Storyboard.SetTargetProperty(lineEndAnimation, new PropertyPath("(Line.X2)"));
+            
+            Storyboard.SetTarget(lineStartAnimation, ProgressBar);
+            Storyboard.SetTargetProperty(lineStartAnimation, new PropertyPath("(Line.X1)"));
+            
+            _progressBarStoryboard.Children.Add(lineEndAnimation);
+            _progressBarStoryboard.Children.Add(lineStartAnimation);
             _progressBarStoryboard.RepeatBehavior = RepeatBehavior.Forever;
 
-            da.Freeze();
-            da1.Freeze();
+            lineEndAnimation.Freeze();
+            lineStartAnimation.Freeze();
 
             ProgressBar.SetResourceReference(StyleProperty, "PendingLineStyle");
             ProgressBar.IsVisibleChanged -= ProgressBar_IsVisibleChanged;

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -1165,7 +1165,7 @@ namespace Flow.Launcher
                 return;
             }
 
-            if (ProgressBar.Visibility == Visibility.Visible)
+            if (ProgressBar.IsVisible)
             {
                 _progressBarStoryboard.Begin(ProgressBar, true);
             }

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -1127,7 +1127,9 @@ namespace Flow.Launcher
                 new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
             var da1 = new DoubleAnimation(ProgressBar.X1, ActualWidth + 0,
                 new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
+            Storyboard.SetTarget(da, ProgressBar);
             Storyboard.SetTargetProperty(da, new PropertyPath("(Line.X2)"));
+            Storyboard.SetTarget(da1, ProgressBar);
             Storyboard.SetTargetProperty(da1, new PropertyPath("(Line.X1)"));
             _progressBarStoryboard.Children.Add(da);
             _progressBarStoryboard.Children.Add(da1);

--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -75,6 +75,7 @@ namespace Flow.Launcher
         // Window Animation
         private const double DefaultRightMargin = 66; //* this value from base.xaml
         private bool _isClockPanelAnimating = false;
+        private Storyboard _progressBarStoryboard;
 
         // IDisposable
         private bool _disposed = false;
@@ -1120,7 +1121,7 @@ namespace Flow.Launcher
 
         private void InitProgressbarAnimation()
         {
-            var progressBarStoryBoard = new Storyboard();
+            _progressBarStoryboard = new Storyboard();
 
             var da = new DoubleAnimation(ProgressBar.X2, ActualWidth + 100,
                 new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
@@ -1128,41 +1129,35 @@ namespace Flow.Launcher
                 new Duration(new TimeSpan(0, 0, 0, 0, 1600)));
             Storyboard.SetTargetProperty(da, new PropertyPath("(Line.X2)"));
             Storyboard.SetTargetProperty(da1, new PropertyPath("(Line.X1)"));
-            progressBarStoryBoard.Children.Add(da);
-            progressBarStoryBoard.Children.Add(da1);
-            progressBarStoryBoard.RepeatBehavior = RepeatBehavior.Forever;
+            _progressBarStoryboard.Children.Add(da);
+            _progressBarStoryboard.Children.Add(da1);
+            _progressBarStoryboard.RepeatBehavior = RepeatBehavior.Forever;
 
             da.Freeze();
             da1.Freeze();
 
-            const string progressBarAnimationName = "ProgressBarAnimation";
-            var beginStoryboard = new BeginStoryboard
-            {
-                Name = progressBarAnimationName, Storyboard = progressBarStoryBoard
-            };
-
-            var stopStoryboard = new StopStoryboard()
-            {
-                BeginStoryboardName = progressBarAnimationName
-            };
-
-            var trigger = new Trigger
-            {
-                Property = VisibilityProperty, Value = Visibility.Visible
-            };
-            trigger.EnterActions.Add(beginStoryboard);
-            trigger.ExitActions.Add(stopStoryboard);
-
-            var progressStyle = new Style(typeof(Line))
-            {
-                BasedOn = FindResource("PendingLineStyle") as Style
-            };
-            progressStyle.RegisterName(progressBarAnimationName, beginStoryboard);
-            progressStyle.Triggers.Add(trigger);
-
-            ProgressBar.Style = progressStyle;
+            ProgressBar.SetResourceReference(StyleProperty, "PendingLineStyle");
+            ProgressBar.IsVisibleChanged -= ProgressBar_IsVisibleChanged;
+            ProgressBar.IsVisibleChanged += ProgressBar_IsVisibleChanged;
 
             _viewModel.ProgressBarVisibility = Visibility.Hidden;
+        }
+
+        private void ProgressBar_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (_progressBarStoryboard == null)
+            {
+                return;
+            }
+
+            if (ProgressBar.Visibility == Visibility.Visible)
+            {
+                _progressBarStoryboard.Begin(ProgressBar, true);
+            }
+            else
+            {
+                _progressBarStoryboard.Stop(ProgressBar);
+            }
         }
 
         private void WindowAnimation()


### PR DESCRIPTION
Should close #4348

## Bug Fix
Avoids the creation of a new style based on PendingLineStyle as there seems to be a WPF bug in handling cloning of styles containing SystemAccentColors - seemingly the trigger for #4348 and other related issues.
That new style was created to add a trigger to play an animation if the progress bar is visible, so instead I moved that to an event handler.

## Refactor
- Generally improved the maintainability and readability of the method by being more explicit and using named variables where possible.
- The length of the progress bar is now calculated based on the existing rect values in the xaml instead of a hardcoded value matching them.
- While effectively the same right now, used the progress bar's actual width instead of the windows for the distance it needs to travel, more explicit and will work better if we want to change that.
- Only start the animation if the progress bar is actually visible on the screen, instead of just when its visibility is set

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the progress bar animation to start/stop based on true visibility and moves style usage to XAML to avoid the style/brush cloning cast issue. Fixes the progress bar styling problem (see #4348) and simplifies the animation logic.

**Summary of changes**
- Changed: Build a single `_progressBarStoryboard` with explicit targets; use `ProgressBar.ActualWidth` and dynamic length; keep animations `Freeze()`d; set `PendingLineStyle` in XAML via `DynamicResource`; use `ProgressBar.IsVisible` instead of `Visibility`.
- Added: `IsVisibleChanged` handler to begin/stop the storyboard only when the bar is truly visible.
- Removed: On-the-fly `Style` creation with visibility `Trigger`, `BeginStoryboard`/`StopStoryboard`, and storyboard name registration.
- Memory impact: Lower allocations by avoiding per-instance style cloning; one storyboard field retained; frozen animations.
- Security risks: None.
- Unit tests: No new tests (UI animation change).

**Release Note**
The progress bar animates more reliably and displays correctly, fixing a visual glitch.

<sup>Written for commit 238162a365afc2add330c1d214aff95d79b8f3cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

