### PR TITLE
Fix canceled Program queries caching empty results

### DIFF
--- a/Flow.Launcher.Test/Plugins/ProgramPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/ProgramPluginTest.cs
@@ -15,6 +15,10 @@ using UwpApp = Flow.Launcher.Plugin.Program.Programs.UWPApp;
 
 namespace Flow.Launcher.Test.Plugins
 {
+    // TODO: Program.Main relies on static state (cache, locks, program lists, settings),
+    // making it unsafe for parallel test execution and forcing these reflection workarounds. 
+    // There's no better option right now,
+    // but this should be replaced once dependency injection is added.
     [TestFixture]
     public class ProgramPluginTest
     {

--- a/Flow.Launcher.Test/Plugins/ProgramPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/ProgramPluginTest.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Flow.Launcher.Plugin;
+using Flow.Launcher.Plugin.SharedModels;
+using Moq;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using ProgramMain = Flow.Launcher.Plugin.Program.Main;
+using ProgramSettings = Flow.Launcher.Plugin.Program.Settings;
+using ProgramWin32 = Flow.Launcher.Plugin.Program.Programs.Win32;
+using UwpApp = Flow.Launcher.Plugin.Program.Programs.UWPApp;
+
+namespace Flow.Launcher.Test.Plugins
+{
+    [TestFixture]
+    public class ProgramPluginTest
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            ResetProgramCache();
+            SetStaticProperty("_settings", new ProgramSettings());
+            SetStaticProperty("_win32s", new List<ProgramWin32>());
+            SetStaticProperty("_uwps", new List<UwpApp>());
+            SetStaticField("_win32sLock", new SemaphoreSlim(1, 1));
+            SetStaticField("_uwpsLock", new SemaphoreSlim(1, 1));
+            SetStaticProperty("Context", null);
+        }
+
+        [Test]
+        public async Task QueryAsync_DoesNotCacheCanceledResultsAsync()
+        {
+            using var cancellation = new CancellationTokenSource();
+            var searchStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            SetStaticField("_win32sLock", new SemaphoreSlim(1, 1));
+            SetStaticField("_uwpsLock", new SemaphoreSlim(1, 1));
+            SetStaticProperty("_settings", new ProgramSettings());
+            SetStaticProperty("_win32s", new List<ProgramWin32>
+            {
+                new()
+                {
+                    Name = "Visual Studio Code",
+                    Description = string.Empty,
+                    FullPath = @"C:\Users\Test\AppData\Local\Programs\Microsoft VS Code\Code.exe",
+                    IcoPath = @"C:\Users\Test\AppData\Local\Programs\Microsoft VS Code\Code.exe",
+                    ParentDirectory = @"C:\Users\Test\AppData\Local\Programs\Microsoft VS Code",
+                    UniqueIdentifier = @"C:\Users\Test\AppData\Local\Programs\Microsoft VS Code\Code.exe",
+                    Valid = true,
+                    Enabled = true
+                }
+            });
+            SetStaticProperty("_uwps", new List<UwpApp>());
+            SetStaticProperty("Context", new PluginInitContext { API = CreateApi(cancellation, searchStarted).Object });
+            ResetProgramCache();
+
+            var plugin = new ProgramMain();
+            var query = new Query
+            {
+                Search = "vsc",
+                SearchTerms = ["vsc"],
+                TrimmedQuery = "vsc",
+                ActionKeyword = string.Empty
+            };
+
+            var canceledQuery = plugin.QueryAsync(query, cancellation.Token);
+            await searchStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await cancellation.CancelAsync();
+
+            var canceledResults = await canceledQuery;
+            ClassicAssert.AreEqual(0, canceledResults.Count);
+
+            var results = await plugin.QueryAsync(query, CancellationToken.None);
+
+            ClassicAssert.AreEqual(1, results.Count);
+            ClassicAssert.AreEqual("Visual Studio Code", results[0].Title);
+        }
+
+        private static Mock<IPublicAPI> CreateApi(CancellationTokenSource cancellation, TaskCompletionSource<bool> searchStarted)
+        {
+            var callCount = 0;
+            var api = new Mock<IPublicAPI>();
+            api.Setup(x => x.FuzzySearch("vsc", "Visual Studio Code"))
+                .Returns(() =>
+                {
+                    if (Interlocked.Increment(ref callCount) == 1)
+                    {
+                        searchStarted.SetResult(true);
+                        if (!SpinWait.SpinUntil(() => cancellation.IsCancellationRequested, TimeSpan.FromSeconds(5)))
+                            throw new AssertionException("Timed out waiting for query cancellation.");
+
+                        throw new OperationCanceledException(cancellation.Token);
+                    }
+
+                    return new MatchResult(true, SearchPrecisionScore.None, [0, 1, 2], 100);
+                });
+            return api;
+        }
+
+        private static void SetStaticProperty(string name, object value)
+        {
+            var property = typeof(ProgramMain).GetProperty(name, BindingFlags.NonPublic | BindingFlags.Static);
+            if (property == null)
+                Assert.Fail($"Could not find static property '{name}' on Program plugin Main.");
+
+            property.SetValue(null, value);
+        }
+
+        private static void SetStaticField(string name, object value)
+        {
+            var field = typeof(ProgramMain).GetField(name, BindingFlags.NonPublic | BindingFlags.Static);
+            if (field == null)
+                Assert.Fail($"Could not find static field '{name}' on Program plugin Main.");
+
+            field.SetValue(null, value);
+        }
+
+        private static void ResetProgramCache()
+        {
+            var method = typeof(ProgramMain).GetMethod("ResetCache", BindingFlags.NonPublic | BindingFlags.Static);
+            if (method == null)
+                Assert.Fail("Could not find static method 'ResetCache' on Program plugin Main.");
+
+            method.Invoke(null, null);
+        }
+    }
+}

--- a/Plugins/Flow.Launcher.Plugin.Program/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Main.cs
@@ -80,51 +80,43 @@ namespace Flow.Launcher.Plugin.Program
 
         public async Task<List<Result>> QueryAsync(Query query, CancellationToken token)
         {
-            var result = await cache.GetOrCreateAsync(query.Search, async entry =>
+            try
             {
-                var resultList = await Task.Run(async () =>
+                var result = await cache.GetOrCreateAsync(query.Search, async entry =>
                 {
-                    // Preparing win32 programs
-                    List<Win32> win32s;
-                    bool win32LockAcquired = false;
-                    try
+                    var resultList = await Task.Run(async () =>
                     {
-                        await _win32sLock.WaitAsync(token);
-                        win32LockAcquired = true;
-                        win32s = [.. _win32s];
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        return emptyResults;
-                    }
-                    finally
-                    {
-                        // Only release the lock if it was acquired
-                        if (win32LockAcquired) _win32sLock.Release();
-                    }
+                        // Preparing win32 programs
+                        List<Win32> win32s;
+                        bool win32LockAcquired = false;
+                        try
+                        {
+                            await _win32sLock.WaitAsync(token);
+                            win32LockAcquired = true;
+                            win32s = [.. _win32s];
+                        }
+                        finally
+                        {
+                            // Only release the lock if it was acquired
+                            if (win32LockAcquired) _win32sLock.Release();
+                        }
 
-                    // Preparing UWP programs
-                    List<UWPApp> uwps;
-                    bool uwpsLockAcquired = false;
-                    try
-                    {
-                        await _uwpsLock.WaitAsync(token);
-                        uwpsLockAcquired = true;
-                        uwps = [.. _uwps];
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        return emptyResults;
-                    }
-                    finally
-                    {
-                        // Only release the lock if it was acquired
-                        if (uwpsLockAcquired) _uwpsLock.Release();
-                    }
+                        // Preparing UWP programs
+                        List<UWPApp> uwps;
+                        bool uwpsLockAcquired = false;
+                        try
+                        {
+                            await _uwpsLock.WaitAsync(token);
+                            uwpsLockAcquired = true;
+                            uwps = [.. _uwps];
+                        }
+                        finally
+                        {
+                            // Only release the lock if it was acquired
+                            if (uwpsLockAcquired) _uwpsLock.Release();
+                        }
 
-                    // Start querying programs
-                    try
-                    {
+                        // Start querying programs
                         // Collect all UWP Windows app directories
                         var uwpsDirectories = _settings.HideDuplicatedWindowsApp ? _uwps
                             .Where(uwp => !string.IsNullOrEmpty(uwp.Location)) // Exclude invalid paths
@@ -143,22 +135,22 @@ namespace Flow.Launcher.Plugin.Program
                             .Select(p => p.Result(query.Search, Context.API))
                             .Where(r => string.IsNullOrEmpty(query.Search) || r?.Score > 0)
                             .ToList();
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        return emptyResults;
-                    }
-                }, token);
+                    }, token);
 
-                resultList = resultList.Count != 0 ? resultList : emptyResults;
+                    resultList = resultList.Count != 0 ? resultList : emptyResults;
 
-                entry.SetSize(resultList.Count);
-                entry.SetSlidingExpiration(TimeSpan.FromHours(8));
+                    entry.SetSize(resultList.Count);
+                    entry.SetSlidingExpiration(TimeSpan.FromHours(8));
 
-                return resultList;
-            });
+                    return resultList;
+                });
 
-            return result;
+                return result;
+            }
+            catch (OperationCanceledException)
+            {
+                return emptyResults;
+            }
         }
 
         private bool HideUninstallersFilter(IProgram program)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops caching empty results when Program queries are canceled, ensuring follow-up searches show the right apps. Adds a unit test and simplifies cancellation/lock handling.

- **Summary of changes**
  - Changed: Centralized cancellation handling in `QueryAsync`; wraps `cache.GetOrCreateAsync(...)` in a try/catch so canceled queries return `emptyResults` and do not create cache entries. Simplified `_win32sLock` and `_uwpsLock` release with `try/finally`.
  - Added: Top-level `OperationCanceledException` catch that returns `emptyResults` without caching.
  - Removed: Inner `OperationCanceledException` catches during Win32/UWP preparation and scoring.
  - Memory: Avoids storing empty lists in the cache; small memory reduction.
  - Security: No impact or new risks.
  - Tests: Added `ProgramPluginTest.QueryAsync_DoesNotCacheCanceledResultsAsync`. Includes a TODO noting tests rely on static state/reflection until DI is introduced.

- **Release Note**
  Canceled searches no longer cache empty results, so future searches show the correct apps.

<sup>Written for commit bce09b0cad61f2bb3ac891e92bbebf75c9405660. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

