### PR TITLE
Expand DevTools adding test windows

### DIFF
--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -487,6 +487,8 @@
     <system:String x:Key="userdatapathToolTip">User settings and installed plugins are saved in the user data folder. This location may vary depending on whether it's in portable mode or not.</system:String>
     <system:String x:Key="userdatapathButton">Open Folder</system:String>
     <system:String x:Key="openFolderButton">Open Folder</system:String>
+    <system:String x:Key="devtoolsReportWindow">Report Window</system:String>
+    <system:String x:Key="devtoolsOpenTestWindow">Open Test Window</system:String>
     <system:String x:Key="advanced">Advanced</system:String>
     <system:String x:Key="logLevel">Log Level</system:String>
     <system:String x:Key="LogLevelNONE">Silent</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -490,6 +490,7 @@
     <system:String x:Key="devtoolsReportWindow">Report Window</system:String>
     <system:String x:Key="devtoolsProgressWindow">Progress Window</system:String>
     <system:String x:Key="devtoolsPluginUpdateWindow">Plugin Update Window</system:String>
+    <system:String x:Key="devtoolsMessageBoxWindow">Message Box Window</system:String>
     <system:String x:Key="devtoolsOpenTestWindow">Open Test Window</system:String>
     <system:String x:Key="advanced">Advanced</system:String>
     <system:String x:Key="logLevel">Log Level</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -486,6 +486,7 @@
     <system:String x:Key="userdatapath">User Data Location</system:String>
     <system:String x:Key="userdatapathToolTip">User settings and installed plugins are saved in the user data folder. This location may vary depending on whether it's in portable mode or not.</system:String>
     <system:String x:Key="userdatapathButton">Open Folder</system:String>
+    <system:String x:Key="openFolderButton">Open Folder</system:String>
     <system:String x:Key="advanced">Advanced</system:String>
     <system:String x:Key="logLevel">Log Level</system:String>
     <system:String x:Key="LogLevelNONE">Silent</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -483,6 +483,7 @@
     <system:String x:Key="clearcachefolderMessage">Are you sure you want to delete all caches?</system:String>
     <system:String x:Key="clearfolderfailMessage">Failed to clear part of folders and files. Please see log file for more information</system:String>
     <system:String x:Key="welcomewindow">Wizard</system:String>
+    <system:String x:Key="openWelcomeWindow">Open Welcome Window</system:String>
     <system:String x:Key="userdatapath">User Data Location</system:String>
     <system:String x:Key="userdatapathToolTip">User settings and installed plugins are saved in the user data folder. This location may vary depending on whether it's in portable mode or not.</system:String>
     <system:String x:Key="userdatapathButton">Open Folder</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -488,6 +488,7 @@
     <system:String x:Key="userdatapathButton">Open Folder</system:String>
     <system:String x:Key="openFolderButton">Open Folder</system:String>
     <system:String x:Key="devtoolsReportWindow">Report Window</system:String>
+    <system:String x:Key="devtoolsProgressWindow">Progress Window</system:String>
     <system:String x:Key="devtoolsOpenTestWindow">Open Test Window</system:String>
     <system:String x:Key="advanced">Advanced</system:String>
     <system:String x:Key="logLevel">Log Level</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -491,6 +491,11 @@
     <system:String x:Key="devtoolsProgressWindow">Progress Window</system:String>
     <system:String x:Key="devtoolsPluginUpdateWindow">Plugin Update Window</system:String>
     <system:String x:Key="devtoolsMessageBoxWindow">Message Box Window</system:String>
+    <system:String x:Key="devtoolsMessageBoxOkLabel">OK</system:String>
+    <system:String x:Key="devtoolsMessageBoxOkCancelLabel">OK / Cancel</system:String>
+    <system:String x:Key="devtoolsMessageBoxYesNoLabel">Yes / No</system:String>
+    <system:String x:Key="devtoolsMessageBoxYesNoCancelLabel">Yes / No / Cancel</system:String>
+    <system:String x:Key="devtoolsMessageBoxTestMessage">This is a test message box.</system:String>
     <system:String x:Key="devtoolsOpenTestWindow">Open Test Window</system:String>
     <system:String x:Key="advanced">Advanced</system:String>
     <system:String x:Key="logLevel">Log Level</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -489,6 +489,7 @@
     <system:String x:Key="openFolderButton">Open Folder</system:String>
     <system:String x:Key="devtoolsReportWindow">Report Window</system:String>
     <system:String x:Key="devtoolsProgressWindow">Progress Window</system:String>
+    <system:String x:Key="devtoolsPluginUpdateWindow">Plugin Update Window</system:String>
     <system:String x:Key="devtoolsOpenTestWindow">Open Test Window</system:String>
     <system:String x:Key="advanced">Advanced</system:String>
     <system:String x:Key="logLevel">Log Level</system:String>

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -490,6 +490,7 @@
     <system:String x:Key="devtoolsReportWindow">Report Window</system:String>
     <system:String x:Key="devtoolsProgressWindow">Progress Window</system:String>
     <system:String x:Key="devtoolsPluginUpdateWindow">Plugin Update Window</system:String>
+    <system:String x:Key="devtoolsMessageBoxWindow">Message Window</system:String>
     <system:String x:Key="devtoolsOpenTestWindow">Open Test Window</system:String>
     <system:String x:Key="advanced">Advanced</system:String>
     <system:String x:Key="logLevel">Log Level</system:String>

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -93,6 +93,15 @@ public partial class SettingsPaneAboutViewModel : BaseModel
     }
 
     [RelayCommand]
+    private void OpenTestReportWindow()
+    {
+        var reportWindow = new ReportWindow(
+            new Exception("Dev Tools test exception")
+        );
+        reportWindow.Show();
+    }
+
+    [RelayCommand]
     private void AskClearLogFolderConfirmation()
     {
         var confirmResult = App.API.ShowMsgBox(

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using CommunityToolkit.Mvvm.Input;
 using Flow.Launcher.Core;
+using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.UserSettings;
@@ -132,6 +133,13 @@ public partial class SettingsPaneAboutViewModel : BaseModel
                 }
             },
             cancellationTokenSource.Cancel);
+    }
+
+    [RelayCommand]
+    private void OpenTestPluginUpdateWindow()
+    {
+        var window = new PluginUpdateWindow(new List<PluginUpdateInfo>());
+        window.ShowDialog();
     }
 
     [RelayCommand]

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using CommunityToolkit.Mvvm.Input;
@@ -99,6 +100,38 @@ public partial class SettingsPaneAboutViewModel : BaseModel
             new Exception("Dev Tools test exception")
         );
         reportWindow.Show();
+    }
+
+    [RelayCommand]
+    private async Task OpenTestProgressWindowAsync()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await ProgressBoxEx.ShowAsync(
+            Localize.devtoolsProgressWindow(),
+            async reportProgress =>
+            {
+                if (reportProgress == null)
+                    return;
+
+                var duration = TimeSpan.FromMinutes(1);
+                var updateInterval = TimeSpan.FromSeconds(0.5);
+                var totalSteps = (int)(duration.Ticks / updateInterval.Ticks);
+
+                try
+                {
+                    for (var currentStep = 1; currentStep <= totalSteps; currentStep++)
+                    {
+                        await Task.Delay(updateInterval, cancellationTokenSource.Token).ConfigureAwait(false);
+                        reportProgress((double)currentStep / totalSteps * 100);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Progress window cancel action triggers this path.
+                }
+            },
+            cancellationTokenSource.Cancel);
     }
 
     [RelayCommand]

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -143,9 +143,43 @@ public partial class SettingsPaneAboutViewModel : BaseModel
     }
 
     [RelayCommand]
-    private void OpenTestMessageBoxWindow()
+    private void OpenTestMessageBox(string buttonType)
     {
-        MessageBoxEx.Show("Dev Tools test message", "Dev Tools Test", MessageBoxButton.OKCancel, MessageBoxImage.Information);
+        MessageBoxButton button;
+        string caption;
+        MessageBoxImage icon;
+
+        switch (buttonType)
+        {
+            case "OK":
+                button = MessageBoxButton.OK;
+                caption = Localize.devtoolsMessageBoxOkLabel();
+                icon = MessageBoxImage.Information;
+                break;
+            case "OKCancel":
+                button = MessageBoxButton.OKCancel;
+                caption = Localize.devtoolsMessageBoxOkCancelLabel();
+                icon = MessageBoxImage.Question;
+                break;
+            case "YesNo":
+                button = MessageBoxButton.YesNo;
+                caption = Localize.devtoolsMessageBoxYesNoLabel();
+                icon = MessageBoxImage.Question;
+                break;
+            case "YesNoCancel":
+                button = MessageBoxButton.YesNoCancel;
+                caption = Localize.devtoolsMessageBoxYesNoCancelLabel();
+                icon = MessageBoxImage.Question;
+                break;
+            default:
+                var ex = new ArgumentException($"Invalid button type: {buttonType}", nameof(buttonType));
+                App.API.LogException(ClassName, "Invalid button type passed for Test MessageBox", ex);
+                App.API.ShowMsg($"Invalid button type: {buttonType}");
+                return;
+        }
+
+        var result = MessageBoxEx.Show(Localize.devtoolsMessageBoxTestMessage(), caption, button, icon);
+        App.API.ShowMsg($"{buttonType} result: {result}");
     }
 
     [RelayCommand]

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -143,6 +143,12 @@ public partial class SettingsPaneAboutViewModel : BaseModel
     }
 
     [RelayCommand]
+    private void OpenTestMessageBoxWindow()
+    {
+        MessageBoxEx.Show("Dev Tools test message", "Dev Tools Test", MessageBoxButton.OKCancel, MessageBoxImage.Information);
+    }
+
+    [RelayCommand]
     private void AskClearLogFolderConfirmation()
     {
         var confirmResult = App.API.ShowMsgBox(

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using CommunityToolkit.Mvvm.Input;
 using Flow.Launcher.Core;
+using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.UserSettings;
@@ -129,6 +130,13 @@ public partial class SettingsPaneAboutViewModel : BaseModel
                 }
             },
             cancellationTokenSource.Cancel);
+    }
+
+    [RelayCommand]
+    private void OpenTestPluginUpdateWindow()
+    {
+        var window = new PluginUpdateWindow(new List<PluginUpdateInfo>());
+        window.ShowDialog();
     }
 
     [RelayCommand]

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using CommunityToolkit.Mvvm.Input;
@@ -99,6 +100,35 @@ public partial class SettingsPaneAboutViewModel : BaseModel
             new Exception("Dev Tools test exception")
         );
         reportWindow.Show();
+    }
+
+    [RelayCommand]
+    private async Task OpenTestProgressWindowAsync()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await ProgressBoxEx.ShowAsync(
+            Localize.devtoolsProgressWindow(),
+            async reportProgress =>
+            {
+                var duration = TimeSpan.FromMinutes(1);
+                var updateInterval = TimeSpan.FromSeconds(0.5);
+                var totalSteps = (int)(duration.Ticks / updateInterval.Ticks);
+
+                try
+                {
+                    for (var currentStep = 1; currentStep <= totalSteps; currentStep++)
+                    {
+                        await Task.Delay(updateInterval, cancellationTokenSource.Token).ConfigureAwait(false);
+                        reportProgress((double)currentStep / totalSteps * 100);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Progress window cancel action triggers this path.
+                }
+            },
+            cancellationTokenSource.Cancel);
     }
 
     [RelayCommand]

--- a/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
+++ b/Flow.Launcher/SettingPages/ViewModels/SettingsPaneAboutViewModel.cs
@@ -140,6 +140,12 @@ public partial class SettingsPaneAboutViewModel : BaseModel
     }
 
     [RelayCommand]
+    private void OpenTestMessageBoxWindow()
+    {
+        MessageBoxEx.Show("Dev Tools test message", "Dev Tools Test", MessageBoxButton.OKCancel, MessageBoxImage.Information);
+    }
+
+    [RelayCommand]
     private void AskClearLogFolderConfirmation()
     {
         var confirmResult = App.API.ShowMsgBox(

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -138,7 +138,7 @@
                         <ui:SettingsCard.HeaderIcon>
                             <ui:FontIcon Glyph="&#xe939;" />
                         </ui:SettingsCard.HeaderIcon>
-                        <Button Command="{Binding OpenWelcomeWindowCommand}" Content="{DynamicResource welcomewindow}" />
+                        <Button Command="{Binding OpenWelcomeWindowCommand}" Content="{DynamicResource openWelcomeWindow}" />
                     </ui:SettingsCard>
 
                     <ui:SettingsCard Header="{DynamicResource devtoolsReportWindow}">

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -166,7 +166,19 @@
                         <ui:SettingsCard.HeaderIcon>
                             <ui:FontIcon Glyph="&#xE8BD;" />
                         </ui:SettingsCard.HeaderIcon>
-                        <Button Command="{Binding OpenTestMessageBoxWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
+                        <Button>
+                            <ikw:SimpleStackPanel Orientation="Horizontal" Spacing="6">
+                                <TextBlock VerticalAlignment="Center" Text="{DynamicResource devtoolsOpenTestWindow}" />
+                            </ikw:SimpleStackPanel>
+                            <ui:FlyoutService.Flyout>
+                                <ui:MenuFlyout>
+                                    <MenuItem Command="{Binding OpenTestMessageBoxCommand}" CommandParameter="OK" Header="{DynamicResource devtoolsMessageBoxOkLabel}" />
+                                    <MenuItem Command="{Binding OpenTestMessageBoxCommand}" CommandParameter="OKCancel" Header="{DynamicResource devtoolsMessageBoxOkCancelLabel}" />
+                                    <MenuItem Command="{Binding OpenTestMessageBoxCommand}" CommandParameter="YesNo" Header="{DynamicResource devtoolsMessageBoxYesNoLabel}" />
+                                    <MenuItem Command="{Binding OpenTestMessageBoxCommand}" CommandParameter="YesNoCancel" Header="{DynamicResource devtoolsMessageBoxYesNoCancelLabel}" />
+                                </ui:MenuFlyout>
+                            </ui:FlyoutService.Flyout>
+                        </Button>
                     </ui:SettingsCard>
                 </ui:SettingsExpander.Items>
             </ui:SettingsExpander>

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -154,6 +154,13 @@
                         </ui:SettingsCard.HeaderIcon>
                         <Button Command="{Binding OpenTestProgressWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
                     </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="{DynamicResource devtoolsPluginUpdateWindow}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xecc5;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenTestPluginUpdateWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
+                    </ui:SettingsCard>
                 </ui:SettingsExpander.Items>
             </ui:SettingsExpander>
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -89,52 +89,59 @@
                 <ui:HyperlinkButton Content="icons8.com" NavigateUri="https://icons8.com/" />
             </ui:SettingsCard>
 
-            <ui:SettingsCard Margin="0 14 0 0" Header="{DynamicResource devtool}">
-                <ui:SettingsCard.HeaderIcon>
+            <ui:SettingsExpander Margin="0 14 0 0" Header="{DynamicResource devtool}">
+                <ui:SettingsExpander.HeaderIcon>
                     <ui:FontIcon Glyph="&#xf12b;" />
-                </ui:SettingsCard.HeaderIcon>
+                </ui:SettingsExpander.HeaderIcon>
 
-                <ikw:SimpleStackPanel Orientation="Horizontal" Spacing="12">
-                    <Button
-                        x:Name="AskClearCacheFolderConfirmationButton"
-                        Command="{Binding AskClearCacheFolderConfirmationCommand}"
-                        Content="{Binding CacheFolderSize, Mode=OneWay}" />
-                    <Button
-                        Height="{Binding ElementName=AskClearCacheFolderConfirmationButton, Path=ActualHeight}"
-                        Command="{Binding AskClearLogFolderConfirmationCommand}"
-                        Content="{Binding LogFolderSize, Mode=OneWay}" />
-                    <Button Height="{Binding ElementName=AskClearCacheFolderConfirmationButton, Path=ActualHeight}">
-                        <ui:FontIcon FontSize="16" Glyph="&#xec7a;" />
-                        <ui:FlyoutService.Flyout>
-                            <ui:MenuFlyout>
-                                <MenuItem Command="{Binding OpenWelcomeWindowCommand}" Header="{DynamicResource welcomewindow}">
-                                    <MenuItem.Icon>
-                                        <ui:FontIcon Glyph="&#xe939;" />
-                                    </MenuItem.Icon>
-                                </MenuItem>
+                <ui:SettingsExpander.Items>
+                    <ui:SettingsCard Header="{DynamicResource clearcachefolder}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe74d;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button
+                            Command="{Binding AskClearCacheFolderConfirmationCommand}"
+                            Content="{Binding CacheFolderSize, Mode=OneWay}" />
+                    </ui:SettingsCard>
 
-                                <MenuItem Command="{Binding OpenSettingsFolderCommand}" Header="{DynamicResource settingfolder}">
-                                    <MenuItem.Icon>
-                                        <ui:FontIcon Glyph="&#xe8b7;" />
-                                    </MenuItem.Icon>
-                                </MenuItem>
+                    <ui:SettingsCard Header="{DynamicResource clearlogfolder}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe74d;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button
+                            Command="{Binding AskClearLogFolderConfirmationCommand}"
+                            Content="{Binding LogFolderSize, Mode=OneWay}" />
+                    </ui:SettingsCard>
 
-                                <MenuItem Command="{Binding OpenLogsFolderCommand}" Header="{DynamicResource logfolder}">
-                                    <MenuItem.Icon>
-                                        <ui:FontIcon Glyph="&#xe8b7;" />
-                                    </MenuItem.Icon>
-                                </MenuItem>
+                    <ui:SettingsCard Header="{DynamicResource settingfolder}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe8b7;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenSettingsFolderCommand}" Content="{DynamicResource openFolderButton}" />
+                    </ui:SettingsCard>
 
-                                <MenuItem Command="{Binding OpenCacheFolderCommand}" Header="{DynamicResource cachefolder}">
-                                    <MenuItem.Icon>
-                                        <ui:FontIcon Glyph="&#xe8b7;" />
-                                    </MenuItem.Icon>
-                                </MenuItem>
-                            </ui:MenuFlyout>
-                        </ui:FlyoutService.Flyout>
-                    </Button>
-                </ikw:SimpleStackPanel>
-            </ui:SettingsCard>
+                    <ui:SettingsCard Header="{DynamicResource logfolder}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe8b7;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenLogsFolderCommand}" Content="{DynamicResource openFolderButton}" />
+                    </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="{DynamicResource cachefolder}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe8b7;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenCacheFolderCommand}" Content="{DynamicResource openFolderButton}" />
+                    </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="{DynamicResource welcomewindow}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe939;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenWelcomeWindowCommand}" Content="{DynamicResource welcomewindow}" />
+                    </ui:SettingsCard>
+                </ui:SettingsExpander.Items>
+            </ui:SettingsExpander>
 
             <ui:SettingsExpander Margin="0 4 0 0" Header="{DynamicResource advanced}">
                 <ui:SettingsExpander.HeaderIcon>

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -147,6 +147,13 @@
                         </ui:SettingsCard.HeaderIcon>
                         <Button Command="{Binding OpenTestReportWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
                     </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="{DynamicResource devtoolsProgressWindow}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe895;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenTestProgressWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
+                    </ui:SettingsCard>
                 </ui:SettingsExpander.Items>
             </ui:SettingsExpander>
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -161,6 +161,13 @@
                         </ui:SettingsCard.HeaderIcon>
                         <Button Command="{Binding OpenTestPluginUpdateWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
                     </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="{DynamicResource devtoolsMessageBoxWindow}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xE8BD;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenTestMessageBoxWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
+                    </ui:SettingsCard>
                 </ui:SettingsExpander.Items>
             </ui:SettingsExpander>
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -140,6 +140,13 @@
                         </ui:SettingsCard.HeaderIcon>
                         <Button Command="{Binding OpenWelcomeWindowCommand}" Content="{DynamicResource welcomewindow}" />
                     </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="{DynamicResource devtoolsReportWindow}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe783;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenTestReportWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
+                    </ui:SettingsCard>
                 </ui:SettingsExpander.Items>
             </ui:SettingsExpander>
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -148,6 +148,13 @@
                         </ui:SettingsCard.HeaderIcon>
                         <Button Command="{Binding OpenTestReportWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
                     </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="{DynamicResource devtoolsProgressWindow}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe895;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenTestProgressWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
+                    </ui:SettingsCard>
                 </ui:SettingsExpander.Items>
             </ui:SettingsExpander>
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -162,6 +162,13 @@
                         </ui:SettingsCard.HeaderIcon>
                         <Button Command="{Binding OpenTestPluginUpdateWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
                     </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="{DynamicResource devtoolsMessageBoxWindow}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xE8BD;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenTestMessageBoxWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
+                    </ui:SettingsCard>
                 </ui:SettingsExpander.Items>
             </ui:SettingsExpander>
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -155,6 +155,13 @@
                         </ui:SettingsCard.HeaderIcon>
                         <Button Command="{Binding OpenTestProgressWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
                     </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="{DynamicResource devtoolsPluginUpdateWindow}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xecc5;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenTestPluginUpdateWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
+                    </ui:SettingsCard>
                 </ui:SettingsExpander.Items>
             </ui:SettingsExpander>
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -141,6 +141,13 @@
                         </ui:SettingsCard.HeaderIcon>
                         <Button Command="{Binding OpenWelcomeWindowCommand}" Content="{DynamicResource welcomewindow}" />
                     </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="{DynamicResource devtoolsReportWindow}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe783;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenTestReportWindowCommand}" Content="{DynamicResource devtoolsOpenTestWindow}" />
+                    </ui:SettingsCard>
                 </ui:SettingsExpander.Items>
             </ui:SettingsExpander>
 

--- a/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
+++ b/Flow.Launcher/SettingPages/Views/SettingsPaneAbout.xaml
@@ -89,52 +89,60 @@
                 <ui:HyperlinkButton Content="icons8.com" NavigateUri="https://icons8.com/" />
             </ui:SettingsCard>
 
-            <ui:SettingsCard Margin="0 14 0 0" Header="{DynamicResource devtool}">
-                <ui:SettingsCard.HeaderIcon>
+            <ui:SettingsExpander Margin="0 14 0 0" Header="{DynamicResource devtool}">
+                <ui:SettingsExpander.HeaderIcon>
                     <ui:FontIcon Glyph="&#xf12b;" />
-                </ui:SettingsCard.HeaderIcon>
+                </ui:SettingsExpander.HeaderIcon>
 
-                <ikw:SimpleStackPanel Orientation="Horizontal" Spacing="12">
-                    <Button
-                        x:Name="AskClearCacheFolderConfirmationButton"
-                        Command="{Binding AskClearCacheFolderConfirmationCommand}"
-                        Content="{Binding CacheFolderSize, Mode=OneWay}" />
-                    <Button
-                        Height="{Binding ElementName=AskClearCacheFolderConfirmationButton, Path=ActualHeight}"
-                        Command="{Binding AskClearLogFolderConfirmationCommand}"
-                        Content="{Binding LogFolderSize, Mode=OneWay}" />
-                    <Button Height="{Binding ElementName=AskClearCacheFolderConfirmationButton, Path=ActualHeight}">
-                        <ui:FontIcon FontSize="16" Glyph="&#xec7a;" />
-                        <ui:FlyoutService.Flyout>
-                            <ui:MenuFlyout>
-                                <MenuItem Command="{Binding OpenWelcomeWindowCommand}" Header="{DynamicResource welcomewindow}">
-                                    <MenuItem.Icon>
-                                        <ui:FontIcon Glyph="&#xe939;" />
-                                    </MenuItem.Icon>
-                                </MenuItem>
+                <ui:SettingsExpander.Items>
+                    <ui:SettingsCard Header="{DynamicResource clearcachefolder}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe74d;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button
+                            x:Name="AskClearCacheFolderConfirmationButton"
+                            Command="{Binding AskClearCacheFolderConfirmationCommand}"
+                            Content="{Binding CacheFolderSize, Mode=OneWay}" />
+                    </ui:SettingsCard>
 
-                                <MenuItem Command="{Binding OpenSettingsFolderCommand}" Header="{DynamicResource settingfolder}">
-                                    <MenuItem.Icon>
-                                        <ui:FontIcon Glyph="&#xe8b7;" />
-                                    </MenuItem.Icon>
-                                </MenuItem>
+                    <ui:SettingsCard Header="{DynamicResource clearlogfolder}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe74d;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button
+                            Command="{Binding AskClearLogFolderConfirmationCommand}"
+                            Content="{Binding LogFolderSize, Mode=OneWay}" />
+                    </ui:SettingsCard>
 
-                                <MenuItem Command="{Binding OpenLogsFolderCommand}" Header="{DynamicResource logfolder}">
-                                    <MenuItem.Icon>
-                                        <ui:FontIcon Glyph="&#xe8b7;" />
-                                    </MenuItem.Icon>
-                                </MenuItem>
+                    <ui:SettingsCard Header="{DynamicResource settingfolder}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe8b7;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenSettingsFolderCommand}" Content="{DynamicResource openFolderButton}" />
+                    </ui:SettingsCard>
 
-                                <MenuItem Command="{Binding OpenCacheFolderCommand}" Header="{DynamicResource cachefolder}">
-                                    <MenuItem.Icon>
-                                        <ui:FontIcon Glyph="&#xe8b7;" />
-                                    </MenuItem.Icon>
-                                </MenuItem>
-                            </ui:MenuFlyout>
-                        </ui:FlyoutService.Flyout>
-                    </Button>
-                </ikw:SimpleStackPanel>
-            </ui:SettingsCard>
+                    <ui:SettingsCard Header="{DynamicResource logfolder}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe8b7;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenLogsFolderCommand}" Content="{DynamicResource openFolderButton}" />
+                    </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="{DynamicResource cachefolder}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe8b7;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenCacheFolderCommand}" Content="{DynamicResource openFolderButton}" />
+                    </ui:SettingsCard>
+
+                    <ui:SettingsCard Header="{DynamicResource welcomewindow}">
+                        <ui:SettingsCard.HeaderIcon>
+                            <ui:FontIcon Glyph="&#xe939;" />
+                        </ui:SettingsCard.HeaderIcon>
+                        <Button Command="{Binding OpenWelcomeWindowCommand}" Content="{DynamicResource welcomewindow}" />
+                    </ui:SettingsCard>
+                </ui:SettingsExpander.Items>
+            </ui:SettingsExpander>
 
             <ui:SettingsExpander Margin="0 4 0 0" Header="{DynamicResource advanced}">
                 <ui:SettingsExpander.HeaderIcon>


### PR DESCRIPTION
Add new dev tools to open test windows so their behavior and look can be verified at runtime
These specific windows are usually hard to trigger or unsafe to use if you don't want to mess with your configuration.

The progress window has a simulated timer (1m) thats short enough to see change but long enough to get a look at it.

The message box windows are available in all the supported button types and send the result back as a notification - so you can test its behavior.

## UI Changes
To make room for all these new test windows I turned DevTools into an expander

### Before
<img width="1204" height="228" alt="image" src="https://github.com/user-attachments/assets/0a93d205-7960-4b40-a431-de6a0a497c85" />

### After
<img width="1202" height="602" alt="image" src="https://github.com/user-attachments/assets/98367be4-19b1-4abc-ab97-89c2962f9dbc" />

(Messsage Box Type Flyout)
<img width="1192" height="198" alt="image" src="https://github.com/user-attachments/assets/c942f266-454d-44ab-bb78-f86ddb7acfa6" />





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the DevTools flyout with a structured expander and adds test windows for Report, Progress (cancelable), Plugin Update, and Message Box. Improves discoverability and lets you verify these UIs safely.

**Summary of changes**
- Changed: Converted DevTools `SettingsCard` + flyout into a `SettingsExpander` with individual `SettingsCard`s; use shared `openFolderButton` for settings/log/cache folders; welcome button label is now “Open Welcome Window” (card header still “Wizard”).
- Added: Buttons to open test Report, Progress (async, ~1 min, cancelable), Plugin Update, and Message Box windows; Message Box includes a flyout for OK, OK/Cancel, Yes/No, Yes/No/Cancel and posts the result as a notification; new localization keys for these labels and `openFolderButton`.
- Removed: DevTools flyout and its grouped actions.
- Memory impact: Minimal; windows are created on demand and disposed on close; progress demo has small, temporary allocations.
- Security risks: None; all actions are local UI only with no new I/O or network work.
- Unit tests: None (UI-only changes).

**Release Note**
About > DevTools now uses an expander with clear actions and adds test windows for reports, progress, plugin updates, and message boxes.

<sup>Written for commit b39d2105285b16600fb1db06767723a6bbff2b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



