### PR TITLE
Fix IsAcronymNumber and correctly group digit runs in acronym counting

### DIFF
--- a/Flow.Launcher.Infrastructure/StringMatcher.cs
+++ b/Flow.Launcher.Infrastructure/StringMatcher.cs
@@ -72,6 +72,8 @@ namespace Flow.Launcher.Infrastructure
 
             var currentAcronymQueryIndex = 0;
             var acronymMatchData = new List<int>();
+            // Count of distinct acronym groups in the compare string.
+            // Digit runs count as one group (e.g. "2019" is 1 group, not 4).
             int acronymsTotalCount = 0;
             int acronymsMatched = 0;
 
@@ -215,7 +217,9 @@ namespace Flow.Launcher.Infrastructure
             // return acronym match if all query char matched
             if (acronymsMatched > 0 && acronymsMatched == query.Length)
             {
-                int acronymScore = acronymsMatched * 100 / acronymsTotalCount;
+                // we need to consider groups to avoid counting digit runs multiple times
+                int matchedGroups = CountDistinctAcronymGroups(acronymMatchData, stringToCompare);
+                int acronymScore = matchedGroups * 100 / acronymsTotalCount;
 
                 if (acronymScore >= (int)UserSettingSearchPrecision)
                 {
@@ -269,6 +273,45 @@ namespace Flow.Launcher.Infrastructure
 
         private static bool IsAcronymNumber(string stringToCompare, int compareStringIndex)
             => char.IsAsciiDigit(stringToCompare[compareStringIndex]);
+
+        /// <summary>
+        /// Counts distinct acronym groups from matched character indices in <paramref name="stringToCompare"/>.
+        /// Each matched non-digit character index forms its own group.
+        /// Contiguous digit characters in the string form a single group regardless of how many indices match within the run.
+        ///
+        /// Example:
+        /// For "Visual Studio 2019", matched indices [0, 14, 17] refer to characters 'V', '2', and '9'.
+        /// These produce 2 groups: 'V' and the digit run "2019".
+        /// </summary>
+        private static int CountDistinctAcronymGroups(List<int> matchedIndices, string stringToCompare)
+        {
+            int groups = 0;
+            var processedIndices = new HashSet<int>();
+
+            foreach (int matchedIndex in matchedIndices)
+            {
+                // try process index and skip if already processed in a previous group
+                if (!processedIndices.Add(matchedIndex))
+                    continue;
+
+                // since we processed a new index we start a new group
+                groups += 1;
+
+                // if this isn't a digit then its a single index group so we stop here
+                if (!IsAcronymNumber(stringToCompare, matchedIndex))
+                    continue;
+
+                // check if this is a digit run and process any indices in that run as they are part of this group
+                int digitRunEnd = matchedIndex;
+                while (digitRunEnd < stringToCompare.Length - 1 && IsAcronymNumber(stringToCompare, digitRunEnd + 1))
+                {
+                    digitRunEnd += 1;
+                    processedIndices.Add(digitRunEnd);
+                }
+            }
+
+            return groups;
+        }
 
         // To get the index of the closest space which preceeds the first matching index
         private static int CalculateClosestSpaceIndex(List<int> spaceIndices, int firstMatchIndex)

--- a/Flow.Launcher.Infrastructure/StringMatcher.cs
+++ b/Flow.Launcher.Infrastructure/StringMatcher.cs
@@ -268,7 +268,7 @@ namespace Flow.Launcher.Infrastructure
                char.IsWhiteSpace(stringToCompare[compareStringIndex - 1]);
 
         private static bool IsAcronymNumber(string stringToCompare, int compareStringIndex)
-            => stringToCompare[compareStringIndex] >= 0 && stringToCompare[compareStringIndex] <= 9;
+            => char.IsAsciiDigit(stringToCompare[compareStringIndex]);
 
         // To get the index of the closest space which preceeds the first matching index
         private static int CalculateClosestSpaceIndex(List<int> spaceIndices, int firstMatchIndex)

--- a/Flow.Launcher.Infrastructure/StringMatcher.cs
+++ b/Flow.Launcher.Infrastructure/StringMatcher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using CommunityToolkit.Mvvm.DependencyInjection;
@@ -43,6 +43,8 @@ namespace Flow.Launcher.Infrastructure
         /// 4. Character that is number
         /// 
         /// Acronym Match will succeed when all query characters match with acronyms in stringToCompare.
+        /// Contiguous digit characters are considered as one acronym group -> e.g. vs19 for Visual Studio 2019 is
+        /// considered 3 matched groups [v][s][19].
         /// If any of the characters in the query isn't matched with stringToCompare, Acronym Match will fail.
         /// Score will be calculated based the percentage of all query characters matched with total acronyms in stringToCompare.
         /// 

--- a/Flow.Launcher.Infrastructure/StringMatcher.cs
+++ b/Flow.Launcher.Infrastructure/StringMatcher.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using CommunityToolkit.Mvvm.DependencyInjection;
@@ -262,8 +262,10 @@ namespace Flow.Launcher.Infrastructure
             if (IsAcronymChar(stringToCompare, compareStringIndex))
                 return true;
 
+            // Count only the first digit of a contiguous digit run as a single acronym group,
+            // matching the same grouping logic used by CountDistinctAcronymGroups.
             if (IsAcronymNumber(stringToCompare, compareStringIndex))
-                return compareStringIndex == 0 || char.IsWhiteSpace(stringToCompare[compareStringIndex - 1]);
+                return compareStringIndex == 0 || !IsAcronymNumber(stringToCompare, compareStringIndex - 1);
 
             return false;
         }

--- a/Flow.Launcher.Test/FuzzyMatcherTest.cs
+++ b/Flow.Launcher.Test/FuzzyMatcherTest.cs
@@ -359,6 +359,24 @@ namespace Flow.Launcher.Test
         [TestCase("vsp", "Visual Studio", 0)]
         [TestCase("vps", "Visual Studio", 0)]
         [TestCase(Chrome, HelpCureHopeRaiseOnMindEntityChrome, 75)]
+        // --- Digit run acronym matching ---
+        // A run of consecutive digits (e.g. "2019") counts as a single acronym unit.
+        // Matching any digit within the run "claims" it, but extra digits from the
+        // same run don't increase the group count.
+        // "Visual Studio 2019" has 3 acronym units: V, S, 2019-run.
+
+        // All words + digit run matched: V S 2019 = 3/3
+        [TestCase("vs2",   "Visual Studio 2019", 100)]
+        [TestCase("vs19",  "Visual Studio 2019", 100)]
+        [TestCase("vs2019","Visual Studio 2019", 100)]
+        // Partial: only V + digit run (missing S) = 2/3 = 66
+        [TestCase("v29",   "Visual Studio 2019", 66)]
+        [TestCase("v2019", "Visual Studio 2019", 66)]
+        [TestCase("v19",   "Visual Studio 2019", 66)]
+        // Digit run does not match comparison string — no acronym match
+        [TestCase("vs19",  "Visual Studio 2018", 0)]
+        // Shorter digit run treated identically: V S 19-run = 3/3
+        [TestCase("vs19",  "Visual Studio 19", 100)]
         public void WhenGivenAnAcronymQuery_ShouldReturnAcronymScore(string queryString, string compareString,
             int desiredScore)
         {

--- a/Flow.Launcher.Test/FuzzyMatcherTest.cs
+++ b/Flow.Launcher.Test/FuzzyMatcherTest.cs
@@ -377,6 +377,8 @@ namespace Flow.Launcher.Test
         [TestCase("vs19",  "Visual Studio 2018", 0)]
         // Shorter digit run treated identically: V S 19-run = 3/3
         [TestCase("vs19",  "Visual Studio 19", 100)]
+        [TestCase("vs2019", "VisualStudio2019", 100)]
+        [TestCase("vs2019", "visualStudio2019", 100)]
         public void WhenGivenAnAcronymQuery_ShouldReturnAcronymScore(string queryString, string compareString,
             int desiredScore)
         {


### PR DESCRIPTION
Fixes #4508

Replaces incorrect comparison of char to the intergers 0 and 9 (instead of the actual ASCII values of those characters) with char.IsAsciiDigit

Used IsAsciiDigit instead of IsDigit as that more closely replicates what originally existed and the other parts of this class don't seem ready to accept non ascii digits

Now the digits are actually being detected, we also need to fix the inconsistency where sometimes a digit run was treated as a single count in tallying but not in scoring - so score could exceed the 100 maximum.
Added a new CountDistinctAcronymGroups method to group digit runs into a single count, while leaving alphabetic acronyms as individual counts.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes acronym matching with numbers in `StringMatcher` so digit runs count as a single unit, preventing scoring inflation past 100 and restoring correct matches for names like "Visual Studio 2019". Digit runs also score correctly when attached directly to words, such as `VisualStudio2019`.

**Summary of changes**
- `IsAcronymNumber` now uses `char.IsAsciiDigit`; `IsAcronymCount` treats the first digit of a run as an acronym even when preceded by a non-digit character.
- Added `CountDistinctAcronymGroups` to score digit runs once; unit tests cover queries like `vs2`, `vs19`, `vs2019`, and `v29`.
- Removed the invalid `char >= 0 && <= 9` comparison and per-digit overcounting in acronym scoring.
- Memory impact: minimal — a small short-lived `HashSet` during matching.
- Security risks: none.
- Unit tests: added cases for digit-run acronyms, including runs without whitespace separators.

**Release Note**
Abbreviation matching now treats number sequences like "2019" as a single part, improving search results and ranking.

<sup>Written for commit 55aea8969be5cf6c693723bbc29e7b7acec2e9c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->







