### PR TITLE
Fix blur theme backdrop, corners, margin issues & simplify AutoDropShadow

### DIFF
--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -743,6 +743,7 @@ namespace Flow.Launcher.Core.Resource
                     SetWindowCornerPreference("Round");
                     if (Application.Current.Resources.Contains("WindowBorderStyle"))
                         Application.Current.Resources.Remove("WindowBorderStyle");
+                    SetResizeBoarderThickness(null);
                 }
                 else
                 {

--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -554,6 +554,11 @@ namespace Flow.Launcher.Core.Resource
             ThemeHelper.CopyStyle(windowBorderStyle, newWindowBorderStyle);
 
             // Copy Setters, excluding the Effect setter and updating the Margin setter
+            // Only adjust margin if there's actually a shadow effect to remove,
+            // preventing it from shrinking on repeated calls.
+            bool hasEffect = windowBorderStyle.Setters.OfType<Setter>()
+                .Any(s => s.Property == UIElement.EffectProperty);
+
             foreach (var setterBase in windowBorderStyle.Setters)
             {
                 if (setterBase is Setter setter)
@@ -562,7 +567,7 @@ namespace Flow.Launcher.Core.Resource
                     if (setter.Property == UIElement.EffectProperty) continue;
 
                     // Update Margin by subtracting the extra margin we added for the shadow
-                    if (setter.Property == FrameworkElement.MarginProperty)
+                    if (hasEffect && setter.Property == FrameworkElement.MarginProperty)
                     {
                         var currentMargin = (Thickness)setter.Value;
                         var newMargin = new Thickness(

--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -640,9 +640,6 @@ namespace Flow.Launcher.Core.Resource
                 // Get the actual backdrop type and drop shadow effect settings
                 var (backdropType, useDropShadowEffect) = GetActualValue();
 
-                // Remove OS minimizing/maximizing animation
-                // Methods.SetWindowAttribute(new WindowInteropHelper(mainWindow).Handle, DWMWINDOWATTRIBUTE.DWMWA_TRANSITIONS_FORCEDISABLED, 3);
-
                 SetBlurForWindow(_settings.Theme, backdropType);
                 AutoDropShadow(useDropShadowEffect);
             }, DispatcherPriority.Render);

--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -643,17 +643,8 @@ namespace Flow.Launcher.Core.Resource
                 // Remove OS minimizing/maximizing animation
                 // Methods.SetWindowAttribute(new WindowInteropHelper(mainWindow).Handle, DWMWINDOWATTRIBUTE.DWMWA_TRANSITIONS_FORCEDISABLED, 3);
 
-                // The timing of adding the shadow effect should vary depending on whether the theme is transparent.
-                if (BlurEnabled)
-                {
-                    AutoDropShadow(useDropShadowEffect);
-                }
                 SetBlurForWindow(_settings.Theme, backdropType);
-
-                if (!BlurEnabled)
-                {
-                    AutoDropShadow(useDropShadowEffect);
-                }
+                AutoDropShadow(useDropShadowEffect);
             }, DispatcherPriority.Render);
         }
 
@@ -747,10 +738,11 @@ namespace Flow.Launcher.Core.Resource
             {
                 if (BlurEnabled && Win32Helper.IsBackdropSupported())
                 {
-                    // For themes with blur enabled, the window border is rendered by the system,
-                    // so we set corner preference to round and remove drop shadow effect to avoid rendering issues.
+                    // Blur themes: DWM handles corners. Clear any stale directly-set
+                    // resource so the merged dictionary entry (from SetBlurForWindow) wins.
                     SetWindowCornerPreference("Round");
-                    RemoveDropShadowEffectFromCurrentTheme();
+                    if (Application.Current.Resources.Contains("WindowBorderStyle"))
+                        Application.Current.Resources.Remove("WindowBorderStyle");
                 }
                 else
                 {

--- a/Flow.Launcher.Core/Resource/Theme.cs
+++ b/Flow.Launcher.Core/Resource/Theme.cs
@@ -718,12 +718,26 @@ namespace Flow.Launcher.Core.Resource
                 // Apply the blur effect
                 Win32Helper.DWMSetBackdropForWindow(mainWindow, backdropType);
                 ColorizeWindow(theme, backdropType);
+
+                // DWM renders rounded corners for backdrop windows
+                SetWindowCornerPreference("Round");
+
+                // Clear any stale directly-set WindowBorderStyle that might shadow
+                // the merged dictionary entry we just modified above.
+                if (Application.Current.Resources.Contains("WindowBorderStyle"))
+                    Application.Current.Resources.Remove("WindowBorderStyle");
+
+                // For blur themes the resize border defaults to the system thickness.
+                SetResizeBoarderThickness(null);
             }
             else
             {
                 // Apply default style when Blur is disabled
                 Win32Helper.DWMSetBackdropForWindow(mainWindow, BackdropTypes.None);
                 ColorizeWindow(theme, backdropType);
+
+                // Non-blur themes use the default window corner preference
+                SetWindowCornerPreference("Default");
             }
 
             UpdateResourceDictionary(dict);
@@ -731,28 +745,15 @@ namespace Flow.Launcher.Core.Resource
 
         private void AutoDropShadow(bool useDropShadowEffect)
         {
+            if (BlurEnabled)
+                return; // Blur themes have no drop shadow effect
+
             if (useDropShadowEffect)
             {
-                if (BlurEnabled && Win32Helper.IsBackdropSupported())
-                {
-                    // Blur themes: DWM handles corners. Clear any stale directly-set
-                    // resource so the merged dictionary entry (from SetBlurForWindow) wins.
-                    SetWindowCornerPreference("Round");
-                    if (Application.Current.Resources.Contains("WindowBorderStyle"))
-                        Application.Current.Resources.Remove("WindowBorderStyle");
-                    SetResizeBoarderThickness(null);
-                }
-                else
-                {
-                    // For themes without blur, we set corner preference to default and add drop shadow effect.
-                    SetWindowCornerPreference("Default");
-                    AddDropShadowEffectToCurrentTheme();
-                }
+                AddDropShadowEffectToCurrentTheme();
             }
             else
             {
-                // When drop shadow effect is disabled, we set corner preference to default and remove drop shadow effect.
-                SetWindowCornerPreference("Default");
                 RemoveDropShadowEffectFromCurrentTheme();
             }
         }

--- a/Flow.Launcher.Infrastructure/NativeMethods.txt
+++ b/Flow.Launcher.Infrastructure/NativeMethods.txt
@@ -14,6 +14,7 @@ VIRTUAL_KEY
 EnumWindows
 
 DwmSetWindowAttribute
+DwmExtendFrameIntoClientArea
 DWM_SYSTEMBACKDROP_TYPE
 DWM_WINDOW_CORNER_PREFERENCE
 

--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -21,6 +21,7 @@ using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Dwm;
 using Windows.Win32.System.Power;
 using Windows.Win32.System.Threading;
+using Windows.Win32.UI.Controls;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 using Windows.Win32.UI.Shell.Common;
 using Windows.Win32.UI.WindowsAndMessaging;
@@ -60,6 +61,14 @@ namespace Flow.Launcher.Infrastructure
                 BackdropTypes.MicaAlt => DWM_SYSTEMBACKDROP_TYPE.DWMSBT_TABBEDWINDOW,
                 _ => DWM_SYSTEMBACKDROP_TYPE.DWMSBT_AUTO
             };
+
+            // The backdrop renders in the non-client frame area. WindowStyle=None
+            // removes that area, so we extend it across the entire client area.
+            // This is harmless when backdrop is None or blur not enabled
+            // as DWM has nothing to render in the extended area.
+            // https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/nf-dwmapi-dwmextendframeintoclientarea
+            var margins = new MARGINS { cxLeftWidth = -1, cxRightWidth = -1, cyTopHeight = -1, cyBottomHeight = -1 };
+            PInvoke.DwmExtendFrameIntoClientArea(GetWindowHandle(window), in margins);
 
             return PInvoke.DwmSetWindowAttribute(
                 GetWindowHandle(window),


### PR DESCRIPTION
Closes #4457 and #4512
Potentially also closes #3624

## Bug Fixes
- Fixes the double corners issue by removing the call to `RemoveDropShadowEffectFromCurrentTheme` for blur themes as they both made conflicting modifications to the style - instead just clear all window border styles in the `SetBlurForWindow` method
- Improves `RemoveDropShadowEffectFromCurrentTheme` so that it only removes the drop shadow margin if necessary - avoiding shrinking of the main window
- Calls `DwmExtendFrameIntoClientArea` when using blur themes so that removal of non client area by `WindowStyle=None` is not an issue

## Minor Refactor
Simplified `AutoDropShadow` by moving any non drop shadow related code to `SetBlurForWindow`, including the cleanup for it in the now removed BlurEnabled branch but also the DWM corner prefernce as that only needs to consider if the theme has blur or not.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blur/backdrop and drop shadow interactions so Windows themes render correctly. Mica/Acrylic now cover the full window with `WindowStyle=None`; corners, margins, and resize borders are correct.

**Summary of changes**
- Changed: Always call `AutoDropShadow` after `SetBlurForWindow`; it only adds/removes the effect and no-ops on blur.
- Changed: `SetBlurForWindow` now sets corner preference (Round for blur, Default otherwise), clears any directly set `WindowBorderStyle`, and resets resize border to system default.
- Changed: `RemoveDropShadowEffectFromCurrentTheme` subtracts shadow margin only when an `Effect` setter exists to avoid cumulative shrink.
- Added: Extend the DWM frame into the client area via `DwmExtendFrameIntoClientArea` (MARGINS = -1) so backdrops render across the entire window.
- Removed: Calling `RemoveDropShadowEffectFromCurrentTheme` for blur themes; removed stale commented code in `RefreshFrameAsync`.
- Memory: Negligible; one extra P/Invoke per refresh, no long-lived allocations.
- Security: Low risk; uses OS APIs only, no new inputs.
- Tests: None.

**Release Note**
Windows blur themes now render full-window Mica/Acrylic with correct corners, shadows, margins, and resize borders.

<sup>Written for commit 7cf0b9772ba59f9316ede96adaec4ec7928f79c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





