### PR TITLE
Fix incorrect system language

### DIFF
--- a/Flow.Launcher.Core/Resource/Internationalization.cs
+++ b/Flow.Launcher.Core/Resource/Internationalization.cs
@@ -59,6 +59,7 @@ namespace Flow.Launcher.Core.Resource
                     string.Equals(languageCode, fullName, StringComparison.OrdinalIgnoreCase))
                 {
                     SystemLanguageCode = languageCode;
+                    return;
                 }
             }
 


### PR DESCRIPTION
Fix #4518

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure system language detection stops on the first match to prevent overwriting and select the correct language. Fixes incorrect language selection in some cases (issue #4518).

- **Summary of changes**
  - Changed: Added an early return in InitSystemLanguageCode after setting SystemLanguageCode to stop further checks.
  - Added: Early-exit logic to lock in the first valid match and avoid later overwrites.
  - Removed: Implicit behavior where later iterations could overwrite SystemLanguageCode.
  - Memory: No impact; minor CPU reduction from fewer iterations.
  - Security: No risks.
  - Tests: No new unit tests added.

- **Release Note**
  Fixes a bug that could set the app to the wrong language on startup.

<sup>Written for commit 97218046a1d7ad214534173fa3ec2740c396f0d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

