### PR TITLE
Fix possible null issues in Win32Helper.IsForegroundWindowFullscreen function

### DIFF
--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -292,14 +292,16 @@ namespace Flow.Launcher.Infrastructure
                 return appBounds.top < 0 && appBounds.bottom < 0;
             }
 
-            // For desktop (Progman or WorkerW, depends on the system), we have to check
+            // For desktop (Progman or WorkerW, depends on the system),
+            // we have to check for this hierarchy:
+            // Progman/WorkerW -> SHELLDLL_DefView -> SysListView32("FolderView")
             if (windowClass is WINDOW_CLASS_PROGMAN or WINDOW_CLASS_WORKERW)
             {
-                var hWndDesktop = PInvoke.FindWindowEx(hWnd, HWND.Null, "SHELLDLL_DefView", null);
-                if (hWndDesktop != HWND.Null)
+                var hWndDefView = PInvoke.FindWindowEx(hWnd, HWND.Null, "SHELLDLL_DefView", null);
+                if (hWndDefView != HWND.Null)
                 {
-                    hWndDesktop = PInvoke.FindWindowEx(hWndDesktop, HWND.Null, "SysListView32", "FolderView");
-                    if (hWndDesktop != HWND.Null)
+                    var hWndFolderView = PInvoke.FindWindowEx(hWndDefView, HWND.Null, "SysListView32", "FolderView");
+                    if (hWndFolderView != HWND.Null)
                     {
                         return false;
                     }

--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -296,14 +296,13 @@ namespace Flow.Launcher.Infrastructure
             if (windowClass is WINDOW_CLASS_PROGMAN or WINDOW_CLASS_WORKERW)
             {
                 var hWndDesktop = PInvoke.FindWindowEx(hWnd, HWND.Null, "SHELLDLL_DefView", null);
-                if (hWndDesktop == HWND.Null)
-                {
-                    return false;
-                }
-                hWndDesktop = PInvoke.FindWindowEx(hWndDesktop, HWND.Null, "SysListView32", "FolderView");
                 if (hWndDesktop != HWND.Null)
                 {
-                    return false;
+                    hWndDesktop = PInvoke.FindWindowEx(hWndDesktop, HWND.Null, "SysListView32", "FolderView");
+                    if (hWndDesktop != HWND.Null)
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/Flow.Launcher.Infrastructure/Win32Helper.cs
+++ b/Flow.Launcher.Infrastructure/Win32Helper.cs
@@ -296,6 +296,10 @@ namespace Flow.Launcher.Infrastructure
             if (windowClass is WINDOW_CLASS_PROGMAN or WINDOW_CLASS_WORKERW)
             {
                 var hWndDesktop = PInvoke.FindWindowEx(hWnd, HWND.Null, "SHELLDLL_DefView", null);
+                if (hWndDesktop == HWND.Null)
+                {
+                    return false;
+                }
                 hWndDesktop = PInvoke.FindWindowEx(hWndDesktop, HWND.Null, "SysListView32", "FolderView");
                 if (hWndDesktop != HWND.Null)
                 {
@@ -304,6 +308,10 @@ namespace Flow.Launcher.Infrastructure
             }
 
             var monitorInfo = MonitorInfo.GetNearestDisplayMonitor(hWnd);
+            if (monitorInfo == null)
+            {
+                return false;
+            }
             return (appBounds.bottom - appBounds.top) == monitorInfo.Bounds.Height &&
                    (appBounds.right - appBounds.left) == monitorInfo.Bounds.Width;
         }


### PR DESCRIPTION
Fix #4494

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Win32Helper.IsForegroundWindowFullscreen with null checks and stricter desktop hierarchy checks to avoid crashes and false fullscreen detections. Returns false when monitor info is missing; only treats the desktop as active when both `SHELLDLL_DefView` and `SysListView32("FolderView")` are present.

**Summary of changes**
- Changed: Check for `SHELLDLL_DefView` first, then look for `SysListView32("FolderView")` only if found; clearer names/comments for the Progman/WorkerW path.
- Added: Early return when `MonitorInfo.GetNearestDisplayMonitor(hWnd)` is null; null-guard before the second `FindWindowEx`.
- Removed: Early return that triggered solely on missing `SHELLDLL_DefView`.
- Memory: No impact beyond trivial conditionals.
- Security: No new risks; reduces crash surface.
- Tests: No new unit tests.

**Release Note**
More reliable fullscreen detection on Windows with reduced chance of crashes.

<sup>Written for commit 82a37427603af7ec1b268e0c7a84d8284e553a3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

