### PR TITLE
Support more url schemes and remove insecure ftp scheme in Url Plugin

### DIFF
--- a/Flow.Launcher.Test/Plugins/UrlPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/UrlPluginTest.cs
@@ -21,7 +21,6 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase("http://www.google.com")]
         [TestCase("https://www.google.com")]
         [TestCase("http://google.com")]
-        [TestCase("ftp://google.com")]
         [TestCase("www.google.com")]
         [TestCase("google.com")]
         [TestCase("http://localhost")]
@@ -35,7 +34,6 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase("110.10.10.10:8080")]
         [TestCase("192.168.1.1")]
         [TestCase("192.168.1.1:3000")]
-        [TestCase("ftp://110.10.10.10")]
         [TestCase("[2001:db8::1]")]
         [TestCase("[2001:db8::1]:8080")]
         [TestCase("http://[2001:db8::1]")]
@@ -66,6 +64,23 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase("192.168.1.1#fragment")]
         [TestCase("localhost:8080?test=123")]
         [TestCase("example.com#fragment")]
+        // Non-host-validated :// schemes
+        [TestCase("chrome://settings")]
+        [TestCase("edge://about")]
+        [TestCase("brave://settings")]
+        [TestCase("opera://history")]
+        [TestCase("vivaldi://bookmarks")]
+        [TestCase("chrome-extension://abc123def456/")]
+        [TestCase("moz-extension://abc123def456/")]
+        [TestCase("file:///C:/path/to/file.txt")]
+        // Colon-only schemes
+        [TestCase("about:blank")]
+        [TestCase("about:config")]
+        [TestCase("data:text/plain,hello")]
+        [TestCase("data:,Hello%2C%20World%21")]
+        // Chromium schemes in colon form
+        [TestCase("chrome:settings")]
+        [TestCase("chrome-extension:settings")]
         public void WhenValidUrlThenIsUrlReturnsTrue(string url)
         {
             Assert.That(plugin.IsURL(url), Is.True);
@@ -87,6 +102,14 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase(".com")]
         [TestCase("http://.com")]
         [TestCase("2001:db8:::1")]
+        // Colon scheme with whitespace
+        [TestCase("about: blank")]
+        // Empty colon schemes
+        [TestCase("about:")]
+        [TestCase("chrome:")]
+        // Empty non host validated ://
+        [TestCase("chrome://")]
+        [TestCase("moz-extension://")]
         public void WhenInvalidUrlThenIsUrlReturnsFalse(string url)
         {
             Assert.That(plugin.IsURL(url), Is.False);

--- a/Flow.Launcher.Test/Plugins/UrlPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/UrlPluginTest.cs
@@ -21,7 +21,6 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase("http://www.google.com")]
         [TestCase("https://www.google.com")]
         [TestCase("http://google.com")]
-        [TestCase("ftp://google.com")]
         [TestCase("www.google.com")]
         [TestCase("google.com")]
         [TestCase("http://localhost")]
@@ -35,7 +34,6 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase("110.10.10.10:8080")]
         [TestCase("192.168.1.1")]
         [TestCase("192.168.1.1:3000")]
-        [TestCase("ftp://110.10.10.10")]
         [TestCase("[2001:db8::1]")]
         [TestCase("[2001:db8::1]:8080")]
         [TestCase("http://[2001:db8::1]")]
@@ -66,6 +64,23 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase("192.168.1.1#fragment")]
         [TestCase("localhost:8080?test=123")]
         [TestCase("example.com#fragment")]
+        // Non-host-validated :// schemes
+        [TestCase("chrome://settings")]
+        [TestCase("edge://about")]
+        [TestCase("brave://settings")]
+        [TestCase("opera://history")]
+        [TestCase("vivaldi://bookmarks")]
+        [TestCase("chrome-extension://abc123def456/")]
+        [TestCase("moz-extension://abc123def456/")]
+        [TestCase("file:///C:/path/to/file.txt")]
+        // Colon-only schemes
+        [TestCase("about:blank")]
+        [TestCase("about:config")]
+        [TestCase("data:text/plain,hello")]
+        [TestCase("data:,Hello%2C%20World%21")]
+        // Chromium schemes in colon form
+        [TestCase("chrome:settings")]
+        [TestCase("chrome-extension:settings")]
         public void WhenValidUrlThenIsUrlReturnsTrue(string url)
         {
             Assert.That(plugin.IsURL(url), Is.True);
@@ -87,6 +102,13 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase(".com")]
         [TestCase("http://.com")]
         [TestCase("2001:db8:::1")]
+        // Colon scheme with whitespace
+        [TestCase("about: blank")]
+        // Empty colon schemes
+        [TestCase("about:")]
+        [TestCase("chrome:")]
+        // Empty non host validated ://
+        [TestCase("chrome://")]
         public void WhenInvalidUrlThenIsUrlReturnsFalse(string url)
         {
             Assert.That(plugin.IsURL(url), Is.False);

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
@@ -104,7 +104,7 @@ public class Main : ISettingProvider, IPlugin, IReloadable, IPluginI18n, IContex
                         Score = BookmarkLoader.MatchProgram(c, param).Score,
                         Action = _ =>
                         {
-                            Context.API.OpenUrl(c.Url);
+                            SearchWeb.OpenInBrowserTab(c.Url);
 
                             return true;
                         },
@@ -128,7 +128,7 @@ public class Main : ISettingProvider, IPlugin, IReloadable, IPluginI18n, IContex
                         Score = 5,
                         Action = _ =>
                         {
-                            Context.API.OpenUrl(c.Url);
+                            SearchWeb.OpenInBrowserTab(c.Url);
                             return true;
                         },
                         ContextData = new BookmarkAttributes { Url = c.Url }

--- a/Plugins/Flow.Launcher.Plugin.Url/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Url/Main.cs
@@ -12,7 +12,13 @@ namespace Flow.Launcher.Plugin.Url
         internal static PluginInitContext Context { get; private set; }
         internal static Settings Settings { get; private set; }
 
-        private static readonly string[] UrlSchemes = ["http", "https"];
+        // Schemes requiring full host validation: domain with TLD, IP address, or localhost
+        private static readonly string[] HostValidatedSchemes = ["http", "https"];
+
+        // Schemes validated by scheme recognition alone — any valid URI structure is accepted
+        private static readonly string[] SchemeOnlySchemes = ["file", "brave", "opera", "vivaldi", "edge", "chrome", "chrome-extension", "moz-extension"];
+
+        private static readonly string[] UrlSchemes = [.. HostValidatedSchemes, .. SchemeOnlySchemes];
 
         public List<Result> Query(Query query)
         {
@@ -130,6 +136,16 @@ namespace Flow.Launcher.Plugin.Url
                 return false;
 
             var host = uri.Host;
+
+            // Scheme-only validation: any valid URI structure is accepted, no host checks
+            // Reject bare scheme:// with no actual content (e.g. chrome://)
+            if (SchemeOnlySchemes.Any(scheme => uri.Scheme == scheme))
+            {
+                var schemePrefix = uri.Scheme + "://";
+                var hasContent = input.Length > schemePrefix.Length;
+
+                return hasContent;
+            }
 
             // localhost is valid
             if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase))

--- a/Plugins/Flow.Launcher.Plugin.Url/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Url/Main.cs
@@ -12,7 +12,7 @@ namespace Flow.Launcher.Plugin.Url
         internal static PluginInitContext Context { get; private set; }
         internal static Settings Settings { get; private set; }
 
-        private static readonly string[] UrlSchemes = ["http", "https", "ftp"];
+        private static readonly string[] UrlSchemes = ["http", "https"];
 
         public List<Result> Query(Query query)
         {

--- a/Plugins/Flow.Launcher.Plugin.Url/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Url/Main.cs
@@ -15,10 +15,18 @@ namespace Flow.Launcher.Plugin.Url
         // Schemes requiring full host validation: domain with TLD, IP address, or localhost
         private static readonly string[] HostValidatedSchemes = ["http", "https"];
 
-        // Schemes validated by scheme recognition alone — any valid URI structure is accepted
-        private static readonly string[] SchemeOnlySchemes = ["file", "brave", "opera", "vivaldi", "edge", "chrome", "chrome-extension", "moz-extension"];
+        // Chromium browser schemes accepting both :// and : forms (e.g. chrome://settings, chrome:settings)
+        private static readonly string[] ChromiumSchemes = ["chrome-extension", "chrome", "brave", "edge", "opera", "vivaldi"];
 
-        private static readonly string[] UrlSchemes = [.. HostValidatedSchemes, .. SchemeOnlySchemes];
+        // Schemes using :// that are validated by scheme recognition alone — any valid URI structure is accepted
+        private static readonly string[] NonHostValidatedDoubleSlashSchemes = [.. ChromiumSchemes, "file", "moz-extension"];
+
+        // Schemes using colon-only syntax (e.g. about:blank, chrome:settings)
+        // Chromium schemes also accept the colon form
+        private static readonly string[] ColonOnlySchemes = [.. ChromiumSchemes, "about", "data"];
+
+        // All :// schemes
+        private static readonly string[] AllDoubleSlashSchemes = [.. HostValidatedSchemes, .. NonHostValidatedDoubleSlashSchemes];
 
         public List<Result> Query(Query query)
         {
@@ -50,7 +58,12 @@ namespace Flow.Launcher.Plugin.Url
                             // if url was accepted without having any of the recognized scheme, 
                             // then that means no scheme was specified (e.g. www.google.com)
                             // so we add the preferred http/https scheme
-                            if (!UrlSchemes.Any(scheme => raw.StartsWith(scheme + "://", StringComparison.OrdinalIgnoreCase)))
+                            var hasScheme = (
+                                AllDoubleSlashSchemes.Any(scheme => raw.StartsWith(scheme + "://", StringComparison.OrdinalIgnoreCase))
+                                ||
+                                ColonOnlySchemes.Any(scheme => raw.StartsWith(scheme + ":", StringComparison.OrdinalIgnoreCase))
+                            );
+                            if (!hasScheme)
                             {
                                 raw = GetHttpPreference() + "://" + raw;
                             }
@@ -122,8 +135,30 @@ namespace Flow.Launcher.Plugin.Url
                 return true;
             }
 
+            // Check colon-only schemes (e.g. about:blank, chrome:settings)
+            // by extracting the scheme as everything before the first colon
+            var colonIndex = input.IndexOf(':');
+            if (colonIndex > 0)
+            {
+                var scheme = input[..colonIndex];
+                if (ColonOnlySchemes.Any(s => scheme.Equals(s, StringComparison.OrdinalIgnoreCase)))
+                {
+                    var content = input[(colonIndex + 1)..];
+
+                    // Some schemes accept both : and :// syntax, so :// forms
+                    // are handled by the Uri validation below instead
+                    if (!content.StartsWith("//"))
+                    {
+                        var hasContent = content.Length > 0;
+                        var hasNoWhitespace = !content.Any(char.IsWhiteSpace);
+
+                        return hasContent && hasNoWhitespace;
+                    }
+                }
+            }
+
             // Add protocol if missing for Uri validation
-            var urlToValidate = UrlSchemes.Any(s => input.StartsWith(s + "://", StringComparison.OrdinalIgnoreCase))
+            var urlToValidate = AllDoubleSlashSchemes.Any(s => input.StartsWith(s + "://", StringComparison.OrdinalIgnoreCase))
                 ? input
                 : GetHttpPreference() + "://" + input;
 
@@ -131,15 +166,15 @@ namespace Flow.Launcher.Plugin.Url
                 return false;
             
 
-            // Validate protocol against known schemes
-            if (!UrlSchemes.Any(scheme => uri.Scheme == scheme))
+            // Validate protocol against known :// schemes
+            if (!AllDoubleSlashSchemes.Any(scheme => uri.Scheme == scheme))
                 return false;
 
             var host = uri.Host;
 
             // Scheme-only validation: any valid URI structure is accepted, no host checks
             // Reject bare scheme:// with no actual content (e.g. chrome://)
-            if (SchemeOnlySchemes.Any(scheme => uri.Scheme == scheme))
+            if (NonHostValidatedDoubleSlashSchemes.Any(scheme => uri.Scheme == scheme))
             {
                 var schemePrefix = uri.Scheme + "://";
                 var hasContent = input.Length > schemePrefix.Length;

--- a/Plugins/Flow.Launcher.Plugin.Url/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Url/Main.cs
@@ -114,80 +114,136 @@ namespace Flow.Launcher.Plugin.Url
                 return false;
 
             // Check if it's a bare IP address with optional port, path, query, or fragment
-            var ipPart = input.Split('/', '?', '#')[0]; // Remove path, query, and fragment
-            if (IPEndPoint.TryParse(ipPart, out var endpoint))
-            {
-                switch (endpoint.AddressFamily)
-                {
-                    case System.Net.Sockets.AddressFamily.InterNetwork:
-                        return !endpoint.Address.Equals(IPAddress.Any);
-                    case System.Net.Sockets.AddressFamily.InterNetworkV6:
-                        if (input.Contains('/') || input.Contains('?') || input.Contains('#'))
-                        {
-                            // Check if IPv6 address is properly bracketed
-                            var bracketStart = input.IndexOf('[');
-                            var bracketEnd = input.IndexOf(']');
-                            if (bracketStart == -1 || bracketEnd == -1 || bracketStart > bracketEnd)
-                                return false;
-                        }
-                        return !endpoint.Address.Equals(IPAddress.IPv6Any);
-                }
-                return true;
-            }
+            if (TryMatchBareIP(input, out var bareIPValid))
+                return bareIPValid;
 
             // Check colon-only schemes (e.g. about:blank, chrome:settings)
-            // by extracting the scheme as everything before the first colon
-            var colonIndex = input.IndexOf(':');
-            if (colonIndex > 0)
-            {
-                var scheme = input[..colonIndex];
-                if (ColonOnlySchemes.Any(s => scheme.Equals(s, StringComparison.OrdinalIgnoreCase)))
-                {
-                    var content = input[(colonIndex + 1)..];
-
-                    // Some schemes accept both : and :// syntax, so :// forms
-                    // are handled by the Uri validation below instead
-                    if (!content.StartsWith("//"))
-                    {
-                        var hasContent = content.Length > 0;
-                        var hasNoWhitespace = !content.Any(char.IsWhiteSpace);
-
-                        return hasContent && hasNoWhitespace;
-                    }
-                }
-            }
+            if (TryMatchColonScheme(input, out var colonValid))
+                return colonValid;
 
             // Add protocol if missing for Uri validation
             var urlToValidate = AllDoubleSlashSchemes.Any(s => input.StartsWith(s + "://", StringComparison.OrdinalIgnoreCase))
                 ? input
                 : GetHttpPreference() + "://" + input;
 
+            // At this point it must be a valid absolute URI
             if (!Uri.TryCreate(urlToValidate, UriKind.Absolute, out var uri))
                 return false;
-            
 
-            // Validate protocol against known :// schemes
+            // Other types of supported schemes are handled above so reject if its not a supported :// scheme
             if (!AllDoubleSlashSchemes.Any(scheme => uri.Scheme == scheme))
                 return false;
 
-            var host = uri.Host;
+            // Check Non-host-validated :// schemes (e.g. chrome://settings, file:///C:/path)
+            if (TryMatchNonHostScheme(uri, input, out var nonHostValid))
+                return nonHostValid;
 
-            // Scheme-only validation: any valid URI structure is accepted, no host checks
-            // Reject bare scheme:// with no actual content (e.g. chrome://)
-            if (NonHostValidatedDoubleSlashSchemes.Any(scheme => uri.Scheme == scheme))
+            // Not matched by any other case so treat as a standard host-validated URL
+            return ValidateSchemeHost(uri);
+        }
+
+        /// <summary>
+        /// Checks if input is a bare IP address. 
+        /// isValid indicates whether it is a valid/usable address (excludes 0.0.0.0 and ::).
+        /// </summary>
+        /// <returns>true if input matches IP format, false otherwise</returns>
+        private static bool TryMatchBareIP(string input, out bool isValid)
+        {
+            var ipPart = input.Split('/', '?', '#')[0]; // Remove path, query, and fragment
+            if (!IPEndPoint.TryParse(ipPart, out var endpoint))
             {
-                var schemePrefix = uri.Scheme + "://";
-                var hasContent = input.Length > schemePrefix.Length;
-
-                return hasContent;
+                isValid = false;
+                return false;
             }
+
+            switch (endpoint.AddressFamily)
+            {
+                case System.Net.Sockets.AddressFamily.InterNetwork:
+                    isValid = !endpoint.Address.Equals(IPAddress.Any);
+                    return true;
+                case System.Net.Sockets.AddressFamily.InterNetworkV6:
+                    if (input.Contains('/') || input.Contains('?') || input.Contains('#'))
+                    {
+                        // Check if IPv6 address is properly bracketed
+                        var bracketStart = input.IndexOf('[');
+                        var bracketEnd = input.IndexOf(']');
+                        if (bracketStart == -1 || bracketEnd == -1 || bracketStart > bracketEnd)
+                        {
+                            isValid = false;
+                            return true;
+                        }
+                    }
+                    isValid = !endpoint.Address.Equals(IPAddress.IPv6Any);
+                    return true;
+            }
+
+            isValid = true;
+            return true;
+        }
+
+        /// <summary>
+        /// Checks if input matches a colon-only scheme. 
+        /// isValid indicates whether the content is non-empty with no whitespace.
+        /// </summary>
+        /// <returns>true if input matches colon scheme format, false otherwise</returns>
+        private static bool TryMatchColonScheme(string input, out bool isValid)
+        {
+            int colonIndex = input.IndexOf(':');
+
+            bool hasColonPrefix = colonIndex > 0;
+
+            bool isKnownScheme = hasColonPrefix
+                && ColonOnlySchemes.Any(s => input[..colonIndex].Equals(s, StringComparison.OrdinalIgnoreCase));
+            
+            bool isColonOnlySyntax = isKnownScheme 
+                && !input[(colonIndex + 1)..].StartsWith("//");
+
+            if (!isColonOnlySyntax)
+            {
+                isValid = false;
+                return false;
+            }
+
+            var content = input[(colonIndex + 1)..];
+            bool hasContent = content.Length > 0;
+            bool hasNoWhitespace = !content.Any(char.IsWhiteSpace);
+
+            isValid = hasContent && hasNoWhitespace;
+            return true;
+        }
+
+        /// <summary>
+        /// Checks if the URI matches a non-host-validated :// scheme. 
+        /// isValid indicates whether there is content after the scheme prefix.
+        /// </summary>
+        /// <returns>true if URI matches a non-host scheme, false otherwise</returns>
+        private static bool TryMatchNonHostScheme(Uri uri, string input, out bool isValid)
+        {
+            if (!NonHostValidatedDoubleSlashSchemes.Any(scheme => uri.Scheme == scheme))
+            {
+                isValid = false;
+                return false;
+            }
+
+            string schemePrefix = uri.Scheme + "://";
+            bool hasContent = input.Length > schemePrefix.Length;
+            isValid = hasContent;
+            return true;
+        }
+
+        /// <summary>
+        /// Validates the host portion of a :// scheme URI.
+        /// </summary>
+        private static bool ValidateSchemeHost(Uri uri)
+        {
+            var host = uri.Host;
 
             // localhost is valid
             if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
                 return true;
 
             // Valid IP address (excluding 0.0.0.0)
-            if (IPEndPoint.TryParse(host, out endpoint))
+            if (IPEndPoint.TryParse(host, out var endpoint))
                 return !endpoint.Address.Equals(IPAddress.Any) && !endpoint.Address.Equals(IPAddress.IPv6Any);
 
             // Domain must have valid format with TLD

--- a/Plugins/Flow.Launcher.Plugin.Url/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Url/Main.cs
@@ -12,7 +12,13 @@ namespace Flow.Launcher.Plugin.Url
         internal static PluginInitContext Context { get; private set; }
         internal static Settings Settings { get; private set; }
 
-        private static readonly string[] UrlSchemes = ["http", "https"];
+        // Schemes requiring full host validation: domain with TLD, IP address, or localhost
+        private static readonly string[] HostValidatedSchemes = ["http", "https"];
+
+        // Schemes validated by scheme recognition alone — any valid URI structure is accepted
+        private static readonly string[] SchemeOnlySchemes = ["file", "brave", "opera", "vivaldi", "edge", "chrome", "chrome-extension", "moz-extension"];
+
+        private static readonly string[] UrlSchemes = [.. HostValidatedSchemes, .. SchemeOnlySchemes];
 
         public List<Result> Query(Query query)
         {
@@ -130,6 +136,10 @@ namespace Flow.Launcher.Plugin.Url
                 return false;
 
             var host = uri.Host;
+
+            // Scheme-only validation: any valid URI structure is accepted, no host checks
+            if (SchemeOnlySchemes.Any(scheme => uri.Scheme == scheme))
+                return true;
 
             // localhost is valid
             if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase))

--- a/Plugins/Flow.Launcher.Plugin.Url/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Url/Main.cs
@@ -15,10 +15,18 @@ namespace Flow.Launcher.Plugin.Url
         // Schemes requiring full host validation: domain with TLD, IP address, or localhost
         private static readonly string[] HostValidatedSchemes = ["http", "https"];
 
-        // Schemes validated by scheme recognition alone — any valid URI structure is accepted
-        private static readonly string[] SchemeOnlySchemes = ["file", "brave", "opera", "vivaldi", "edge", "chrome", "chrome-extension", "moz-extension"];
+        // Chromium browser schemes accepting both :// and : forms (e.g. chrome://settings, chrome:settings)
+        private static readonly string[] ChromiumSchemes = ["chrome-extension", "chrome", "brave", "edge", "opera", "vivaldi"];
 
-        private static readonly string[] UrlSchemes = [.. HostValidatedSchemes, .. SchemeOnlySchemes];
+        // Schemes using :// that are validated by scheme recognition alone — any valid URI structure is accepted
+        private static readonly string[] NonHostValidatedDoubleSlashSchemes = [.. ChromiumSchemes, "file", "moz-extension"];
+
+        // Schemes using colon-only syntax (e.g. about:blank, chrome:settings)
+        // Chromium schemes also accept the colon form
+        private static readonly string[] ColonOnlySchemes = [.. ChromiumSchemes, "about", "data"];
+
+        // All :// schemes
+        private static readonly string[] AllDoubleSlashSchemes = [.. HostValidatedSchemes, .. NonHostValidatedDoubleSlashSchemes];
 
         public List<Result> Query(Query query)
         {
@@ -50,7 +58,12 @@ namespace Flow.Launcher.Plugin.Url
                             // if url was accepted without having any of the recognized scheme, 
                             // then that means no scheme was specified (e.g. www.google.com)
                             // so we add the preferred http/https scheme
-                            if (!UrlSchemes.Any(scheme => raw.StartsWith(scheme + "://", StringComparison.OrdinalIgnoreCase)))
+                            var hasScheme = (
+                                AllDoubleSlashSchemes.Any(scheme => raw.StartsWith(scheme + "://", StringComparison.OrdinalIgnoreCase))
+                                ||
+                                ColonOnlySchemes.Any(scheme => raw.StartsWith(scheme + ":", StringComparison.OrdinalIgnoreCase))
+                            );
+                            if (!hasScheme)
                             {
                                 raw = GetHttpPreference() + "://" + raw;
                             }
@@ -122,8 +135,20 @@ namespace Flow.Launcher.Plugin.Url
                 return true;
             }
 
+            // Check colon-only schemes (e.g. about:blank, chrome:settings)
+            var colonIndex = input.IndexOf(':');
+            if (colonIndex > 0)
+            {
+                var scheme = input[..colonIndex];
+                if (ColonOnlySchemes.Any(s => scheme.Equals(s, StringComparison.OrdinalIgnoreCase)))
+                {
+                    var content = input[(colonIndex + 1)..];
+                    return content.Length > 0 && !content.Any(char.IsWhiteSpace);
+                }
+            }
+
             // Add protocol if missing for Uri validation
-            var urlToValidate = UrlSchemes.Any(s => input.StartsWith(s + "://", StringComparison.OrdinalIgnoreCase))
+            var urlToValidate = AllDoubleSlashSchemes.Any(s => input.StartsWith(s + "://", StringComparison.OrdinalIgnoreCase))
                 ? input
                 : GetHttpPreference() + "://" + input;
 
@@ -131,14 +156,14 @@ namespace Flow.Launcher.Plugin.Url
                 return false;
             
 
-            // Validate protocol against known schemes
-            if (!UrlSchemes.Any(scheme => uri.Scheme == scheme))
+            // Validate protocol against known :// schemes
+            if (!AllDoubleSlashSchemes.Any(scheme => uri.Scheme == scheme))
                 return false;
 
             var host = uri.Host;
 
             // Scheme-only validation: any valid URI structure is accepted, no host checks
-            if (SchemeOnlySchemes.Any(scheme => uri.Scheme == scheme))
+            if (NonHostValidatedDoubleSlashSchemes.Any(scheme => uri.Scheme == scheme))
                 return true;
 
             // localhost is valid


### PR DESCRIPTION
closes #4535 - see it for more context

Also closes #4014

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the URL plugin to support `chrome://`, `file:///`, and colon-only links like `about:`, and removed `ftp`. Tightened validation to reject empty or bare inputs; parsing was refactored into focused helpers without changing expected behavior.

**Summary of changes**
- Changed: URL detection recognizes both `://` and `:` schemes before auto-adding `http/https`; host validation now only for `http/https`; rejects bare `scheme://` and empty/whitespace `scheme:`; colon-only parsing no longer matches `://` forms; internal `IsURL` logic refactored into `TryMatchBareIP`, `TryMatchColonScheme`, `TryMatchNonHostScheme`, and `ValidateSchemeHost`.
- Added: Support for `chrome://`, `edge://`, `brave://`, `opera://`, `vivaldi://`, `chrome-extension://`, `moz-extension://`, `file:///`, plus colon-only `about:`, `data:`, `chrome:`, and `chrome-extension:`.
- Removed: `ftp://` support and related tests.
- Memory: No material change; small static arrays and simple checks; refactor does not add meaningful allocations.
- Security: Dropping `ftp` removes an insecure protocol; stricter validations block empty or bare scheme inputs.
- Tests: Added unit tests for valid/invalid cases of new schemes and for rejecting bare/empty inputs; removed `ftp` cases.

**Release Note**
You can now open browser, file, and about/data links directly; ftp links are no longer supported.

<sup>Written for commit d6243c073e8160207b480bf128049c31c36e5b46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

