### PR TITLE
Fix CMD shell quoted command handling

### DIFF
--- a/Flow.Launcher.Test/Flow.Launcher.Test.csproj
+++ b/Flow.Launcher.Test/Flow.Launcher.Test.csproj
@@ -43,6 +43,7 @@
     <ProjectReference Include="..\Plugins\Flow.Launcher.Plugin.Calculator\Flow.Launcher.Plugin.Calculator.csproj" />
     <ProjectReference Include="..\Plugins\Flow.Launcher.Plugin.Explorer\Flow.Launcher.Plugin.Explorer.csproj" />
     <ProjectReference Include="..\Plugins\Flow.Launcher.Plugin.Program\Flow.Launcher.Plugin.Program.csproj" />
+    <ProjectReference Include="..\Plugins\Flow.Launcher.Plugin.Shell\Flow.Launcher.Plugin.Shell.csproj" />
     <ProjectReference Include="..\Plugins\Flow.Launcher.Plugin.Url\Flow.Launcher.Plugin.Url.csproj" />
     <ProjectReference Include="..\Flow.Launcher.Core\Flow.Launcher.Core.csproj" />
     <ProjectReference Include="..\Flow.Launcher.Infrastructure\Flow.Launcher.Infrastructure.csproj" />

--- a/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using Flow.Launcher.Plugin.Shell;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Flow.Launcher.Test.Plugins
+{
+    [TestFixture]
+    public class ShellPluginTest
+    {
+        [Test]
+        public void ConfigureCmdProcessStartInfo_ShouldPreserveQuotedCommands()
+        {
+            var info = new ProcessStartInfo
+            {
+                FileName = "cmd.exe"
+            };
+
+            Main.ConfigureCmdProcessStartInfo(
+                info,
+                "\"cmd.exe\"",
+                leaveShellOpen: false,
+                closeShellAfterPress: false,
+                notifyStr: "Press any key to close",
+                useWindowsTerminal: false);
+
+            ClassicAssert.AreEqual("/c \"cmd.exe\"", info.Arguments);
+            ClassicAssert.IsEmpty(info.ArgumentList);
+        }
+
+        [Test]
+        public void ConfigureCmdProcessStartInfo_ShouldKeepArgumentListForWindowsTerminal()
+        {
+            var info = new ProcessStartInfo
+            {
+                FileName = "wt.exe"
+            };
+
+            Main.ConfigureCmdProcessStartInfo(
+                info,
+                "\"cmd.exe\"",
+                leaveShellOpen: false,
+                closeShellAfterPress: false,
+                notifyStr: "Press any key to close",
+                useWindowsTerminal: true);
+
+            CollectionAssert.AreEqual(new[] { "cmd", "/c", "\"cmd.exe\"" }, info.ArgumentList);
+            ClassicAssert.IsEmpty(info.Arguments);
+        }
+    }
+}

--- a/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
@@ -11,10 +11,7 @@ namespace Flow.Launcher.Test.Plugins
         [Test]
         public void ConfigureCmdProcessStartInfo_ShouldPreserveQuotedCommands()
         {
-            var info = new ProcessStartInfo
-            {
-                FileName = "cmd.exe"
-            };
+            var info = new ProcessStartInfo();
 
             Main.ConfigureCmdProcessStartInfo(
                 info,
@@ -24,6 +21,7 @@ namespace Flow.Launcher.Test.Plugins
                 notifyStr: "Press any key to close",
                 useWindowsTerminal: false);
 
+            ClassicAssert.AreEqual("cmd.exe", info.FileName);
             ClassicAssert.AreEqual("/c \"cmd.exe\"", info.Arguments);
             ClassicAssert.IsEmpty(info.ArgumentList);
         }
@@ -31,10 +29,7 @@ namespace Flow.Launcher.Test.Plugins
         [Test]
         public void ConfigureCmdProcessStartInfo_ShouldKeepArgumentListForWindowsTerminal()
         {
-            var info = new ProcessStartInfo
-            {
-                FileName = "wt.exe"
-            };
+            var info = new ProcessStartInfo();
 
             Main.ConfigureCmdProcessStartInfo(
                 info,
@@ -44,6 +39,7 @@ namespace Flow.Launcher.Test.Plugins
                 notifyStr: "Press any key to close",
                 useWindowsTerminal: true);
 
+            ClassicAssert.AreEqual("wt.exe", info.FileName);
             CollectionAssert.AreEqual(new[] { "cmd", "/c", "\"cmd.exe\"" }, info.ArgumentList);
             ClassicAssert.IsEmpty(info.Arguments);
         }

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -362,7 +362,11 @@ namespace Flow.Launcher.Plugin.Shell
             }
             catch (Exception e)
             {
-                Context.API.LogException(ClassName, $"Error executing command: {info.FileName} {string.Join(" ", info.ArgumentList)}", e);
+                // ArgumentList and Arguments are mutually exclusive (https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist?view=net-10.0#remarks).
+                var arguments = info.ArgumentList.Count > 0
+                    ? string.Join(" ", info.ArgumentList)
+                    : info.Arguments;
+                Context.API.LogException(ClassName, $"Error executing command: {info.FileName} {arguments}", e);
             }
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -215,19 +215,13 @@ namespace Flow.Launcher.Plugin.Shell
                         {
                             info.FileName = "cmd.exe";
                         }
-                        if (_settings.LeaveShellOpen)
-                        {
-                            info.ArgumentList.Add("/k");
-                        }
-                        else
-                        {
-                            info.ArgumentList.Add("/c");
-                        }
-                        info.ArgumentList.Add(
-                            $"{command}" +
-                            $"{(_settings.CloseShellAfterPress ?
-                                $" && echo {notifyStr} && pause > nul /c" :
-                                "")}");
+                        ConfigureCmdProcessStartInfo(
+                            info,
+                            command,
+                            _settings.LeaveShellOpen,
+                            _settings.CloseShellAfterPress,
+                            notifyStr,
+                            _settings.UseWindowsTerminal);
                         break;
                     }
 
@@ -326,6 +320,28 @@ namespace Flow.Launcher.Plugin.Shell
             _settings.AddCmdHistory(command);
 
             return info;
+        }
+
+        internal static void ConfigureCmdProcessStartInfo(
+            ProcessStartInfo info,
+            string command,
+            bool leaveShellOpen,
+            bool closeShellAfterPress,
+            string notifyStr,
+            bool useWindowsTerminal)
+        {
+            var shellSwitch = leaveShellOpen ? "/k" : "/c";
+            var commandToRun = $"{command}{(closeShellAfterPress ? $" && echo {notifyStr} && pause > nul /c" : "")}";
+
+            if (useWindowsTerminal)
+            {
+                info.ArgumentList.Add("cmd");
+                info.ArgumentList.Add(shellSwitch);
+                info.ArgumentList.Add(commandToRun);
+                return;
+            }
+
+            info.Arguments = $"{shellSwitch} {commandToRun}";
         }
 
         private void Execute(Func<ProcessStartInfo, Process> startProcess, ProcessStartInfo info)

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -206,15 +206,6 @@ namespace Flow.Launcher.Plugin.Shell
             {
                 case Shell.Cmd:
                     {
-                        if (_settings.UseWindowsTerminal)
-                        {
-                            info.FileName = "wt.exe";
-                            info.ArgumentList.Add("cmd");
-                        }
-                        else
-                        {
-                            info.FileName = "cmd.exe";
-                        }
                         ConfigureCmdProcessStartInfo(
                             info,
                             command,
@@ -335,13 +326,19 @@ namespace Flow.Launcher.Plugin.Shell
 
             if (useWindowsTerminal)
             {
+                // Windows Terminal takes individual arguments via ArgumentList.
+                info.FileName = "wt.exe";
                 info.ArgumentList.Add("cmd");
                 info.ArgumentList.Add(shellSwitch);
                 info.ArgumentList.Add(commandToRun);
-                return;
             }
-
-            info.Arguments = $"{shellSwitch} {commandToRun}";
+            else
+            {
+                // Must use Arguments (not ArgumentList) 
+                // so that quoted commands are passed to cmd.exe /c without backslash-escaping
+                info.FileName = "cmd.exe";
+                info.Arguments = $"{shellSwitch} {commandToRun}";
+            }
         }
 
         private void Execute(Func<ProcessStartInfo, Process> startProcess, ProcessStartInfo info)

--- a/Plugins/Flow.Launcher.Plugin.Shell/Properties/AssemblyInfo.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Flow.Launcher.Test")]


### PR DESCRIPTION
## Summary
- Fix the Shell plugin's default CMD path so quoted commands like `> "cmd.exe"` are passed to `cmd.exe` without backslash-escaped quotes.
- Keep the Windows Terminal path on `ArgumentList` to avoid changing its argument handling.
- Add Shell plugin unit coverage for quoted CMD commands and the Windows Terminal argument path.

## Validation
- Reproduced the failure with `ProcessStartInfo.ArgumentList`: `cmd.exe /c "cmd.exe"` is seen by CMD as `'\"cmd.exe\"'`.
- Verified the fixed `ProcessStartInfo.Arguments` path executes the same quoted command successfully.
- `dotnet test Flow.Launcher.Test\Flow.Launcher.Test.csproj --filter "FullyQualifiedName~ShellPluginTest"`
- `dotnet test Flow.Launcher.Test\Flow.Launcher.Test.csproj --no-restore --filter "FullyQualifiedName~ShellPluginTest"`

Closes #4505

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes quoted command handling for CMD in `Flow.Launcher.Plugin.Shell` and centralizes process setup to avoid duplicate args and clearer error logs.

**Summary of changes**
- Changed: CMD now uses `ProcessStartInfo.Arguments` (preserves quotes); Windows Terminal (`wt.exe`) keeps `ArgumentList`. Exception logs now include either `Arguments` or `ArgumentList`, whichever applies.
- Added: `ConfigureCmdProcessStartInfo` builds both CMD and Windows Terminal paths end-to-end, including `FileName`, shell switch, and command string.
- Removed: Use of `ArgumentList` for the CMD path; duplicate `cmd` addition in the Windows Terminal path.
- Memory impact: None meaningful; minor string allocations only.
- Security risks: No new risks; same executables and inputs with safer quoting and clearer logging.
- Unit tests: Yes—tests cover quoted CMD commands and the Windows Terminal argument path (`InternalsVisibleTo` added for test access).

**Release Note**
Quoted commands now run correctly in the Windows CMD shell, and command launching via Windows Terminal is more reliable.

<sup>Written for commit 60cb04a35048be656dfd2bf12a995cb3f5f74461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

