### PR TITLE
Always open browser bookmarks in browser

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Languages/en.xaml
@@ -9,6 +9,7 @@
 
     <!--  Main  -->
     <system:String x:Key="flowlauncher_plugin_browserbookmark_copy_failed">Failed to set url in clipboard</system:String>
+    <system:String x:Key="flowlauncher_plugin_browserbookmark_open_failed">Failed to open url in the browser</system:String>
 
     <!--  Settings  -->
     <system:String x:Key="flowlauncher_plugin_browserbookmark_bookmarkDataSetting">Bookmark Data</system:String>

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
@@ -10,6 +10,7 @@ using Flow.Launcher.Plugin.BrowserBookmark.Commands;
 using Flow.Launcher.Plugin.BrowserBookmark.Models;
 using Flow.Launcher.Plugin.BrowserBookmark.Views;
 using Flow.Launcher.Plugin.SharedCommands;
+using System.Security.Policy;
 
 namespace Flow.Launcher.Plugin.BrowserBookmark;
 
@@ -117,8 +118,17 @@ public class Main : ISettingProvider, IPlugin, IReloadable, IPluginI18n, IContex
             Score = score,
             Action = _ =>
             {
-                Context.API.OpenWebUrl(bookmark.Url);
-                return true;
+                try
+                {
+                    Context.API.OpenWebUrl(bookmark.Url);
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    Context.API.LogException(ClassName, $"Failed to open bookmark: {bookmark.Url}", e);
+                    Context.API.ShowMsgError(Localize.flowlauncher_plugin_browserbookmark_open_failed(), bookmark.Url);
+                    return false;
+                }
             },
             ContextData = new BookmarkAttributes { Url = bookmark.Url }
         };

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
@@ -26,7 +26,7 @@ public class Main : ISettingProvider, IPlugin, IReloadable, IPluginI18n, IContex
     private static List<Bookmark> _cachedBookmarks = new();
 
     private static bool _initialized = false;
-    
+
     public void Init(PluginInitContext context)
     {
         Context = context;
@@ -93,49 +93,35 @@ public class Main : ISettingProvider, IPlugin, IReloadable, IPluginI18n, IContex
         {
             // Since we mixed chrome and firefox bookmarks, we should order them again
             return _cachedBookmarks
-                .Select(
-                    c => new Result
-                    {
-                        Title = c.Name,
-                        SubTitle = c.Url,
-                        IcoPath = !string.IsNullOrEmpty(c.FaviconPath) && File.Exists(c.FaviconPath)
-                            ? c.FaviconPath
-                            : @"Images\bookmark.png",
-                        Score = BookmarkLoader.MatchProgram(c, param).Score,
-                        Action = _ =>
-                        {
-                            Context.API.OpenWebUrl(c.Url);
-
-                            return true;
-                        },
-                        ContextData = new BookmarkAttributes { Url = c.Url }
-                    }
-                )
+                .Select(c => BookmarkToResult(bookmark: c, score: BookmarkLoader.MatchProgram(c, param).Score))
                 .Where(r => r.Score > 0)
                 .ToList();
         }
         else
         {
             return _cachedBookmarks
-                .Select(
-                    c => new Result
-                    {
-                        Title = c.Name,
-                        SubTitle = c.Url,
-                        IcoPath = !string.IsNullOrEmpty(c.FaviconPath) && File.Exists(c.FaviconPath)
-                            ? c.FaviconPath
-                            : @"Images\bookmark.png",
-                        Score = 5,
-                        Action = _ =>
-                        {
-                            Context.API.OpenWebUrl(c.Url);
-                            return true;
-                        },
-                        ContextData = new BookmarkAttributes { Url = c.Url }
-                    }
-                )
+                .Select(c => BookmarkToResult(bookmark: c, score: 5))
                 .ToList();
         }
+    }
+
+    private static Result BookmarkToResult(Bookmark bookmark, int score)
+    {
+        return new Result
+        {
+            Title = bookmark.Name,
+            SubTitle = bookmark.Url,
+            IcoPath = !string.IsNullOrEmpty(bookmark.FaviconPath) && File.Exists(bookmark.FaviconPath)
+                ? bookmark.FaviconPath
+                : @"Images\bookmark.png",
+            Score = score,
+            Action = _ =>
+            {
+                Context.API.OpenWebUrl(bookmark.Url);
+                return true;
+            },
+            ContextData = new BookmarkAttributes { Url = bookmark.Url }
+        };
     }
 
     private static readonly Channel<byte> _refreshQueue = Channel.CreateBounded<byte>(1);

--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/Main.cs
@@ -104,7 +104,7 @@ public class Main : ISettingProvider, IPlugin, IReloadable, IPluginI18n, IContex
                         Score = BookmarkLoader.MatchProgram(c, param).Score,
                         Action = _ =>
                         {
-                            Context.API.OpenUrl(c.Url);
+                            Context.API.OpenWebUrl(c.Url);
 
                             return true;
                         },
@@ -128,7 +128,7 @@ public class Main : ISettingProvider, IPlugin, IReloadable, IPluginI18n, IContex
                         Score = 5,
                         Action = _ =>
                         {
-                            Context.API.OpenUrl(c.Url);
+                            Context.API.OpenWebUrl(c.Url);
                             return true;
                         },
                         ContextData = new BookmarkAttributes { Url = c.Url }


### PR DESCRIPTION
## Enhancement
Use OpenWebUrl instead of OpenUrl in Browser Bookmark plugin - all bookmarks coming from a browser should be opened in a browser. This means schemes like chrome:// will also be supported now in bookmarks.

## Minor Refactor
Also extracted out the result creation to its own method as it was mostly duplicated code.
Then let it catch exceptions and show a new localizaed error message.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bookmarks now always open in your default browser, including browser-only URLs like chrome:// and about:. Adds error handling with a localized error message and refactors result creation for consistency.

**Summary of changes**
- Changed: Use `OpenWebUrl` to open bookmarks so browser-specific schemes (e.g., chrome://, edge://, about:) work.
- Added: Central `BookmarkToResult` helper; exception handling around `OpenWebUrl` that logs and shows a localized error (`flowlauncher_plugin_browserbookmark_open_failed` in `en.xaml`).
- Removed: Duplicate inline bookmark result creation in both query paths.
- Memory: No meaningful impact; tiny reduction in transient allocations from the refactor; one extra localized string is negligible.
- Security: Low risk; URLs still originate from user bookmarks and now fail gracefully on errors.
- Tests: No unit tests added; behavior verified manually.

**Release Note**
Bookmarks now open in your default browser and support special browser pages like Settings; errors show a clear message if opening fails.

<sup>Written for commit 9fdb66c5565f9e1a5ea103607a450e4b164105e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



