### PR TITLE
Refactor shell plugin, add tests & fix bugs

### DIFF
--- a/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.Shell;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
@@ -9,16 +10,15 @@ namespace Flow.Launcher.Test.Plugins
     public class ShellPluginTest
     {
         [Test]
-        public void ConfigureCmdProcessStartInfo_ShouldPreserveQuotedCommands()
+        public void CreateProcessStartInfo_Cmd_ShouldPreserveQuotedCommands()
         {
-            var info = new ProcessStartInfo();
-
-            Main.ConfigureCmdProcessStartInfo(
-                info,
+            var info = Main.CreateProcessStartInfo(
                 "\"cmd.exe\"",
+                Shell.Cmd,
                 leaveShellOpen: false,
                 closeShellAfterPress: false,
                 useWindowsTerminal: false,
+                runAsAdmin: false,
                 closePrompt: "Press any key to close");
 
             ClassicAssert.AreEqual("cmd.exe", info.FileName);
@@ -27,16 +27,15 @@ namespace Flow.Launcher.Test.Plugins
         }
 
         [Test]
-        public void ConfigureCmdProcessStartInfo_ShouldKeepArgumentListForWindowsTerminal()
+        public void CreateProcessStartInfo_Cmd_ShouldUseArgumentListForWindowsTerminal()
         {
-            var info = new ProcessStartInfo();
-
-            Main.ConfigureCmdProcessStartInfo(
-                info,
+            var info = Main.CreateProcessStartInfo(
                 "\"cmd.exe\"",
+                Shell.Cmd,
                 leaveShellOpen: false,
                 closeShellAfterPress: false,
                 useWindowsTerminal: true,
+                runAsAdmin: false,
                 closePrompt: "Press any key to close");
 
             ClassicAssert.AreEqual("wt.exe", info.FileName);

--- a/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
@@ -1,46 +1,300 @@
+using System;
 using System.Diagnostics;
+using System.Linq;
 using Flow.Launcher.Plugin;
 using Flow.Launcher.Plugin.Shell;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
 
 namespace Flow.Launcher.Test.Plugins
 {
     [TestFixture]
     public class ShellPluginTest
     {
-        [Test]
-        public void CreateProcessStartInfo_Cmd_ShouldPreserveQuotedCommands()
-        {
-            var info = Main.CreateProcessStartInfo(
-                "\"cmd.exe\"",
-                Shell.Cmd,
-                leaveShellOpen: false,
-                closeShellAfterPress: false,
-                useWindowsTerminal: false,
-                runAsAdmin: false,
-                closePrompt: "Press any key to close");
+        private const string ClosePrompt = "Press any key to close...";
 
-            ClassicAssert.AreEqual("cmd.exe", info.FileName);
-            ClassicAssert.AreEqual("/c \"cmd.exe\"", info.Arguments);
-            ClassicAssert.IsEmpty(info.ArgumentList);
+        private static ProcessStartInfo Create(
+            string command = "test",
+            Shell shell = Shell.Cmd,
+            bool leaveShellOpen = false,
+            bool closeShellAfterPress = false,
+            bool useWindowsTerminal = false,
+            bool runAsAdmin = false)
+            => Main.CreateProcessStartInfo(
+                command,
+                shell,
+                leaveShellOpen,
+                closeShellAfterPress,
+                useWindowsTerminal,
+                runAsAdmin,
+                ClosePrompt);
+
+        #region CMD
+
+        [Test]
+        public void Cmd_ShouldPreserveQuotedCommands()
+        {
+            var info = Create(
+                command: "\"cmd.exe\"",
+                shell: Shell.Cmd);
+
+            Assert.That(info.FileName, Is.EqualTo("cmd.exe"));
+            Assert.That(info.Arguments, Is.EqualTo("/c \"cmd.exe\""));
+            Assert.That(info.ArgumentList, Is.Empty);
         }
 
         [Test]
-        public void CreateProcessStartInfo_Cmd_ShouldUseArgumentListForWindowsTerminal()
+        public void Cmd_ShouldUseArgumentListForWindowsTerminal()
         {
-            var info = Main.CreateProcessStartInfo(
-                "\"cmd.exe\"",
-                Shell.Cmd,
-                leaveShellOpen: false,
-                closeShellAfterPress: false,
-                useWindowsTerminal: true,
-                runAsAdmin: false,
-                closePrompt: "Press any key to close");
+            var info = Create(
+                command: "\"cmd.exe\"",
+                shell: Shell.Cmd,
+                useWindowsTerminal: true);
 
-            ClassicAssert.AreEqual("wt.exe", info.FileName);
-            CollectionAssert.AreEqual(new[] { "cmd", "/c", "\"cmd.exe\"" }, info.ArgumentList);
-            ClassicAssert.IsEmpty(info.Arguments);
+            Assert.That(info.FileName, Is.EqualTo("wt.exe"));
+            Assert.That(info.ArgumentList, Is.EqualTo(["cmd", "/c", "\"cmd.exe\""]));
+            Assert.That(info.Arguments, Is.Empty);
         }
+
+        [TestCase(true, "/k")]
+        [TestCase(false, "/c")]
+        public void Cmd_UsesCorrectShellSwitch(bool leaveShellOpen, string expectedSwitch)
+        {
+            const string command = "test";
+            var info = Create(
+                command: command,
+                leaveShellOpen: leaveShellOpen,
+                shell: Shell.Cmd);
+
+            Assert.That(info.Arguments, Is.EqualTo($"{expectedSwitch} {command}"));
+        }
+
+        [Test]
+        public void Cmd_CloseShellAfterPress_AppendsPause()
+        {
+            const string command = "test";
+            var info = Create(
+                command: command,
+                closeShellAfterPress: true,
+                shell: Shell.Cmd);
+
+            Assert.That(info.Arguments, Is.EqualTo($"/c {command} && echo {ClosePrompt} && pause > nul /c"));
+        }
+
+        [Test]
+        public void Cmd_TrimsCommandWhitespace()
+        {
+            var info = Create(
+                command: "  dir  ",
+                shell: Shell.Cmd);
+
+            Assert.That(info.Arguments, Is.EqualTo("/c dir"));
+        }
+
+        [Test]
+        public void Cmd_WithSpacesAndQuotes_PassesThroughUnchanged()
+        {
+            var info = Create(
+                command: "\"C:\\Program Files\\app.exe\" --flag",
+                shell: Shell.Cmd);
+
+            Assert.That(info.Arguments, Is.EqualTo("/c \"C:\\Program Files\\app.exe\" --flag"));
+        }
+
+        #endregion
+
+        #region PowerShell
+
+        [Test]
+        public void Powershell_DirectExecution()
+        {
+            var info = Create(shell: Shell.Powershell);
+
+            Assert.That(info.FileName, Is.EqualTo("powershell.exe"));
+            Assert.That(info.ArgumentList, Is.EqualTo(["-Command", "test;"]));
+        }
+
+        [Test]
+        public void Powershell_WithSpecialCharacters_PassesThrough()
+        {
+            var info = Create(
+                command: "$env:USERNAME",
+                shell: Shell.Powershell);
+
+            Assert.That(info.ArgumentList, Is.EqualTo(["-Command", "$env:USERNAME;"]));
+        }
+
+        [Test]
+        public void Powershell_CloseShellAfterPress_AppendsPrompt()
+        {
+            var info = Create(
+                shell: Shell.Powershell,
+                closeShellAfterPress: true);
+
+            var commandArg = info.ArgumentList.Last();
+            Assert.That(commandArg, Does.Contain($"Write-Host '{ClosePrompt}'"));
+        }
+
+        [Test]
+        public void Powershell_WT_UsesWindowsTerminal()
+        {
+            var info = Create(
+                shell: Shell.Powershell,
+                useWindowsTerminal: true);
+
+            Assert.That(info.FileName, Is.EqualTo("wt.exe"));
+            Assert.That(info.ArgumentList, Does.Contain("powershell"));
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Powershell_AddsNoExitOnlyWhenLeaveShellOpen(bool leaveShellOpen)
+        {
+            var info = Create(
+                shell: Shell.Powershell,
+                leaveShellOpen: leaveShellOpen);
+
+            Assert.That(info.ArgumentList, leaveShellOpen
+                ? Does.Contain("-NoExit")
+                : Does.Not.Contain("-NoExit"));
+        }
+
+        [Test]
+        public void Powershell_LeaveShellOpen_OmitsCommandSwitch()
+        {
+            var info = Create(
+                shell: Shell.Powershell,
+                leaveShellOpen: true);
+
+            Assert.That(info.ArgumentList, Does.Not.Contain("-Command"));
+        }
+
+        #endregion
+
+        #region Pwsh
+
+        [Test]
+        public void Pwsh_AlwaysAddsCommandSwitch()
+        {
+            var info = Create(shell: Shell.Pwsh);
+
+            Assert.That(info.FileName, Is.EqualTo("pwsh.exe"));
+            Assert.That(info.ArgumentList, Does.Contain("-Command"));
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Pwsh_AddsNoExitOnlyWhenLeaveShellOpen(bool leaveShellOpen)
+        {
+            var info = Create(
+                shell: Shell.Pwsh,
+                leaveShellOpen: leaveShellOpen);
+
+            Assert.That(
+                info.ArgumentList, 
+                leaveShellOpen
+                    ? Does.Contain("-NoExit")
+                    : Does.Not.Contain("-NoExit")
+                );
+        }
+
+        [Test]
+        public void Pwsh_CloseShellAfterPress_AppendsPrompt()
+        {
+            var info = Create(
+                shell: Shell.Pwsh,
+                closeShellAfterPress: true);
+
+            var commandArg = info.ArgumentList.Last();
+            Assert.That(commandArg, Does.Contain($"Write-Host '{ClosePrompt}'"));
+        }
+
+        #endregion
+
+        #region RunCommand
+
+        [Test]
+        public void RunCommand_SingleWord_SetsFileName()
+        {
+            var info = Create(
+                command: "notepad",
+                shell: Shell.RunCommand);
+
+            Assert.That(info.FileName, Is.EqualTo("notepad"));
+        }
+
+        [Test]
+        public void RunCommand_UnknownExecutable_SetsWholeCommandAsFileName()
+        {
+            var info = Create(
+                command: "nonexistentapp123 argument",
+                shell: Shell.RunCommand);
+
+            Assert.That(info.FileName, Is.EqualTo("nonexistentapp123 argument"));
+        }
+
+        #endregion
+
+        #region Common
+
+        [TestCase(false, "")]
+        [TestCase(true, "runas")]
+        public void SetsRunAsAdminVerb(bool runAsAdmin, string expectedVerb)
+        {
+            var info = Create(runAsAdmin: runAsAdmin);
+
+            Assert.That(info.Verb, Is.EqualTo(expectedVerb));
+        }
+
+        [TestCase(Shell.Cmd)]
+        [TestCase(Shell.Powershell)]
+        [TestCase(Shell.Pwsh)]
+        [TestCase(Shell.RunCommand)]
+        public void SetsWorkingDirectory(Shell shell)
+        {
+            var info = Create(shell: shell);
+
+            var expected = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            Assert.That(info.WorkingDirectory, Is.EqualTo(expected));
+        }
+
+        [TestCase(Shell.Cmd)]
+        [TestCase(Shell.Powershell)]
+        [TestCase(Shell.Pwsh)]
+        [TestCase(Shell.RunCommand)]
+        public void SetsUseShellExecute(Shell shell)
+        {
+            var info = Create(shell: shell);
+
+            Assert.That(info.UseShellExecute, Is.True);
+        }
+
+        [TestCase(Shell.Cmd)]
+        [TestCase(Shell.Powershell)]
+        [TestCase(Shell.Pwsh)]
+        [TestCase(Shell.RunCommand)]
+        public void ExpandsEnvironmentVariables(Shell shell)
+        {
+            var info = Create(
+                command: "%USERPROFILE%\\test",
+                shell: shell);
+
+            var expandedPath = Environment.ExpandEnvironmentVariables("%USERPROFILE%\\test");
+
+            switch (shell)
+            {
+                case Shell.Cmd:
+                    Assert.That(info.Arguments, Is.EqualTo($"/c {expandedPath}"));
+                    break;
+                case Shell.Powershell:
+                case Shell.Pwsh:
+                    Assert.That(info.ArgumentList, Does.Contain(expandedPath + ";"));
+                    break;
+                case Shell.RunCommand:
+                    Assert.That(info.FileName, Is.EqualTo(expandedPath));
+                    break;
+            }
+        }
+
+        #endregion
     }
 }

--- a/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
@@ -77,7 +77,7 @@ namespace Flow.Launcher.Test.Plugins
                 closeShellAfterPress: true,
                 shell: Shell.Cmd);
 
-            Assert.That(info.Arguments, Is.EqualTo($"/c {command} && echo {ClosePrompt} && pause > nul /c"));
+            Assert.That(info.Arguments, Is.EqualTo($"/c {command} && echo {ClosePrompt} && pause > nul"));
         }
 
         [Test]

--- a/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
@@ -18,8 +18,8 @@ namespace Flow.Launcher.Test.Plugins
                 "\"cmd.exe\"",
                 leaveShellOpen: false,
                 closeShellAfterPress: false,
-                notifyStr: "Press any key to close",
-                useWindowsTerminal: false);
+                useWindowsTerminal: false,
+                closePrompt: "Press any key to close");
 
             ClassicAssert.AreEqual("cmd.exe", info.FileName);
             ClassicAssert.AreEqual("/c \"cmd.exe\"", info.Arguments);
@@ -36,8 +36,8 @@ namespace Flow.Launcher.Test.Plugins
                 "\"cmd.exe\"",
                 leaveShellOpen: false,
                 closeShellAfterPress: false,
-                notifyStr: "Press any key to close",
-                useWindowsTerminal: true);
+                useWindowsTerminal: true,
+                closePrompt: "Press any key to close");
 
             ClassicAssert.AreEqual("wt.exe", info.FileName);
             CollectionAssert.AreEqual(new[] { "cmd", "/c", "\"cmd.exe\"" }, info.ArgumentList);

--- a/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
@@ -220,6 +220,7 @@ namespace Flow.Launcher.Test.Plugins
                 shell: Shell.RunCommand);
 
             Assert.That(info.FileName, Is.EqualTo("notepad"));
+            Assert.That(info.Arguments, Is.Empty);
         }
 
         [Test]
@@ -230,6 +231,63 @@ namespace Flow.Launcher.Test.Plugins
                 shell: Shell.RunCommand);
 
             Assert.That(info.FileName, Is.EqualTo("nonexistentapp123 argument"));
+        }
+
+        [Test]
+        public void RunCommand_UnknownQuotedExecutable_SetsWholeCommandAsFileName()
+        {
+            var info = Create(
+                command: "\"C:\\nonexistent\\app.exe\" --flag",
+                shell: Shell.RunCommand);
+
+            Assert.That(info.FileName, Is.EqualTo("\"C:\\nonexistent\\app.exe\" --flag"));
+        }
+
+        [Test]
+        public void RunCommand_QuotedPathNoArgs_ExtractsFileName()
+        {
+            var systemDir = Environment.SystemDirectory;
+            var info = Create(
+                command: $"\"{systemDir}\\cmd.exe\"",
+                shell: Shell.RunCommand);
+
+            Assert.That(info.FileName, Is.EqualTo($"{systemDir}\\cmd.exe"));
+            Assert.That(info.Arguments, Is.Empty);
+        }
+
+        [Test]
+        public void RunCommand_QuotedPath_WithQuotedArgs_Preserved()
+        {
+            var systemDir = Environment.SystemDirectory;
+            var info = Create(
+                command: $"\"{systemDir}\\cmd.exe\" /c echo \"hello world\"",
+                shell: Shell.RunCommand);
+
+            Assert.That(info.FileName, Is.EqualTo($"{systemDir}\\cmd.exe"));
+            Assert.That(info.Arguments, Is.EqualTo("/c echo \"hello world\""));
+        }
+
+        [Test]
+        public void RunCommand_UsesArgumentsForCommandTail()
+        {
+            var info = Create(
+                command: "cmd /c echo hello",
+                shell: Shell.RunCommand);
+
+            Assert.That(info.FileName, Is.EqualTo("cmd"));
+            Assert.That(info.Arguments, Is.EqualTo("/c echo hello"));
+        }
+
+        [Test]
+        public void RunCommand_QuotedExecutablePath_ExtractsFileName()
+        {
+            var systemDir = Environment.SystemDirectory;
+            var info = Create(
+                command: $"\"{systemDir}\\cmd.exe\" /c echo hello",
+                shell: Shell.RunCommand);
+
+            Assert.That(info.FileName, Is.EqualTo($"{systemDir}\\cmd.exe"));
+            Assert.That(info.Arguments, Is.EqualTo("/c echo hello"));
         }
 
         #endregion

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -193,7 +193,7 @@ namespace Flow.Launcher.Plugin.Shell
             command = command.Trim();
             command = Environment.ExpandEnvironmentVariables(command);
             var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var runAsAdministratorArg = !runAsAdministrator && !_settings.RunAsAdministrator ? "" : "runas";
+            var runAsAdministratorArg = (runAsAdministrator || _settings.RunAsAdministrator) ? "runas" : "";
 
             var info = new ProcessStartInfo()
             {

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -297,8 +297,6 @@ namespace Flow.Launcher.Plugin.Shell
                             info.FileName = command;
                         }
 
-                        info.UseShellExecute = true;
-
                         break;
                     }
 

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -272,7 +272,7 @@ namespace Flow.Launcher.Plugin.Shell
             return info;
         }
 
-        internal static void ConfigureCmdProcessStartInfo(
+        private static void ConfigureCmdProcessStartInfo(
             ProcessStartInfo info,
             string command,
             bool leaveShellOpen,
@@ -300,7 +300,7 @@ namespace Flow.Launcher.Plugin.Shell
             }
         }
 
-        internal static void ConfigurePowershellProcessStartInfo(
+        private static void ConfigurePowershellProcessStartInfo(
             ProcessStartInfo info,
             string command,
             bool leaveShellOpen,
@@ -339,7 +339,7 @@ namespace Flow.Launcher.Plugin.Shell
             }
         }
 
-        internal static void ConfigurePwshProcessStartInfo(
+        private static void ConfigurePwshProcessStartInfo(
             ProcessStartInfo info,
             string command,
             bool leaveShellOpen,
@@ -375,7 +375,7 @@ namespace Flow.Launcher.Plugin.Shell
             info.ArgumentList.Add(commandStr);
         }
 
-        internal static void ConfigureRunCommandStartInfo(
+        private static void ConfigureRunCommandStartInfo(
             ProcessStartInfo info,
             string command)
         {

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -281,7 +281,7 @@ namespace Flow.Launcher.Plugin.Shell
             string closePrompt)
         {
             var shellSwitch = leaveShellOpen ? "/k" : "/c";
-            var commandToRun = $"{command}{(closeShellAfterPress ? $" && echo {closePrompt} && pause > nul /c" : "")}";
+            var commandToRun = $"{command}{(closeShellAfterPress ? $" && echo {closePrompt} && pause > nul" : "")}";
 
             if (useWindowsTerminal)
             {

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -201,104 +201,43 @@ namespace Flow.Launcher.Plugin.Shell
                 WorkingDirectory = workingDirectory,
             };
             var notifyStr = Localize.flowlauncher_plugin_cmd_press_any_key_to_close();
-            var addedCharacter = _settings.UseWindowsTerminal ? "\\" : "";
             switch (_settings.Shell)
             {
                 case Shell.Cmd:
-                    {
-                        ConfigureCmdProcessStartInfo(
-                            info,
-                            command,
-                            _settings.LeaveShellOpen,
-                            _settings.CloseShellAfterPress,
-                            notifyStr,
-                            _settings.UseWindowsTerminal);
-                        break;
-                    }
+                    ConfigureCmdProcessStartInfo(
+                        info,
+                        command,
+                        _settings.LeaveShellOpen,
+                        _settings.CloseShellAfterPress,
+                        notifyStr,
+                        _settings.UseWindowsTerminal);
+                    break;
 
                 case Shell.Powershell:
-                    {
-                        // Using just a ; doesn't work with wt, as it's used to create a new tab for the terminal window
-                        // \\ must be escaped for it to work properly, or breaking it into multiple arguments
-                        if (_settings.UseWindowsTerminal)
-                        {
-                            info.FileName = "wt.exe";
-                            info.ArgumentList.Add("powershell");
-                        }
-                        else
-                        {
-                            info.FileName = "powershell.exe";
-                        }
-                        if (_settings.LeaveShellOpen)
-                        {
-                            info.ArgumentList.Add("-NoExit");
-                            info.ArgumentList.Add(command);
-                        }
-                        else
-                        {
-                            info.ArgumentList.Add("-Command");
-                            info.ArgumentList.Add(
-                                $"{command}{addedCharacter};" +
-                                $"{(_settings.CloseShellAfterPress ?
-                                    $" Write-Host '{notifyStr}'{addedCharacter}; [System.Console]::ReadKey(){addedCharacter}; exit" :
-                                    "")}");
-                        }
-                        break;
-                    }
+                    ConfigurePowershellProcessStartInfo(
+                        info,
+                        command,
+                        _settings.LeaveShellOpen,
+                        _settings.CloseShellAfterPress,
+                        notifyStr,
+                        _settings.UseWindowsTerminal);
+                    break;
 
                 case Shell.Pwsh:
-                    {
-                        // Using just a ; doesn't work with wt, as it's used to create a new tab for the terminal window
-                        // \\ must be escaped for it to work properly, or breaking it into multiple arguments
-                        if (_settings.UseWindowsTerminal)
-                        {
-                            info.FileName = "wt.exe";
-                            info.ArgumentList.Add("pwsh");
-                        }
-                        else
-                        {
-                            info.FileName = "pwsh.exe";
-                        }
-                        if (_settings.LeaveShellOpen)
-                        {
-                            info.ArgumentList.Add("-NoExit");
-                        }
-                        info.ArgumentList.Add("-Command");
-                        info.ArgumentList.Add(
-                            $"{command}{addedCharacter};" +
-                            $"{(_settings.CloseShellAfterPress ?
-                                $" Write-Host '{notifyStr}'{addedCharacter}; [System.Console]::ReadKey(){addedCharacter}; exit" :
-                                "")}");
-                        break;
-                    }
+                    ConfigurePwshProcessStartInfo(
+                        info,
+                        command,
+                        _settings.LeaveShellOpen,
+                        _settings.CloseShellAfterPress,
+                        notifyStr,
+                        _settings.UseWindowsTerminal);
+                    break;
 
                 case Shell.RunCommand:
-                    {
-                        var parts = command.Split(
-                        [
-                            ' '
-                        ], 2);
-                        if (parts.Length == 2)
-                        {
-                            var filename = parts[0];
-                            if (ExistInPath(filename))
-                            {
-                                var arguments = parts[1];
-                                info.FileName = filename;
-                                info.ArgumentList.Add(arguments);
-                            }
-                            else
-                            {
-                                info.FileName = command;
-                            }
-                        }
-                        else
-                        {
-                            info.FileName = command;
-                        }
-
-                        break;
-                    }
+                    ConfigureRunCommandStartInfo(
+                        info,
+                        command);
+                    break;
 
                 default:
                     throw new NotImplementedException();
@@ -336,6 +275,106 @@ namespace Flow.Launcher.Plugin.Shell
                 // so that quoted commands are passed to cmd.exe /c without backslash-escaping
                 info.FileName = "cmd.exe";
                 info.Arguments = $"{shellSwitch} {commandToRun}";
+            }
+        }
+
+        internal static void ConfigurePowershellProcessStartInfo(
+            ProcessStartInfo info,
+            string command,
+            bool leaveShellOpen,
+            bool closeShellAfterPress,
+            string notifyStr,
+            bool useWindowsTerminal)
+        {
+            // Using just a ; doesn't work with wt, as it's used to create a new tab for the terminal window.
+            // \\ must be escaped for it to work properly, or breaking it into multiple arguments.
+            var escape = useWindowsTerminal ? "\\" : "";
+
+            if (useWindowsTerminal)
+            {
+                info.FileName = "wt.exe";
+                info.ArgumentList.Add("powershell");
+            }
+            else
+            {
+                info.FileName = "powershell.exe";
+            }
+
+            if (leaveShellOpen)
+            {
+                info.ArgumentList.Add("-NoExit");
+                info.ArgumentList.Add(command);
+            }
+            else
+            {
+                info.ArgumentList.Add("-Command");
+                var commandStr = $"{command}{escape};";
+                if (closeShellAfterPress)
+                {
+                    commandStr += $" Write-Host '{notifyStr}'{escape}; [System.Console]::ReadKey(){escape}; exit";
+                }
+                info.ArgumentList.Add(commandStr);
+            }
+        }
+
+        internal static void ConfigurePwshProcessStartInfo(
+            ProcessStartInfo info,
+            string command,
+            bool leaveShellOpen,
+            bool closeShellAfterPress,
+            string notifyStr,
+            bool useWindowsTerminal)
+        {
+            // Using just a ; doesn't work with wt, as it's used to create a new tab for the terminal window.
+            // \\ must be escaped for it to work properly, or breaking it into multiple arguments.
+            var escape = useWindowsTerminal ? "\\" : "";
+
+            if (useWindowsTerminal)
+            {
+                info.FileName = "wt.exe";
+                info.ArgumentList.Add("pwsh");
+            }
+            else
+            {
+                info.FileName = "pwsh.exe";
+            }
+
+            if (leaveShellOpen)
+            {
+                info.ArgumentList.Add("-NoExit");
+            }
+
+            info.ArgumentList.Add("-Command");
+            var commandStr = $"{command}{escape};";
+            if (closeShellAfterPress)
+            {
+                commandStr += $" Write-Host '{notifyStr}'{escape}; [System.Console]::ReadKey(){escape}; exit";
+            }
+            info.ArgumentList.Add(commandStr);
+        }
+
+        internal static void ConfigureRunCommandStartInfo(
+            ProcessStartInfo info, 
+            string command
+        ) {
+            var parts = command.Split([' '], 2);
+            if (parts.Length == 2)
+            {
+                var filename = parts[0];
+                if (ExistInPath(filename))
+                {
+                    var arguments = parts[1];
+                    info.FileName = filename;
+                    info.ArgumentList.Add(arguments);
+                }
+                else
+                {
+                    info.FileName = command;
+                }
+            }
+            else
+            {
+                info.FileName = command;
             }
         }
 

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -200,7 +200,7 @@ namespace Flow.Launcher.Plugin.Shell
                 Verb = runAsAdministratorArg,
                 WorkingDirectory = workingDirectory,
             };
-            var notifyStr = Localize.flowlauncher_plugin_cmd_press_any_key_to_close();
+            var closePrompt = Localize.flowlauncher_plugin_cmd_press_any_key_to_close();
             switch (_settings.Shell)
             {
                 case Shell.Cmd:
@@ -209,8 +209,8 @@ namespace Flow.Launcher.Plugin.Shell
                         command,
                         _settings.LeaveShellOpen,
                         _settings.CloseShellAfterPress,
-                        notifyStr,
-                        _settings.UseWindowsTerminal);
+                        _settings.UseWindowsTerminal,
+                        closePrompt);
                     break;
 
                 case Shell.Powershell:
@@ -219,8 +219,8 @@ namespace Flow.Launcher.Plugin.Shell
                         command,
                         _settings.LeaveShellOpen,
                         _settings.CloseShellAfterPress,
-                        notifyStr,
-                        _settings.UseWindowsTerminal);
+                        _settings.UseWindowsTerminal,
+                        closePrompt);
                     break;
 
                 case Shell.Pwsh:
@@ -229,8 +229,8 @@ namespace Flow.Launcher.Plugin.Shell
                         command,
                         _settings.LeaveShellOpen,
                         _settings.CloseShellAfterPress,
-                        notifyStr,
-                        _settings.UseWindowsTerminal);
+                        _settings.UseWindowsTerminal,
+                        closePrompt);
                     break;
 
                 case Shell.RunCommand:
@@ -255,11 +255,11 @@ namespace Flow.Launcher.Plugin.Shell
             string command,
             bool leaveShellOpen,
             bool closeShellAfterPress,
-            string notifyStr,
-            bool useWindowsTerminal)
+            bool useWindowsTerminal,
+            string closePrompt)
         {
             var shellSwitch = leaveShellOpen ? "/k" : "/c";
-            var commandToRun = $"{command}{(closeShellAfterPress ? $" && echo {notifyStr} && pause > nul /c" : "")}";
+            var commandToRun = $"{command}{(closeShellAfterPress ? $" && echo {closePrompt} && pause > nul /c" : "")}";
 
             if (useWindowsTerminal)
             {
@@ -283,8 +283,8 @@ namespace Flow.Launcher.Plugin.Shell
             string command,
             bool leaveShellOpen,
             bool closeShellAfterPress,
-            string notifyStr,
-            bool useWindowsTerminal)
+            bool useWindowsTerminal,
+            string closePrompt)
         {
             // Using just a ; doesn't work with wt, as it's used to create a new tab for the terminal window.
             // \\ must be escaped for it to work properly, or breaking it into multiple arguments.
@@ -311,7 +311,7 @@ namespace Flow.Launcher.Plugin.Shell
                 var commandStr = $"{command}{escape};";
                 if (closeShellAfterPress)
                 {
-                    commandStr += $" Write-Host '{notifyStr}'{escape}; [System.Console]::ReadKey(){escape}; exit";
+                    commandStr += $" Write-Host '{closePrompt}'{escape}; [System.Console]::ReadKey(){escape}; exit";
                 }
                 info.ArgumentList.Add(commandStr);
             }
@@ -322,8 +322,8 @@ namespace Flow.Launcher.Plugin.Shell
             string command,
             bool leaveShellOpen,
             bool closeShellAfterPress,
-            string notifyStr,
-            bool useWindowsTerminal)
+            bool useWindowsTerminal,
+            string closePrompt)
         {
             // Using just a ; doesn't work with wt, as it's used to create a new tab for the terminal window.
             // \\ must be escaped for it to work properly, or breaking it into multiple arguments.
@@ -348,15 +348,15 @@ namespace Flow.Launcher.Plugin.Shell
             var commandStr = $"{command}{escape};";
             if (closeShellAfterPress)
             {
-                commandStr += $" Write-Host '{notifyStr}'{escape}; [System.Console]::ReadKey(){escape}; exit";
+                commandStr += $" Write-Host '{closePrompt}'{escape}; [System.Console]::ReadKey(){escape}; exit";
             }
             info.ArgumentList.Add(commandStr);
         }
 
         internal static void ConfigureRunCommandStartInfo(
-            ProcessStartInfo info, 
-            string command
-        ) {
+            ProcessStartInfo info,
+            string command)
+        {
             var parts = command.Split([' '], 2);
             if (parts.Length == 2)
             {

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -379,23 +379,49 @@ namespace Flow.Launcher.Plugin.Shell
             ProcessStartInfo info,
             string command)
         {
-            var parts = command.Split([' '], 2);
-            if (parts.Length == 2)
+            string filename = null;
+            string arguments = null;
+
+            bool isQuotedPath = command.StartsWith("\"");
+
+            if (isQuotedPath)
             {
-                var filename = parts[0];
-                if (ExistInPath(filename))
+                // Quoted paths ("C:\Program Files\app.exe") can have spaces in the path. 
+                
+                // We know the command starts with a quote,
+                // So strip it off and split to see if theres a second one
+                var parts = command[1..].Split("\"", 2);
+                bool hasMatchingQuotes = parts.Length > 1;
+
+                if (hasMatchingQuotes)
                 {
-                    var arguments = parts[1];
-                    info.FileName = filename;
-                    info.ArgumentList.Add(arguments);
+                    filename = parts[0];
+                    arguments = parts[1];
                 }
-                else
-                {
-                    info.FileName = command;
-                }
+                // If there is no closing quote then we leave both as null
             }
             else
             {
+                // Without a quoted path,
+                // we split on the first space to get the filename and args
+                var parts = command.Split(' ', 2);
+                filename = parts[0];
+                arguments = parts.Length > 1 ? parts[1] : null;
+            }
+
+            if (filename != null && ExistInPath(filename))
+            {
+                info.FileName = filename;
+                
+                // catch unnecessary space or arguments that are just whitespace
+                var trimmedArgs = arguments?.TrimStart();
+                if (!string.IsNullOrEmpty(trimmedArgs))
+                    info.Arguments = trimmedArgs;
+            }
+            else
+            {
+                // Could not parse a valid filename or it was not found.
+                // Pass the whole command anyways so the OS produces a meaningful error.
                 info.FileName = command;
             }
         }

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -190,26 +190,52 @@ namespace Flow.Launcher.Plugin.Shell
 
         private ProcessStartInfo PrepareProcessStartInfo(string command, bool runAsAdministrator = false)
         {
+            var runAsAdmin = runAsAdministrator || _settings.RunAsAdministrator;
+            var closePrompt = Localize.flowlauncher_plugin_cmd_press_any_key_to_close();
+            var info = CreateProcessStartInfo(
+                command,
+                _settings.Shell,
+                _settings.LeaveShellOpen,
+                _settings.CloseShellAfterPress,
+                _settings.UseWindowsTerminal,
+                runAsAdmin,
+                closePrompt);
+
+            _settings.AddCmdHistory(command);
+            return info;
+        }
+
+        internal static ProcessStartInfo CreateProcessStartInfo(
+            string command,
+            Shell shell,
+            bool leaveShellOpen,
+            bool closeShellAfterPress,
+            bool useWindowsTerminal,
+            bool runAsAdmin,
+            string closePrompt)
+        {
             command = command.Trim();
             command = Environment.ExpandEnvironmentVariables(command);
+
             var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var runAsAdministratorArg = (runAsAdministrator || _settings.RunAsAdministrator) ? "runas" : "";
+            var runAsAdministratorArg = runAsAdmin ? "runas" : "";
 
             var info = new ProcessStartInfo()
             {
                 Verb = runAsAdministratorArg,
                 WorkingDirectory = workingDirectory,
+                UseShellExecute = true,
             };
-            var closePrompt = Localize.flowlauncher_plugin_cmd_press_any_key_to_close();
-            switch (_settings.Shell)
+
+            switch (shell)
             {
                 case Shell.Cmd:
                     ConfigureCmdProcessStartInfo(
                         info,
                         command,
-                        _settings.LeaveShellOpen,
-                        _settings.CloseShellAfterPress,
-                        _settings.UseWindowsTerminal,
+                        leaveShellOpen,
+                        closeShellAfterPress,
+                        useWindowsTerminal,
                         closePrompt);
                     break;
 
@@ -217,9 +243,9 @@ namespace Flow.Launcher.Plugin.Shell
                     ConfigurePowershellProcessStartInfo(
                         info,
                         command,
-                        _settings.LeaveShellOpen,
-                        _settings.CloseShellAfterPress,
-                        _settings.UseWindowsTerminal,
+                        leaveShellOpen,
+                        closeShellAfterPress,
+                        useWindowsTerminal,
                         closePrompt);
                     break;
 
@@ -227,9 +253,9 @@ namespace Flow.Launcher.Plugin.Shell
                     ConfigurePwshProcessStartInfo(
                         info,
                         command,
-                        _settings.LeaveShellOpen,
-                        _settings.CloseShellAfterPress,
-                        _settings.UseWindowsTerminal,
+                        leaveShellOpen,
+                        closeShellAfterPress,
+                        useWindowsTerminal,
                         closePrompt);
                     break;
 
@@ -242,10 +268,6 @@ namespace Flow.Launcher.Plugin.Shell
                 default:
                     throw new NotImplementedException();
             }
-
-            info.UseShellExecute = true;
-
-            _settings.AddCmdHistory(command);
 
             return info;
         }


### PR DESCRIPTION
Follow up PR from #4545

Finish the job of refactoring the shell plugin and in doing that make it testable and then add tests for it.
Also did some bug fixes in the process.

### Bug fixes
- **RunCommand** — rewrote method to use `Arguments` instead of
 `ArgumentList` so OS correctly splits args by spaces, add support for quoted executable
  paths with spaces, and improve whitespace handling in args.
- **Command history** - stores the original input (e.g. `echo %USERPROFILE%`) instead of expanded environment variables, matching what the user actually typed.
- **CMD close-after-press** - removed extra `/c` after `pause > nul` in the pause command. `pause` ignores arguments, so it had no effect, but better to clean it up.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the shell plugin to centralize process creation and add per‑shell helpers, fixing argument parsing, elevation, and Windows Terminal quirks. Improves reliability across CMD, PowerShell, pwsh, Windows Terminal, and RunCommand; history now records exactly what you typed.

**Summary of changes**
- Changed: Centralized setup in `CreateProcessStartInfo` (trim, env var expansion, working dir, `UseShellExecute = true`). Simplified admin elevation (`Verb = "runas"` if either flag is true). Windows Terminal escaping and argument handling are more robust. PowerShell now adds `-NoExit` when leaving open and omits `-Command` in that case; `pwsh` always uses `-Command` and adds `-NoExit` when leaving open. CMD close-after-press uses `pause > nul` (no trailing `/c`). RunCommand now uses `Arguments` for the tail, handles quoted executable paths, trims leading whitespace, and falls back to the whole command when the executable isn’t found.
- Added: Private per-shell helpers (`ConfigureCmdProcessStartInfo`, `ConfigurePowershellProcessStartInfo`, `ConfigurePwshProcessStartInfo`, `ConfigureRunCommandStartInfo`). Unified close prompt parameter (`closePrompt`).
- Removed: Duplicate `UseShellExecute` assignment in RunCommand. Public visibility of shell-specific config methods (now private).
- Memory: No meaningful impact.
- Security: No new risks; command history stores the original input (not expanded).
- Unit tests: Switched tests to `CreateProcessStartInfo` to validate the full pipeline across shells and Windows Terminal. Added coverage for leave-open/close, `-NoExit`/`-Command` behavior, close prompt, quoting and quoted-paths, env var expansion, working dir, PATH lookup, admin verb, and multi-word arguments in RunCommand; updated the CMD pause assertion.

**Release Note**
Commands now launch more reliably across shells; multi-word arguments and quoted paths work in RunCommand, and your history shows exactly what you typed.

<sup>Written for commit 049ffe58bfdcfd7713d7075a523dabaeb4acd3d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




