### PR TITLE
Fix floating-point precision error in calculator

### DIFF
--- a/Flow.Launcher.Test/Plugins/CalculatorTest.cs
+++ b/Flow.Launcher.Test/Plugins/CalculatorTest.cs
@@ -114,6 +114,8 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase(@"sqrt(-1)", "")]
         [TestCase(@"log(0)", "")]
         [TestCase(@"invalid_expression", "")]
+        // Floating point precision
+        [TestCase(@"3000000-2911111.82", "88888.18")]
         public void CalculatorTest(string expression, string result)
         {
             _settings.UseThousandsSeparator = false;

--- a/Flow.Launcher.Test/Plugins/CalculatorTest.cs
+++ b/Flow.Launcher.Test/Plugins/CalculatorTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Flow.Launcher.Plugin.Calculator;
@@ -116,6 +116,8 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase(@"invalid_expression", "")]
         // Floating point precision
         [TestCase(@"3000000-2911111.82", "88888.18")]
+        [TestCase(@"123456789012345", "123456789012345")]
+        [TestCase(@"9007199254740991", "9007199254740991")]
         public void CalculatorTest(string expression, string result)
         {
             _settings.UseThousandsSeparator = false;

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -130,13 +130,14 @@ namespace Flow.Launcher.Plugin.Calculator
                 {
                     double rawValue = Convert.ToDouble(result);
                     decimal decValue;
-                    try
-                    {
-                        decValue = decimal.Parse(rawValue.ToString("G14", CultureInfo.InvariantCulture), NumberStyles.Any, CultureInfo.InvariantCulture);
-                    }
-                    catch (FormatException)
+                    if (double.IsNaN(rawValue) || double.IsInfinity(rawValue))
                     {
                         decValue = (decimal)rawValue;
+                    }
+                    else
+                    {
+                        string format = (rawValue % 1 == 0) ? "G17" : "G14";
+                        decValue = decimal.Parse(rawValue.ToString(format, CultureInfo.InvariantCulture), NumberStyles.Any, CultureInfo.InvariantCulture);
                     }
                     decimal roundedResult = Math.Round(decValue, _settings.MaxDecimalPlaces, MidpointRounding.AwayFromZero);
                     string newResult = FormatResult(roundedResult);

--- a/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Calculator/Main.cs
@@ -128,7 +128,17 @@ namespace Flow.Launcher.Plugin.Calculator
 
                 if (!string.IsNullOrEmpty(result.ToString()))
                 {
-                    decimal roundedResult = Math.Round(Convert.ToDecimal(result), _settings.MaxDecimalPlaces, MidpointRounding.AwayFromZero);
+                    double rawValue = Convert.ToDouble(result);
+                    decimal decValue;
+                    try
+                    {
+                        decValue = decimal.Parse(rawValue.ToString("G14", CultureInfo.InvariantCulture), NumberStyles.Any, CultureInfo.InvariantCulture);
+                    }
+                    catch (FormatException)
+                    {
+                        decValue = (decimal)rawValue;
+                    }
+                    decimal roundedResult = Math.Round(decValue, _settings.MaxDecimalPlaces, MidpointRounding.AwayFromZero);
                     string newResult = FormatResult(roundedResult);
 
                     return
@@ -138,7 +148,6 @@ namespace Flow.Launcher.Plugin.Calculator
                             Title = newResult,
                             IcoPath = IcoPath,
                             Score = 300,
-                            // Check context nullability for unit testing
                             SubTitle = Context == null ? string.Empty : Localize.flowlauncher_plugin_calculator_copy_number_to_clipboard(),
                             CopyText = newResult,
                             Action = c =>


### PR DESCRIPTION
Fixes #4547

Fixes floating-point precision error in the calculator by rounding the double result to 14 significant digits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes floating‑point rounding errors and preserves full precision for large integers by formatting results with culture‑invariant significant‑digit strings before rounding to user settings.

**Summary of changes**
- Changed: Result handling converts to `double`, formats with `"G17"` for integers and `"G14"` for non‑integers using `InvariantCulture`, parses to `decimal`, then rounds to `_settings.MaxDecimalPlaces` with `MidpointRounding.AwayFromZero`. Replaces direct `Convert.ToDecimal(result)` rounding that leaked FP noise.
- Added: Explicit handling for `NaN`/Infinity paths before parsing.
- Removed: A stale inline comment near `SubTitle` assignment (no behavior change).
- Memory: Negligible. One extra format/parse per evaluation; no long‑lived allocations.
- Security: No new risks. Pure in‑process numeric formatting.
- Tests: Expanded coverage—keeps the floating‑point case (`3000000-2911111.82` → `88888.18`) and adds two large‑integer cases (`123456789012345`, `9007199254740991`) to verify integer precision.

**Release Note**
Calculator now shows accurate decimals and preserves exact large integers.

<sup>Written for commit 330b93a4ce7a4179b36f3c317115aba66f25df8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

