### PR TITLE
Fix JsonStorage temp file truncation

### DIFF
--- a/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
+++ b/Flow.Launcher.Infrastructure/Storage/JsonStorage.cs
@@ -217,9 +217,12 @@ namespace Flow.Launcher.Infrastructure.Storage
             // User may delete the directory, so we need to check it
             FilesFolders.ValidateDirectory(DirectoryPath);
 
-            await using var tempOutput = File.OpenWrite(TempFilePath);
-            await JsonSerializer.SerializeAsync(tempOutput, Data,
-                new JsonSerializerOptions { WriteIndented = true });
+            await using (var tempOutput = new FileStream(TempFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                await JsonSerializer.SerializeAsync(tempOutput, Data,
+                    new JsonSerializerOptions { WriteIndented = true });
+            }
+
             AtomicWriteSetting();
         }
 

--- a/Flow.Launcher.Test/JsonStorageTest.cs
+++ b/Flow.Launcher.Test/JsonStorageTest.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Flow.Launcher.Infrastructure.Storage;
+using NUnit.Framework;
+
+namespace Flow.Launcher.Test
+{
+    [TestFixture]
+    public class JsonStorageTest
+    {
+        [Test]
+        public async Task SaveAsync_WhenExistingTempFileIsLonger_OverwritesWithoutTrailingBytesAsync()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), $"json-storage-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var filePath = Path.Combine(tempDir, "settings.json");
+                await File.WriteAllTextAsync($"{filePath}.tmp", new string('x', 4096));
+
+                var storage = new JsonStorage<JsonStoragePayload>(filePath);
+                var data = await storage.LoadAsync();
+                data.Value = "ok";
+
+                await storage.SaveAsync();
+
+                var reloaded = await new JsonStorage<JsonStoragePayload>(filePath).LoadAsync();
+
+                Assert.That(reloaded.Value, Is.EqualTo("ok"));
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+
+        private sealed class JsonStoragePayload
+        {
+            public string Value { get; set; } = string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `JsonStorage.SaveAsync` so an existing `.tmp` file is truncated before writing new JSON.
- Add a regression test for saving shorter JSON over a longer temp file.

## Verification
```bash
dotnet test Flow.Launcher.Test/Flow.Launcher.Test.csproj --filter FullyQualifiedName~Flow.Launcher.Test.JsonStorageTest.SaveAsync_WhenExistingTempFileIsLonger_OverwritesWithoutTrailingBytesAsync
```

Passed: 1, Failed: 0.
