### PR TITLE
Fix message box close behavior

### DIFF
--- a/Flow.Launcher/MessageBoxEx.xaml
+++ b/Flow.Launcher/MessageBoxEx.xaml
@@ -33,6 +33,7 @@
         </Grid.RowDefinitions>
         
         <controls:CustomWindowTitleBar
+            x:Name="TitleBar"
             Grid.Row="0"
             ShowIcon="False"
             ShowTitle="False"

--- a/Flow.Launcher/MessageBoxEx.xaml.cs
+++ b/Flow.Launcher/MessageBoxEx.xaml.cs
@@ -20,6 +20,11 @@ namespace Flow.Launcher
         {
             _button = button;
             InitializeComponent();
+
+            // For YesNo dialogs, hide the close button to match native windows message box behavior
+            // https://learn.microsoft.com/en-us/dotnet/api/system.windows.messageboxbutton?view=windowsdesktop-10.0#remarks
+            if (_button == MessageBoxButton.YesNo)
+                TitleBar.ShowCloseButton = false;
         }
 
         public static MessageBoxResult Show(
@@ -196,11 +201,10 @@ namespace Flow.Launcher
             
             switch (_button)
             {
-                // For YesNo, the windows MessageBox disables the close button entirely.
-                // Since we don't have that we fall back to returning No.
+                // For YesNo, the close button should be hidden and inaccessible.
                 case MessageBoxButton.YesNo:
-                    _result = MessageBoxResult.No;
-                    break;
+                    App.API.LogWarn(ClassName, "Close button was invoked despite being hidden for YesNo dialog");
+                    return;
                 case MessageBoxButton.OK:
                     _result = MessageBoxResult.OK;
                     break;

--- a/Flow.Launcher/MessageBoxEx.xaml.cs
+++ b/Flow.Launcher/MessageBoxEx.xaml.cs
@@ -57,6 +57,11 @@ namespace Flow.Launcher
                     _ = SetImageOfMessageBoxAsync(icon);
                 }
                 SetButtonVisibilityFocusAndResult(button, defaultResult);
+
+                // This ensures that if the message box is closed without using the answer buttons
+                // It will still have a meaningful result based on its type
+                _result = msgBox.DefaultCloseResult;
+
                 msgBox.ShowDialog();
                 return _result;
             }
@@ -163,15 +168,30 @@ namespace Flow.Launcher
             Img.Source = imageSource;
         }
 
+        // What the result should be if the message box is closed outside of the direct response buttons - e.g title bar close button
+        // Mostly replicates System.Windows.MessageBox behavior
+        // https://learn.microsoft.com/en-us/dotnet/api/system.windows.messageboxresult#remarks
+        private MessageBoxResult DefaultCloseResult => _button switch
+        {
+            MessageBoxButton.OK => MessageBoxResult.OK,
+            MessageBoxButton.OKCancel => MessageBoxResult.Cancel,
+            MessageBoxButton.YesNoCancel => MessageBoxResult.Cancel,
+            
+            // For YesNo this should only be used in a forced close edge case (e.g. alt f4)
+            // Most callers make the mistake of checking for No instead of not Yes - so best not to return None etc
+            MessageBoxButton.YesNo => MessageBoxResult.No,
+            
+            // covers unsupported types, e.g. AbortRetryIgnore
+            _ => MessageBoxResult.None 
+        };
+
+
         private void KeyEsc_OnPress(object sender, ExecutedRoutedEventArgs e)
         {
             if (_button == MessageBoxButton.YesNo)
                 // Follow System.Windows.MessageBox behavior
                 return;
-            else if (_button == MessageBoxButton.OK)
-                _result = MessageBoxResult.OK;
-            else
-                _result = MessageBoxResult.Cancel;
+            
             DialogResult = false;
             Close();
         }
@@ -196,23 +216,11 @@ namespace Flow.Launcher
         {
             e.Handled = true;
 
-            // Replicates System.Windows.MessageBox behavior
-            // https://learn.microsoft.com/en-us/dotnet/api/system.windows.messageboxresult#remarks
-            
-            switch (_button)
+            if (_button == MessageBoxButton.YesNo)
             {
                 // For YesNo, the close button should be hidden and inaccessible.
-                case MessageBoxButton.YesNo:
-                    App.API.LogWarn(ClassName, "Close button was invoked despite being hidden for YesNo dialog");
-                    return;
-                case MessageBoxButton.OK:
-                    _result = MessageBoxResult.OK;
-                    break;
-                case MessageBoxButton.OKCancel:
-                case MessageBoxButton.YesNoCancel:
-                default:
-                    _result = MessageBoxResult.Cancel;
-                    break;
+                App.API.LogWarn(ClassName, "Close button was invoked despite being hidden for YesNo dialog");
+                return;
             }
 
             msgBox.Close();

--- a/Flow.Launcher/MessageBoxEx.xaml.cs
+++ b/Flow.Launcher/MessageBoxEx.xaml.cs
@@ -191,13 +191,26 @@ namespace Flow.Launcher
         {
             e.Handled = true;
 
-            if (_button == MessageBoxButton.YesNo)
-                // Follow System.Windows.MessageBox behavior
-                return;
-            else if (_button == MessageBoxButton.OK)
-                _result = MessageBoxResult.OK;
-            else
-                _result = MessageBoxResult.Cancel;
+            // Replicates System.Windows.MessageBox behavior
+            // https://learn.microsoft.com/en-us/dotnet/api/system.windows.messageboxresult#remarks
+            
+            switch (_button)
+            {
+                // For YesNo, the windows MessageBox disables the close button entirely.
+                // Since we don't have that we fall back to returning No.
+                case MessageBoxButton.YesNo:
+                    _result = MessageBoxResult.No;
+                    break;
+                case MessageBoxButton.OK:
+                    _result = MessageBoxResult.OK;
+                    break;
+                case MessageBoxButton.OKCancel:
+                case MessageBoxButton.YesNoCancel:
+                default:
+                    _result = MessageBoxResult.Cancel;
+                    break;
+            }
+
             msgBox.Close();
             msgBox = null;
         }

--- a/Flow.Launcher/Resources/Controls/CustomWindowTitleBar.xaml.cs
+++ b/Flow.Launcher/Resources/Controls/CustomWindowTitleBar.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows.Controls;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Shell;
 
 namespace Flow.Launcher.Resources.Controls
 {
@@ -113,6 +114,7 @@ namespace Flow.Launcher.Resources.Controls
 
         private Window _hostWindow;
         private WindowState _lastNonMinimizedWindowState = WindowState.Normal;
+        private bool? _savedUseAeroCaptionButtons;
 
         private Button MinimizeButtonElement => FindName("MinimizeButton") as Button;
         private Button MaximizeButtonElement => FindName("MaximizeButton") as Button;
@@ -242,6 +244,14 @@ namespace Flow.Launcher.Resources.Controls
                 return;
             }
 
+            // Disable system caption buttons since this control provides custom ones
+            var chrome = WindowChrome.GetWindowChrome(_hostWindow);
+            if (chrome != null)
+            {
+                _savedUseAeroCaptionButtons = chrome.UseAeroCaptionButtons;
+                chrome.UseAeroCaptionButtons = false;
+            }
+
             if (IconSource is null)
             {
                 IconSource = _hostWindow.Icon ?? DefaultWindowIcon;
@@ -267,6 +277,17 @@ namespace Flow.Launcher.Resources.Controls
             if (_hostWindow == null)
             {
                 return;
+            }
+
+            // Restore original system caption buttons if we disabled them
+            if (_savedUseAeroCaptionButtons.HasValue)
+            {
+                var chrome = WindowChrome.GetWindowChrome(_hostWindow);
+                if (chrome != null)
+                {
+                    chrome.UseAeroCaptionButtons = _savedUseAeroCaptionButtons.Value;
+                }
+                _savedUseAeroCaptionButtons = null;
             }
 
             _hostWindow.StateChanged -= HostWindow_StateChanged;


### PR DESCRIPTION
Should fix #4503

Tries to make the message box follow the official behavior described in https://learn.microsoft.com/en-us/dotnet/api/system.windows.messageboxbutton?view=windowsdesktop-10.0#remarks

Particularly regarding the Yes/No type
For that type the close button is to be disabled ( I also hide it), and the close by esc functionality is also disabled
Its not really supposed to have a way to close it without selecting yes or no.
Despite that in the edge case of a forced close (e.g. alt-f4) we still have to decide on a result
It's not 100% clear what the result should be in that case, e.g. Cancel or None
But given how many users of this message box make the mistake of treating !No as Yes, it is probably safer to return No here



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns MessageBoxEx close behavior with Windows. Hides the close button for Yes/No, fixes titlebar close handling, and sets a safe default result when closed indirectly.

**Summary of changes**
- Changed
  - Hide the close button for Yes/No via named `TitleBar` (`TitleBar.ShowCloseButton = false`).
  - Disable system caption buttons when using `CustomWindowTitleBar` (`WindowChrome.UseAeroCaptionButtons = false`) so the OS close isn’t clickable behind the custom bar.
  - Titlebar close now works correctly for supported types and maps to a sensible result; Esc is ignored for Yes/No, and for others falls back to the default result.
- Added
  - `DefaultCloseResult` to mirror `System.Windows.MessageBox` when closed indirectly: OK→OK, OKCancel/YesNoCancel→Cancel, YesNo→No, else→None.
  - Initialize `_result` to `DefaultCloseResult` before showing the dialog to ensure consistent outcomes.
- Removed
  - Manual `_result` assignments in Esc/close handlers; rely on `DefaultCloseResult`.
- Memory usage
  - No material impact; only a small saved flag and default result state.
- Security risks
  - None expected; reduces unintended close paths. Logs a warning if a Yes/No dialog somehow receives a close request.
- Unit tests
  - No new tests added.

**Release Note**
Message boxes now follow Windows behavior: the close button is hidden for Yes/No, and closing the window picks a reasonable default answer.

<sup>Written for commit 834ba11ec74f621c9106a313f196c72bd560146f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





