### PR TITLE
Show result badges by default

### DIFF
--- a/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
+++ b/Flow.Launcher.Infrastructure/UserSettings/Settings.cs
@@ -173,7 +173,7 @@ namespace Flow.Launcher.Infrastructure.UserSettings
             }
         }
         public double SoundVolume { get; set; } = 50;
-        public bool ShowBadges { get; set; } = false;
+        public bool ShowBadges { get; set; } = true;
         public bool ShowBadgesGlobalOnly { get; set; } = false;
 
         private string _settingWindowFont { get; set; } = Win32Helper.GetSystemDefaultFont(false);


### PR DESCRIPTION
I see no reason for this to be disabled, its already up to the plugins to decide to use these, so it certainly shouldn't be off by default globally

This is the safest change but it could also be worth considering just removing this setting altogether

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turned on result badges by default. New profiles will see badges unless they turn them off.

**Summary of changes**
- Changed: Default `ShowBadges` from false to true in `Flow.Launcher.Infrastructure/UserSettings/Settings.cs`.
- Added: No new logic; setting remains user-configurable and plugin-driven.
- Removed: Nothing removed; `ShowBadgesGlobalOnly` unchanged.
- Memory impact: None.
- Security risks: None.
- Unit tests: No new tests added.

**Release Note**
Badges on results are now shown by default for new installs; you can disable them in Settings.

<sup>Written for commit fe03b803348cba54406e45cc3b931829230cf247. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

