### PR TITLE
Add Custom Template shell option to Shell plugin  

### DIFF
--- a/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
@@ -18,7 +18,8 @@ namespace Flow.Launcher.Test.Plugins
             bool leaveShellOpen = false,
             bool closeShellAfterPress = false,
             bool useWindowsTerminal = false,
-            bool runAsAdmin = false)
+            bool runAsAdmin = false,
+            CustomTemplateShellConfig customConfig = null)
             => Main.CreateProcessStartInfo(
                 command,
                 shell,
@@ -26,7 +27,8 @@ namespace Flow.Launcher.Test.Plugins
                 closeShellAfterPress,
                 useWindowsTerminal,
                 runAsAdmin,
-                ClosePrompt);
+                ClosePrompt,
+                customConfig);
 
         #region CMD
 
@@ -292,6 +294,181 @@ namespace Flow.Launcher.Test.Plugins
 
         #endregion
 
+                #region CustomTemplate
+
+        [Test]
+        public void CustomTemplate_BasicExePath_WithDefaultTemplate()
+        {
+            var config = new CustomTemplateShellConfig
+            {
+                ExecutablePath = "pwsh.exe"
+            };
+            var info = Create(
+                command: "Get-Process",
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            Assert.That(info.FileName, Is.EqualTo("pwsh.exe"));
+            Assert.That(info.Arguments, Is.EqualTo("Get-Process"));
+        }
+
+        [Test]
+        public void CustomTemplate_NullConfig_FallsBackToRunCommand()
+        {
+            var info = Create(
+                command: "notepad",
+                shell: Shell.CustomTemplate);
+
+            Assert.That(info.FileName, Is.EqualTo("notepad"));
+        }
+
+        [Test]
+        public void CustomTemplate_EmptyConfig_FallsBackToRunCommand()
+        {
+            var config = new CustomTemplateShellConfig();
+            var info = Create(
+                command: "notepad test.txt",
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            Assert.That(info.FileName, Is.EqualTo("notepad"));
+            Assert.That(info.Arguments, Is.EqualTo("test.txt"));
+        }
+
+        [Test]
+        public void CustomTemplate_ReplacesCommandPlaceholder()
+        {
+            var config = new CustomTemplateShellConfig
+            {
+                ExecutablePath = "cmd.exe",
+                ArgumentsTemplate = "/c \"{command}\""
+            };
+            var info = Create(
+                command: "dir",
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            Assert.That(info.FileName, Is.EqualTo("cmd.exe"));
+            Assert.That(info.Arguments, Is.EqualTo("/c \"dir\""));
+        }
+
+        [Test]
+        public void CustomTemplate_WhitespaceExecutablePath_FallsBackToRunCommand()
+        {
+            var config = new CustomTemplateShellConfig
+            {
+                ExecutablePath = "  "
+            };
+            var info = Create(
+                command: "notepad",
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            Assert.That(info.FileName, Is.EqualTo("notepad"));
+        }
+
+        [Test]
+        public void CustomTemplate_EmptyTemplate_FallsBackToDefaultTemplate()
+        {
+            var config = new CustomTemplateShellConfig
+            {
+                ExecutablePath = "pwsh.exe",
+                ArgumentsTemplate = ""
+            };
+            var info = Create(
+                command: "ls",
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            Assert.That(info.FileName, Is.EqualTo("pwsh.exe"));
+            Assert.That(info.Arguments, Is.EqualTo("ls"));
+        }
+
+        [Test]
+        public void CustomTemplate_WhitespaceTemplate_FallsBackToDefaultTemplate()
+        {
+            var config = new CustomTemplateShellConfig
+            {
+                ExecutablePath = "pwsh.exe",
+                ArgumentsTemplate = "  "
+            };
+            var info = Create(
+                command: "ls",
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            Assert.That(info.FileName, Is.EqualTo("pwsh.exe"));
+            Assert.That(info.Arguments, Is.EqualTo("ls"));
+        }
+
+        [Test]
+        public void CustomTemplate_TrimsExecutablePath()
+        {
+            var config = new CustomTemplateShellConfig
+            {
+                ExecutablePath = "  pwsh.exe  ",
+                ArgumentsTemplate = "/c \"{command}\""
+            };
+            var info = Create(
+                command: "dir",
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            Assert.That(info.FileName, Is.EqualTo("pwsh.exe"));
+            Assert.That(info.Arguments, Is.EqualTo("/c \"dir\""));
+        }
+
+        [Test]
+        public void CustomTemplate_ExpandsEnvironmentVariablesInExecutablePath()
+        {
+            var config = new CustomTemplateShellConfig
+            {
+                ExecutablePath = "%USERPROFILE%\\pwsh.exe"
+            };
+            var info = Create(
+                command: "ls",
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            var expectedPath = Environment.ExpandEnvironmentVariables("%USERPROFILE%\\pwsh.exe");
+            Assert.That(info.FileName, Is.EqualTo(expectedPath));
+        }
+
+        [Test]
+        public void CustomTemplate_StripsQuotesFromExecutablePath()
+        {
+            var config = new CustomTemplateShellConfig
+            {
+                ExecutablePath = "\"C:\\Program Files\\pwsh.exe\""
+            };
+            var info = Create(
+                command: "ls",
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            Assert.That(info.FileName, Is.EqualTo("C:\\Program Files\\pwsh.exe"));
+            Assert.That(info.Arguments, Is.EqualTo("ls"));
+        }
+
+        [Test]
+        public void CustomTemplate_ExpandsEnvironmentVariablesInTemplate()
+        {
+            var config = new CustomTemplateShellConfig
+            {
+                ExecutablePath = "cmd.exe",
+                ArgumentsTemplate = "/c \"%USERPROFILE%\\{command}\""
+            };
+            var info = Create(
+                command: "test.cmd",
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            var expectedArg = $"/c \"{Environment.ExpandEnvironmentVariables("%USERPROFILE%")}\\test.cmd\"";
+            Assert.That(info.Arguments, Is.EqualTo(expectedArg));
+        }
+
+        #endregion
+
         #region Common
 
         [TestCase(false, "")]
@@ -307,6 +484,7 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase(Shell.Powershell)]
         [TestCase(Shell.Pwsh)]
         [TestCase(Shell.RunCommand)]
+        [TestCase(Shell.CustomTemplate)]
         public void SetsWorkingDirectory(Shell shell)
         {
             var info = Create(shell: shell);
@@ -319,6 +497,7 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase(Shell.Powershell)]
         [TestCase(Shell.Pwsh)]
         [TestCase(Shell.RunCommand)]
+        [TestCase(Shell.CustomTemplate)]
         public void SetsUseShellExecute(Shell shell)
         {
             var info = Create(shell: shell);
@@ -330,13 +509,25 @@ namespace Flow.Launcher.Test.Plugins
         [TestCase(Shell.Powershell)]
         [TestCase(Shell.Pwsh)]
         [TestCase(Shell.RunCommand)]
+        [TestCase(Shell.CustomTemplate)]
         public void ExpandsEnvironmentVariables(Shell shell)
         {
+            var expandedPath = Environment.ExpandEnvironmentVariables("%USERPROFILE%\\test");
+
+            CustomTemplateShellConfig config = null;
+            if (shell == Shell.CustomTemplate)
+            {
+                config = new CustomTemplateShellConfig
+                {
+                    ExecutablePath = "cmd.exe",
+                    ArgumentsTemplate = "/c \"{command}\""
+                };
+            }
+
             var info = Create(
                 command: "%USERPROFILE%\\test",
-                shell: shell);
-
-            var expandedPath = Environment.ExpandEnvironmentVariables("%USERPROFILE%\\test");
+                shell: shell,
+                customConfig: config);
 
             switch (shell)
             {
@@ -350,9 +541,14 @@ namespace Flow.Launcher.Test.Plugins
                 case Shell.RunCommand:
                     Assert.That(info.FileName, Is.EqualTo(expandedPath));
                     break;
+                case Shell.CustomTemplate:
+                    Assert.That(info.Arguments, Is.EqualTo($"/c \"{expandedPath}\""));
+                    break;
             }
         }
 
         #endregion
+
+
     }
 }

--- a/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
+++ b/Flow.Launcher.Test/Plugins/ShellPluginTest.cs
@@ -294,14 +294,60 @@ namespace Flow.Launcher.Test.Plugins
 
         #endregion
 
-                #region CustomTemplate
+        #region CustomTemplate
 
         [Test]
-        public void CustomTemplate_BasicExePath_WithDefaultTemplate()
+        public void CustomTemplate_NullConfig_LeavesFileNameAsEmptyString()
+        {
+            var info = Create(
+                command: "notepad",
+                shell: Shell.CustomTemplate);
+
+            Assert.That(info.FileName, Is.Empty);
+        }
+
+        [TestCase("")]
+        [TestCase("  ")]
+        public void CustomTemplate_EmptyExecutablePath_LeavesFileNameAsEmptyString(string exePath)
+        {
+            var config = new CustomTemplateShellConfig { ExecutablePath = exePath };
+            var info = Create(
+                command: "notepad",
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            Assert.That(info.FileName, Is.Empty);
+        }
+
+
+        [TestCase("cmd.exe", "/c \"{command}\"", "dir", "/c \"dir\"")]
+        [TestCase("powershell.exe", "-Command \"{command};\"", "Get-Process", "-Command \"Get-Process;\"")]
+        [TestCase("wsl.exe", "{command}", "ls", "ls")]
+        public void CustomTemplate_ReplacesCommandPlaceholder(
+            string exePath, string template, string command, string expectedArgs)
         {
             var config = new CustomTemplateShellConfig
             {
-                ExecutablePath = "pwsh.exe"
+                ExecutablePath = exePath,
+                ArgumentsTemplate = template
+            };
+            var info = Create(
+                command: command,
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            Assert.That(info.FileName, Is.EqualTo(exePath));
+            Assert.That(info.Arguments, Is.EqualTo(expectedArgs));
+        }
+
+        [TestCase("")]
+        [TestCase("  ")]
+        public void CustomTemplate_EmptyTemplate_DoesNotSetArguments(string template)
+        {
+            var config = new CustomTemplateShellConfig
+            {
+                ExecutablePath = "pwsh.exe",
+                ArgumentsTemplate = template
             };
             var info = Create(
                 command: "Get-Process",
@@ -309,96 +355,7 @@ namespace Flow.Launcher.Test.Plugins
                 customConfig: config);
 
             Assert.That(info.FileName, Is.EqualTo("pwsh.exe"));
-            Assert.That(info.Arguments, Is.EqualTo("Get-Process"));
-        }
-
-        [Test]
-        public void CustomTemplate_NullConfig_FallsBackToRunCommand()
-        {
-            var info = Create(
-                command: "notepad",
-                shell: Shell.CustomTemplate);
-
-            Assert.That(info.FileName, Is.EqualTo("notepad"));
-        }
-
-        [Test]
-        public void CustomTemplate_EmptyConfig_FallsBackToRunCommand()
-        {
-            var config = new CustomTemplateShellConfig();
-            var info = Create(
-                command: "notepad test.txt",
-                shell: Shell.CustomTemplate,
-                customConfig: config);
-
-            Assert.That(info.FileName, Is.EqualTo("notepad"));
-            Assert.That(info.Arguments, Is.EqualTo("test.txt"));
-        }
-
-        [Test]
-        public void CustomTemplate_ReplacesCommandPlaceholder()
-        {
-            var config = new CustomTemplateShellConfig
-            {
-                ExecutablePath = "cmd.exe",
-                ArgumentsTemplate = "/c \"{command}\""
-            };
-            var info = Create(
-                command: "dir",
-                shell: Shell.CustomTemplate,
-                customConfig: config);
-
-            Assert.That(info.FileName, Is.EqualTo("cmd.exe"));
-            Assert.That(info.Arguments, Is.EqualTo("/c \"dir\""));
-        }
-
-        [Test]
-        public void CustomTemplate_WhitespaceExecutablePath_FallsBackToRunCommand()
-        {
-            var config = new CustomTemplateShellConfig
-            {
-                ExecutablePath = "  "
-            };
-            var info = Create(
-                command: "notepad",
-                shell: Shell.CustomTemplate,
-                customConfig: config);
-
-            Assert.That(info.FileName, Is.EqualTo("notepad"));
-        }
-
-        [Test]
-        public void CustomTemplate_EmptyTemplate_FallsBackToDefaultTemplate()
-        {
-            var config = new CustomTemplateShellConfig
-            {
-                ExecutablePath = "pwsh.exe",
-                ArgumentsTemplate = ""
-            };
-            var info = Create(
-                command: "ls",
-                shell: Shell.CustomTemplate,
-                customConfig: config);
-
-            Assert.That(info.FileName, Is.EqualTo("pwsh.exe"));
-            Assert.That(info.Arguments, Is.EqualTo("ls"));
-        }
-
-        [Test]
-        public void CustomTemplate_WhitespaceTemplate_FallsBackToDefaultTemplate()
-        {
-            var config = new CustomTemplateShellConfig
-            {
-                ExecutablePath = "pwsh.exe",
-                ArgumentsTemplate = "  "
-            };
-            var info = Create(
-                command: "ls",
-                shell: Shell.CustomTemplate,
-                customConfig: config);
-
-            Assert.That(info.FileName, Is.EqualTo("pwsh.exe"));
-            Assert.That(info.Arguments, Is.EqualTo("ls"));
+            Assert.That(info.Arguments, Is.Empty);
         }
 
         [Test]
@@ -407,31 +364,14 @@ namespace Flow.Launcher.Test.Plugins
             var config = new CustomTemplateShellConfig
             {
                 ExecutablePath = "  pwsh.exe  ",
-                ArgumentsTemplate = "/c \"{command}\""
+                ArgumentsTemplate = "-Command \"{command};\""
             };
             var info = Create(
-                command: "dir",
+                command: "Get-Process",
                 shell: Shell.CustomTemplate,
                 customConfig: config);
 
             Assert.That(info.FileName, Is.EqualTo("pwsh.exe"));
-            Assert.That(info.Arguments, Is.EqualTo("/c \"dir\""));
-        }
-
-        [Test]
-        public void CustomTemplate_ExpandsEnvironmentVariablesInExecutablePath()
-        {
-            var config = new CustomTemplateShellConfig
-            {
-                ExecutablePath = "%USERPROFILE%\\pwsh.exe"
-            };
-            var info = Create(
-                command: "ls",
-                shell: Shell.CustomTemplate,
-                customConfig: config);
-
-            var expectedPath = Environment.ExpandEnvironmentVariables("%USERPROFILE%\\pwsh.exe");
-            Assert.That(info.FileName, Is.EqualTo(expectedPath));
         }
 
         [Test]
@@ -439,15 +379,32 @@ namespace Flow.Launcher.Test.Plugins
         {
             var config = new CustomTemplateShellConfig
             {
-                ExecutablePath = "\"C:\\Program Files\\pwsh.exe\""
+                ExecutablePath = "\"C:\\Program Files\\pwsh.exe\"",
+                ArgumentsTemplate = "-Command \"{command};\""
             };
             var info = Create(
-                command: "ls",
+                command: "Get-Process",
                 shell: Shell.CustomTemplate,
                 customConfig: config);
 
             Assert.That(info.FileName, Is.EqualTo("C:\\Program Files\\pwsh.exe"));
-            Assert.That(info.Arguments, Is.EqualTo("ls"));
+        }
+
+        [Test]
+        public void CustomTemplate_ExpandsEnvironmentVariablesInExecutablePath()
+        {
+            var config = new CustomTemplateShellConfig
+            {
+                ExecutablePath = "%USERPROFILE%\\pwsh.exe",
+                ArgumentsTemplate = "-Command \"{command};\""
+            };
+            var info = Create(
+                command: "Get-Process",
+                shell: Shell.CustomTemplate,
+                customConfig: config);
+
+            var expectedPath = Environment.ExpandEnvironmentVariables("%USERPROFILE%\\pwsh.exe");
+            Assert.That(info.FileName, Is.EqualTo(expectedPath));
         }
 
         [Test]

--- a/Plugins/Flow.Launcher.Plugin.Shell/Converters/LeaveShellOpenOrCloseShellAfterPressEnabledConverter.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Converters/LeaveShellOpenOrCloseShellAfterPressEnabledConverter.cs
@@ -15,7 +15,7 @@ public class LeaveShellOpenOrCloseShellAfterPressEnabledConverter : IMultiValueC
         )
             return Binding.DoNothing;
 
-        return (!closeShellAfterPressOrLeaveShellOpen) && shell != Shell.RunCommand;
+        return (!closeShellAfterPressOrLeaveShellOpen) && shell != Shell.RunCommand && shell != Shell.CustomTemplate;
     }
 
     public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/Plugins/Flow.Launcher.Plugin.Shell/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Languages/en.xaml
@@ -20,6 +20,9 @@
     <system:String x:Key="flowlauncher_plugin_cmd_command_not_found">Command not found: {0}</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_error_running_command">Error running the command: {0}</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_custom_template_exe_path">Executable path</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_custom_template_browse">Browse...</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_custom_template_browse_filter_exe">Executable files</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_custom_template_browse_filter_all">All files</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_custom_template_arguments">Arguments template</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_custom_template_exe_path_tooltip">Full path to the shell executable. Example: C:\Windows\System32\cmd.exe</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_custom_template_arguments_tooltip">Use {command} as a placeholder. Example: /k "{command}"</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Shell/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Languages/en.xaml
@@ -19,11 +19,12 @@
     <system:String x:Key="flowlauncher_plugin_cmd_history">Only show number of most used commands:</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_command_not_found">Command not found: {0}</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_error_running_command">Error running the command: {0}</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_error_no_exe_path_set">No executable path set. Check your shell plugin settings.</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_custom_template_exe_path">Executable path</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_custom_template_browse">Browse...</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_custom_template_browse_filter_exe">Executable files</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_custom_template_browse_filter_all">All files</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_custom_template_arguments">Arguments template</system:String>
-    <system:String x:Key="flowlauncher_plugin_cmd_custom_template_exe_path_tooltip">Full path to the shell executable. Example: C:\Windows\System32\cmd.exe</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_custom_template_exe_path_tooltip">Can be an absolute path or a name resolved via PATH. Example: cmd.exe</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_custom_template_arguments_tooltip">Use {command} as a placeholder. Example: /k "{command}"</system:String>
 </ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Shell/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Languages/en.xaml
@@ -19,4 +19,8 @@
     <system:String x:Key="flowlauncher_plugin_cmd_history">Only show number of most used commands:</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_command_not_found">Command not found: {0}</system:String>
     <system:String x:Key="flowlauncher_plugin_cmd_error_running_command">Error running the command: {0}</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_custom_template_exe_path">Executable path</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_custom_template_arguments">Arguments template</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_custom_template_exe_path_tooltip">Full path to the shell executable. Example: C:\Windows\System32\cmd.exe</system:String>
+    <system:String x:Key="flowlauncher_plugin_cmd_custom_template_arguments_tooltip">Use {command} as a placeholder. Example: /k "{command}"</system:String>
 </ResourceDictionary>

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -440,24 +440,28 @@ namespace Flow.Launcher.Plugin.Shell
             string command,
             CustomTemplateShellConfig config)
         {
-            if (config == null || string.IsNullOrWhiteSpace(config.ExecutablePath))
-            {
-                // No valid custom shell configured, fall back to RunCommand behavior
-                ConfigureRunCommandStartInfo(info, command);
+            if (config == null)
                 return;
+
+            if (!string.IsNullOrWhiteSpace(config.ExecutablePath))
+                info.FileName = Environment.ExpandEnvironmentVariables(config.ExecutablePath).Trim().Trim('"');
+
+            if (!string.IsNullOrWhiteSpace(config.ArgumentsTemplate))
+            {
+                var template = Environment.ExpandEnvironmentVariables(config.ArgumentsTemplate).Trim();
+                info.Arguments = template.Replace("{command}", command);
             }
-
-            info.FileName = Environment.ExpandEnvironmentVariables(config.ExecutablePath).Trim().Trim('"');;
-
-            var template = string.IsNullOrWhiteSpace(config.ArgumentsTemplate)
-                ? "{command}"
-                : Environment.ExpandEnvironmentVariables(config.ArgumentsTemplate).Trim();
-
-            info.Arguments = template.Replace("{command}", command);
         }
 
         private void Execute(Func<ProcessStartInfo, Process> startProcess, ProcessStartInfo info)
         {
+            if (string.IsNullOrEmpty(info.FileName))
+            {
+                Context.API.ShowMsgError(GetTranslatedPluginTitle(),
+                    Localize.flowlauncher_plugin_cmd_error_no_exe_path_set());
+                return;
+            }
+
             try
             {
                 ShellCommand.Execute(startProcess, info);

--- a/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Main.cs
@@ -199,7 +199,8 @@ namespace Flow.Launcher.Plugin.Shell
                 _settings.CloseShellAfterPress,
                 _settings.UseWindowsTerminal,
                 runAsAdmin,
-                closePrompt);
+                closePrompt,
+                _settings.CustomTemplateShellConfig);
 
             _settings.AddCmdHistory(command);
             return info;
@@ -212,7 +213,8 @@ namespace Flow.Launcher.Plugin.Shell
             bool closeShellAfterPress,
             bool useWindowsTerminal,
             bool runAsAdmin,
-            string closePrompt)
+            string closePrompt,
+            CustomTemplateShellConfig customTemplateShellConfig = null)
         {
             command = command.Trim();
             command = Environment.ExpandEnvironmentVariables(command);
@@ -263,6 +265,13 @@ namespace Flow.Launcher.Plugin.Shell
                     ConfigureRunCommandStartInfo(
                         info,
                         command);
+                    break;
+
+                case Shell.CustomTemplate:
+                    ConfigureCustomTemplateShellStartInfo(
+                        info,
+                        command,
+                        customTemplateShellConfig);
                     break;
 
                 default:
@@ -424,6 +433,27 @@ namespace Flow.Launcher.Plugin.Shell
                 // Pass the whole command anyways so the OS produces a meaningful error.
                 info.FileName = command;
             }
+        }
+
+        private static void ConfigureCustomTemplateShellStartInfo(
+            ProcessStartInfo info,
+            string command,
+            CustomTemplateShellConfig config)
+        {
+            if (config == null || string.IsNullOrWhiteSpace(config.ExecutablePath))
+            {
+                // No valid custom shell configured, fall back to RunCommand behavior
+                ConfigureRunCommandStartInfo(info, command);
+                return;
+            }
+
+            info.FileName = Environment.ExpandEnvironmentVariables(config.ExecutablePath).Trim().Trim('"');;
+
+            var template = string.IsNullOrWhiteSpace(config.ArgumentsTemplate)
+                ? "{command}"
+                : Environment.ExpandEnvironmentVariables(config.ArgumentsTemplate).Trim();
+
+            info.Arguments = template.Replace("{command}", command);
         }
 
         private void Execute(Func<ProcessStartInfo, Process> startProcess, ProcessStartInfo info)

--- a/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
@@ -117,6 +117,20 @@ namespace Flow.Launcher.Plugin.Shell
             }
         }
 
+        private CustomTemplateShellConfig _customTemplateShellConfig = new();
+        public CustomTemplateShellConfig CustomTemplateShellConfig
+        {
+            get => _customTemplateShellConfig;
+            set
+            {
+                if (_customTemplateShellConfig != value)
+                {
+                    _customTemplateShellConfig = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         public Dictionary<string, int> CommandHistory { get; set; } = [];
 
         public void AddCmdHistory(string cmdName)
@@ -124,6 +138,37 @@ namespace Flow.Launcher.Plugin.Shell
             if (!CommandHistory.TryAdd(cmdName, 1))
             {
                 CommandHistory[cmdName] += 1;
+            }
+        }
+    }
+
+    public class CustomTemplateShellConfig : BaseModel
+    {
+        private string _executablePath = "";
+        public string ExecutablePath
+        {
+            get => _executablePath;
+            set
+            {
+                if (_executablePath != value)
+                {
+                    _executablePath = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private string _argumentsTemplate = "{command}";
+        public string ArgumentsTemplate
+        {
+            get => _argumentsTemplate;
+            set
+            {
+                if (_argumentsTemplate != value)
+                {
+                    _argumentsTemplate = value;
+                    OnPropertyChanged();
+                }
             }
         }
     }
@@ -142,5 +187,8 @@ namespace Flow.Launcher.Plugin.Shell
 
         [EnumLocalizeValue("Pwsh")]
         Pwsh = 3,
+
+        [EnumLocalizeValue("Custom Template")]
+        CustomTemplate = 4,
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Settings.cs
@@ -144,7 +144,7 @@ namespace Flow.Launcher.Plugin.Shell
 
     public class CustomTemplateShellConfig : BaseModel
     {
-        private string _executablePath = "";
+        private string _executablePath = "cmd.exe";
         public string ExecutablePath
         {
             get => _executablePath;
@@ -158,7 +158,7 @@ namespace Flow.Launcher.Plugin.Shell
             }
         }
 
-        private string _argumentsTemplate = "{command}";
+        private string _argumentsTemplate = "/k \"{command}\"";
         public string ArgumentsTemplate
         {
             get => _argumentsTemplate;

--- a/Plugins/Flow.Launcher.Plugin.Shell/ViewModels/ShellSettingViewModel.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/ViewModels/ShellSettingViewModel.cs
@@ -17,9 +17,15 @@ public class ShellSettingViewModel : BaseModel
             {
                 Settings.Shell = value;
                 OnPropertyChanged();
+                OnPropertyChanged(nameof(IsCustomTemplateShell));
+                OnPropertyChanged(nameof(IsWindowsTerminalEnabled));
             }
         }
     }
+
+    public bool IsCustomTemplateShell => SelectedShell == Shell.CustomTemplate;
+
+    public bool IsWindowsTerminalEnabled => SelectedShell != Shell.CustomTemplate && SelectedShell != Shell.RunCommand;
 
     public List<int> OnlyMostUsedCMDsNumbers { get; } = [5, 10, 20];
     public int SelectedOnlyMostUsedCMDsNumber

--- a/Plugins/Flow.Launcher.Plugin.Shell/Views/ShellSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Views/ShellSetting.xaml
@@ -111,6 +111,11 @@
                 VerticalAlignment="Center"
                 Text="{Binding Settings.CustomTemplateShellConfig.ExecutablePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 ToolTip="{DynamicResource flowlauncher_plugin_cmd_custom_template_exe_path_tooltip}" />
+            <Button
+                Margin="{StaticResource SettingPanelItemLeftMargin}"
+                VerticalAlignment="Center"
+                Click="BrowseExecutablePath_Click"
+                Content="{DynamicResource flowlauncher_plugin_cmd_custom_template_browse}" />
         </StackPanel>
         <StackPanel
             Grid.Row="7"

--- a/Plugins/Flow.Launcher.Plugin.Shell/Views/ShellSetting.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Views/ShellSetting.xaml
@@ -23,6 +23,8 @@
             <RowDefinition />
             <RowDefinition />
             <RowDefinition />
+            <RowDefinition />
+            <RowDefinition />
         </Grid.RowDefinitions>
         <CheckBox
             x:Name="ReplaceWinR"
@@ -72,7 +74,8 @@
             Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
             HorizontalAlignment="Left"
             Content="{DynamicResource flowlauncher_plugin_cmd_use_windows_terminal}"
-            IsChecked="{Binding Settings.UseWindowsTerminal, Mode=TwoWay}" />
+            IsChecked="{Binding Settings.UseWindowsTerminal, Mode=TwoWay}"
+            IsEnabled="{Binding IsWindowsTerminalEnabled}" />
         <ComboBox
             x:Name="ShellComboBox"
             Grid.Row="5"
@@ -82,7 +85,60 @@
             ItemsSource="{Binding AllShells, Mode=OneTime}"
             SelectedValue="{Binding SelectedShell, Mode=TwoWay}"
             SelectedValuePath="Value" />
-        <StackPanel Grid.Row="6" Orientation="Horizontal">
+
+        <!-- Custom Template fields: visible when CustomTemplate is selected -->
+        <StackPanel
+            Grid.Row="6"
+            Orientation="Horizontal">
+            <StackPanel.Style>
+                <Style TargetType="StackPanel">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsCustomTemplateShell}" Value="True">
+                            <Setter Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </StackPanel.Style>
+            <TextBlock
+                Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
+                VerticalAlignment="Center"
+                FontSize="14"
+                Text="{DynamicResource flowlauncher_plugin_cmd_custom_template_exe_path}" />
+            <TextBox
+                MinWidth="400"
+                Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
+                VerticalAlignment="Center"
+                Text="{Binding Settings.CustomTemplateShellConfig.ExecutablePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                ToolTip="{DynamicResource flowlauncher_plugin_cmd_custom_template_exe_path_tooltip}" />
+        </StackPanel>
+        <StackPanel
+            Grid.Row="7"
+            Orientation="Horizontal">
+            <StackPanel.Style>
+                <Style TargetType="StackPanel">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsCustomTemplateShell}" Value="True">
+                            <Setter Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </StackPanel.Style>
+            <TextBlock
+                Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"
+                VerticalAlignment="Center"
+                FontSize="14"
+                Text="{DynamicResource flowlauncher_plugin_cmd_custom_template_arguments}" />
+            <TextBox
+                MinWidth="400"
+                Margin="{StaticResource SettingPanelItemLeftTopBottomMargin}"
+                VerticalAlignment="Center"
+                Text="{Binding Settings.CustomTemplateShellConfig.ArgumentsTemplate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                ToolTip="{DynamicResource flowlauncher_plugin_cmd_custom_template_arguments_tooltip}" />
+        </StackPanel>
+        
+        <StackPanel Grid.Row="8" Orientation="Horizontal">
             <CheckBox
                 x:Name="ShowOnlyMostUsedCMDs"
                 Margin="{StaticResource SettingPanelItemRightTopBottomMargin}"

--- a/Plugins/Flow.Launcher.Plugin.Shell/Views/ShellSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Views/ShellSetting.xaml.cs
@@ -1,15 +1,34 @@
-﻿using System.Windows.Controls;
-using Flow.Launcher.Plugin.Shell.ViewModels;
+﻿using Microsoft.Win32;
+using System.Windows;
+using System.Windows.Controls;
 
 namespace Flow.Launcher.Plugin.Shell.Views
 {
     public partial class CMDSetting : UserControl
     {
+        private readonly Settings _settings;
+
         public CMDSetting(Settings settings)
         {
-            var viewModel = new ShellSettingViewModel(settings);
-            DataContext = viewModel;
+            _settings = settings;
+            DataContext = new ViewModels.ShellSettingViewModel(settings);;
             InitializeComponent();
+        }
+
+        private void BrowseExecutablePath_Click(object sender, RoutedEventArgs e)
+        {
+            var exeLabel = Localize.flowlauncher_plugin_cmd_custom_template_browse_filter_exe();
+            var allLabel = Localize.flowlauncher_plugin_cmd_custom_template_browse_filter_all();
+
+            var dialog = new OpenFileDialog
+            {
+                Filter = $"{exeLabel} (*.exe)|*.exe|{allLabel} (*.*)|*.*"
+            };
+
+            if (dialog.ShowDialog() == true && !string.IsNullOrEmpty(dialog.FileName))
+            {
+                _settings.CustomTemplateShellConfig.ExecutablePath = dialog.FileName;
+            }
         }
     }
 }

--- a/Plugins/Flow.Launcher.Plugin.Shell/Views/ShellSetting.xaml.cs
+++ b/Plugins/Flow.Launcher.Plugin.Shell/Views/ShellSetting.xaml.cs
@@ -11,7 +11,7 @@ namespace Flow.Launcher.Plugin.Shell.Views
         public CMDSetting(Settings settings)
         {
             _settings = settings;
-            DataContext = new ViewModels.ShellSettingViewModel(settings);;
+            DataContext = new ViewModels.ShellSettingViewModel(settings);
             InitializeComponent();
         }
 


### PR DESCRIPTION
Adds a "Custom Template" entry to the shell selection dropdown. 

Should resolve #187 (The most upvoted feature request) - users can fully control shell configuration with this.
Also should resolve #4580

Users can provide any executable path and an arguments template using {command} as a placeholder. 
Browse button calls OpenFileDialog for executable file path.

Shows error message when command ran with no executable path is set, though empty arguments templates are accepted for full user control.

Leave Shell Open, Close After Press, and Use Windows Terminal settings are disabled for Custom Template - the user has to manually implement those.

Use Windows Terminal is also now correctly disabled for RunCommand, which never supported it.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Custom Template shell so you can run commands with any executable using a simple {command} placeholder. If no executable is set, we show an error and do not run.

- **Summary of changes**
  - Changed
    - Disabled “Use Windows Terminal” for `RunCommand` and `CustomTemplate`.
    - Disabled “Leave Shell Open” and “Close After Press” for `CustomTemplate`.
    - Settings panel shows Custom Template fields only when selected; Windows Terminal toggle now respects a view-model flag.
    - Execution stops with a clear error if the executable path is empty.
  - Added
    - New `Shell.CustomTemplate` and `Settings.CustomTemplateShellConfig` with example defaults: ExecutablePath "cmd.exe", ArgumentsTemplate `/k "{command}"`.
    - Process creation for Custom Template: expands env vars in path and template, trims and strips quotes from the path, replaces `{command}`, and allows empty templates.
    - Browse button for the executable path plus matching localization strings and tooltips.
  - Removed
    - Silent fallback to `RunCommand`/default template when no executable was set.
  - Memory
    - Minimal: one small settings object and two UI rows.
  - Security
    - Same as `RunCommand`: users can target any executable; no new elevation paths beyond existing “Run as Admin”.
  - Unit tests
    - Added coverage for placeholder replacement, empty template support, null/empty config leaving `FileName` empty, trim and quote stripping, env var expansion (path, template, and command), working directory, `UseShellExecute`, and admin verb.

- **Release Note**
  Choose any app to run your commands with a simple {command} template, with a clear error if no app is set.

<sup>Written for commit 62d3edb689dac01254952a508f67b057ed75dd48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





