### PR TITLE
Fixed focus search box when Flow Launcher starts with Windows

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -212,6 +212,22 @@ namespace Flow.Launcher
             // Since the default main window visibility is visible, so we need set focus during startup
             QueryTextBox.Focus();
 
+            // When the window is shown on startup, focusing QueryTextBox is not enough: the window also
+            // has to be activated to actually take OS-level keyboard focus. Otherwise, when Flow Launcher
+            // is auto-started with Windows (Startup folder or logon task), the search box looks focused but
+            // keystrokes go elsewhere until the user clicks it.
+            // This is dispatched at Loaded priority because Activate() throws if the window has not finished
+            // being shown yet, and skipped entirely when the window starts hidden for the same reason.
+            if (!_settings.HideOnStartup)
+            {
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    if (!_viewModel.MainWindowVisibilityStatus) return;
+                    Activate();
+                    QueryTextBox.Focus();
+                }), DispatcherPriority.Loaded);
+            }
+
             // Set the initial state of the QueryTextBoxCursorMovedToEnd property
             // Without this part, when shown for the first time, switching the context menu does not move the cursor to the end.
             _viewModel.QueryTextCursorMovedToEnd = false;


### PR DESCRIPTION
### Problem

When Flow Launcher is configured to start with Windows and "Hide on startup"
is disabled, the main window appears after login but does not hold keyboard
focus. The search box looks focused, yet keystrokes go nowhere until the user
clicks it. Invoking the window later with the hotkey works fine.

### Cause

`MainWindow.OnLoaded` shows the window through `MainViewModel.Show()`, which
sets `MainWindowVisibilityStatus = true`. That property already defaults to
`true`, so no `PropertyChanged` event is raised and the handler that runs
`Activate()` before `QueryTextBox.Focus()` — the path used on every
hotkey-triggered show — never executes during startup.

Startup therefore only ran the bare `QueryTextBox.Focus()`. That sets WPF's
internal keyboard focus, but a process launched in the background by Windows
is not the foreground window, so it never receives real keyboard input.
The hotkey path always transitions visibility `false -> true`, which is why
it is unaffected.

### Fix

Activate the window on startup as well, once it has actually been shown.

The call is dispatched at `DispatcherPriority.Loaded` and skipped when
`HideOnStartup` is enabled, because `Window.Activate()` throws
`InvalidOperationException: Cannot call DragMove or Activate before a Window
is shown` if the window has not finished being shown — which is the case in
the hidden-on-startup path, the default configuration.

### Testing

- [ ] `HideOnStartup` enabled (default): starts hidden, no exception, hotkey works as before
- [ ] `HideOnStartup` disabled: window visible and immediately typeable after a reboot
- [ ] Hotkey-triggered show still focuses and selects the query text as before

Note the testing section is left as unchecked boxes deliberately — I could not build or run this (no .NET SDK available here), so those still need your confirmation on Windows before you open the PR. Given the last iteration crashed on the default configuration, the first box in particular is worth exercising.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost keyboard focus on Windows startup by activating the main window after it’s shown. When “Hide on startup” is off, the search box now accepts typing immediately.

**Summary of changes**
- Changed: Startup path now mirrors the hotkey path by activating the window before focusing the search box.
- Added: A `Dispatcher.BeginInvoke` (at `Loaded` priority) that:
  - Skips when `_settings.HideOnStartup` is true.
  - Checks `_viewModel.MainWindowVisibilityStatus` before calling `Activate()` and re-focusing `QueryTextBox`.
- Removed: No existing logic removed.
- Memory: Negligible impact (one short-lived dispatcher action on startup).
- Security: No new security risks.
- Tests: No unit tests added; behavior verified manually. Please confirm both startup modes and hotkey invocation.

**Release Note**
The app now takes keyboard focus on Windows startup (when not hidden), so you can type in the search box right away.

<sup>Written for commit 2f69032eea71046d3994c5c7e2554147371c0cac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

