### PR TITLE
Fix home page result context menus

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -461,8 +461,7 @@ namespace Flow.Launcher
                     break;
                 case Key.Right:
                     if (_viewModel.QueryResultsSelected()
-                        && QueryTextBox.CaretIndex == QueryTextBox.Text.Length
-                        && !string.IsNullOrEmpty(QueryTextBox.Text))
+                        && QueryTextBox.CaretIndex == QueryTextBox.Text.Length)            
                     {
                         _viewModel.LoadContextMenuCommand.Execute(null);
                         e.Handled = true;

--- a/Flow.Launcher/ViewModel/MainViewModel.cs
+++ b/Flow.Launcher/ViewModel/MainViewModel.cs
@@ -897,6 +897,7 @@ namespace Flow.Launcher.ViewModel
                     // so we need manually call Query()
                     // http://stackoverflow.com/posts/25895769/revisions
                     QueryText = string.Empty;
+
                     // When we are changing query because selected results are changed to history or context menu,
                     // we should not delay the query
                     Query(false);
@@ -1220,22 +1221,25 @@ namespace Flow.Launcher.ViewModel
 
         public void Query(bool searchDelay, bool isReQuery = false)
         {
-            if (_ignoredQueryText != null)
-            {
-                if (_ignoredQueryText == QueryText)
-                {
-                    _ignoredQueryText = null;
-                    return;
-                }
-                else
-                {
-                    // If _ignoredQueryText does not match current QueryText, we should still execute Query
-                    _ignoredQueryText = null;
-                }
-            }
-
             if (QueryResultsSelected())
             {
+                // We use this to skip creating a new result set and keep the old results.
+                // This matching is used for programmatic QueryText changes (not user typing), 
+                // such as when returning to the results from the context menu
+                if (_ignoredQueryText != null)
+                {
+                    if (_ignoredQueryText == QueryText)
+                    {
+                        _ignoredQueryText = null;
+                        return;
+                    }
+                    else
+                    {
+                        // If _ignoredQueryText does not match current QueryText, we should still execute Query
+                        _ignoredQueryText = null;
+                    }
+                }
+
                 _ = QueryResultsAsync(searchDelay, isReQuery);
             }
             else if (ContextMenuSelected())


### PR DESCRIPTION
Fixes two bugs related to home page results and context menus.

## Fix 1 Arrow Input Broken
Fixes #4599 where the right arrow input to open the context menu wasn't working.

## Fix 2 Stale Context Menus
Also fixes another bug where the context menu itself was stale and not rebuilt when a new result had its context menu opened.
This was becasue of the ignored query text flag incorrectly applying because each context menu used the same empty string query.
Fixed that by making that check only apply to search queries.

(the problem for fix 2 wasn't obvious before because the plugin indicator plugin for example had nothing to show in its context menu anyways)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two home page context menu bugs: the Right arrow now opens menus on results without a search query, and menus rebuild so they no longer show stale options.

- **Summary of changes**
  - Changed: Right arrow key handling no longer requires a non-empty query to open the context menu.
  - Changed: `_ignoredQueryText` now applies only when search results are selected, preventing stale context menus/history.
  - Added: Always rebuild context menu/history when their view is active; skip only redundant searches on programmatic query restores.
  - Removed: The empty-query check blocking Right arrow; global use of `_ignoredQueryText` outside search views.
  - Memory impact: None expected.
  - Security risks: None.
  - Unit tests: No new unit tests; verified via manual testing.

- **Release Note**
  - Context menus on the home page now open with the right arrow and show up-to-date options.

<sup>Written for commit 3c5eaaf4d487eedfd6c11841b8fd351d47593e6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

