### PR TITLE
Add option to plugin indicator context menu to open settings window of indicated plugin

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/Languages/en.xaml
@@ -4,6 +4,9 @@
 
     <system:String x:Key="flowlauncher_plugin_pluginindicator_result_subtitle">Activate {0} plugin action keyword</system:String>
 
+    <system:String x:Key="flowlauncher_plugin_pluginindicator_plugin_settings_title">Settings: {0}</system:String>
+    <system:String x:Key="flowlauncher_plugin_pluginindicator_plugin_settings_subtitle">Open the settings page for the {0} plugin</system:String>
+
     <system:String x:Key="flowlauncher_plugin_pluginindicator_plugin_name">Plugin Indicator</system:String>
     <system:String x:Key="flowlauncher_plugin_pluginindicator_plugin_description">Provides plugins action words suggestions</system:String>
 

--- a/Plugins/Flow.Launcher.Plugin.PluginIndicator/Main.cs
+++ b/Plugins/Flow.Launcher.Plugin.PluginIndicator/Main.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Flow.Launcher.Plugin.PluginIndicator
 {
-    public class Main : IPlugin, IPluginI18n, IHomeQuery
+    public class Main : IPlugin, IPluginI18n, IHomeQuery, IContextMenu
     {
         internal static PluginInitContext Context { get; private set; }
 
@@ -38,6 +38,7 @@ namespace Flow.Launcher.Plugin.PluginIndicator
                     SubTitle = Localize.flowlauncher_plugin_pluginindicator_result_subtitle(plugin.Name),
                     Score = score,
                     IcoPath = plugin.IcoPath,
+                    ContextData = plugin,
                     AutoCompleteText = $"{keyword}{Plugin.Query.TermSeparator}",
                     Action = c =>
                     {
@@ -46,6 +47,23 @@ namespace Flow.Launcher.Plugin.PluginIndicator
                     }
                 };
             return [.. results];
+        }
+
+        public List<Result> LoadContextMenus(Result selectedResult)
+        {
+            if (selectedResult.ContextData is not PluginMetadata plugin)
+                return [];
+
+            return new List<Result>
+            {
+                new Result
+                {
+                    Title = Localize.flowlauncher_plugin_pluginindicator_plugin_settings_title(plugin.Name),
+                    SubTitle = Localize.flowlauncher_plugin_pluginindicator_plugin_settings_subtitle(plugin.Name),
+                    IcoPath = plugin.IcoPath, // icon of indicated plugin
+                    Action = _ => Context.API.OpenPluginSettingsWindow(plugin.ID)
+                }
+            };
         }
 
         private static Dictionary<string, List<PluginPair>> GetNonGlobalPlugins()


### PR DESCRIPTION
Calls the OpenPluginSettingsWindow api method with the id of the indicated plugin.

## Screenshot
<img width="1586" height="878" alt="image" src="https://github.com/user-attachments/assets/b54e8346-c12b-4e27-b633-3d123ba29d56" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a context menu action in Plugin Indicator results to open the indicated plugin’s settings window for faster access to configuration.

- **Summary of changes**
  - Changed: Implemented `IContextMenu` in `Main` and set `Result.ContextData = plugin` for produced results.
  - Added: `LoadContextMenus` returns a “Settings: {plugin}” action that calls `Context.API.OpenPluginSettingsWindow(plugin.ID)`; added English title/subtitle strings.
  - Removed: No existing logic removed.
  - Memory: Negligible impact; stores a `PluginMetadata` reference per result only during query lifecycle.
  - Security: Low risk; uses trusted plugin metadata and existing API; no external input or elevated permissions.
  - Tests: No new unit tests added.

- **Release Note**
  Open a plugin’s settings directly from its result in the Plugin Indicator via the context menu.

<sup>Written for commit 99daf578fec466cef65cb4255485683c6322da53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

