### PR TITLE
Fix show history result start up

### DIFF
--- a/Flow.Launcher/MainWindow.xaml.cs
+++ b/Flow.Launcher/MainWindow.xaml.cs
@@ -349,7 +349,7 @@ namespace Flow.Launcher
                 .AddValueChanged(History, (s, e) => UpdateClockPanelVisibility());
 
             // Initialize query state
-            if (_settings.ShowHomePage && string.IsNullOrEmpty(_viewModel.QueryText))
+            if ((_settings.ShowHomePage || _settings.ShowHistoryResultsForHomePage) && string.IsNullOrEmpty(_viewModel.QueryText))
             {
                 _viewModel.QueryResults();
             }


### PR DESCRIPTION
When history results option is turned on but home page results is not, starting up flow will not show history results.

~~Follows on from #4042~~. Exists in production too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes startup so history results show when that option is enabled, even if the home page is disabled. Users now see their recent history on launch as expected.

**Summary of changes**
- Changed: In OnLoaded, trigger initial QueryResults when ShowHomePage OR ShowHistoryResultsForHomePage is true and the query is empty.
- Added: Support showing history results on startup when only history-for-home-page is enabled.
- Removed: Nothing; no logic paths or settings were removed.
- Memory impact: None; a single conditional check changed.
- Security risks: None; UI initialization only.
- Tests: No new unit tests added.

**Release Note**
History results now appear on startup when the “show history on home page” option is enabled, even if the home page is turned off.

<sup>Written for commit 59e637198777ea34ec3bc3d8668d1b94fc3f3f71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

