### PR TITLE
Use QueryContentLocale for locale detection in tests

### DIFF
--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -98,7 +98,7 @@ namespace Flow.Launcher.Test.Plugins
 
             // The system running this test could have a different content locale than the hard-coded 1033 LCID en-US.
             var queryContentLocale = baseQuery.QueryContentLocale;
-            expectedString = expectedString.Replace("1033", queryContentLocale.ToString());
+expectedString = expectedString.Replace("1033", queryContentLocale.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
             // When
             var resultString = queryConstructor.FilesAndFolders(userSearchString);

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -96,11 +96,11 @@ namespace Flow.Launcher.Test.Plugins
             var queryConstructor = new QueryConstructor(new Settings());
             var baseQuery = queryConstructor.CreateBaseQuery();
 
-            // system running this test could have different locale than the hard-coded 1033 LCID en-US.
-            var queryKeywordLocale = baseQuery.QueryKeywordLocale;
-            expectedString = expectedString.Replace("1033", queryKeywordLocale.ToString());
+            // The system running this test could have a different content locale than the hard-coded 1033 LCID en-US.
+            var queryContentLocale = baseQuery.QueryContentLocale;
+            expectedString = expectedString.Replace("1033", queryContentLocale.ToString());
 
-            //When
+            // When
             var resultString = queryConstructor.FilesAndFolders(userSearchString);
 
             // Then

--- a/Flow.Launcher.Test/Plugins/ExplorerTest.cs
+++ b/Flow.Launcher.Test/Plugins/ExplorerTest.cs
@@ -7,6 +7,7 @@ using Flow.Launcher.Plugin.SharedCommands;
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using System;
+using System.Globalization;
 using System.IO;
 using System.Runtime.Versioning;
 using static Flow.Launcher.Plugin.Explorer.Search.SearchManager;
@@ -98,7 +99,7 @@ namespace Flow.Launcher.Test.Plugins
 
             // The system running this test could have a different content locale than the hard-coded 1033 LCID en-US.
             var queryContentLocale = baseQuery.QueryContentLocale;
-expectedString = expectedString.Replace("1033", queryContentLocale.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            expectedString = expectedString.Replace("1033", queryContentLocale.ToString(CultureInfo.InvariantCulture));
 
             // When
             var resultString = queryConstructor.FilesAndFolders(userSearchString);


### PR DESCRIPTION
Replaced QueryKeywordLocale with QueryContentLocale to ensure tests adapt to the system's content locale, improving reliability across environments. Clarified a comment for better readability.

Under my system with Chinese locale, I happened to find that explorer test failed. So this a quick fix for that.

<img width="1953" height="467" alt="image" src="https://github.com/user-attachments/assets/fcefd205-b5dd-444d-b3c1-b27c887953d5" />

```
GivenWindowsIndexSearch_WhenSearchAllFoldersAndFiles_ThenQueryShouldUseExpectedString("flow.launcher.sln","SELECT TOP 100 \"System.FileName\", \"System.ItemUrl\", \"System.ItemType\" FROM \"SystemIndex\" WHERE (System.FileName LIKE 'flow.launcher.sln%' OR CONTAINS(System.FileName,'\"flow.launcher.sln*\"',1033)) AND scope='file:' ORDER BY System.Search.Rank DESC")
   Source: ExplorerTest.cs line 92
   Duration: 55 ms

  Message: 
  Assert.That(actual, Is.EqualTo(expected))
  String lengths are both 246. Strings differ at index 192.
  Expected: "...*"',2057)) AND scope='file:' ORDER BY System.Search.Rank DESC"
  But was:  "...*"',2052)) AND scope='file:' ORDER BY System.Search.Rank DESC"
  ---------------------^


  Stack Trace: 
ClassicAssert.AreEqual(Object expected, Object actual)
ExplorerTest.GivenWindowsIndexSearch_WhenSearchAllFoldersAndFiles_ThenQueryShouldUseExpectedString(String userSearchString, String expectedString) line 107
1)    at NUnit.Framework.Legacy.ClassicAssert.AreEqual(Object expected, Object actual)
ExplorerTest.GivenWindowsIndexSearch_WhenSearchAllFoldersAndFiles_ThenQueryShouldUseExpectedString(String userSearchString, String expectedString) line 107
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Explorer tests to use `QueryContentLocale` with invariant formatting so LCID assertions match the system content locale across machines.

**Summary of changes**
- Changed: In Explorer tests, replaced `QueryKeywordLocale` with `QueryContentLocale` for LCID substitution; used `ToString(CultureInfo.InvariantCulture)`; minor comment/format tweaks.
- Added: Tests adapt to the query builder’s content locale and use culture-invariant digits for LCID values.
- Removed: Dependence on keyword locale and the implicit en-US (`1033`) assumption in assertions.
- Memory impact: None.
- Security risks: None.
- Unit tests: Updated the existing Explorer test; no new tests added.

**Release Note**
No user-facing changes; improves test reliability on non‑en‑US systems.

<sup>Written for commit 45d9cf8e6d76efbb1fc8b7a97ef44688554ba31b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

