### PR TITLE
Lower program plugin shortcut description E_FAIL logs to debug level

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Program/Logger/ProgramLogger.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Logger/ProgramLogger.cs
@@ -86,6 +86,16 @@ namespace Flow.Launcher.Plugin.Program.Logger
             LogException(classname, callingMethodName, loadingProgramPath, interpretationMessage, e);
         }
 
+        /// <summary>
+        /// Logs a debug message
+        /// </summary>
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        internal static void LogDebug(string classname, string callingMethodName, string loadingProgramPath, string message)
+        {
+            var logger = LogManager.GetLogger("");
+            logger.Debug($"{classname}.{callingMethodName}: {message} ({loadingProgramPath})");
+        }
+
         private static bool IsKnownWinProgramError(Exception e, string callingMethodName)
         {
             if (e.TargetSite?.Name == "GetDescription" && callingMethodName == "LnkProgram")

--- a/Plugins/Flow.Launcher.Plugin.Program/Programs/ShellLinkReader.cs
+++ b/Plugins/Flow.Launcher.Plugin.Program/Programs/ShellLinkReader.cs
@@ -15,6 +15,8 @@ namespace Flow.Launcher.Plugin.Program.Programs
 {
     public static class ShellLinkReader
     {
+        private const int E_FAIL = unchecked((int)0x80004005); // HResult returned by IShellLinkW.GetDescription
+
         // Retrieves the target path, arguments, and description from a shell link
         public static ShellLinkReadResult Read(string path)
         {
@@ -85,12 +87,28 @@ namespace Flow.Launcher.Plugin.Program.Programs
             }
             catch (COMException e)
             {
-                // C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\MiracastView.lnk always cause exception
-                ProgramLogger.LogException(
-                    $"|ShellLinkReader|retrieveDescription|{path}" +
-                    "|Error caused likely due to trying to get the description of the program",
-                    e
-                );
+                // GetDescription returns an undocumented E_FAIL 
+                // that does not distinguish a missing description from a real failure
+                // It regularly occurs for shortcuts without a description (see #4616, #3812) 
+                // so log at Debug to avoid error spam.
+                if (e.HResult == E_FAIL)
+                {
+                    ProgramLogger.LogDebug(
+                        nameof(ShellLinkReader), 
+                        nameof(retrieveDescription), 
+                        path, 
+                        "Shortcut description read gave E_FAIL, returning empty"
+                    );
+                }
+                else
+                {
+                    ProgramLogger.LogException(
+                        $"|ShellLinkReader|retrieveDescription|{path}" +
+                        "|Unexpected error occurred when trying to get the description of the shortcut",
+                        e
+                    );
+                }
+
                 return string.Empty;
             }
         }


### PR DESCRIPTION
Resolves #4616 and also readdresses #3812

Added a LogDebug to the program plugin's ProgramLogger and used it specifically for E_FAIL hresults from description reads

There doesn't seem to be any way to distinguish between a shortcut missing a description and an actual failure here, but it is expected in many cases, so as a compromise I downgraded this log to debug level

I decided against removing the call entirely when EnableDescription is false as that would require reindexing when its toggled on.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
**Summary of changes**

Downgrades logging for expected shortcut description failures from error to debug. This reduces error log noise when Windows shortcuts lack a description.

- Changed behavior: When `IShellLinkW.GetDescription` returns `E_FAIL`, `ShellLinkReader.retrieveDescription` logs via `ProgramLogger.LogDebug` and returns an empty string. Previously it called `LogException` and produced error logs.
- New logic: Added `ProgramLogger.LogDebug` (synchronized) to emit debug messages with class, method, and path; added `E_FAIL` constant in `ShellLinkReader`.
- Removed logic: None. The description read remains even when description support is disabled to avoid forcing a reindex when the setting is toggled later.
- Memory impact: None material. The change only alters log level and adds a small debug-only code path.
- Security risks: None. This is a logging-only change; no changes to permissions, data handling, or external interfaces.
- Unit tests: No new tests added; behavior change is limited to logging level for `E_FAIL`.

**Release Note**

Reduces error log noise by treating missing shortcut descriptions as debug messages instead of errors.

<sup>Written for commit 229b586eace12fb8fc90dd616b0823a1b1d7deed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

