### PR TITLE
Raise PropertyChanged when ResultViewModel image properties are set

### DIFF
--- a/Flow.Launcher/ViewModel/ResultViewModel.cs
+++ b/Flow.Launcher/ViewModel/ResultViewModel.cs
@@ -175,7 +175,11 @@ namespace Flow.Launcher.ViewModel
 
                 return _image;
             }
-            private set => _image = value;
+            private set
+            {
+                _image = value;
+                OnPropertyChanged();
+            }
         }
 
         public ImageSource BadgeImage
@@ -190,7 +194,11 @@ namespace Flow.Launcher.ViewModel
 
                 return _badgeImage;
             }
-            private set => _badgeImage = value;
+            private set
+            {
+                _badgeImage = value;
+                OnPropertyChanged();
+            }
         }
 
         public ImageSource PreviewImage
@@ -205,7 +213,11 @@ namespace Flow.Launcher.ViewModel
 
                 return _previewImage;
             }
-            private set => _previewImage = value;
+            private set
+            {
+                _previewImage = value;
+                OnPropertyChanged();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Problem

`ResultViewModel.Image`, `BadgeImage`, and `PreviewImage` never raise `PropertyChanged` when set. `LoadImageAsync` awaits the image load and then assigns the property, and its comment states that "modifying the property" triggers the change notification — but the setters are plain field assignments:

```csharp
private set => _image = value;
```

### Root cause

The notification was lost in e8691c210 (May 2021, "No need for the wrapped Lazy instance in image loading"), which inlined the `LazyAsync<ImageSource>` wrapper. That wrapper's `updateCallback` was what called `OnPropertyChanged(nameof(Image))`; when it was removed, nothing replaced it.

### Why it usually doesn't show

A repeat lookup of the same `IcoPath` hits `ImageCache` synchronously inside the getter, so the binding already sees the real image the first time it evaluates. The bug only surfaces when a brand-new `IcoPath` arrives *and* the host doesn't virtualize the row out and back in — e.g. a single-result query such as a chat plugin's "Ask" preview. There the field is mutated after the await, the binding is never re-evaluated, and the row stays on `LoadingImage` indefinitely.

### Fix

Raise `OnPropertyChanged()` in all three image setters. `ResultViewModel` already derives from `BaseModel`, so no other plumbing is needed.

### Testing

- `dotnet build Flow.Launcher.sln -c Release` — 0 errors
- `dotnet test -c Release` — 433 passed

`ImageLoaderTests.ShellThumbnailFailure_Directory_ReturnsDefaultFolderImageAsync` fails on the first run against a fresh build output on my machine, but it fails identically on unmodified `dev`, so it is unrelated to this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
**Summary of changes**

Ensures `ResultViewModel` image properties notify bindings after async loads so icons refresh. Previously, `Image`, `BadgeImage`, and `PreviewImage` setters did not raise `PropertyChanged`, so some results stayed on `LoadingImage`.

- Changed: Added `OnPropertyChanged()` in the setters for `Image`, `BadgeImage`, and `PreviewImage`, restoring behavior lost when the `LazyAsync<ImageSource>` wrapper was removed.
- Added: Bindings now re-evaluate when the image finishes loading; no public API changes.
- Removed: No logic removed.
- Memory impact: None beyond an extra method call per property set; no new allocations.
- Security risks: None.
- Unit tests: No new tests. Existing suite passes locally (433 tests). One known unrelated thumbnail test is flaky on a fresh build in both this branch and `dev`.

**Release Note**

Fixes an issue where some result icons stayed stuck on the loading image by updating them automatically once the icon finishes loading.

<sup>Written for commit 4ee56ab77aab6468c87829fdf11c44847daac03c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

