### PR TITLE
Add settings page navigation to flow-launcher:// deep links

### DIFF
--- a/Flow.Launcher.Test/DeepLinkTest.cs
+++ b/Flow.Launcher.Test/DeepLinkTest.cs
@@ -104,5 +104,47 @@ namespace Flow.Launcher.Test
         {
             Assert.That(DeepLink.HasExactlyOneInstallIdentifier(path, id, url), Is.False);
         }
+
+        [TestCase("flow-launcher://settings", "settings")]
+        [TestCase("flow-launcher://settings/general", "settings/general")]
+        [TestCase("flow-launcher://settings/plugins", "settings/plugins")]
+        [TestCase("flow-launcher://settings/store", "settings/store")]
+        [TestCase("flow-launcher://settings/theme", "settings/theme")]
+        [TestCase("flow-launcher://settings/hotkey", "settings/hotkey")]
+        [TestCase("flow-launcher://settings/proxy", "settings/proxy")]
+        [TestCase("flow-launcher://settings/about", "settings/about")]
+        [TestCase("FLOW-LAUNCHER://Settings/Plugins", "settings/plugins")]
+        public void SettingsPages_EveryDocumentedLink_MapsToAPane(string payload, string expectedVerb)
+        {
+            var ok = DeepLink.TryParse(payload, out var verb, out _);
+            Assert.That(ok, Is.True);
+            Assert.That(verb, Is.EqualTo(expectedVerb));
+            Assert.That(DeepLink.SettingsPages.ContainsKey(verb), Is.True);
+        }
+
+        [Test]
+        public void SettingsPages_UnknownSubpage_NotMapped()
+        {
+            DeepLink.TryParse("flow-launcher://settings/nope", out var verb, out _);
+            Assert.That(DeepLink.SettingsPages.ContainsKey(verb), Is.False);
+        }
+
+        [Test]
+        public void TryParse_SettingsPluginsWithPluginId_ExtractsParameter()
+        {
+            var ok = DeepLink.TryParse("flow-launcher://settings/plugins?plugin=abc-123", out var verb, out var parameters);
+            Assert.That(ok, Is.True);
+            Assert.That(verb, Is.EqualTo("settings/plugins"));
+            Assert.That(parameters["plugin"], Is.EqualTo("abc-123"));
+        }
+
+        [Test]
+        public void TryParse_SettingsStoreWithQuery_ExtractsParameter()
+        {
+            var ok = DeepLink.TryParse("flow-launcher://settings/store?q=clipboard%20history", out var verb, out var parameters);
+            Assert.That(ok, Is.True);
+            Assert.That(verb, Is.EqualTo("settings/store"));
+            Assert.That(parameters["q"], Is.EqualTo("clipboard history"));
+        }
     }
 }

--- a/Flow.Launcher.Test/DeepLinkTest.cs
+++ b/Flow.Launcher.Test/DeepLinkTest.cs
@@ -125,7 +125,9 @@ namespace Flow.Launcher.Test
         [Test]
         public void SettingsPages_UnknownSubpage_NotMapped()
         {
-            DeepLink.TryParse("flow-launcher://settings/nope", out var verb, out _);
+            var ok = DeepLink.TryParse("flow-launcher://settings/nope", out var verb, out _);
+            Assert.That(ok, Is.True);
+            Assert.That(verb, Is.EqualTo("settings/nope"));
             Assert.That(DeepLink.SettingsPages.ContainsKey(verb), Is.False);
         }
 

--- a/Flow.Launcher.Test/SettingWindowViewModelTest.cs
+++ b/Flow.Launcher.Test/SettingWindowViewModelTest.cs
@@ -1,0 +1,44 @@
+using Flow.Launcher.Infrastructure.UserSettings;
+using Flow.Launcher.SettingPages.Views;
+using Flow.Launcher.ViewModel;
+using NUnit.Framework;
+
+namespace Flow.Launcher.Test
+{
+    [TestFixture]
+    public class SettingWindowViewModelTest
+    {
+        [Test]
+        public void PendingNavigation_ConsumeReturnsValueOnceThenNull()
+        {
+            var viewModel = new SettingWindowViewModel(new Settings());
+
+            viewModel.SetPendingNavigation(typeof(SettingsPanePlugins), "Calculator");
+
+            Assert.That(viewModel.ConsumePendingPageType(), Is.EqualTo(typeof(SettingsPanePlugins)));
+            Assert.That(viewModel.ConsumePendingFilterText(), Is.EqualTo("Calculator"));
+            Assert.That(viewModel.ConsumePendingPageType(), Is.Null);
+            Assert.That(viewModel.ConsumePendingFilterText(), Is.Null);
+        }
+
+        [Test]
+        public void PendingNavigation_NothingPending_ConsumeReturnsNull()
+        {
+            var viewModel = new SettingWindowViewModel(new Settings());
+
+            Assert.That(viewModel.ConsumePendingPageType(), Is.Null);
+            Assert.That(viewModel.ConsumePendingFilterText(), Is.Null);
+        }
+
+        [Test]
+        public void PendingNavigation_FilterDefaultsToNull()
+        {
+            var viewModel = new SettingWindowViewModel(new Settings());
+
+            viewModel.SetPendingNavigation(typeof(SettingsPaneTheme));
+
+            Assert.That(viewModel.ConsumePendingPageType(), Is.EqualTo(typeof(SettingsPaneTheme)));
+            Assert.That(viewModel.ConsumePendingFilterText(), Is.Null);
+        }
+    }
+}

--- a/Flow.Launcher/Helper/DeepLink.cs
+++ b/Flow.Launcher/Helper/DeepLink.cs
@@ -5,8 +5,12 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web;
+using System.Windows;
+using CommunityToolkit.Mvvm.DependencyInjection;
 using Flow.Launcher.Core.Plugin;
 using Flow.Launcher.Infrastructure.Logger;
+using Flow.Launcher.SettingPages.Views;
+using Flow.Launcher.ViewModel;
 
 namespace Flow.Launcher.Helper;
 
@@ -22,12 +26,43 @@ public static class DeepLink
 
     private static readonly string ClassName = nameof(DeepLink);
 
-    private static readonly Dictionary<string, Action<NameValueCollection>> Handlers = new()
+    /// <summary>
+    /// Maps settings deep link verbs to the settings pane each one opens.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, Type> SettingsPages = new Dictionary<string, Type>
     {
-        ["query"] = HandleQuery,
-        ["settings"] = HandleSettings,
-        ["plugin/install"] = HandlePluginInstall,
+        ["settings"] = typeof(SettingsPaneGeneral),
+        ["settings/general"] = typeof(SettingsPaneGeneral),
+        ["settings/plugins"] = typeof(SettingsPanePlugins),
+        ["settings/store"] = typeof(SettingsPanePluginStore),
+        ["settings/theme"] = typeof(SettingsPaneTheme),
+        ["settings/hotkey"] = typeof(SettingsPaneHotkey),
+        ["settings/proxy"] = typeof(SettingsPaneProxy),
+        ["settings/about"] = typeof(SettingsPaneAbout),
     };
+
+    private static readonly Dictionary<string, Action<NameValueCollection>> Handlers = BuildHandlers();
+
+    private static Dictionary<string, Action<NameValueCollection>> BuildHandlers()
+    {
+        var handlers = new Dictionary<string, Action<NameValueCollection>>
+        {
+            ["query"] = HandleQuery,
+            ["plugin/install"] = HandlePluginInstall,
+        };
+
+        foreach (var (verb, paneType) in SettingsPages)
+        {
+            handlers[verb] = verb switch
+            {
+                "settings/plugins" => HandleSettingsPlugins,
+                "settings/store" => parameters => OpenSettingsPage(paneType, parameters["q"]),
+                _ => _ => OpenSettingsPage(paneType),
+            };
+        }
+
+        return handlers;
+    }
 
     /// <summary>
     /// Normalizes command line arguments to a single deep link URI string, or null for a normal launch.
@@ -145,9 +180,44 @@ public static class DeepLink
         App.API.ChangeQuery(query, true);
     }
 
-    private static void HandleSettings(NameValueCollection parameters)
+    private static void HandleSettingsPlugins(NameValueCollection parameters)
     {
-        App.API.OpenSettingDialog();
+        var pluginId = parameters["plugin"];
+        string filterText = null;
+
+        if (!string.IsNullOrEmpty(pluginId))
+        {
+            var plugin = PluginManager.GetPluginForId(pluginId);
+            if (plugin == null)
+            {
+                App.API.ShowMsgError(Localize.deepLinkSettingsPluginNotInstalledTitle(),
+                    Localize.deepLinkSettingsPluginNotInstalledSubtitle(pluginId));
+            }
+            else
+            {
+                filterText = plugin.Metadata.Name;
+            }
+        }
+
+        OpenSettingsPage(typeof(SettingsPanePlugins), filterText);
+    }
+
+    /// <summary>
+    /// Opens the settings window at a specific pane. The destination is stashed on the
+    /// singleton view model; a freshly created window consumes it when its frame loads,
+    /// an already open window is navigated immediately.
+    /// </summary>
+    private static void OpenSettingsPage(Type paneType, string filterText = null)
+    {
+        Application.Current.Dispatcher.Invoke(() =>
+        {
+            Ioc.Default.GetRequiredService<SettingWindowViewModel>().SetPendingNavigation(paneType, filterText);
+            var window = SingletonWindowOpener.Open<SettingWindow>();
+            if (window.IsLoaded)
+            {
+                window.NavigateToPendingPage();
+            }
+        });
     }
 
     private static void HandlePluginInstall(NameValueCollection parameters)

--- a/Flow.Launcher/Helper/DeepLink.cs
+++ b/Flow.Launcher/Helper/DeepLink.cs
@@ -26,6 +26,9 @@ public static class DeepLink
 
     private static readonly string ClassName = nameof(DeepLink);
 
+    private const string SettingsPluginsVerb = "settings/plugins";
+    private const string SettingsStoreVerb = "settings/store";
+
     /// <summary>
     /// Maps settings deep link verbs to the settings pane each one opens.
     /// </summary>
@@ -33,8 +36,8 @@ public static class DeepLink
     {
         ["settings"] = typeof(SettingsPaneGeneral),
         ["settings/general"] = typeof(SettingsPaneGeneral),
-        ["settings/plugins"] = typeof(SettingsPanePlugins),
-        ["settings/store"] = typeof(SettingsPanePluginStore),
+        [SettingsPluginsVerb] = typeof(SettingsPanePlugins),
+        [SettingsStoreVerb] = typeof(SettingsPanePluginStore),
         ["settings/theme"] = typeof(SettingsPaneTheme),
         ["settings/hotkey"] = typeof(SettingsPaneHotkey),
         ["settings/proxy"] = typeof(SettingsPaneProxy),
@@ -55,8 +58,8 @@ public static class DeepLink
         {
             handlers[verb] = verb switch
             {
-                "settings/plugins" => HandleSettingsPlugins,
-                "settings/store" => parameters => OpenSettingsPage(paneType, parameters["q"]),
+                SettingsPluginsVerb => HandleSettingsPlugins,
+                SettingsStoreVerb => parameters => OpenSettingsPage(paneType, NormalizeFilter(parameters["q"])),
                 _ => _ => OpenSettingsPage(paneType),
             };
         }
@@ -165,6 +168,12 @@ public static class DeepLink
         }
     }
 
+    /// <summary>
+    /// Treats a whitespace-only filter value the same as an absent one.
+    /// </summary>
+    private static string NormalizeFilter(string filterText) =>
+        string.IsNullOrWhiteSpace(filterText) ? null : filterText;
+
     private static void HandleQuery(NameValueCollection parameters)
     {
         ChangeQueryAndShow(parameters["q"]);
@@ -185,9 +194,10 @@ public static class DeepLink
         var pluginId = parameters["plugin"];
         string filterText = null;
 
-        if (!string.IsNullOrEmpty(pluginId))
+        if (!string.IsNullOrWhiteSpace(pluginId))
         {
-            var plugin = PluginManager.GetPluginForId(pluginId);
+            var plugin = PluginManager.GetAllLoadedPlugins()
+                .FirstOrDefault(p => string.Equals(p.Metadata.ID, pluginId, StringComparison.OrdinalIgnoreCase));
             if (plugin == null)
             {
                 App.API.ShowMsgError(Localize.deepLinkSettingsPluginNotInstalledTitle(),

--- a/Flow.Launcher/Languages/en.xaml
+++ b/Flow.Launcher/Languages/en.xaml
@@ -48,6 +48,8 @@
     <system:String x:Key="deepLinkInstallInvalidSubtitle">A plugin install link must contain exactly one of: path, id, or url.</system:String>
     <system:String x:Key="deepLinkInstallFileNotFound">Plugin package not found: {0}</system:String>
     <system:String x:Key="deepLinkInstallPluginNotFound">No plugin with id "{0}" was found in the plugin store.</system:String>
+    <system:String x:Key="deepLinkSettingsPluginNotInstalledTitle">Plugin not installed</system:String>
+    <system:String x:Key="deepLinkSettingsPluginNotInstalledSubtitle">No installed plugin with id "{0}" was found.</system:String>
     <system:String x:Key="deepLinkInstallHttpsOnly">Plugin install links must use an https download URL.</system:String>
     <system:String x:Key="deepLinkManifestUpdateFailed">Could not load the plugin store manifest. Check your internet connection and try again.</system:String>
     <system:String x:Key="couldnotStartCmd">Could not start {0}</system:String>

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
@@ -30,7 +30,7 @@ public partial class SettingsPanePluginStore
             InitializeComponent();
         }
         var pendingFilter = _settingViewModel.ConsumePendingFilterText();
-        if (!string.IsNullOrEmpty(pendingFilter))
+        if (!string.IsNullOrWhiteSpace(pendingFilter))
         {
             _viewModel.FilterText = pendingFilter;
         }

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePluginStore.xaml.cs
@@ -29,6 +29,11 @@ public partial class SettingsPanePluginStore
         {
             InitializeComponent();
         }
+        var pendingFilter = _settingViewModel.ConsumePendingFilterText();
+        if (!string.IsNullOrEmpty(pendingFilter))
+        {
+            _viewModel.FilterText = pendingFilter;
+        }
         UpdateCategoryGrouping();
         _viewModel.PropertyChanged += ViewModel_PropertyChanged;
         base.OnNavigatedTo(e);

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
@@ -31,6 +31,11 @@ public partial class SettingsPanePlugins
         {
             InitializeComponent();
         }
+        var pendingFilter = _settingViewModel.ConsumePendingFilterText();
+        if (!string.IsNullOrEmpty(pendingFilter))
+        {
+            _viewModel.FilterText = pendingFilter;
+        }
         _viewModel.PropertyChanged += ViewModel_PropertyChanged;
         _ = _viewModel.CheckForUpdatesSilentlyAsync();
         base.OnNavigatedTo(e);

--- a/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
+++ b/Flow.Launcher/SettingPages/Views/SettingsPanePlugins.xaml.cs
@@ -32,7 +32,7 @@ public partial class SettingsPanePlugins
             InitializeComponent();
         }
         var pendingFilter = _settingViewModel.ConsumePendingFilterText();
-        if (!string.IsNullOrEmpty(pendingFilter))
+        if (!string.IsNullOrWhiteSpace(pendingFilter))
         {
             _viewModel.FilterText = pendingFilter;
         }

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -246,6 +246,10 @@ public partial class SettingWindow
         var pendingPage = _viewModel.ConsumePendingPageType();
         if (pendingPage != null)
         {
+            // Reset the stale page type left over from the last time this singleton window was open,
+            // otherwise SetPageType below returns false when the deep link targets the same pane and
+            // NavigationView_SelectionChanged never navigates the frame (mirrors the branch below).
+            _viewModel.SetPageType(null);
             NavView.SelectedItem = NavView.MenuItems[PageIndexOf(pendingPage)];
             return;
         }

--- a/Flow.Launcher/SettingWindow.xaml.cs
+++ b/Flow.Launcher/SettingWindow.xaml.cs
@@ -53,21 +53,22 @@ public partial class SettingWindow
         switch (e.PropertyName)
         {
             case nameof(SettingWindowViewModel.PageType):
-                var selectedIndex = _viewModel.PageType.Name switch
-                {
-                    nameof(SettingsPaneGeneral) => 0,
-                    nameof(SettingsPanePlugins) => 1,
-                    nameof(SettingsPanePluginStore) => 2,
-                    nameof(SettingsPaneTheme) => 3,
-                    nameof(SettingsPaneHotkey) => 4,
-                    nameof(SettingsPaneProxy) => 5,
-                    nameof(SettingsPaneAbout) => 6,
-                    _ => 0
-                };
-                NavView.SelectedItem = NavView.MenuItems[selectedIndex];
+                NavView.SelectedItem = NavView.MenuItems[PageIndexOf(_viewModel.PageType)];
                 break;
         }
     }
+
+    private static int PageIndexOf(Type pageType) => pageType?.Name switch
+    {
+        nameof(SettingsPaneGeneral) => 0,
+        nameof(SettingsPanePlugins) => 1,
+        nameof(SettingsPanePluginStore) => 2,
+        nameof(SettingsPaneTheme) => 3,
+        nameof(SettingsPaneHotkey) => 4,
+        nameof(SettingsPaneProxy) => 5,
+        nameof(SettingsPaneAbout) => 6,
+        _ => 0
+    };
 
     private void OnClosed(object sender, EventArgs e)
     {
@@ -242,8 +243,36 @@ public partial class SettingWindow
 
     private void ContentFrame_Loaded(object sender, RoutedEventArgs e)
     {
+        var pendingPage = _viewModel.ConsumePendingPageType();
+        if (pendingPage != null)
+        {
+            NavView.SelectedItem = NavView.MenuItems[PageIndexOf(pendingPage)];
+            return;
+        }
+
         _viewModel.SetPageType(null); // Set page type to null so that NavigationView_SelectionChanged can navigate the frame
         NavView.SelectedItem = NavView.MenuItems[0]; /* Set First Page */
+    }
+
+    /// <summary>
+    /// Navigates an already open window to the pending deep link destination.
+    /// Re-navigating to the current pane still goes through the frame so the pane's
+    /// OnNavigatedTo runs and consumes any pending filter text.
+    /// </summary>
+    public void NavigateToPendingPage()
+    {
+        var pendingPage = _viewModel.ConsumePendingPageType();
+        if (pendingPage == null) return;
+
+        var targetItem = NavView.MenuItems[PageIndexOf(pendingPage)];
+        if (ReferenceEquals(NavView.SelectedItem, targetItem))
+        {
+            ContentFrame.Navigate(pendingPage);
+        }
+        else
+        {
+            NavView.SelectedItem = targetItem;
+        }
     }
 
     #endregion

--- a/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
+++ b/Flow.Launcher/ViewModel/SettingWindowViewModel.cs
@@ -35,6 +35,34 @@ public partial class SettingWindowViewModel : BaseModel
         }
     }
 
+    private Type _pendingPageType;
+    private string _pendingFilterText;
+
+    /// <summary>
+    /// Stores a one-shot navigation destination for the settings window, set before
+    /// the window is opened (deep links). Consumed once by the window and panes so a
+    /// later manual visit does not re-apply a stale destination or filter.
+    /// </summary>
+    public void SetPendingNavigation(Type pageType, string filterText = null)
+    {
+        _pendingPageType = pageType;
+        _pendingFilterText = filterText;
+    }
+
+    public Type ConsumePendingPageType()
+    {
+        var pageType = _pendingPageType;
+        _pendingPageType = null;
+        return pageType;
+    }
+
+    public string ConsumePendingFilterText()
+    {
+        var filterText = _pendingFilterText;
+        _pendingFilterText = null;
+        return filterText;
+    }
+
     public double SettingWindowWidth
     {
         get => _settings.SettingWindowWidth;


### PR DESCRIPTION
## What

Extends the `flow-launcher://settings` deep link from #4565 so links can open a specific settings pane, jump to an installed plugin in the Plugins pane, or pre-fill the Plugin Store search.

> Stacked on #4565 (`feature/query-command-line-arg`). Will retarget to `dev` once that merges; only the last 5 commits are new here.

| Link | Behavior |
|---|---|
| `flow-launcher://settings` | unchanged, opens settings at General |
| `flow-launcher://settings/general` / `theme` / `hotkey` / `proxy` / `about` | opens that pane |
| `flow-launcher://settings/plugins` | opens the Plugins pane |
| `flow-launcher://settings/plugins?plugin=<id>` | Plugins pane with the filter pre-set to that plugin's name; unknown id shows an error notification and still opens the pane unfiltered (id match is case-insensitive, same as `plugin/install`) |
| `flow-launcher://settings/store?q=<term>` | Plugin Store pane with the search box pre-filled |
| `flow-launcher://settings/<anything else>` | existing unrecognized-link error path |

## How

- `DeepLink.cs`: a public `SettingsPages` map (verb to pane type) drives the handler registrations, so the documented links, the dispatch table, and the tests share one source of truth. `settings/plugins` resolves the id via loaded plugins; `settings/store` passes `q` through; whitespace-only params are treated as absent.
- `SettingWindowViewModel`: one-shot pending destination (pane type + optional filter text) with consume-once accessors, so a later manual visit never re-applies a stale destination or filter.
- `SettingWindow`: the frame-loaded handler consumes the pending page instead of always selecting General (resetting the stale page type first so navigation actually fires); an already open window is navigated via `NavigateToPendingPage`, which re-navigates the frame directly when the target pane is already selected so a new filter still applies.
- `SettingsPanePlugins` / `SettingsPanePluginStore`: consume the pending filter in `OnNavigatedTo` and assign it to their existing `FilterText`.
- Two new strings in `en.xaml` for the unknown-plugin notification.

## Tests

- Unit: `DeepLinkTest` covers every documented link mapping (including case-insensitivity and an unmapped subpage), plus `plugin`/`q` parameter extraction; `SettingWindowViewModelTest` covers the consume-once semantics.
- Manual (Windows) matrix in progress, draft until complete:
  1. Each pane link, cold and warm start
  2. `?plugin=<installed id>` filters; unknown id shows the notification and opens unfiltered
  3. `?q=clipboard` pre-fills the store search
  4. Warm same-pane link updates the filter
  5. Reopening settings manually shows no stale filter
  6. Close settings on the Plugins pane, then cold-start `flow-launcher://settings/plugins` (regression check for the stale page type)
  7. Plain `flow-launcher://settings` unchanged


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
**Summary of changes**

Adds navigation for `flow-launcher://settings` deep links so links can open a specific pane, jump to an installed plugin in Plugins, or pre-fill the Plugin Store search. Previously, `flow-launcher://settings` always opened General; now subpaths select panes, Plugins supports `?plugin=<id>`, Store supports `?q=<term>`, and unknown plugin ids show a notification while still opening Plugins.

- Changed behavior/logic:
  - Deep link dispatch now derives settings handlers from a single `SettingsPages` map; the same map drives tests and routing.
  - `settings/plugins?plugin=<id>` looks up installed plugins case-insensitively; whitespace-only parameters are ignored.
  - Settings window resets a stale page type and re-navigates the current pane so new filters apply even when already open.
  - Added user-facing strings for the unknown-plugin notification.
- New behavior/logic:
  - Added `OpenSettingsPage` and `HandleSettingsPlugins`, plus a consume-once pending navigation state on `SettingWindowViewModel`.
  - Plugins and Store panes consume pending filter text in `OnNavigatedTo`.
  - New `NavigateToPendingPage` enables warm navigation to the target pane.
  - Tests cover link-to-pane mappings, parameter extraction, case-insensitivity, and consume-once semantics.
- Removed behavior/logic:
  - Replaced the single “always open General” settings handler with per-pane handlers built from `SettingsPages`.
  - Removed duplicated string literals for `settings/plugins` and `settings/store`.
- Memory impact:
  - Negligible. Adds a small immutable `SettingsPages` map and two short-lived fields for pending navigation on an existing singleton view model.
- Security risks:
  - Low. Parameters are normalized and only drive in-app navigation and filtering; no elevated actions are executed. Unknown plugin ids result in a local notification only.
- Unit tests:
  - `DeepLinkTest` validates all documented settings links and parameter parsing.
  - `SettingWindowViewModelTest` verifies one-shot pending navigation and default behaviors.

**Release Note**

You can now open specific Settings pages via links (for example, Plugins or Store) and even pre-fill plugin filters or store search directly from a `flow-launcher://settings/...` link.

<sup>Written for commit 72fe41d98a51bd8bb21c6e5c4204da824f1159ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

