### PR TITLE
Fix Overflow / Property Not Found issue with run count scoring in everything v3 API

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
@@ -275,6 +275,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             // if there is any error then set score to zero (this also covers PROPERTY_NOT_FOUND when run count is not requested)
             if (lastError != EVERYTHING3_OK)
             {
+                Main.Context?.API?.LogDebug(nameof(EverythingApiV3), $"{nameof(Everything3ApiDllImport.Everything3_GetResultRunCount)} failed with error 0x{lastError:X8}");
                 return 0;
             }
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
@@ -42,6 +42,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
         const uint EVERYTHING3_ERROR_DISCONNECTED = 0xE0000003;
         const uint EVERYTHING3_ERROR_INVALID_PARAMETER = 0xE0000004;
         const uint EVERYTHING3_ERROR_PROPERTY_NOT_FOUND = 0xE0000007;
+        const uint EVERYTHING3_OK = 0;
 
         private static void LogIfEverything3CallFailed(string callName, bool succeeded)
         {
@@ -270,13 +271,14 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
         {
             var runCount = Everything3ApiDllImport.Everything3_GetResultRunCount(resultList, resultIndex);
             var lastError = Everything3ApiDllImport.Everything3_GetLastError();
-            var propertyNotFound = runCount == uint.MaxValue && lastError == EVERYTHING3_ERROR_PROPERTY_NOT_FOUND;
 
-            if (propertyNotFound)
+            // if there is any error then set score to zero (this also covers PROPERTY_NOT_FOUND when run count is not requested)
+            if (lastError != EVERYTHING3_OK)
             {
                 return 0;
             }
 
+            // if genuinely a value too large for int then clamp it
             if (runCount > int.MaxValue)
             {
                 return int.MaxValue;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
@@ -229,7 +229,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                         yield break;
                     }
 
-                    if (!TryCreateSearchResult(resultList, idx, out var result))
+                    if (!TryCreateSearchResult(resultList, idx, includeRunCount, out var result))
                         continue;
 
                     yield return result;
@@ -249,7 +249,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             await Task.CompletedTask;
         }
 
-        private static bool TryCreateSearchResult(IntPtr resultList, nuint resultIndex, out SearchResult result)
+        private static bool TryCreateSearchResult(IntPtr resultList, nuint resultIndex, bool includeRunCount, out SearchResult result)
         {
             result = default;
 
@@ -260,7 +260,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             {
                 FullPath = fullPath,
                 Type = GetResultType(resultList, resultIndex),
-                Score = GetResultScore(resultList, resultIndex),
+                Score = includeRunCount ? GetResultScore(resultList, resultIndex) : 0,
                 HighlightData = GetHighlightData(resultList, resultIndex)
             };
 

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
@@ -259,11 +259,30 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             {
                 FullPath = fullPath,
                 Type = GetResultType(resultList, resultIndex),
-                Score = Convert.ToInt32(Everything3ApiDllImport.Everything3_GetResultRunCount(resultList, resultIndex)),
+                Score = GetResultScore(resultList, resultIndex),
                 HighlightData = GetHighlightData(resultList, resultIndex)
             };
 
             return true;
+        }
+
+        private static int GetResultScore(IntPtr resultList, nuint resultIndex)
+        {
+            var runCount = Everything3ApiDllImport.Everything3_GetResultRunCount(resultList, resultIndex);
+            var lastError = Everything3ApiDllImport.Everything3_GetLastError();
+            var propertyNotFound = runCount == uint.MaxValue && lastError == EVERYTHING3_ERROR_PROPERTY_NOT_FOUND;
+
+            if (propertyNotFound)
+            {
+                return 0;
+            }
+
+            if (runCount > int.MaxValue)
+            {
+                return int.MaxValue;
+            }
+
+            return (int)runCount;
         }
 
         private static bool TryGetResultFullPath(IntPtr resultList, nuint resultIndex, out string fullPath)


### PR DESCRIPTION
resolves #4630

Add GetResultScore helper to catch run count erroring or overflowing


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
**Summary of changes**

Fixes overflow and “property not found” errors when scoring Everything v3 results by run count, and skips the run count call when it’s not requested. Previously we always read and cast the value; now scoring is defensive to avoid crashes and bad ordering.

- Changed: TryCreateSearchResult takes includeRunCount and only reads run count when true; otherwise sets Score to 0.
- Changed: Score assignment uses GetResultScore to check Everything3_GetLastError and clamp values above int.MaxValue.
- Added: EVERYTHING3_OK constant and a debug log with the hex error code when run count retrieval fails.
- Removed: Direct Convert.ToInt32(...) of the run count.
- Memory impact: Negligible; one helper and one constant, no persistent allocations.
- Security risks: None.
- Unit tests: None yet; add cases for generic error, PROPERTY_NOT_FOUND, overflow, and includeRunCount=false.

**Release Note**

Prevents crashes and sorting glitches in Everything-based search by safely handling run count errors and skipping that data when unavailable.

<sup>Written for commit 23b30b7bb0d876745c0c9f97da97bb2d99c273e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



