### PR TITLE
Improve Everything client validation and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -305,3 +305,4 @@ Output-Performance.txt
 # vscode
 .vscode
 .history
+/.copilot

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/Everything3ApiDllImport.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/Everything3ApiDllImport.cs
@@ -35,6 +35,9 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
         internal static extern IntPtr Everything3_ConnectW(string instanceName);
 
         [DllImport(Dll)]
+        internal static extern uint Everything3_GetMajorVersion(IntPtr client);
+
+        [DllImport(Dll)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool Everything3_DestroyClient(IntPtr client);
 
@@ -128,7 +131,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
 
         [DllImport(Dll)]
         internal static extern uint Everything3_GetLastError();
-
 
         [DllImport(Dll)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
@@ -133,7 +133,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                 {
                     try
                     {
-                        Everything3ApiDllImport.Everything3_IncRunCountFromFilenameW(_client, fileOrFolder);
+                        var incremented = Everything3ApiDllImport.Everything3_IncRunCountFromFilenameW(_client, fileOrFolder) != 0;
+                        CheckEverything3Call(nameof(Everything3ApiDllImport.Everything3_IncRunCountFromFilenameW), incremented);
                     }
                     catch (IPCErrorException)
                     {
@@ -154,7 +155,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
 
         public bool IsFastSortOption(EverythingSortOption sortOption)
         {
-            _semaphore.Wait();
+            if (!_semaphore.Wait(TimeSpan.FromSeconds(1)))
+                return false;
 
             try
             {
@@ -363,7 +365,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                 _client = Everything3ApiDllImport.Everything3_ConnectW(_instanceName);
             }
 
-            return _client != IntPtr.Zero && Everything3ApiDllImport.Everything3_GetMajorVersion(_client) != 0;
+            return _client != IntPtr.Zero;
         }
 
         private void DestroyEverythingClient(IntPtr client)

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
@@ -507,6 +507,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                     throw new InvalidCallException();
                 case EVERYTHING3_ERROR_PROPERTY_NOT_FOUND:
                     throw new ArgumentException("EVERYTHING3_ERROR_PROPERTY_NOT_FOUND");
+                case EVERYTHING3_OK:
+                    return;
                 default:
                     throw new InvalidCallException();
             }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
@@ -51,7 +51,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             {
                 Main.Context?.API?.LogDebug(nameof(EverythingApiV3), $"{callName} failed");
                 CheckAndThrowExceptionOnErrorFromEverything3();
-                throw new InvalidCallException();
             }
         }
 
@@ -508,6 +507,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                     throw new InvalidCallException();
                 case EVERYTHING3_ERROR_PROPERTY_NOT_FOUND:
                     throw new ArgumentException("EVERYTHING3_ERROR_PROPERTY_NOT_FOUND");
+                default:
+                    throw new InvalidCallException();
             }
         }
     }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingApiV3.cs
@@ -12,10 +12,11 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
     public class EverythingApiV3 : IEverythingApi
     {
         private const int BufferSize = 4096;
-        private static readonly SemaphoreSlim _semaphore = new(1, 1);
-        private static readonly StringBuilder _buffer = new(BufferSize);
+        private readonly SemaphoreSlim _semaphore = new(1, 1);
+        private readonly StringBuilder _buffer = new(BufferSize);
 
         private readonly string _instanceName;
+        private IntPtr _client;
 
         public EverythingApiV3(string instanceName)
         {
@@ -44,11 +45,13 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
         const uint EVERYTHING3_ERROR_PROPERTY_NOT_FOUND = 0xE0000007;
         const uint EVERYTHING3_OK = 0;
 
-        private static void LogIfEverything3CallFailed(string callName, bool succeeded)
+        private void CheckEverything3Call(string callName, bool succeeded)
         {
             if (!succeeded)
             {
                 Main.Context?.API?.LogDebug(nameof(EverythingApiV3), $"{callName} failed");
+                CheckAndThrowExceptionOnErrorFromEverything3();
+                throw new InvalidCallException();
             }
         }
 
@@ -71,9 +74,13 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
 
             try
             {
-                if (!TryConnectEverything3(out var client))
+                token.ThrowIfCancellationRequested();
+
+                if (!EverythingClientConnected())
+                {
+                    _client = IntPtr.Zero;
                     throw new IPCErrorException();
-                _ = Everything3ApiDllImport.Everything3_DestroyClient(client);
+                }
             }
             finally
             {
@@ -100,10 +107,10 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                 if (token.IsCancellationRequested)
                     yield break;
 
-                if (!TryConnectEverything3(out var client))
+                if (!EverythingClientConnected())
                     throw new IPCErrorException();
 
-                await foreach (var result in SearchWithEverything3Async(client, preparedOption, query, token))
+                await foreach (var result in SearchWithEverything3Async(preparedOption, query, token))
                     yield return result;
             }
             finally
@@ -122,15 +129,16 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             }
             try
             {
-                if (TryConnectEverything3(out var client))
+                if (EverythingClientConnected())
                 {
                     try
                     {
-                        Everything3ApiDllImport.Everything3_IncRunCountFromFilenameW(client, fileOrFolder);
+                        Everything3ApiDllImport.Everything3_IncRunCountFromFilenameW(_client, fileOrFolder);
                     }
-                    finally
+                    catch (IPCErrorException)
                     {
-                        _ = Everything3ApiDllImport.Everything3_DestroyClient(client);
+                        DestroyEverythingClient(_client);
+                        throw;
                     }
                 }
             }
@@ -146,37 +154,47 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
 
         public bool IsFastSortOption(EverythingSortOption sortOption)
         {
-            if (!TryConnectEverything3(out var client))
-                throw new IPCErrorException();
+            _semaphore.Wait();
 
             try
             {
+                if (!EverythingClientConnected())
+                    throw new IPCErrorException();
+
                 if (TryConvertSortOption(sortOption, out var propertyId, out _))
                 {
-                    var isFastSort = Everything3ApiDllImport.Everything3_IsPropertyFastSort(client, propertyId);
+                    var isFastSort = Everything3ApiDllImport.Everything3_IsPropertyFastSort(_client, propertyId);
                     CheckAndThrowExceptionOnErrorFromEverything3();
                     return isFastSort;
                 }
             }
+            catch (IPCErrorException)
+            {
+                DestroyEverythingClient(_client);
+                throw;
+            }
             finally
             {
-                _ = Everything3ApiDllImport.Everything3_DestroyClient(client);
+                _semaphore.Release();
             }
 
             return false;
         }
 
-        private static async IAsyncEnumerable<SearchResult> SearchWithEverything3Async(IntPtr client,
+        private async IAsyncEnumerable<SearchResult> SearchWithEverything3Async(
             EverythingSearchOption option,
             EverythingHelper.PreparedQuery query,
             [EnumeratorCancellation] CancellationToken token)
         {
             IntPtr searchState = IntPtr.Zero;
             IntPtr resultList = IntPtr.Zero;
+            var completed = false;
             var includeRunCount = option.IsRunCounterEnabled || option.SortOption == EverythingSortOption.RUN_COUNT_DESCENDING || option.SortOption == EverythingSortOption.RUN_COUNT_ASCENDING;
 
             try
             {
+                if (token.IsCancellationRequested)
+                    yield break;
                 searchState = Everything3ApiDllImport.Everything3_CreateSearchState();
                 if (searchState == IntPtr.Zero)
                 {
@@ -184,37 +202,41 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                     yield break;
                 }
 
-                LogIfEverything3CallFailed(nameof(Everything3ApiDllImport.Everything3_SetSearchRegex),
+                CheckEverything3Call(nameof(Everything3ApiDllImport.Everything3_SetSearchRegex),
                     Everything3ApiDllImport.Everything3_SetSearchRegex(searchState, option.UseRegex));
-                LogIfEverything3CallFailed(nameof(Everything3ApiDllImport.Everything3_SetSearchMatchPath),
+                CheckEverything3Call(nameof(Everything3ApiDllImport.Everything3_SetSearchMatchPath),
                     Everything3ApiDllImport.Everything3_SetSearchMatchPath(searchState, option.IsFullPathSearch));
-                LogIfEverything3CallFailed(nameof(Everything3ApiDllImport.Everything3_SetSearchTextW),
+                CheckEverything3Call(nameof(Everything3ApiDllImport.Everything3_SetSearchTextW),
                     Everything3ApiDllImport.Everything3_SetSearchTextW(searchState, query.SearchText));
-                LogIfEverything3CallFailed(nameof(Everything3ApiDllImport.Everything3_SetSearchHideResultOmissions),
+                CheckEverything3Call(nameof(Everything3ApiDllImport.Everything3_SetSearchHideResultOmissions),
                     Everything3ApiDllImport.Everything3_SetSearchHideResultOmissions(searchState, true));
-                LogIfEverything3CallFailed(nameof(Everything3ApiDllImport.Everything3_SetSearchViewportOffset),
+                CheckEverything3Call(nameof(Everything3ApiDllImport.Everything3_SetSearchViewportOffset),
                     Everything3ApiDllImport.Everything3_SetSearchViewportOffset(searchState, (nuint)option.Offset));
-                LogIfEverything3CallFailed(nameof(Everything3ApiDllImport.Everything3_SetSearchViewportCount),
+                CheckEverything3Call(nameof(Everything3ApiDllImport.Everything3_SetSearchViewportCount),
                     Everything3ApiDllImport.Everything3_SetSearchViewportCount(searchState, (nuint)option.MaxCount));
 
                 if (TryConvertSortOption(option.SortOption, out var sortPropertyId, out var ascending))
                 {
                     if (!Everything3ApiDllImport.Everything3_AddSearchSort(searchState, sortPropertyId, ascending))
                     {
-                        CheckAndThrowExceptionOnErrorFromEverything3();
-                        yield break;
+                        CheckEverything3Call(nameof(Everything3ApiDllImport.Everything3_AddSearchSort), false);
                     }
                 }
 
-                _ = Everything3ApiDllImport.Everything3_ClearSearchPropertyRequests(searchState);
-                _ = Everything3ApiDllImport.Everything3_AddSearchPropertyRequestHighlighted(searchState, EVERYTHING3_PROPERTY_ID_NAME);
-                _ = Everything3ApiDllImport.Everything3_AddSearchPropertyRequest(searchState, EVERYTHING3_PROPERTY_ID_PATH_AND_NAME);
+                CheckEverything3Call(nameof(Everything3ApiDllImport.Everything3_ClearSearchPropertyRequests),
+                    Everything3ApiDllImport.Everything3_ClearSearchPropertyRequests(searchState));
+                CheckEverything3Call(nameof(Everything3ApiDllImport.Everything3_AddSearchPropertyRequestHighlighted),
+                    Everything3ApiDllImport.Everything3_AddSearchPropertyRequestHighlighted(searchState, EVERYTHING3_PROPERTY_ID_NAME));
+                CheckEverything3Call(nameof(Everything3ApiDllImport.Everything3_AddSearchPropertyRequest),
+                    Everything3ApiDllImport.Everything3_AddSearchPropertyRequest(searchState, EVERYTHING3_PROPERTY_ID_PATH_AND_NAME));
                 if (includeRunCount)
-                    _ = Everything3ApiDllImport.Everything3_AddSearchPropertyRequest(searchState, EVERYTHING3_PROPERTY_ID_RUN_COUNT);
+                {
+                    CheckEverything3Call(nameof(Everything3ApiDllImport.Everything3_AddSearchPropertyRequest),
+                        Everything3ApiDllImport.Everything3_AddSearchPropertyRequest(searchState, EVERYTHING3_PROPERTY_ID_RUN_COUNT));
+                }
                 if (token.IsCancellationRequested)
                     yield break;
-
-                resultList = Everything3ApiDllImport.Everything3_Search(client, searchState);
+                resultList = Everything3ApiDllImport.Everything3_Search(_client, searchState);
                 if (resultList == IntPtr.Zero)
                 {
                     CheckAndThrowExceptionOnErrorFromEverything3();
@@ -234,6 +256,8 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
 
                     yield return result;
                 }
+
+                completed = true;
             }
             finally
             {
@@ -243,13 +267,14 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                 if (searchState != IntPtr.Zero)
                     _ = Everything3ApiDllImport.Everything3_DestroySearchState(searchState);
 
-                _ = Everything3ApiDllImport.Everything3_DestroyClient(client);
+                if (!completed)
+                    DestroyEverythingClient(_client);
             }
 
             await Task.CompletedTask;
         }
 
-        private static bool TryCreateSearchResult(IntPtr resultList, nuint resultIndex, bool includeRunCount, out SearchResult result)
+        private bool TryCreateSearchResult(IntPtr resultList, nuint resultIndex, bool includeRunCount, out SearchResult result)
         {
             result = default;
 
@@ -267,7 +292,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             return true;
         }
 
-        private static int GetResultScore(IntPtr resultList, nuint resultIndex)
+        private int GetResultScore(IntPtr resultList, nuint resultIndex)
         {
             var runCount = Everything3ApiDllImport.Everything3_GetResultRunCount(resultList, resultIndex);
             var lastError = Everything3ApiDllImport.Everything3_GetLastError();
@@ -288,7 +313,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             return (int)runCount;
         }
 
-        private static bool TryGetResultFullPath(IntPtr resultList, nuint resultIndex, out string fullPath)
+        private bool TryGetResultFullPath(IntPtr resultList, nuint resultIndex, out string fullPath)
         {
             _buffer.Clear();
             var fullPathLength = Everything3ApiDllImport.Everything3_GetResultFullPathNameW(resultList, resultIndex, _buffer, BufferSize);
@@ -303,7 +328,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             return !string.IsNullOrEmpty(fullPath);
         }
 
-        private static ResultType GetResultType(IntPtr resultList, nuint resultIndex)
+        private ResultType GetResultType(IntPtr resultList, nuint resultIndex)
         {
             return Everything3ApiDllImport.Everything3_IsFolderResult(resultList, resultIndex)
                 ? ResultType.Folder
@@ -312,7 +337,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                     : ResultType.File;
         }
 
-        private static List<int> GetHighlightData(IntPtr resultList, nuint resultIndex)
+        private List<int> GetHighlightData(IntPtr resultList, nuint resultIndex)
         {
             _buffer.Clear();
             var highlightedFileNameLength = Everything3ApiDllImport.Everything3_GetResultPropertyTextHighlightedW(
@@ -327,10 +352,27 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                 : [];
         }
 
-        private bool TryConnectEverything3(out IntPtr client)
+        private bool EverythingClientConnected()
         {
-            client = Everything3ApiDllImport.Everything3_ConnectW(_instanceName);
-            return client != IntPtr.Zero;
+            if (_client == IntPtr.Zero)
+                _client = Everything3ApiDllImport.Everything3_ConnectW(_instanceName);
+
+            if (_client == IntPtr.Zero || Everything3ApiDllImport.Everything3_GetMajorVersion(_client) == 0)
+            {
+                DestroyEverythingClient(_client);
+                _client = Everything3ApiDllImport.Everything3_ConnectW(_instanceName);
+            }
+
+            return _client != IntPtr.Zero && Everything3ApiDllImport.Everything3_GetMajorVersion(_client) != 0;
+        }
+
+        private void DestroyEverythingClient(IntPtr client)
+        {
+            if (client == IntPtr.Zero || client != _client)
+                return;
+
+            _ = Everything3ApiDllImport.Everything3_DestroyClient(_client);
+            _client = IntPtr.Zero;
         }
 
         /// <summary>
@@ -451,7 +493,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             }
         }
 
-        private static void CheckAndThrowExceptionOnErrorFromEverything3()
+        private void CheckAndThrowExceptionOnErrorFromEverything3()
         {
             switch (Everything3ApiDllImport.Everything3_GetLastError())
             {

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingSearchManager.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Search/Everything/EverythingSearchManager.cs
@@ -68,9 +68,7 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
                 IsRunCounterEnabled: Settings.EverythingEnableRunCount);
 
             await foreach (var result in api.SearchAsync(option, token))
-            {
                 yield return result;
-            }
         }
 
         public async IAsyncEnumerable<SearchResult> EnumerateAsync(string path, string search, bool recursive, [EnumeratorCancellation] CancellationToken token)
@@ -119,7 +117,6 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
 
         private async Task EnsureAvailableAsync(CancellationToken token)
         {
-            var engineName = Enum.GetName(Settings.IndexSearchEngineOption.Everything)!;
             try
             {
                 await api.CheckAvailableAsync(token);
@@ -128,28 +125,42 @@ namespace Flow.Launcher.Plugin.Explorer.Search.Everything
             {
                 // ignore, the search was cancelled
             }
-            catch (Exceptions.IPCErrorException) when (api is LegacyEverythingApi)
+            catch (Exception ex) when (IsAvailabilityException(ex))
             {
-                throw new EngineNotAvailableException(engineName,
+                throw WrapEngineNotAvailableException(ex);
+            }
+        }
+
+        internal static bool IsAvailabilityException(Exception exception) =>
+            exception is Exceptions.IPCErrorException ||
+            exception is DllNotFoundException ||
+            exception is EntryPointNotFoundException;
+
+        internal EngineNotAvailableException WrapEngineNotAvailableException(Exception exception)
+        {
+            var engineName = Enum.GetName(Settings.IndexSearchEngineOption.Everything)!;
+
+            if (exception is Exceptions.IPCErrorException && api is LegacyEverythingApi)
+            {
+                return new EngineNotAvailableException(engineName,
                     Localize.flowlauncher_plugin_everything_click_to_launch_or_install(),
                     Localize.flowlauncher_plugin_everything_is_not_running(),
                     Constants.EverythingErrorImagePath,
                     ClickToInstallEverythingAsync);
             }
-            catch (Exceptions.IPCErrorException)
+
+            if (exception is Exceptions.IPCErrorException)
             {
-                throw new EngineNotAvailableException(engineName,
+                return new EngineNotAvailableException(engineName,
                     Localize.flowlauncher_plugin_everything_15_resolution(),
                     Localize.flowlauncher_plugin_everything_15_unavailable(),
                     Constants.EverythingErrorImagePath);
             }
-            catch (Exception ex) when (ex is DllNotFoundException || ex is EntryPointNotFoundException)
-            {
-                throw new EngineNotAvailableException(engineName,
-                    Localize.flowlauncher_plugin_everything_architecture_check(),
-                    Constants.GeneralSearchErrorImagePath,
-                    Localize.flowlauncher_plugin_everything_sdk_issue());
-            }
+
+            return new EngineNotAvailableException(engineName,
+                Localize.flowlauncher_plugin_everything_architecture_check(),
+                Constants.GeneralSearchErrorImagePath,
+                Localize.flowlauncher_plugin_everything_sdk_issue());
         }
 
         private async ValueTask<bool> ClickToInstallEverythingAsync(ActionContext _)


### PR DESCRIPTION
Reuse named pipe client and error handling. A follow-up of #4370.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
**Summary of changes**

Reworks `EverythingApiV3` to keep a single named pipe client for the lifetime of the instance, validates it before use, and surfaces failed Everything calls as exceptions instead of logging and continuing.

**Existing behavior changed:**
- The Everything 3 client is reused per instance instead of being created and destroyed on every operation.
- The semaphore and result buffer are instance members instead of static so multiple instances don't share state.
- Failed Everything calls now throw via `CheckEverything3Call` instead of only logging.
- Run counter failures now throw after checking the `Everything3_IncRunCountFromFilenameW` return value.
- `IsFastSortOption` waits up to 1 second on the semaphore instead of blocking the UI thread.
- `CheckAndThrowExceptionOnErrorFromEverything3` treats `EVERYTHING3_OK` as success and throws `InvalidCallException` for unknown error codes.
- Availability errors in `EverythingSearchManager` now go through `IsAvailabilityException` and `WrapEngineNotAvailableException`, preserving the existing user messages.

**New behavior added:**
- `Everything3_GetMajorVersion` validates the cached client and triggers a reconnect when invalid.
- `DestroyEverythingClient` only resets the client when the pointer matches the instance's cached client.
- Searches keep the client open on success and destroy it only on failure or cancellation.

**Removed:**
- Per-operation client creation in `SearchCoreAsync`, `IncrementRunCounterAsync`, `IsFastSortOption`, and `SearchWithEverything3Async`.
- The separate `IPCErrorException` catch in `EnsureAvailableAsync`; it is handled by the unified wrapper.

**Memory usage impacts:**
- Each `EverythingApiV3` instance keeps one client connection and one buffer alive for its lifetime; multiple instances scale memory accordingly.

**Security risks:**
- None identified; communication remains scoped to the local Everything named pipe.

**Unit tests:**
- No unit tests added or updated in this PR.

**Release Note**

File search is more reliable with better error handling and a persistent connection to the Everything service.

<sup>Written for commit dbf072089041a9e66c973564f7e8466c0d16bde4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

