### PR TITLE
Fix LF/CRLF issue of Firefox's profiles.ini

### DIFF
--- a/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
+++ b/Plugins/Flow.Launcher.Plugin.BrowserBookmark/FirefoxBookmarkLoader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -270,7 +270,7 @@ public class FirefoxBookmarkLoader : FirefoxBookmarkLoaderBase
         using var sReader = new StreamReader(profileIni);
         var ini = sReader.ReadToEnd();
 
-        var lines = ini.Split("\r\n").ToList();
+        var lines = ini.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None).ToList();
 
         var defaultProfileFolderNameRaw = lines.FirstOrDefault(x => x.Contains("Default=") && x != "Default=1") ?? string.Empty;
 


### PR DESCRIPTION
Fixes #4642. Tested on BOTH CRLF/LF.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
**Summary of changes**
- Fixes Firefox bookmark loading failing when `profiles.ini` uses LF or CR line endings instead of CRLF; the split in `FirefoxBookmarkLoader.cs` now handles all three line ending types, resolving issue #4642.
- Replaced the single `"\r\n"` delimiter with an array of `"\r\n"`, `"\r"`, and `"\n"`; no other logic removed.
- A UTF-8 BOM was added to the top of the file on save; no functional impact.
- Memory usage impact is negligible since the line array is per-file and small.
- No security risk introduced.
- No automated unit tests added; manually tested on both CRLF and LF files.

**Release Note**
- Fixes Firefox bookmark loading when `profiles.ini` uses different line endings.

<sup>Written for commit e8bc78ca08d67b0c68a3d52676e42b96dd7136f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

