### PR TITLE
Implement move to recycle bin feature

### DIFF
--- a/Flow.Launcher.Plugin/NativeMethods.txt
+++ b/Flow.Launcher.Plugin/NativeMethods.txt
@@ -14,3 +14,8 @@ GetMonitorInfo
 MONITORINFOEXW
 GetCursorPos
 MonitorFromPoint
+IFileOperation
+FileOperation
+IShellItem
+SHCreateItemFromParsingName
+FILEOPERATION_FLAGS

--- a/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
+++ b/Flow.Launcher.Plugin/SharedCommands/FilesFolders.cs
@@ -3,6 +3,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using Windows.Win32;
+using Windows.Win32.UI.Shell;
 
 #pragma warning disable IDE0005
 using System.Windows;
@@ -273,6 +276,35 @@ namespace Flow.Launcher.Plugin.SharedCommands
         public static bool FileOrLocationExists(this string path)
         {
             return LocationExists(path) || FileExists(path);
+        }
+
+        /// <summary>
+        /// Moves the specified file or directory to the Recycle Bin.
+        /// </summary>
+        /// <param name="path">The path of the file or directory to move.</param>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+        public static void MoveToRecycleBin(this string path)
+        {
+            var shellItemGuid = typeof(IShellItem).GUID;
+            PInvoke.SHCreateItemFromParsingName(path, null, in shellItemGuid, out var shellItemObject).ThrowOnFailure();
+            var shellItem = (IShellItem)shellItemObject;
+
+            var fileOperation = new FileOperation();
+            try
+            {
+                ((IFileOperation)fileOperation).SetOperationFlags(FILEOPERATION_FLAGS.FOF_ALLOWUNDO | FILEOPERATION_FLAGS.FOF_NOCONFIRMATION | FILEOPERATION_FLAGS.FOF_NOERRORUI);
+                ((IFileOperation)fileOperation).DeleteItem(shellItem, null);
+                ((IFileOperation)fileOperation).PerformOperations();
+                ((IFileOperation)fileOperation).GetAnyOperationsAborted(out var aborted);
+
+                if (aborted)
+                    throw new OperationCanceledException();
+            }
+            finally
+            {
+                Marshal.FinalReleaseComObject(fileOperation);
+                Marshal.FinalReleaseComObject(shellItem);
+            }
         }
 
         /// <summary>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/ContextMenu.cs
@@ -182,28 +182,39 @@ namespace Flow.Launcher.Plugin.Explorer
                     contextMenus.Add(new Result
                     {
                         Title = Localize.plugin_explorer_deletefilefolder(),
-                        SubTitle = isFile ? Localize.plugin_explorer_deletefile_subtitle(): Localize.plugin_explorer_deletefolder_subtitle(),
+                        SubTitle = Settings.DeleteToRecycleBin
+                            ? Localize.plugin_explorer_move_to_recycle_bin_subtitle()
+                            : isFile ? Localize.plugin_explorer_deletefile_subtitle() : Localize.plugin_explorer_deletefolder_subtitle(),
                         Action = (context) =>
                         {
                             try
                             {
-                                if (Context.API.ShowMsgBox(
-                                        Localize.plugin_explorer_delete_folder_link(record.FullPath),
+                                if (Settings.ConfirmBeforeDeleting && Context.API.ShowMsgBox(
+                                        Settings.DeleteToRecycleBin
+                                            ? Localize.plugin_explorer_move_to_recycle_bin_confirmation(record.FullPath)
+                                            : Localize.plugin_explorer_delete_folder_link(record.FullPath),
                                         Localize.plugin_explorer_deletefilefolder(),
                                         MessageBoxButton.OKCancel,
                                         MessageBoxImage.Warning)
                                     == MessageBoxResult.Cancel)
                                     return false;
 
-                                if (isFile)
+                                if (Settings.DeleteToRecycleBin)
+                                    record.FullPath.MoveToRecycleBin();
+                                else if (isFile)
                                     File.Delete(record.FullPath);
                                 else
                                     Directory.Delete(record.FullPath, true);
 
                                 _ = Task.Run(() =>
                                 {
-                                    Context.API.ShowMsg(Localize.plugin_explorer_deletefilefoldersuccess(),
-                                        Localize.plugin_explorer_deletefilefoldersuccess_detail(record.FullPath),
+                                    Context.API.ShowMsg(
+                                        Settings.DeleteToRecycleBin
+                                            ? Localize.plugin_explorer_move_to_recycle_bin_success()
+                                            : Localize.plugin_explorer_deletefilefoldersuccess(),
+                                        Settings.DeleteToRecycleBin
+                                            ? Localize.plugin_explorer_move_to_recycle_bin_success_detail(record.FullPath)
+                                            : Localize.plugin_explorer_deletefilefoldersuccess_detail(record.FullPath),
                                         Constants.ExplorerIconImageFullPath);
                                 });
                             }

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Languages/en.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary
+﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:system="clr-namespace:System;assembly=mscorlib">
@@ -52,6 +52,8 @@
     <system:String x:Key="plugin_explorer_display_more_info_in_tooltip">Display more information like size and age in tooltips</system:String>
     <system:String x:Key="plugin_explorer_default_open_in_file_manager">Hit Enter to open folder in Default File Manager</system:String>
     <system:String x:Key="plugin_explorer_boost_home_folder_score">Prioritize home folders (Documents, Desktop, Downloads, etc.) in search results</system:String>
+    <system:String x:Key="plugin_explorer_move_deleted_items_to_recycle_bin">Move deleted files and folders to the Recycle Bin</system:String>
+    <system:String x:Key="plugin_explorer_confirm_before_deleting">Confirm before deleting files and folders</system:String>
     <system:String x:Key="plugin_explorer_usewindowsindexfordirectorysearch">Use Index Search For Path Search</system:String>
     <system:String x:Key="plugin_explorer_manageindexoptions">Indexing Options</system:String>
     <system:String x:Key="plugin_explorer_actionkeywordview_search">Search:</system:String>
@@ -104,6 +106,10 @@
     <system:String x:Key="plugin_explorer_deletefilefolder">Delete</system:String>
     <system:String x:Key="plugin_explorer_deletefile_subtitle">Permanently delete current file</system:String>
     <system:String x:Key="plugin_explorer_deletefolder_subtitle">Permanently delete current folder</system:String>
+    <system:String x:Key="plugin_explorer_move_to_recycle_bin_subtitle">Move current item to Recycle Bin</system:String>
+    <system:String x:Key="plugin_explorer_move_to_recycle_bin_confirmation">Are you sure you want to move {0} to Recycle Bin?</system:String>
+    <system:String x:Key="plugin_explorer_move_to_recycle_bin_success">Moved to Recycle Bin</system:String>
+    <system:String x:Key="plugin_explorer_move_to_recycle_bin_success_detail">Successfully moved {0} to Recycle Bin</system:String>
     <system:String x:Key="plugin_explorer_name">Name</system:String>
     <system:String x:Key="plugin_explorer_type">Type</system:String>
     <system:String x:Key="plugin_explorer_path">Path</system:String>

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Settings.cs
@@ -41,6 +41,10 @@ namespace Flow.Launcher.Plugin.Explorer
 
         public bool BoostHomeFolderScore { get; set; } = true;
 
+        public bool DeleteToRecycleBin { get; set; } = true;
+
+        public bool ConfirmBeforeDeleting { get; set; } = true;
+
         public string SearchActionKeyword { get; set; } = Query.GlobalPluginWildcardSign;
 
         public bool SearchActionKeywordEnabled { get; set; } = true;

--- a/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
+++ b/Plugins/Flow.Launcher.Plugin.Explorer/Views/ExplorerSettings.xaml
@@ -1,4 +1,4 @@
-<UserControl
+﻿<UserControl
     x:Class="Flow.Launcher.Plugin.Explorer.Views.ExplorerSettings"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -190,6 +190,8 @@
             <!--  Margin="32 -10 0 0" is to make sure elements is left aligned to the text in the expander text  -->
             <Grid Margin="32 -10 0 0">
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
@@ -418,6 +420,24 @@
                     Margin="{StaticResource SettingPanelItemTopBottomMargin}"
                     Click="btnOpenIndexingOptions_Click"
                     Content="{DynamicResource plugin_explorer_Open_Window_Index_Option}" />
+
+                <CheckBox
+                    Grid.Row="13"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    Margin="{StaticResource SettingPanelItemTopBottomMargin}"
+                    HorizontalAlignment="Left"
+                    Content="{DynamicResource plugin_explorer_move_deleted_items_to_recycle_bin}"
+                    IsChecked="{Binding Settings.DeleteToRecycleBin}" />
+
+                <CheckBox
+                    Grid.Row="14"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    Margin="{StaticResource SettingPanelItemTopBottomMargin}"
+                    HorizontalAlignment="Left"
+                    Content="{DynamicResource plugin_explorer_confirm_before_deleting}"
+                    IsChecked="{Binding Settings.ConfirmBeforeDeleting}" />
             </Grid>
         </Expander>
 


### PR DESCRIPTION
Move files and folders to recycle bin instead of permanent delete and an option to show delete confirmation dialog. Both are default to true.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
**Summary of changes**

Changes the Explorer plugin's delete action to send files and folders to the Recycle Bin instead of permanently deleting them. Two new settings control whether the recycle bin is used and whether a confirmation prompt appears.

- The delete context menu now calls `MoveToRecycleBin` when `DeleteToRecycleBin` is enabled; when disabled, it falls back to the existing `File.Delete`/`Directory.Delete` permanent delete path (no existing code removed).
- The confirmation dialog now only appears when `ConfirmBeforeDeleting` is true (previously always shown), and subtitles and success messages change to reflect the chosen destination.
- Added the `MoveToRecycleBin` extension method, which uses the `IFileOperation` COM API with `FOF_ALLOWUNDO`; two new settings (`DeleteToRecycleBin`, `ConfirmBeforeDeleting`, both default true) come with checkboxes in the Explorer settings UI and new localization strings in `en.xaml`.
- COM objects created in `MoveToRecycleBin` are released via `Marshal.FinalReleaseComObject` in a `finally` block, so memory usage impact is minimal.
- No new security risks: the change uses the standard Windows shell API with no privilege escalation, and the default confirmation prompt helps prevent accidental deletions.
- No unit tests are included; manual verification of the shell integration is required.

**Release Note**

Deleted files and folders now go to the Recycle Bin instead of being permanently removed, and you can skip the confirmation prompt if you prefer.

<sup>Written for commit e6968528564e63efeb428e6fc0cbc8c978405302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Flow-Launcher/Flow.Launcher/pull/4648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

